### PR TITLE
fix: critical PR review batch 2 + post-rotation hardening

### DIFF
--- a/company/scripts/sanitise.sh
+++ b/company/scripts/sanitise.sh
@@ -48,4 +48,6 @@ if [ "$found" -eq 1 ]; then
   exit 1
 fi
 
-echo "$input"
+# Use printf '%s\n' instead of echo: echo can interpret leading '-n'/'-e' as
+# flags depending on the shell, mangling content the caller depends on.
+printf '%s\n' "$input"

--- a/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
+++ b/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
@@ -3,7 +3,7 @@
 # Generated from cloud-init.sh.tpl by terraform
 # Runs as root on first boot.
 set -euo pipefail
-trap 'echo "MentisDB cloud-init bootstrap failed on line $LINENO (pid $$$$)" >&2' ERR
+trap 'echo "MentisDB cloud-init bootstrap failed on line $LINENO (pid $$)" >&2' ERR
 
 DOMAIN="${domain_name}"
 EMAIL="${letsencrypt_email}"
@@ -13,6 +13,11 @@ BASIC_AUTH_PASSWORD=$(cat <<'BASIC_AUTH_PASSWORD_END'
 ${basic_auth_password}
 BASIC_AUTH_PASSWORD_END
 )
+# Validate non-empty (an empty TF var would silently create empty Basic Auth).
+if [ -z "$BASIC_AUTH_PASSWORD" ] || [ "$(printf '%s' "$BASIC_AUTH_PASSWORD" | tr -d '[:space:]')" = "" ]; then
+  echo "ERROR: basic_auth_password is empty or whitespace-only" >&2
+  exit 1
+fi
 DATA_DIR="/var/lib/mentisdb"
 USER="mentisdb"
 
@@ -138,9 +143,19 @@ EOF
 
 # --- 7b. Basic Auth credentials file ---
 # Use -i (stdin) instead of -b (argv) to avoid leaking the password via /proc.
-printf '%s' "$BASIC_AUTH_PASSWORD" | htpasswd -ciB /etc/nginx/.htpasswd mentisdb
+# Newline-terminated stdin — some htpasswd implementations expect a line.
+printf '%s\n' "$BASIC_AUTH_PASSWORD" | htpasswd -ciB /etc/nginx/.htpasswd mentisdb
 chown root:www-data /etc/nginx/.htpasswd
 chmod 0640 /etc/nginx/.htpasswd
+# Drop the rendered password from the in-memory shell variable; the bcrypt
+# hash in /etc/nginx/.htpasswd is the only artifact we want to retain.
+unset BASIC_AUTH_PASSWORD
+# cloud-init persists the rendered user-data at /var/lib/cloud/instance/user-data.txt
+# with the plaintext password. Shred + remove so the only on-disk credential
+# representation is the bcrypt hash in nginx's .htpasswd.
+if [ -f /var/lib/cloud/instance/user-data.txt ]; then
+  shred -u /var/lib/cloud/instance/user-data.txt 2>/dev/null || rm -f /var/lib/cloud/instance/user-data.txt
+fi
 
 ln -sf /etc/nginx/sites-available/mentisdb /etc/nginx/sites-enabled/mentisdb
 rm -f /etc/nginx/sites-enabled/default

--- a/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
+++ b/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
@@ -84,7 +84,7 @@ curl -u mentisdb:<pass> ... → auth:200, real JSON response
 - Pipeline module first-apply needs `terraform import` for 4 pre-existing resources (`github_repository.wgmesh`, `cloudflare_record.dashboard`, `cloudflare_page_rule.dashboard_redirect`, `github_repository_file.pipeline_health_alert`). Currently fails loud per push; mentisdb job continues independently.
 - mentisdb skill registry doesn't enforce Ed25519 signing by default (upstream concern).
 - Public dashboard (port 9475) only reachable via SSH tunnel — could expose via additional nginx vhost on a separate path/subdomain if needed.
-- Rotate the password leaked in Claude conversation history.
+- ~~Rotate the password leaked in Claude conversation history.~~ (DONE 2026-04-27)
 - Test downstream consumer pattern from a wgmesh workflow (write a thought, read it back).
 
 ## Memory artifacts created/updated this session

--- a/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
+++ b/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
@@ -53,5 +53,5 @@ Same as last session export, all still open:
 - Pipeline module first-apply needs `terraform import` for 4 pre-existing resources
 - mentisdb skill registry doesn't enforce Ed25519 signing by default
 - Public dashboard (port 9475) only via SSH tunnel
-- Rotate the password leaked in conversation history
+- ~~Rotate the password leaked in conversation history~~ (DONE 2026-04-27 via PR #601, then again via task/critical-batch-2 after a transient re-leak during user-data inspection)
 - Consume MentisDB from a wgmesh workflow (smoketest only validates from ai-pipeline-template — should also dispatch from wgmesh to confirm cross-repo org-secret access works)


### PR DESCRIPTION
Five fixes including the trap PID expansion (verified empirically), htpasswd newline, empty-password validation, sanitise.sh echo->printf, and post-htpasswd shred of cloud-init user-data.txt. Plus stale TODO cleanup. Password re-rotated before this commit due to inadvertent re-leak during verification.