### PR TITLE
fix: auto-merge for loop assessment PRs

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -224,7 +224,19 @@ jobs:
             --body "Automated assessment from observation loop." \
             --base main \
             --head "$branch")
-          gh pr merge "$pr_url" --squash --delete-branch
+
+          # Enable auto-merge — waits for required reviews (Copilot)
+          # before merging. If no branch protection, merges immediately.
+          gh pr merge "$pr_url" --squash --delete-branch --auto
+
+          # Wait for merge (up to 2 minutes for Copilot review)
+          for i in $(seq 1 24); do
+            state=$(gh pr view "$pr_url" --json state --jq '.state')
+            if [ "$state" = "MERGED" ]; then
+              break
+            fi
+            sleep 5
+          done
 
           git checkout main
           git pull origin main


### PR DESCRIPTION
## Summary
- Use `gh pr merge --auto` instead of immediate merge for loop assessment PRs
- Waits for Copilot review (up to 2 min) before merging
- Required now that main branch protection requires 1 approving review

## Test plan
- [ ] Trigger observation loop manually, verify PR gets auto-merged after Copilot review