### PR TITLE
feat: teach observation loop to close stale issues and PRs

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -113,6 +113,25 @@ jobs:
             echo "No shared memory available." > /tmp/shared_memory.txt
           }
 
+      - name: Collect open issues and PRs
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          target="atvirokodosprendimai/wgmesh"
+          {
+            echo "## Open Issues (wgmesh)"
+            echo ""
+            gh issue list --repo "$target" --state open --limit 50 \
+              --json number,title,labels \
+              --jq '.[] | "- #\(.number) \(.title) [\([.labels[].name] | join(", "))]"' 2>/dev/null || echo "- (failed to fetch)"
+            echo ""
+            echo "## Open PRs (wgmesh)"
+            echo ""
+            gh pr list --repo "$target" --state open --limit 20 \
+              --json number,title,author \
+              --jq '.[] | "- PR #\(.number) \(.title) (by \(.author.login))"' 2>/dev/null || echo "- (failed to fetch)"
+          } > /tmp/open_board.txt
+
       - name: Read recent assessments
         run: |
           {
@@ -181,6 +200,11 @@ jobs:
           Curated knowledge and recent agent activity from the shared memory subsystem.
           Use this to maintain continuity across runs and avoid repeating past mistakes.
           $(cat /tmp/shared_memory.txt)
+
+          ## Open Issues & PRs
+          Review this list every run. Close issues and PRs that are stale, superseded, or
+          describe features that already exist (check the Product Codebase Summary).
+          $(cat /tmp/open_board.txt)
 
           ## Recent Assessment History
           $(cat /tmp/history.txt)
@@ -457,4 +481,18 @@ jobs:
             else
               echo "Skipping duplicate needs-human: $request"
             fi
+          done
+
+      - name: Close PRs from assessment
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          jq -c '.prs_to_close // [] | .[]' /tmp/assessment.json | while read -r item; do
+            repo=$(echo "$item" | jq -r '.repo')
+            number=$(echo "$item" | jq -r '.number')
+            reason=$(echo "$item" | jq -r '.reason')
+            full_repo="atvirokodosprendimai/${repo}"
+            gh pr close "$number" --repo "$full_repo" \
+              --comment "Closed by observation loop: $reason" || true
+            echo "Closed PR #${number} in ${full_repo}: ${reason}"
           done

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -98,6 +98,25 @@ You will receive a **Product Codebase Summary** in each run. This describes the 
 
 If no Product Codebase Summary is provided, state this as a blocker rather than assuming the product doesn't exist.
 
+## Issue and PR hygiene
+
+You receive an **Open Issues & PRs** list each run. This is your board — keep it clean.
+
+### When to close issues (`issues_to_close`)
+
+- **Feature already exists**: The Product Codebase Summary describes a feature that an open issue asks to build. Close it with reason: "Feature already implemented — see [package/function]."
+- **Superseded**: A newer issue covers the same ground. Close the older one.
+- **No longer relevant**: The funnel stage has advanced past the issue's concern, or the blocker it describes has been resolved.
+- **Stale needs-human**: A `needs-human` issue whose request has been fulfilled (check the signals).
+
+### When to close PRs (`prs_to_close`)
+
+- **Spec for existing feature**: A spec PR describes implementing something that already exists in the codebase.
+- **Superseded by newer PR**: A newer spec or implementation PR covers the same work.
+- **Based on stale assessment**: A PR was created when the loop had incorrect information (e.g., Foundation stage when the product was already functional).
+
+**Every run, review the open issues and PRs list. If any should be closed, include them in your output.** A clean board is a fast board.
+
 ## Your output format
 
 Return valid JSON with this structure:
@@ -137,6 +156,13 @@ Return valid JSON with this structure:
     {
       "number": 123,
       "reason": "Why this is no longer relevant"
+    }
+  ],
+  "prs_to_close": [
+    {
+      "repo": "wgmesh",
+      "number": 123,
+      "reason": "Why this PR should be closed"
     }
   ],
   "contributions": [


### PR DESCRIPTION
## Summary

The observation loop could create issues but never cleaned up after itself. Three root causes:

1. **No guidance** — system prompt had zero instructions on when to use `issues_to_close`
2. **No data** — the LLM received repo-level stats (`open_issues_total: 14`) but never saw the actual issue list with titles and numbers
3. **No PR cleanup** — the output schema and action steps had no mechanism for closing PRs

## Changes

- **System prompt**: Added "Issue and PR hygiene" section with specific close criteria (feature exists, superseded, stale, based on wrong assessment)
- **Output schema**: Added `prs_to_close` field with repo, number, reason
- **Workflow**: New "Collect open issues and PRs" step feeds the full board to the LLM
- **Workflow**: New "Close PRs from assessment" action step executes PR closures
- **User message**: Added "Open Issues & PRs" section with explicit review instruction

## Impact

Next loop run should close the 3 bogus spec PRs (#456, #459, #462) and stale issues (#460, #461, #463, #450) that were created before the codebase awareness fix.

## Test plan

- [ ] YAML validates cleanly
- [ ] Next loop run receives the open board in its prompt
- [ ] LLM outputs non-empty `issues_to_close` / `prs_to_close` for known stale items
- [ ] Stale issues and PRs are actually closed with explanatory comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)