### PR TITLE
docs: spec 003 — universal bot PR review and merge

### DIFF
--- a/.claude/hookify.block-manual-pr-merge.local.md
+++ b/.claude/hookify.block-manual-pr-merge.local.md
@@ -1,0 +1,17 @@
+---
+name: block-manual-pr-merge
+enabled: true
+event: bash
+pattern: ^\s*gh\s+pr\s+merge\b
+action: block
+---
+
+**BLOCKED: Manual PR merge detected**
+
+You must not merge PRs manually. All merges go through `company/scripts/pr-review-merge.sh` which enforces Copilot review + guardrails.
+
+This rule exists because you repeatedly merged PRs before review comments were addressed (PR #70, #73, #74).
+
+**What to do instead:**
+- Let the workflow call `bash company/scripts/pr-review-merge.sh`
+- The script polls for review, checks guardrails, and merges only when safe

--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -1,0 +1,33 @@
+name: Bot PR Review and Merge
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  review-merge:
+    if: >-
+      github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
+      github.event.pull_request.user.login == 'goose[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Autonomous PR review and merge
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          bash company/scripts/pr-review-merge.sh

--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -391,10 +391,7 @@ jobs:
           pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
           echo "Created PR #${pr_number}"
 
-          # Autonomous review-merge: poll for Copilot review, enforce guardrails,
-          # merge or escalate. See docs/patterns/pr-review-merge.md
-          PR_NUMBER="$pr_number" TARGET_REPO="$GITHUB_REPOSITORY" \
-            bash company/scripts/pr-review-merge.sh
+          # Review-merge handled by bot-pr-review-merge.yml workflow
 
       - name: Create issues from assessment
         env:

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -739,7 +739,4 @@ jobs:
           pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
           echo "Created PR #${pr_number}"
 
-          # Autonomous review-merge: poll for Copilot review, enforce guardrails,
-          # merge or escalate. See docs/patterns/pr-review-merge.md
-          PR_NUMBER="$pr_number" TARGET_REPO="$GITHUB_REPOSITORY" \
-            bash company/scripts/pr-review-merge.sh
+          # Review-merge handled by bot-pr-review-merge.yml workflow

--- a/.start/specs/003-universal-bot-pr-review-merge/README.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/README.md
@@ -1,0 +1,35 @@
+# Specification: 003-universal-bot-pr-review-merge
+
+## Status
+
+| Field | Value |
+|-------|-------|
+| **Created** | 2026-03-22 |
+| **Current Phase** | Ready |
+| **Last Updated** | 2026-03-22 |
+
+## Documents
+
+| Document | Status | Notes |
+|----------|--------|-------|
+| requirements.md | completed | Streamlined PRD |
+| solution.md | completed | 3 ADRs confirmed |
+| plan/ | completed | 1 phase, 3 tasks |
+
+**Status values**: `pending` | `in_progress` | `completed` | `skipped`
+
+## Decisions Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-03-22 | Spec created from issue #76 | Extend pr-review-merge.sh to all bot-authored PRs, not just pipeline-health and observation-loop |
+
+## Context
+
+Spec 002 delivered pr-review-merge.sh and wired it into two workflows. But PRs created by other workflows or triggers don't get autonomous review-merge. This spec adds a universal `pull_request` event workflow that triggers pr-review-merge.sh on any PR by an approved bot author.
+
+Issue: #76
+Depends on: spec 002 (pr-review-merge.sh must exist)
+
+---
+*This file is managed by the specify-meta skill.*

--- a/.start/specs/003-universal-bot-pr-review-merge/plan/README.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/plan/README.md
@@ -21,7 +21,7 @@ version: "1.0"
 
 ## Implementation Phases
 
-- [ ] [Phase 1: Universal Workflow and Inline Removal](phase-1.md)
+- [x] [Phase 1: Universal Workflow and Inline Removal](phase-1.md)
 
 ---
 

--- a/.start/specs/003-universal-bot-pr-review-merge/plan/README.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/plan/README.md
@@ -1,0 +1,35 @@
+---
+title: "Universal Bot PR Review and Merge"
+status: draft
+version: "1.0"
+---
+
+# Implementation Plan
+
+## Context Priming
+
+- `.start/specs/003-universal-bot-pr-review-merge/requirements.md`
+- `.start/specs/003-universal-bot-pr-review-merge/solution.md`
+- `CONSTITUTION.md` v2.0
+- `company/scripts/pr-review-merge.sh` (unchanged, already exists)
+- `.github/workflow-templates/pr-review-merge-step.yml` (reference)
+
+**Key Decisions:**
+- ADR-1: `pull_request: [opened]` trigger (no `synchronize`)
+- ADR-2: Author filter in job `if:` condition
+- ADR-3: Remove inline callers from pipeline-health and observation-loop
+
+## Implementation Phases
+
+- [ ] [Phase 1: Universal Workflow and Inline Removal](phase-1.md)
+
+---
+
+## Plan Verification
+
+| Criterion | Status |
+|-----------|--------|
+| A developer can follow this plan without additional clarification | :white_check_mark: |
+| Every task produces a verifiable deliverable | :white_check_mark: |
+| All PRD acceptance criteria map to specific tasks | :white_check_mark: |
+| Dependencies are explicit | :white_check_mark: |

--- a/.start/specs/003-universal-bot-pr-review-merge/plan/phase-1.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/plan/phase-1.md
@@ -1,0 +1,47 @@
+---
+title: "Phase 1: Universal Workflow and Inline Removal"
+status: pending
+version: "1.0"
+phase: 1
+---
+
+# Phase 1: Universal Workflow and Inline Removal
+
+## Phase Context
+
+**Specification References**:
+- `[ref: SDD/Building Block View/Workflow Specification]` — full YAML
+- `[ref: SDD/Changes to Existing Workflows]` — what to remove
+
+**Dependencies**:
+- `company/scripts/pr-review-merge.sh` exists (spec 002, already on main)
+- `company/scripts/sanitise.sh` exists (already on main)
+
+---
+
+## Tasks
+
+- [ ] **T1.1 Create bot-pr-review-merge.yml** `[activity: ci-cd]`
+
+  1. Prime: Read SDD/Workflow Specification for the full YAML. Read CONSTITUTION.md SEC-1, SEC-3, SEC-4, ARCH-8. `[ref: SDD/Building Block View]`
+  2. Test: Workflow triggers on `pull_request: [opened]`; job filters to approved bot authors; env block passes GH_TOKEN, TARGET_REPO, PR_NUMBER; permissions are minimal; concurrency group is per-PR with cancel-in-progress: false; step checks out repo and runs `bash company/scripts/pr-review-merge.sh`
+  3. Implement: Create `.github/workflows/bot-pr-review-merge.yml` per SDD spec
+  4. Validate: YAML parses cleanly; SEC-1 (no secrets in run:); SEC-3 (PR number via env); SEC-4 (explicit permissions)
+  5. Success: Workflow created `[ref: PRD/AC-1.1, AC-1.2, AC-1.3]`
+
+- [ ] **T1.2 Remove inline callers** `[activity: ci-cd]` `[parallel: true]`
+
+  1. Prime: Read SDD/Changes to Existing Workflows. Read current pipeline-health.yml and observation-loop.yml to find the inline blocks. `[ref: SDD/Architecture Decisions/ADR-3]`
+  2. Test: Inline pr-review-merge.sh calls removed from both workflows; PR creation still works (gh pr create remains); no other functionality affected
+  3. Implement: Remove the 4-line review-merge block from pipeline-health.yml (around line 742-745) and observation-loop.yml (around line 394-397)
+  4. Validate: Workflows still parse cleanly; PR creation steps untouched; only the review-merge call removed
+  5. Success: No inline duplication `[ref: PRD/AC-2.1, AC-3.1]`
+
+- [ ] **T1.3 Phase Validation** `[activity: validate]`
+
+  - Verify: bot-pr-review-merge.yml exists and parses. Inline calls removed from both workflows. Constitution compliance (SEC-1, SEC-3, SEC-4, ARCH-4, ARCH-8). Run `bash -n company/scripts/pr-review-merge.sh` (unchanged, sanity check).
+  - Success:
+    - [ ] New workflow passes YAML validation
+    - [ ] Inline calls removed from pipeline-health.yml and observation-loop.yml
+    - [ ] All workflows parse cleanly
+    - [ ] Constitution compliance verified

--- a/.start/specs/003-universal-bot-pr-review-merge/plan/phase-1.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/plan/phase-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Phase 1: Universal Workflow and Inline Removal"
-status: pending
+status: completed
 version: "1.0"
 phase: 1
 ---

--- a/.start/specs/003-universal-bot-pr-review-merge/requirements.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/requirements.md
@@ -1,0 +1,71 @@
+---
+title: "Universal Bot PR Review and Merge"
+status: draft
+version: "1.0"
+---
+
+# Product Requirements Document
+
+## Product Overview
+
+### Vision
+
+Every bot-authored PR gets autonomous review-merge regardless of which workflow created it.
+
+### Problem Statement
+
+Spec 002 wired pr-review-merge.sh into pipeline-health.yml and observation-loop.yml. But PRs created by other workflows (approve-build, copilot-triage, copilot-undraft, spec-validation) or by manual bot invocation don't trigger the review-merge script. Each new workflow requires manual wiring — that doesn't scale and creates gaps.
+
+### Value Proposition
+
+A single event-driven workflow that catches all bot-authored PRs eliminates per-workflow wiring. New workflows get review-merge for free.
+
+## User Personas
+
+Inherited from spec 002. Primary: Pipeline Operator. Secondary: Developer, Human Reviewer.
+
+## Feature Requirements
+
+### Must Have
+
+#### Feature 1: Universal PR Review-Merge Trigger
+
+- **User Story:** As a pipeline operator, I want all bot-authored PRs to be automatically reviewed and merged so that I don't need to wire each workflow individually.
+- **Acceptance Criteria:**
+  - [ ] Given a PR is opened by an approved bot author, When the `pull_request` event fires, Then pr-review-merge.sh runs against that PR
+  - [ ] Given a PR is opened by a human, When the `pull_request` event fires, Then the workflow skips (no action)
+  - [ ] Given a PR is opened by an unknown bot, When the `pull_request` event fires, Then the workflow skips (author not in approved list)
+  - [ ] Given pr-review-merge.sh is already running inline (e.g., pipeline-health), When the universal workflow also triggers, Then only one instance runs (no double-merge)
+
+#### Feature 2: Deduplication with Inline Callers
+
+- **User Story:** As a pipeline operator, I want the universal workflow to not conflict with workflows that already call pr-review-merge.sh inline.
+- **Acceptance Criteria:**
+  - [ ] Given pipeline-health.yml already calls pr-review-merge.sh after creating a PR, When the universal workflow triggers on the same PR, Then it detects the PR is already being processed and skips
+  - [ ] Given a PR is created by a workflow without inline review-merge, When the universal workflow triggers, Then it runs normally
+
+### Should Have
+
+#### Feature 3: Remove Inline Wiring
+
+- **User Story:** As a pipeline operator, I want to remove the inline pr-review-merge.sh calls from pipeline-health.yml and observation-loop.yml since the universal workflow handles all PRs.
+- **Acceptance Criteria:**
+  - [ ] Given the universal workflow is active, When pipeline-health creates a PR, Then the universal workflow handles review-merge (not the inline call)
+  - [ ] Given inline calls are removed, When the system runs, Then zero duplicate processing occurs
+
+### Won't Have (This Phase)
+
+- Cross-repo PR handling (Phase 3 from spec 002 brainstorm)
+- Human-authored PR review
+
+## Success Metrics
+
+- 100% of bot-authored PRs processed by review-merge (zero gaps)
+- Zero duplicate processing (no double-merge attempts)
+- Zero new per-workflow wiring needed for future workflows
+
+## Constraints
+
+- GitHub Apps (Copilot) don't fire `pull_request_review` events — must use `pull_request` trigger
+- PUSH_TOKEN required (ARCH-8)
+- Must comply with CONSTITUTION v2.0 (Andon, SEC-*, ARCH-*, QUAL-*)

--- a/.start/specs/003-universal-bot-pr-review-merge/solution.md
+++ b/.start/specs/003-universal-bot-pr-review-merge/solution.md
@@ -1,0 +1,135 @@
+---
+title: "Universal Bot PR Review and Merge"
+status: draft
+version: "1.0"
+---
+
+# Solution Design Document
+
+## Constraints
+
+- CON-1: Must not duplicate review-merge for PRs already handled inline
+- CON-2: Must filter to approved bot authors before running the script
+- CON-3: CONSTITUTION v2.0 compliance (Andon, SEC-1/3/4, ARCH-4/8, QUAL-1/5)
+- CON-4: GitHub Actions `pull_request` event has limited token permissions — needs PUSH_TOKEN
+
+## Solution Strategy
+
+**Architecture**: Single event-driven workflow triggered on `pull_request: [opened]`. Filters by author, then calls the existing pr-review-merge.sh. Removes inline calls from pipeline-health.yml and observation-loop.yml to eliminate duplication.
+
+**Why `opened` only (not `synchronize`)**: The fix loop inside pr-review-merge.sh already handles new pushes by polling for the next review. A `synchronize` trigger would cause a second workflow run that races with the in-progress fix loop.
+
+**Deduplication strategy**: Remove inline callers. The universal workflow replaces them — simpler than detecting "already processing" state.
+
+## Architecture Decisions
+
+- [x] **ADR-1: pull_request event trigger**
+  - Choice: Trigger on `pull_request: [opened]`
+  - Rationale: Catches all PRs at creation. `synchronize` excluded to avoid racing with fix loop.
+  - Trade-offs: Won't re-trigger if a PR is manually re-opened after close. Acceptable — edge case.
+
+- [x] **ADR-2: Author filter in workflow `if` condition**
+  - Choice: Filter approved authors via `github.event.pull_request.user.login` in the job's `if:` condition
+  - Rationale: Skips the entire job (no runner cost) for non-bot PRs. Faster than checking inside the script.
+  - Trade-offs: Author list is duplicated between workflow YAML and script env var. Acceptable — the workflow filter is the fast path, script is the authoritative check.
+
+- [x] **ADR-3: Remove inline callers**
+  - Choice: Remove pr-review-merge.sh calls from pipeline-health.yml and observation-loop.yml
+  - Rationale: Universal workflow handles all bot PRs. Inline calls create duplication risk.
+  - Trade-offs: pipeline-health and observation-loop PRs now depend on the universal workflow. If the universal workflow is disabled, those PRs won't auto-merge. Acceptable — the universal workflow is the single source of truth.
+
+## Building Block View
+
+### Directory Map
+
+```
+.github/
+  workflows/
+    bot-pr-review-merge.yml      # NEW: universal trigger
+    pipeline-health.yml          # MODIFY: remove inline pr-review-merge.sh call
+    observation-loop.yml         # MODIFY: remove inline pr-review-merge.sh call
+company/
+  scripts/
+    pr-review-merge.sh           # UNCHANGED: existing script
+```
+
+### Workflow Specification
+
+```yaml
+# .github/workflows/bot-pr-review-merge.yml
+name: Bot PR Review and Merge
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  review-merge:
+    if: >-
+      github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
+      github.event.pull_request.user.login == 'goose[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Autonomous PR review and merge
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          bash company/scripts/pr-review-merge.sh
+```
+
+### Key Design Details
+
+**Concurrency group**: `pr-review-${{ github.event.pull_request.number }}` — one review-merge process per PR. If the same PR triggers multiple events, only one runs. `cancel-in-progress: false` prevents killing an in-progress review-merge.
+
+**Author filter**: The `if:` condition on the job checks `github.event.pull_request.user.login`. This is safe because `user.login` is set by GitHub (not user-controlled input). It's passed via the event context, not interpolated in `run:` (SEC-3 compliant).
+
+**PR_NUMBER**: Uses `github.event.pull_request.number` passed through `env:` block (SEC-1, SEC-3 compliant).
+
+**Checkout**: Required because pr-review-merge.sh and sanitise.sh live in the repo.
+
+### Changes to Existing Workflows
+
+**pipeline-health.yml**: Remove the 4-line block:
+```yaml
+          # Autonomous review-merge: ...
+          # merge or escalate. ...
+          PR_NUMBER="$pr_number" TARGET_REPO="$GITHUB_REPOSITORY" \
+            bash company/scripts/pr-review-merge.sh
+```
+The `pull_request: [opened]` event from `gh pr create` will trigger bot-pr-review-merge.yml.
+
+**observation-loop.yml**: Same removal.
+
+### Constitution Compliance
+
+| Rule | Compliance |
+|------|-----------|
+| SEC-1 | PUSH_TOKEN via env block |
+| SEC-3 | PR number via env, not interpolated in run: |
+| SEC-4 | Explicit minimal permissions |
+| ARCH-4 v2.0 | Uses pr-review-merge.sh with guardrails |
+| ARCH-8 | PUSH_TOKEN, not GITHUB_TOKEN |
+| QUAL-5 | Andon handled by pr-review-merge.sh |
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Universal workflow disabled → no auto-merge | High | Monitor: if no PRs auto-merge for 24h, alert |
+| pull_request event doesn't fire for some bot PRs | Medium | Test with each bot type before removing inline callers |
+| Author login format changes | Low | APPROVED_AUTHORS env var in script is the authoritative check |


### PR DESCRIPTION
## Summary

- **PRD**: Universal trigger for all bot-authored PRs + deduplication with inline callers
- **SDD**: `pull_request: [opened]` workflow, author filter in `if:`, remove inline callers from pipeline-health and observation-loop
- **PLAN**: 1 phase, 3 tasks (create workflow, remove inline calls, validate)

### Key Design

One new workflow (`bot-pr-review-merge.yml`) replaces per-workflow wiring. Triggers on any PR opened by an approved bot. Inline calls in pipeline-health.yml and observation-loop.yml get removed — the universal workflow handles everything.

Closes #76

## Test plan

- [ ] Workflow YAML valid
- [ ] Author filter skips human PRs
- [ ] Inline callers removed without breaking PR creation
- [ ] Constitution v2.0 compliance