### PR TITLE
fix: mandatory issue reconciliation to prevent bogus issue accumulation

### DIFF
--- a/company/loop-state.json
+++ b/company/loop-state.json
@@ -1,7 +1,7 @@
 {
   "funnel_stage": 1,
   "stage_name": "Dogfood",
-  "stage_entered": null,
+  "stage_entered": "2026-03-18T08:53:41Z",
   "last_run": "2026-03-18T08:53:41Z",
   "run_count": 9,
   "history": []

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -117,6 +117,21 @@ You receive an **Open Issues & PRs** list each run. This is your board — keep 
 
 **Every run, review the open issues and PRs list. If any should be closed, include them in your output.** A clean board is a fast board.
 
+### Mandatory reconciliation pass
+
+Before finalising your assessment, perform this check for every open `fn:dev` issue:
+
+1. Read the issue title
+2. Check the Product Codebase Summary for an existing implementation
+3. If the feature already exists → add to `issues_to_close` with reason
+4. If a spec PR exists for that issue → add to `prs_to_close` with reason
+
+Do this **regardless of the issue's current labels** (including `copilot-triaging`). An issue being "in progress" does not mean it should exist — if the feature is already implemented, close the issue and its associated PRs.
+
+### Override stale assessments
+
+If the Product Codebase Summary contradicts your previous assessments or the current `funnel_stage`, **trust the codebase summary**. The code is ground truth. Prior assessments may have been made without codebase visibility. State the correction explicitly in your assessment narrative (e.g., "Correcting previous assessment: feature X already exists").
+
 ## Your output format
 
 Return valid JSON with this structure:

--- a/docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md
+++ b/docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md
@@ -6,6 +6,7 @@ tags: [observation-loop, llm, dedup, codebase-awareness, hallucination]
 related_issues:
   - https://github.com/atvirokodosprendimai/wgmesh/issues/458
   - https://github.com/atvirokodosprendimai/wgmesh/issues/453
+  - https://github.com/atvirokodosprendimai/wgmesh/issues/460
 severity: high
 component: observation-loop
 ---
@@ -68,8 +69,40 @@ gh issue list --repo "$TARGET_REPO" --state closed --limit 200 ...
 New section in `company/system-prompt.md`:
 > **NEVER create issues for features that already exist in the codebase.** Before adding anything to `issues_to_create`, verify it is not already described in the Product Codebase Summary. If no summary is provided, state this as a blocker rather than assuming the product doesn't exist.
 
+## Post-fix failure: #460 created despite codebase summary
+
+The fixes above were deployed on 2026-03-16 10:48. Yet run 7 (2026-03-17 08:58) still created #460 "Implement basic WireGuard mesh networking core" — a feature that obviously exists.
+
+### Why the fix wasn't enough
+
+The codebase summary was a single new signal competing against compounding reinforcement:
+
+1. **`loop-state.json` still had `funnel_stage: 0`** — nobody advanced it after deploying the fix
+2. **Assessment history** (runs 5, 6) both said "No wgmesh core product code exists"
+3. The LLM received 1 signal saying "product exists" vs 3 signals saying "no product" (funnel_stage + 2 prior assessments)
+
+Run 7 wrote: *"Engineering velocity remains high but still focused on infrastructure rather than core product"* — it interpreted 28 merged PRs as infra work because its priors were too strong.
+
+Run 8 (2026-03-18) finally self-corrected after accumulating enough evidence.
+
+### Why bogus issues weren't auto-closed
+
+The `issues_to_close` mechanism existed but run 8 (the first to recognize the product) didn't use it for #453, #458, #460 because:
+
+1. These issues had `copilot-triaging` label with Copilot assigned — the LLM interpreted "in progress" as "legitimate"
+2. No instruction forced systematic reconciliation of every open issue against the codebase summary
+3. The open issues list only shows titles and labels — not enough context for the LLM to determine overlap with existing features without explicit prompting
+
+### Additional fixes (2026-03-18)
+
+1. **Mandatory reconciliation pass** added to system prompt: LLM must check every open `fn:dev` issue against the Product Codebase Summary, regardless of current labels
+2. **Override stale assessments** instruction: if codebase summary contradicts prior assessments, trust the code
+3. **`stage_entered` timestamp** set in `loop-state.json` to track when stages were entered
+
 ## Prevention
 
 - **Any LLM that creates real-world artifacts (issues, PRs, deployments) must have ground-truth context** about what already exists. Metadata alone (counts, velocity) is insufficient — it needs structural awareness.
 - When adding new repos to the observation loop, ensure their `CLAUDE.md` (or equivalent) is included in the product summary collection step.
 - Periodically verify `loop-state.json` funnel stage reflects reality — a stale stage amplifies LLM hallucination.
+- **A single corrective signal is not enough to override compounding priors.** When fixing LLM context, also fix the reinforcing signals (funnel_stage, assessment history) or the LLM will ignore the correction.
+- **Mandatory reconciliation beats voluntary cleanup.** LLMs will not systematically cross-reference issues against codebase unless explicitly instructed to do so on every run.


### PR DESCRIPTION
## Summary

- **RCA**: Codebase summary fix (669fe41) wasn't enough — run 7 still created bogus #460 because `funnel_stage: 0` + 2 stale assessments overwhelmed the corrective signal. Bogus issues also weren't auto-closed because the LLM saw `copilot-triaging` labels as "in progress."
- **Fix**: Mandatory reconciliation pass + override-stale-assessments instruction in system prompt
- **Cleanup**: Closed #453, #458, #460, #461, #450 and PRs #456, #459, #462

## Changes

| File | Change |
|------|--------|
| `company/system-prompt.md` | Add mandatory reconciliation pass and override instruction |
| `company/loop-state.json` | Set `stage_entered` timestamp |
| `docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md` | Add post-fix failure analysis, #460, auto-close gap RCA |

## Key Insight

A single corrective signal (codebase summary) cannot override compounding reinforcement (funnel_stage + assessment history). When fixing LLM context, you must also fix all reinforcing signals, or the LLM will ignore the correction.

## Post-Deploy Monitoring & Validation

- **What to monitor**: Next 2-3 observation loop runs — check that no new bogus issues are created and that any remaining ones are closed
- **Validation**: Run 9+ assessment should include `issues_to_close` if any bogus issues remain
- **Failure signal**: New issues for features that already exist in codebase summary
- **Validation window**: Next 3 daily loop runs
- **Owner**: Pipeline maintainer

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)