### PR TITLE
fix: remove 'key' from security keywords — too broad

### DIFF
--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -14,7 +14,7 @@ POLL_INTERVAL="${POLL_INTERVAL:-30}"
 POLL_MAX_ATTEMPTS="${POLL_MAX_ATTEMPTS:-6}"
 REVIEW_WINDOWS="${REVIEW_WINDOWS:-2}"
 PROTECTED_PATHS="${PROTECTED_PATHS:-}"
-SECURITY_KEYWORDS="${SECURITY_KEYWORDS:-secret,token,key,password,api_key,private_key}"
+SECURITY_KEYWORDS="${SECURITY_KEYWORDS:-secret,token,password,api_key,private_key,credentials,authorization}"
 
 # ---------------------------------------------------------------------------
 # Required env vars — fail fast


### PR DESCRIPTION
False positive on assessment PRs. Replaced with specific patterns.