### PR TITLE
fix: hetzner location fra1 -> hel1

### DIFF
--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -49,7 +49,7 @@ resource "hcloud_server" "mentisdb" {
   name         = "mentisdb-prod"
   image        = "ubuntu-24.04"
   server_type  = "cpx21"
-  location     = "fra1"
+  location     = "hel1"
   firewall_ids = [hcloud_firewall.mentisdb.id]
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {
     domain_name       = var.domain_name


### PR DESCRIPTION
fra1 isn't a Hetzner Cloud location (only nbg1/fsn1/hel1/ash/hil/sin). hel1 matches the TOFU_STATE bucket region (aupipe@hel1).

Caught from terraform-deploy run 24974123959: `Error: datacenter not found`.