### PR TITLE
fix: add contents read permission to sync-labels workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,6 +11,7 @@ on:
       - '.github/labels.yml'
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `contents: read` permission to sync-labels.yml workflow
- Without this permission, the checkout step fails with 'Repository not found' error

The workflow needs to read the `labels.yml` file from the repository to sync labels.