### PR TITLE
feat: nginx Basic Auth on mem.beerpub.dev

### DIFF
--- a/infrastructure/terraform/mentisdb/README.md
+++ b/infrastructure/terraform/mentisdb/README.md
@@ -44,6 +44,24 @@ tofu apply
 
 The `hcloud_server.mentisdb` resource renders `cloud-init.sh.tpl` into Hetzner `user_data`. On first boot, cloud-init installs packages, installs `mentisdbd`, writes the systemd unit and environment file, configures nginx, obtains the Let's Encrypt certificate, and enables the firewall.
 
+## Auth
+
+The public HTTP API is protected by single-user HTTP Basic Auth at nginx. The username is `mentisdb`.
+
+Retrieve the generated password with:
+
+```bash
+tofu output -raw mentisdb_basic_auth_password
+```
+
+Rotate the password with:
+
+```bash
+tofu apply -replace=random_password.basic_auth
+```
+
+The `/.well-known/acme-challenge/` path remains unauthenticated so certbot can renew Let's Encrypt certificates.
+
 ## Debugging cloud-init
 
 ```bash

--- a/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
+++ b/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
@@ -8,6 +8,7 @@ trap 'echo "MentisDB cloud-init bootstrap failed on line $LINENO (pid $$$$)" >&2
 DOMAIN="${domain_name}"
 EMAIL="${letsencrypt_email}"
 VERSION="${mentisdb_version}"
+BASIC_AUTH_PASSWORD="${basic_auth_password}"
 DATA_DIR="/var/lib/mentisdb"
 USER="mentisdb"
 
@@ -17,7 +18,7 @@ apt-get update -y
 apt-get upgrade -y
 apt-get install -y \
   build-essential curl git nginx certbot python3-certbot-nginx ufw \
-  pkg-config libssl-dev libasound2-dev ca-certificates
+  pkg-config libssl-dev libasound2-dev ca-certificates apache2-utils
 
 # --- 2. System user + dirs ---
 id -u "$USER" >/dev/null 2>&1 || \
@@ -116,6 +117,8 @@ server {
     }
 
     location / {
+        auth_basic           "MentisDB";
+        auth_basic_user_file /etc/nginx/.htpasswd;
         proxy_pass http://127.0.0.1:9472;
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
@@ -128,6 +131,12 @@ server {
     }
 }
 EOF
+
+# --- 7b. Basic Auth credentials file ---
+htpasswd -bcB /etc/nginx/.htpasswd mentisdb "$BASIC_AUTH_PASSWORD"
+chown root:www-data /etc/nginx/.htpasswd
+chmod 0640 /etc/nginx/.htpasswd
+
 ln -sf /etc/nginx/sites-available/mentisdb /etc/nginx/sites-enabled/mentisdb
 rm -f /etc/nginx/sites-enabled/default
 nginx -t

--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.0"
@@ -25,6 +29,14 @@ provider "hcloud" {
 
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
+}
+
+resource "random_password" "basic_auth" {
+  length  = 48
+  special = false
+  upper   = true
+  lower   = true
+  numeric = true
 }
 
 resource "tls_private_key" "deploy" {
@@ -69,9 +81,10 @@ resource "hcloud_server" "mentisdb" {
   ssh_keys     = [hcloud_ssh_key.deploy.id]
   firewall_ids = [hcloud_firewall.mentisdb.id]
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {
-    domain_name       = var.domain_name
-    letsencrypt_email = var.letsencrypt_email
-    mentisdb_version  = var.mentisdb_version
+    domain_name         = var.domain_name
+    letsencrypt_email   = var.letsencrypt_email
+    mentisdb_version    = var.mentisdb_version
+    basic_auth_password = random_password.basic_auth.result
   })
   labels = {
     role = "mentisdb"

--- a/infrastructure/terraform/mentisdb/outputs.tf
+++ b/infrastructure/terraform/mentisdb/outputs.tf
@@ -15,3 +15,14 @@ output "mentisdb_ssh_private_key" {
   value       = tls_private_key.deploy.private_key_openssh
   sensitive   = true
 }
+
+output "mentisdb_basic_auth_password" {
+  description = "Random password for mentisdb HTTP Basic Auth (user: mentisdb). Pair with username 'mentisdb' for Authorization: Basic header. Rotate via `tofu apply -replace=random_password.basic_auth`."
+  value       = random_password.basic_auth.result
+  sensitive   = true
+}
+
+output "mentisdb_curl_example" {
+  description = "Working curl command for the protected API"
+  value       = "curl -u mentisdb:<password> -X POST -H 'Content-Type: application/json' -d '{}' https://${var.domain_name}/v1/agents"
+}


### PR DESCRIPTION
Closes the public-write hole. Single-user (mentisdb) Basic Auth, terraform-managed random password (48-char alnum), bcrypt htpasswd, .well-known/acme-challenge stays unauth for certbot renewal.