### PR TITLE
fix: server_type cpx21 -> cx23

### DIFF
--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -48,7 +48,7 @@ resource "hcloud_firewall" "mentisdb" {
 resource "hcloud_server" "mentisdb" {
   name         = "mentisdb-prod"
   image        = "ubuntu-24.04"
-  server_type  = "cpx21"
+  server_type  = "cx23"
   location     = "hel1"
   firewall_ids = [hcloud_firewall.mentisdb.id]
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {


### PR DESCRIPTION
cpx21 deprecated for new orders in hel1. cx23 = newer x86 2c/4GB/40GB.