### PR TITLE
docs: remove dangling memory refs from public session files

### DIFF
--- a/memory/reflection - 2604271010 - mentisdb deploy patterns and open loops.md
+++ b/memory/reflection - 2604271010 - mentisdb deploy patterns and open loops.md
@@ -21,7 +21,7 @@ The original `infrastructure/` was AI-generated and contained ≥6 fabricated fa
 
 **Pattern**: any AI-generated infra targeting external software needs a "verify the upstream facts" pass BEFORE first apply: gh repo exists, version tag exists in crates.io/npm/pypi, port assumptions match `.env.example`, install method matches actual Cargo.toml/setup.py.
 
-Captured as `feedback_verify_ai_scaffolds.md`.
+(Operator captures this learning in their personal knowledge base — not committed to this repo because the same pattern applies to many projects, and the reflection's narrative form is enough for repo readers.)
 
 ### Org-secret-as-source-of-truth beats state-managed secrets for shared credentials
 
@@ -31,31 +31,28 @@ Started with `random_password` in tfstate (PR #590). Pivoted to org-secret-sourc
 - IaC reads via `TF_VAR_*: ${{ secrets.X }}` in workflow
 - Consumer repos reference `${{ secrets.X }}` directly
 
-This decouples IaC from downstream tooling. Captured in `feedback_mentisdb_no_rest_auth.md`.
+This decouples IaC from downstream tooling.
 
 ### Hetzner Cloud has location/server-type catalog drift
 
 `fra1` doesn't exist. `cx22` doesn't exist. `cpx21` is deprecated for new orders in `hel1`. Newer `cx23` works. The server-type "supported" flag in the datacenter API is NOT the same as "available for new orders" — only `apply` reveals the latter.
 
-Captured as `reference_hetzner_cloud_catalog.md`.
 
 ### TUI-coupled binaries running under systemd need a fake PTY
 
 mentisdbd 0.9.5 unconditionally opens `/dev/tty` for TUI init. Fails with `os error 6` (ENXIO) when no controlling terminal. Workaround: wrap ExecStart in `script -qfc CMD /dev/null`. Service user shell must NOT be `/usr/sbin/nologin` for `script` to resolve.
 
-This is a generic Rust-daemon-with-ratatui pattern, not mentisdb-specific. Captured in `feedback_cargo_install_gotchas.md`.
+This is a generic Rust-daemon-with-ratatui pattern, not mentisdb-specific.
 
 ### Codex subagent surfaces are misleading
 
 `codex-rescue` reports "Bash hook is blocking" when the actual cause is auth expiry, model deprecation, broker stale state, anything. `codex-companion.mjs setup --json` returns `loggedIn: true` while the actual API token is dead.
 
-Captured in `feedback_codex_setup_stale_auth.md` + `feedback_codex_rescue_misleading_errors.md`.
 
 ### Dippy body-match denies need allow rules ordered after
 
 `deny * /etc/*` and `deny * /usr/*` match the substring anywhere in the command line, not just prefix. Allow rules for legitimate command paths must be placed BELOW the denies (last-match-wins). For one-off SSH commands containing those paths in script body, the heredoc-stdin bypass works (script content goes via stdin, never lands in dippy's argv view).
 
-Captured in updated `reference_dippy_config.md`.
 
 ## Tasks (deferred items as concrete TODOs)
 

--- a/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
+++ b/memory/session - 2604270958 - mentisdb hetzner deploy with basic auth.md
@@ -87,25 +87,6 @@ curl -u mentisdb:<pass> ... → auth:200, real JSON response
 - ~~Rotate the password leaked in Claude conversation history.~~ (DONE 2026-04-27)
 - Test downstream consumer pattern from a wgmesh workflow (write a thought, read it back).
 
-## Memory artifacts created/updated this session
+## Memory artifacts
 
-Reference:
-- `reference_mentisdb_facts.md` — upstream facts (repo, ports, install method)
-- `reference_mentisdb_hetzner_deploy.md` — service deployment specifics
-- `reference_hetzner_cloud_catalog.md` — locations + server types catalog
-- `reference_cloudflare_ids.md` — account + zone IDs
-- `reference_repo_ruleset_protect_main.md` — ai-pipeline-template ruleset + admin bypass
-- `reference_org_secrets_inventory.md` (updated) — current state of all 3 repos + Hetzner naming inconsistency
-- `reference_dippy_config.md` (updated) — body-match deny precedence + heredoc bypass
-
-Feedback:
-- `feedback_verify_ai_scaffolds.md` — never trust AI infra without upstream verification
-- `feedback_codex_rescue_misleading_errors.md` — subagent dresses up auth failures
-- `feedback_codex_setup_stale_auth.md` — setup --json lies; smoke-test first
-- `feedback_workflow_path_race.md` — overlapping paths fire workflows in parallel
-- `feedback_terraform_provider_binaries_in_git.md` — `**/.terraform/` gitignore
-- `feedback_github_actions_secret_gotchas.md` — workflow_dispatch ≠ secret, github_actions_variable ≠ encrypted, default GITHUB_TOKEN read-only
-- `feedback_check_secrets_before_set.md` — mass-set incident
-- `feedback_terraform_templatefile_escaping.md` — `${}`/`$$`/`\$` rules + tls_private_key trimspace + SSH-debug pattern
-- `feedback_cargo_install_gotchas.md` — git tag ≠ semver + `*-sys` system deps + ENXIO PTY workaround + `set -e` crontab trap
-- `feedback_mentisdb_no_rest_auth.md` — mentisdb 0.9.5 has no REST auth + Basic Auth resolution + org-secret pivot
+The operator captures durable patterns + feedback notes in their personal knowledge base outside this repo (Claude auto-memory, not committed here). Topics covered from this session: AI-scaffold verification, codex subagent error surfaces, terraform templatefile escape rules, cargo install system-dep gotchas, Hetzner Cloud catalog quirks, GH Actions secret gotchas, mentisdb auth + org-secret pivot. The narrative above is the public-facing record; deeper file:line references stay private.

--- a/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
+++ b/memory/session - 2604271010 - mentisdb smoketest end to end verified.md
@@ -29,7 +29,7 @@ POST `/v1/thoughts` shape (from `src/server.rs::AppendThoughtRequest`): required
 
 POST `/v1/search` shape: `chain_key`, `text`, `limit`, `thought_types[]`, `tags_any[]`, `since`/`until`, etc. Returns `{thoughts: [...]}`.
 
-Full REST route inventory + ThoughtType + ThoughtRole catalog now in `reference_mentisdb_facts.md`.
+Full REST route inventory + ThoughtType + ThoughtRole catalog captured in operator's personal knowledge base (Claude auto-memory, not in this repo).
 
 ## PR shipped this session
 
@@ -44,8 +44,7 @@ Full REST route inventory + ThoughtType + ThoughtRole catalog now in `reference_
 
 ## Memory updates
 
-- Extended `reference_mentisdb_facts.md` with full REST API canonical reference
-- Updated `reference_mentisdb_hetzner_deploy.md` PR chain with #593
+- Personal knowledge base updated with the full REST API canonical reference + this PR chain entry. (Repo doesn't carry these notes.)
 
 ## What's next (deferred)
 


### PR DESCRIPTION
Reflection + session exports referenced auto-memory files not committed to this repo (broken links per PR #595 review). Replaced specific filename citations with neutral pointers to operator's private knowledge base. Public record stays self-contained.