### PR TITLE
feat: event-driven loop automerge + 15-min health checks

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -101,3 +101,8 @@
 - name: needs-human
   color: "B60205"
   description: "Requires human decision, capital, or judgment"
+
+# === Health Monitoring ===
+- name: health-check
+  color: "D93F0B"
+  description: "Automated health check alert — auto-closes on recovery"

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,83 @@
+name: Health Check
+
+# Lightweight endpoint health monitor — runs every 15 minutes.
+# Creates a GitHub issue on the first failure, closes it on recovery.
+# No LLM calls, no heavy processing — just curl + issue management.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            company/health.json
+            company/scripts/collect-infra.sh
+
+      - name: Run health checks
+        id: health
+        run: |
+          result=$(bash company/scripts/collect-infra.sh)
+          echo "$result" | jq .
+
+          # Extract failures
+          down=$(echo "$result" | jq -c '[.services[] | select(.status != "up")]')
+          down_count=$(echo "$down" | jq 'length')
+          down_names=$(echo "$down" | jq -r '[.[].name] | join(", ")')
+
+          echo "down_count=$down_count" >> "$GITHUB_OUTPUT"
+          echo "down_names=$down_names" >> "$GITHUB_OUTPUT"
+
+          # Write details for issue body
+          echo "$down" | jq -r '.[] | "- **\(.name)** (\(.url)): \(.status)"' > /tmp/down-details.txt
+
+      - name: Create or update issue on failure
+        if: steps.health.outputs.down_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOWN_NAMES: ${{ steps.health.outputs.down_names }}
+        run: |
+          # Check for existing open health-check issue
+          existing=$(gh issue list --label "health-check" --state open --json number --jq '.[0].number // empty')
+
+          body="**Services down:** $DOWN_NAMES
+
+          $(cat /tmp/down-details.txt)
+
+          *Detected at $(date -u '+%Y-%m-%d %H:%M UTC') — auto-created by health-check workflow.*
+          *Will auto-close when all endpoints recover.*"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "Updated existing issue #${existing}"
+          else
+            gh issue create \
+              --title "Health check: ${DOWN_NAMES} down" \
+              --body "$body" \
+              --label "health-check,needs-human"
+            echo "Created new health-check issue"
+          fi
+
+      - name: Auto-close on recovery
+        if: steps.health.outputs.down_count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --label "health-check" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "All endpoints recovered at $(date -u '+%Y-%m-%d %H:%M UTC'). Auto-closing."
+            echo "Closed issue #${existing} — all endpoints up"
+          else
+            echo "All endpoints up, no open health-check issues."
+          fi

--- a/.github/workflows/loop-automerge.yml
+++ b/.github/workflows/loop-automerge.yml
@@ -1,0 +1,46 @@
+name: Auto-merge Loop PRs
+
+# Event-driven auto-merge for observation loop assessment PRs.
+# Triggers when a review lands on a loop/* PR — no polling, no timing races.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Only loop PRs, only non-blocking reviews
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'loop/') &&
+      github.event.review.state != 'changes_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check reviews and merge
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Check for blocking reviews — latest review per reviewer wins
+          has_blocking=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[group_by(.user.login)[] | sort_by(.submitted_at) | last | select(.state == "CHANGES_REQUESTED")] | length')
+
+          if [ "$has_blocking" -gt 0 ]; then
+            echo "::warning::PR #${PR_NUMBER} has ${has_blocking} blocking review(s). Leaving open for human review."
+            exit 0
+          fi
+
+          # Check for inline review comments
+          comment_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --jq 'length')
+
+          if [ "$comment_count" -gt 0 ]; then
+            echo "::warning::PR #${PR_NUMBER} has ${comment_count} inline comment(s). Leaving open for human review."
+            exit 0
+          fi
+
+          echo "Review clean — no blocking reviews, no inline comments. Merging."
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch --admin

--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -347,50 +347,8 @@ jobs:
             --base main \
             --head "$branch")
 
-          # Wait for Copilot review (up to 90s)
           pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
-          echo "Waiting for review on PR #${pr_number}..."
-          review_received=false
-          for i in $(seq 1 18); do
-            if ! review_count=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews" --jq 'length'); then
-              echo "::warning::API call failed checking reviews. Leaving PR open."
-              exit 0
-            fi
-            if [ "$review_count" -gt 0 ]; then
-              echo "Review received."
-              review_received=true
-              break
-            fi
-            sleep 5
-          done
-
-          if [ "$review_received" = "false" ]; then
-            echo "::warning::No review received within 90s. Leaving PR #${pr_number} open."
-            exit 0
-          fi
-
-          # Check for blocking reviews — latest review per reviewer wins
-          if ! has_blocking=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews" \
-            --jq '[group_by(.user.login)[] | sort_by(.submitted_at) | last | select(.state == "CHANGES_REQUESTED")] | length'); then
-            echo "::warning::API call failed checking review state. Leaving PR open."
-            exit 0
-          fi
-
-          # Check for inline review comments
-          if ! comment_count=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/comments" --jq 'length'); then
-            echo "::warning::API call failed checking comments. Leaving PR open."
-            exit 0
-          fi
-
-          if [ "$has_blocking" -gt 0 ] || [ "$comment_count" -gt 0 ]; then
-            echo "::warning::PR #${pr_number} has ${comment_count} comment(s) and ${has_blocking} blocking review(s). Leaving open for human review."
-            exit 0
-          fi
-
-          echo "Review clean — no comments, no blockers. Merging."
-          gh pr merge "$pr_url" --squash --delete-branch --admin
-          git checkout main
-          git pull origin main
+          echo "Created PR #${pr_number}. Auto-merge handled by loop-automerge.yml when review arrives."
 
       - name: Create issues from assessment
         env:

--- a/docs/solutions/design-decisions/split-monitoring-from-assessment.md
+++ b/docs/solutions/design-decisions/split-monitoring-from-assessment.md
@@ -1,0 +1,38 @@
+---
+title: "Split health monitoring from daily observation loop"
+category: design-decisions
+date: 2026-03-18
+tags: [github-actions, health-check, observation-loop, monitoring, separation-of-concerns]
+---
+
+## Problem
+
+Infrastructure outages (coroot 530, tvcentras, creu connection errors) were only surfaced by the daily observation loop — meaning a 24-hour detection window at worst. The loop assessment on 2026-03-18 flagged these outages, but coroot had already been down for 42+ hours before the previous assessment caught it.
+
+## Root Cause
+
+The observation loop conflated two concerns with different cadence requirements:
+
+| Concern | Right cadence | Was running at |
+|---------|---------------|----------------|
+| Strategic assessment (what to build, blockers, priorities) | Daily | Daily |
+| Outage detection (is infrastructure up?) | Minutes | Daily |
+
+Running the full LLM-powered assessment more frequently would waste API budget on strategic analysis that only changes day-to-day.
+
+## Solution
+
+Created a lightweight `health-check.yml` workflow that runs every 15 minutes:
+
+- Reuses existing `company/scripts/collect-infra.sh` and `company/health.json` (no new infrastructure)
+- Creates a GitHub issue with `health-check` label on first failure
+- Adds comments on subsequent check failures (no duplicate issues)
+- Auto-closes the issue when all endpoints recover
+- No LLM calls — just `curl` + `gh issue` management
+
+The observation loop continues running daily for strategic assessment, undisturbed.
+
+## Prevention
+
+- When a workflow serves multiple concerns, evaluate whether they need different cadences before adding complexity to a single workflow.
+- Lightweight health checks (HTTP status codes) should never depend on LLM availability or API budgets.

--- a/docs/solutions/integration-issues/loop-pr-automerge-timing-race.md
+++ b/docs/solutions/integration-issues/loop-pr-automerge-timing-race.md
@@ -1,0 +1,39 @@
+---
+title: "Loop PR auto-merge fails due to Copilot review timing race"
+category: integration-issues
+date: 2026-03-18
+tags: [github-actions, observation-loop, copilot-reviewer, auto-merge, polling]
+---
+
+## Problem
+
+Daily observation loop PRs intermittently fail to auto-merge. PR #34 (2026-03-18) was left open despite clean Copilot review — the workflow logged `No review received within 90s. Leaving PR #34 open.`
+
+## Root Cause
+
+The observation loop used a **polling strategy** (18 iterations × 5s = 90s) to wait for Copilot's review after PR creation. When Copilot responded slower than 90 seconds — which happened on PR #34 where the review arrived at `08:56:28Z`, ~68s after the polling window expired at `08:55:20Z` — the loop gave up and left the PR open with no retry mechanism.
+
+Polling is fundamentally fragile here because Copilot review latency is unpredictable and varies by load.
+
+## Solution
+
+Replaced polling with an **event-driven** workflow (`loop-automerge.yml`) that triggers on `pull_request_review` events:
+
+```yaml
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  automerge:
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'loop/') &&
+      github.event.review.state != 'changes_requested'
+```
+
+The workflow checks for blocking reviews and inline comments, then merges if clean. The observation loop now creates the PR and moves on immediately — 43 lines of polling logic removed.
+
+## Prevention
+
+- Prefer event-driven workflows over polling when GitHub provides webhook events for the condition you're waiting on.
+- `pull_request_review` event fires regardless of review latency — no timing assumptions needed.

--- a/docs/solutions/runtime-errors/coroot-disk-full-outage-recovery.md
+++ b/docs/solutions/runtime-errors/coroot-disk-full-outage-recovery.md
@@ -1,0 +1,91 @@
+---
+title: "Coroot VPS disk full — 42-hour outage recovery via GitHub Actions"
+category: runtime-errors
+date: 2026-03-17
+tags: [docker, disk-full, hetzner, coroot, github-actions, ci-cd, backup, recovery]
+component: coroot-cicd
+severity: critical
+duration: "42 hours"
+repo: atvirokodosprendimai/coroot-cicd
+---
+
+## Problem
+
+`table.beerpub.dev` returned HTTP 502 for 42 hours (2026-03-16 04:11 UTC to 2026-03-17 22:49 UTC). The uptime monitor created [issue #60](https://github.com/atvirokodosprendimai/coroot-cicd/issues/60) with 32 automated "still down" comments.
+
+## Root Cause
+
+The weekly `coroot-update.yml` auto-update pipeline ran on 2026-03-16 at 05:51 UTC. During the **Backup Volumes** step, the `backup-volumes.sh` script:
+
+1. **Stopped all data services** (coroot, prometheus, clickhouse, node-agent, cluster-agent) for consistent backup
+2. Backed up coroot data (3.1GB) and prometheus (417MB) successfully
+3. Started backing up **ClickHouse data (31.9GB)** via `tar czf` inside an alpine container
+4. The 75GB disk was already at 80% (58GB used). Writing the compressed ClickHouse archive filled the remaining space
+5. **SSH connection broke** (`client_loop: send disconnect: Broken pipe`, exit code 255)
+6. The pipeline crashed at the backup step — **never reached deploy or restart steps**
+7. Services remained stopped. `restart: always` in docker-compose couldn't restart containers because Docker needs disk space for container metadata
+8. Caddy stayed up (wasn't stopped for backup), returning 502 because all upstream services were down
+
+**Disk breakdown at time of outage:**
+
+| Component | Size |
+|-----------|------|
+| ClickHouse data volume | 31.9GB |
+| Coroot data volume | 6.6GB |
+| Backups (`/opt/coroot/backups/`) | ~30GB |
+| Prometheus data volume | 2.4GB |
+| Docker images | 2.25GB |
+| **Total** | **~73GB on 75GB disk** |
+
+## Why Recovery Was Difficult
+
+1. **No local SSH key** — the VPS key only existed as a GitHub Actions secret (`VPS_SSH_KEY`), so all recovery had to go through workflows
+2. **GitHub Actions dispatch caching** — creating or modifying workflow files triggers re-indexing, during which `workflow_dispatch` returns HTTP 422 for 5+ minutes. New workflows took 2+ hours to become dispatchable
+3. **Broken `skip_backup` input** — declared as `type: boolean` but compared with `== 'true'` (string), so boolean `true` never matched
+4. **Each pipeline run made things worse** — `docker compose pull` needs disk for image layers, rollback restores volumes, consuming any space that cleanup had freed
+
+## Solution
+
+Modified the **Post-Pipeline Cleanup** job in `coroot-update.yml` (runs `if: always()`) to delete backups, prune Docker, and restart the stack:
+
+```yaml
+- name: Cleanup VPS
+  run: |
+    ssh ... root@$VPS_HOST 'bash -s' <<'CLEANUP'
+    set +e
+    rm -rf /opt/coroot/backups/*
+    docker system prune -f 2>/dev/null || true
+    apt-get clean 2>/dev/null || true
+    journalctl --vacuum-size=50M 2>/dev/null || true
+    cd /opt/coroot && docker compose up -d
+    CLEANUP
+```
+
+Triggered via: `gh workflow run coroot-update.yml -f force_deploy=true -f skip_backup=true -f skip_staging=true`
+
+Deploy and rollback both failed (disk full), but the `if: always()` Cleanup job:
+- Freed 32GB (backups deleted, Docker pruned)
+- Disk went from **100% to 60%** (29GB free)
+- All containers came up healthy
+- External HTTP check returned **200**
+
+### Additional fixes
+
+- **`backup-volumes.sh` disk pre-check** — skips backup when <15GB free, exits 0 so pipeline continues
+- **Boolean input fix** — `inputs.skip_backup == true || inputs.skip_backup == 'true'`
+
+## Prevention
+
+1. **Remove backup step** if backups aren't needed (confirmed unnecessary for this instance)
+2. **Add ClickHouse TTL/retention** — 32GB volume grows unbounded without data retention policies
+3. **Disk space monitoring** — alert at 80% before it becomes critical
+4. **Consider disk resize** — Hetzner CAX21 (80GB) to CAX31 (160GB) for ~$7/mo more
+5. **Never stop services without a restart guarantee** — use `trap` or a separate `if: always()` step
+6. **Pre-deploy recovery workflows** — creating workflows during an incident is unreliable due to GitHub indexing delays
+
+## Key Learnings
+
+- **`if: always()` jobs are your escape hatch** — the only reliable way to execute recovery commands when prior jobs fail
+- **GitHub Actions workflow dispatch indexing is unreliable for incident response** — have recovery workflows pre-deployed and tested
+- **Backup scripts that stop services must guarantee restart on failure** — the script crashed mid-backup, leaving services stopped with no recovery path
+- **75GB is not enough for 32GB ClickHouse + 30GB backups** — capacity planning must account for backup size equal to sum of all volumes

--- a/memory/session - 2603172358 - coroot disk full 42h outage recovery.md
+++ b/memory/session - 2603172358 - coroot disk full 42h outage recovery.md
@@ -1,0 +1,65 @@
+# Session — Coroot Disk Full 42h Outage Recovery
+
+**Date:** 2026-03-17
+**Branch:** `docs/coroot-disk-full-postmortem`
+
+## Context
+
+User shared [GitHub issue #60](https://github.com/atvirokodosprendimai/coroot-cicd/issues/60) — `table.beerpub.dev` had been down for 35+ hours with the uptime monitor posting "still down" comments every ~45 minutes.
+
+## Investigation
+
+- **DNS:** Resolved fine to `91.99.74.36`
+- **HTTP:** Caddy returning 502 (reverse proxy alive, upstream dead)
+- **Root cause found:** The weekly `coroot-update.yml` auto-update ran on March 16 at 05:51 UTC. The backup script stopped all services, started backing up ClickHouse (31.9GB), and the 75GB disk hit 100%. SSH broke (`broken pipe`, exit 255). Services stayed stopped — no restart path existed.
+
+## Recovery Attempts
+
+### Attempt 1: Create emergency-recovery.yml workflow
+- Created via GitHub contents API with `repository_dispatch` and `workflow_dispatch` triggers
+- **Blocked:** GitHub Actions takes 2+ hours to index new workflow files for dispatch. Every attempt returned HTTP 422.
+
+### Attempt 2: Modify vps-diagnostics.yml
+- Added recovery commands to the existing diagnostics workflow
+- **Blocked:** Modifying ANY workflow file (even just step content) triggers GitHub to re-index triggers, breaking dispatch for 5+ minutes
+
+### Attempt 3: Use coroot-update.yml with skip_backup=true
+- **Blocked:** `skip_backup` input declared as `type: boolean` but compared with `== 'true'` (string). Boolean `true` from CLI never matched — backup ran anyway
+
+### Attempt 4: Fix backup-volumes.sh with disk pre-check
+- Added disk space guard — skip backup when <15GB free, exit 0 to let pipeline continue
+- Script ran, detected 0GB free, deleted old backups (freed 29GB), then proceeded to create a NEW backup
+- Cancelled after 55 minutes of ClickHouse compression
+
+### Attempt 5: Fix boolean comparison + retry
+- Fixed `inputs.skip_backup == 'true'` to `inputs.skip_backup == true || inputs.skip_backup == 'true'`
+- Backup correctly skipped, but deploy step failed: `docker compose pull` → `no space left on device` (disk full again from attempt 4's partial backup + rollback consuming freed space)
+
+### Attempt 6 (SUCCESS): Modify Post-Pipeline Cleanup job
+- The `Post-Pipeline Cleanup` job runs `if: always()` — executes even after deploy/rollback failures
+- Modified its `Cleanup VPS` step to: delete ALL backups → prune Docker → restart stack
+- Deploy failed, rollback failed, but **Cleanup ran and recovered everything**
+
+## Result
+
+- Disk: 100% → **60%** (29GB free)
+- All containers: **UP** (prometheus healthy, clickhouse healthy, coroot up)
+- External check: **HTTP 200**
+- Downtime: 42 hours ended at 22:49 UTC
+
+## Artifacts
+
+- `docs/solutions/runtime-errors/coroot-disk-full-outage-recovery.md` — full postmortem documentation
+- Multiple commits pushed to `atvirokodosprendimai/coroot-cicd`:
+  - Fixed `backup-volumes.sh` with disk space pre-check
+  - Fixed boolean input comparisons in `coroot-update.yml`
+  - Added recovery logic to Post-Pipeline Cleanup job
+  - Added `emergency-recovery.yml` workflow (for future use once indexed)
+
+## Key Learnings
+
+1. **`if: always()` jobs are the escape hatch** for CI/CD recovery
+2. **GitHub Actions workflow dispatch indexing is unreliable** for incident response — pre-deploy recovery workflows
+3. **Backup scripts that stop services must guarantee restart** even on failure
+4. **75GB disk is insufficient** for 32GB ClickHouse + 30GB backups — capacity planning needed
+5. **User doesn't need Coroot backups** — should remove backup step entirely


### PR DESCRIPTION
## Summary

- **New workflow** `loop-automerge.yml` — triggers on `pull_request_review` for `loop/*` branches, checks for blocking reviews and inline comments, merges if clean. Replaces 90s polling loop.
- **New workflow** `health-check.yml` — runs every 15 minutes, curls all endpoints from `company/health.json`, creates/updates a GitHub issue on failure, auto-closes on recovery. No LLM calls.
- **Removed** 43 lines of polling/merge logic from `observation-loop.yml`
- **Added** `health-check` label to `labels.yml`

## Why

**Loop automerge:** PR #34 (today's daily assessment) wasn't auto-merged because Copilot's review arrived ~68s after the 90s polling window expired. Event-driven approach eliminates timing races.

**Health checks:** The observation loop runs daily but flagged infra outages (coroot 530, tvcentras, creu) that shouldn't wait 24h to surface. Splitting monitoring (15-min) from strategic assessment (daily) matches the right cadence to each concern.

## Test plan

**Loop automerge:**
- [ ] Next daily loop run creates PR without waiting for review
- [ ] When Copilot reviews the PR, `loop-automerge.yml` triggers and merges it
- [ ] PR with `changes_requested` review is left open for human review
- [ ] Non-loop PRs are unaffected (job `if` filters on `loop/` branch prefix)

**Health checks:**
- [ ] Manual `workflow_dispatch` triggers health check successfully
- [ ] When an endpoint is down, a `health-check` labeled issue is created
- [ ] Subsequent failures add comments to existing issue (no duplicates)
- [ ] When all endpoints recover, the issue is auto-closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)