### PR TITLE
fix: loop respects reviewer comments before merging

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -224,11 +224,30 @@ jobs:
             --body "Automated assessment from observation loop." \
             --base main \
             --head "$branch")
-          # --admin bypasses branch protection (PUSH_TOKEN is from org admin)
-          gh pr merge "$pr_url" --squash --delete-branch --admin
 
-          git checkout main
-          git pull origin main
+          # Wait for Copilot review (up to 90s)
+          pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
+          echo "Waiting for review on PR #${pr_number}..."
+          for i in $(seq 1 18); do
+            review_count=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews" --jq 'length' 2>/dev/null || echo "0")
+            if [ "$review_count" -gt 0 ]; then
+              echo "Review received."
+              break
+            fi
+            sleep 5
+          done
+
+          # Check for unresolved review comments
+          comment_count=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/comments" --jq 'length' 2>/dev/null || echo "0")
+          if [ "$comment_count" -gt 0 ]; then
+            echo "::warning::PR #${pr_number} has ${comment_count} review comment(s). Leaving open for human review."
+            echo "LOOP_PR_OPEN=true" >> "$GITHUB_ENV"
+          else
+            echo "No review comments. Merging."
+            gh pr merge "$pr_url" --squash --delete-branch --admin
+            git checkout main
+            git pull origin main
+          fi
 
       - name: Create issues from assessment
         env:


### PR DESCRIPTION
## Summary
- Wait up to 90s for Copilot review after creating assessment PR
- If review has comments: leave PR open, warn in logs
- If no comments: merge with --admin as before

Addresses feedback that loop was merging without addressing review comments.

## Test plan
- [ ] Trigger loop manually, verify it waits for review
- [ ] If Copilot comments, PR should stay open