### PR TITLE
refactor: source mentisdb password from org secret

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -109,6 +109,7 @@ jobs:
           TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           TF_VAR_cloudflare_api_token: ${{ secrets.BEERPUB_CLOUDFLARE_API_TOKEN }}
           TF_VAR_beerpub_cloudflare_zone_id: ${{ secrets.BEERPUB_CLOUDFLARE_ZONE_ID }}
+          TF_VAR_mentisdb_password: ${{ secrets.MENTISDB_PASSWORD }}
 
       - name: Tofu Apply
         if: github.ref == 'refs/heads/main'
@@ -117,3 +118,4 @@ jobs:
           TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           TF_VAR_cloudflare_api_token: ${{ secrets.BEERPUB_CLOUDFLARE_API_TOKEN }}
           TF_VAR_beerpub_cloudflare_zone_id: ${{ secrets.BEERPUB_CLOUDFLARE_ZONE_ID }}
+          TF_VAR_mentisdb_password: ${{ secrets.MENTISDB_PASSWORD }}

--- a/infrastructure/terraform/mentisdb/.terraform.lock.hcl
+++ b/infrastructure/terraform/mentisdb/.terraform.lock.hcl
@@ -24,6 +24,23 @@ provider "registry.opentofu.org/cloudflare/cloudflare" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:LsYuJLZcYl1RiH7Hd3w90Ra5+k5cNqfdRUQXItkTI8Y=",
+    "zh:25c458c7c676f15705e872202dad7dcd0982e4a48e7ea1800afa5fc64e77f4c8",
+    "zh:2edeaf6f1b20435b2f81855ad98a2e70956d473be9e52a5fdf57ccd0098ba476",
+    "zh:44becb9d5f75d55e36dfed0c5beabaf4c92e0a2bc61a3814d698271c646d48e7",
+    "zh:7699032612c3b16cc69928add8973de47b10ce81b1141f30644a0e8a895b5cd3",
+    "zh:86d07aa98d17703de9fbf402c89590dc1e01dbe5671dd6bc5e487eb8fe87eee0",
+    "zh:8c411c77b8390a49a8a1bc9f176529e6b32369dd33a723606c8533e5ca4d68c1",
+    "zh:a5ecc8255a612652a56b28149994985e2c4dc046e5d34d416d47fa7767f5c28f",
+    "zh:aea3fe1a5669b932eda9c5c72e5f327db8da707fe514aaca0d0ef60cb24892f9",
+    "zh:f56e26e6977f755d7ae56fa6320af96ecf4bb09580d47cb481efbf27f1c5afff",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/tls" {
   version     = "4.2.1"
   constraints = "~> 4.0"

--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -12,10 +12,6 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6"
-    }
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.0"
@@ -29,14 +25,6 @@ provider "hcloud" {
 
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
-}
-
-resource "random_password" "basic_auth" {
-  length  = 48
-  special = false
-  upper   = true
-  lower   = true
-  numeric = true
 }
 
 resource "tls_private_key" "deploy" {
@@ -84,7 +72,7 @@ resource "hcloud_server" "mentisdb" {
     domain_name         = var.domain_name
     letsencrypt_email   = var.letsencrypt_email
     mentisdb_version    = var.mentisdb_version
-    basic_auth_password = random_password.basic_auth.result
+    basic_auth_password = var.mentisdb_password
   })
   labels = {
     role = "mentisdb"

--- a/infrastructure/terraform/mentisdb/outputs.tf
+++ b/infrastructure/terraform/mentisdb/outputs.tf
@@ -16,13 +16,7 @@ output "mentisdb_ssh_private_key" {
   sensitive   = true
 }
 
-output "mentisdb_basic_auth_password" {
-  description = "Random password for mentisdb HTTP Basic Auth (user: mentisdb). Pair with username 'mentisdb' for Authorization: Basic header. Rotate via `tofu apply -replace=random_password.basic_auth`."
-  value       = random_password.basic_auth.result
-  sensitive   = true
-}
-
 output "mentisdb_curl_example" {
-  description = "Working curl command for the protected API"
-  value       = "curl -u mentisdb:<password> -X POST -H 'Content-Type: application/json' -d '{}' https://${var.domain_name}/v1/agents"
+  description = "Working curl command for the protected API. Pull the password from MENTISDB_PASSWORD org secret or your password manager."
+  value       = "curl -u mentisdb:$MENTISDB_PASSWORD -X POST -H 'Content-Type: application/json' -d '{}' https://${var.domain_name}/v1/agents"
 }

--- a/infrastructure/terraform/mentisdb/variables.tf
+++ b/infrastructure/terraform/mentisdb/variables.tf
@@ -32,3 +32,9 @@ variable "mentisdb_version" {
   type        = string
   default     = "0.9.5"
 }
+
+variable "mentisdb_password" {
+  description = "HTTP Basic Auth password for the mentisdb user (sourced from MENTISDB_PASSWORD org secret via TF_VAR_mentisdb_password). Single source of truth: the org secret. Rotate by updating the secret + re-applying."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Org secret MENTISDB_PASSWORD = single source of truth. Other repos reference the same secret. Drops random_password, adds var.mentisdb_password sourced from TF_VAR_mentisdb_password.