### PR TITLE
security: rotate mentisdb password + redact public memory files

### DIFF
--- a/memory/reflection - 2604271010 - mentisdb deploy patterns and open loops.md
+++ b/memory/reflection - 2604271010 - mentisdb deploy patterns and open loops.md
@@ -61,7 +61,7 @@ Captured in updated `reference_dippy_config.md`.
 
 ### High priority
 
-- [ ] **Rotate the password leaked in conversation history** — `openssl rand -base64 36 | tr -d '=+/' | head -c 48`, `gh secret set MENTISDB_PASSWORD`, push trigger to re-deploy. The current value (`SOzLRn68ij...`) appeared in chat AND in the commit `feat: nginx Basic Auth` description AND in the now-merged tfstate.
+- [x] **Rotate the password leaked in conversation history** (DONE 2026-04-27) — generated new value, set as `MENTISDB_PASSWORD` org secret, triggered terraform-deploy workflow_dispatch to rebuild the server with the new htpasswd. Old value invalidated server-side. The leaked fragment is redacted from this file but git history retains it; this is acceptable post-rotation since the value is no longer authoritative anywhere.
 
 ### Medium priority
 

--- a/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
+++ b/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
@@ -11,7 +11,7 @@ duration: ~12 hours (with idle gaps)
 
 Live MentisDB deployment at `https://mem.beerpub.dev`:
 
-- Hetzner Cloud VPS `mentisdb-prod` (cx23 hel1 ubuntu-24.04, IPv4 `157.180.23.70`)
+- Hetzner Cloud VPS (cx23 hel1 ubuntu-24.04). Server name and IPv4 redacted; current values discoverable via `dig mem.beerpub.dev` and the Hetzner Cloud Console for operators with access.
 - mentisdbd 0.9.5 installed via cargo from crates.io, running under systemd (Restart=on-failure) wrapped in `script -qfc` for fake PTY
 - nginx + Let's Encrypt + auto-renewal cron (03:17 daily) terminating TLS at 443
 - nginx Basic Auth (single user `mentisdb`) gating REST + MCP API
@@ -45,7 +45,7 @@ Visibility selected → `ai-pipeline-template`, `wgmesh`:
 
 - `MENTISDB_URL` = `https://mem.beerpub.dev`
 - `MENTISDB_USER` = `mentisdb`
-- `MENTISDB_PASSWORD` = (47-char alnum)
+- `MENTISDB_PASSWORD` (value redacted; rotate via `gh secret set` + redeploy)
 - `HCLOUD_TOKEN` (org-level, scoped wgmesh+ai-pipeline)
 - `TOFU_STATE_BUCKET=aupipe`, `TOFU_STATE_REGION=eu-central-1`, `TOFU_STATE_ENDPOINT=https://hel1.your-objectstorage.com`, `TOFU_STATE_ACCESS_KEY`, `TOFU_STATE_SECRET_KEY`
 - Per-repo Cloudflare: `BEERPUB_CLOUDFLARE_API_TOKEN`, `BEERPUB_CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_ACCOUNT_ID`

--- a/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
+++ b/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
@@ -12,7 +12,7 @@ duration: ~12 minutes
 - **Org secrets shipped** (visibility selected → `ai-pipeline-template`, `wgmesh`):
   - `MENTISDB_URL` = `https://mem.beerpub.dev`
   - `MENTISDB_USER` = `mentisdb`
-  - `MENTISDB_PASSWORD` = (47-char alnum)
+  - `MENTISDB_PASSWORD` (value redacted; rotate via `gh secret set` + redeploy)
 - **Smoketest workflow** at `.github/workflows/mentisdb-smoketest.yml`
   - workflow_dispatch + daily 04:17 UTC cron (after certbot renewal at 03:17)
   - Round-trip: POST `/v1/thoughts` (Finding type, unique marker per run) → POST `/v1/search` (text=marker) → assert marker in response


### PR DESCRIPTION
Rotated MENTISDB_PASSWORD org secret; triggered terraform-deploy to rebuild server with new htpasswd. Redacted leaked fragment from reflection, server IPv4 + name from session exports, password length disclosure. Git history retains prior commits — acceptable post-rotation.