### PR TITLE
fix: top_actions must create issues or nothing happens

### DIFF
--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -153,6 +153,10 @@ If the Product Codebase Summary contradicts your previous assessments or the cur
 
 ## Your output format
 
+**Critical rule**: Every `fn:dev` action in `top_actions` MUST have a corresponding issue in `issues_to_create` — unless an open issue already covers that work. `top_actions` is a report for humans reading the assessment. `issues_to_create` is what actually drives the pipeline. If you list an action but don't create an issue, nothing happens. The pipeline only acts on issues.
+
+Before finalizing output, verify: for each top_action with `function: "fn:dev"`, either an open issue exists for it OR you have an entry in `issues_to_create`.
+
 Return valid JSON with this structure:
 
 ```json
@@ -186,6 +190,7 @@ Return valid JSON with this structure:
       "priority": "high|medium|low"
     }
   ],
+  "_rule_top_actions_must_create_issues": "EVERY top_action with function fn:dev MUST have a corresponding entry in issues_to_create (unless an open issue already covers it). top_actions is a report; issues_to_create is what drives the pipeline. If you list an action but don't create an issue, nothing happens.",
   "issues_to_close": [
     {
       "number": 123,

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -153,9 +153,9 @@ If the Product Codebase Summary contradicts your previous assessments or the cur
 
 ## Your output format
 
-**Critical rule**: Every `fn:dev` action in `top_actions` MUST have a corresponding issue in `issues_to_create` — unless an open issue already covers that work. `top_actions` is a report for humans reading the assessment. `issues_to_create` is what actually drives the pipeline. If you list an action but don't create an issue, nothing happens. The pipeline only acts on issues.
+**Critical rule**: Every `fn:dev` action in `top_actions` MUST have a corresponding issue in `issues_to_create` — unless an open issue already covers that work. `top_actions` is a report for humans reading the assessment. `issues_to_create` is what actually drives the development pipeline. If you list an action but don't create the appropriate structured output entry (usually an issue), nothing happens; `top_actions` alone does not trigger automation.
 
-Before finalizing output, verify: for each top_action with `function: "fn:dev"`, either an open issue exists for it OR you have an entry in `issues_to_create`.
+Before finalising output, verify: for each top_action with `function: "fn:dev"`, either an open issue exists for it OR you have an entry in `issues_to_create`.
 
 Return valid JSON with this structure:
 
@@ -190,7 +190,6 @@ Return valid JSON with this structure:
       "priority": "high|medium|low"
     }
   ],
-  "_rule_top_actions_must_create_issues": "EVERY top_action with function fn:dev MUST have a corresponding entry in issues_to_create (unless an open issue already covers it). top_actions is a report; issues_to_create is what drives the pipeline. If you list an action but don't create an issue, nothing happens.",
   "issues_to_close": [
     {
       "number": 123,


### PR DESCRIPTION
LLM lists actions but doesn't create issues. Pipeline is inert without issues. Added mandatory rule linking the two.