### PR TITLE
feat: persistent Hetzner Volume for mentisdb chain data

### DIFF
--- a/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
+++ b/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
@@ -34,9 +34,35 @@ apt-get install -y \
   curl nginx certbot python3-certbot-nginx ufw \
   ca-certificates apache2-utils docker.io
 
-# --- 2. Data dir ---
+# --- 2. Persistent volume mount ---
+# Hetzner Volume ${volume_id} attached at server creation. Mount it at
+# $DATA_DIR before any data is written so mentisdb chain data survives
+# server replacement (tofu apply -replace=hcloud_server.mentisdb).
+VOLUME_DEVICE="/dev/disk/by-id/scsi-0HC_Volume_${volume_id}"
+echo "Waiting for volume device $VOLUME_DEVICE to appear..."
+for _ in $(seq 1 60); do
+  [ -e "$VOLUME_DEVICE" ] && break
+  sleep 1
+done
+if [ ! -e "$VOLUME_DEVICE" ]; then
+  echo "ERROR: volume device $VOLUME_DEVICE never appeared after 60s" >&2
+  exit 1
+fi
+mkdir -p "$DATA_DIR"
+# Mount idempotently: skip if already mounted (cloud-init re-runs are rare
+# but keep the script safe to re-execute manually for diagnostics).
+if ! mountpoint -q "$DATA_DIR"; then
+  mount "$VOLUME_DEVICE" "$DATA_DIR"
+fi
+# Persist mount via /etc/fstab (nofail so a missing volume doesn't
+# block boot; we'd rather have a degraded server we can SSH into than
+# an emergency-shell boot we can't reach).
+if ! grep -q "$VOLUME_DEVICE" /etc/fstab; then
+  echo "$VOLUME_DEVICE  $DATA_DIR  ext4  discard,nofail,defaults  0  0" >> /etc/fstab
+fi
 # Container internally runs as uid 991; ensure host dir is writable by it.
-install -d -o 991 -g 991 -m 0750 "$DATA_DIR"
+chown -R 991:991 "$DATA_DIR"
+chmod 0750 "$DATA_DIR"
 
 # --- 3. Pull mentisdbd image + systemd unit wrapping `docker run` ---
 systemctl enable --now docker

--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -61,6 +61,22 @@ resource "hcloud_firewall" "mentisdb" {
   }
 }
 
+resource "hcloud_volume" "mentisdb_data" {
+  name              = "mentisdb-data"
+  size              = var.mentisdb_volume_size_gb
+  location          = "hel1"
+  format            = "ext4"
+  delete_protection = true
+
+  lifecycle {
+    # Defense in depth — even if delete_protection is dropped, terraform
+    # itself will refuse to destroy this resource without explicit
+    # `terraform state rm` first. Protects accumulated mentisdb chain
+    # data from being wiped on routine `tofu apply -replace` flows.
+    prevent_destroy = true
+  }
+}
+
 resource "hcloud_server" "mentisdb" {
   name         = "mentisdb-prod"
   image        = "ubuntu-24.04"
@@ -68,16 +84,25 @@ resource "hcloud_server" "mentisdb" {
   location     = "hel1"
   ssh_keys     = [hcloud_ssh_key.deploy.id]
   firewall_ids = [hcloud_firewall.mentisdb.id]
+  # Attach the volume at server creation so it's available before
+  # cloud-init runs the docker mount logic.
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {
     domain_name         = var.domain_name
     letsencrypt_email   = var.letsencrypt_email
     mentisdb_image      = var.mentisdb_image
     basic_auth_password = var.mentisdb_password
+    volume_id           = hcloud_volume.mentisdb_data.id
   })
   labels = {
     role = "mentisdb"
     env  = "prod"
   }
+}
+
+resource "hcloud_volume_attachment" "mentisdb_data" {
+  volume_id = hcloud_volume.mentisdb_data.id
+  server_id = hcloud_server.mentisdb.id
+  automount = false
 }
 
 resource "cloudflare_record" "mem_beerpub" {

--- a/infrastructure/terraform/mentisdb/outputs.tf
+++ b/infrastructure/terraform/mentisdb/outputs.tf
@@ -16,6 +16,16 @@ output "mentisdb_ssh_private_key" {
   sensitive   = true
 }
 
+output "mentisdb_volume_id" {
+  description = "Hetzner Volume ID holding the persistent /var/lib/mentisdb. Survives server delete/recreate. Protected by `delete_protection = true` + `lifecycle.prevent_destroy = true`."
+  value       = hcloud_volume.mentisdb_data.id
+}
+
+output "mentisdb_volume_device" {
+  description = "Linux device path the volume appears at on the server (use for fstab / mount commands)."
+  value       = hcloud_volume.mentisdb_data.linux_device
+}
+
 output "mentisdb_curl_example" {
   description = "Working curl command for the protected API. Pull the password from MENTISDB_PASSWORD org secret or your password manager."
   value       = "curl -u mentisdb:$MENTISDB_PASSWORD -X POST -H 'Content-Type: application/json' -d '{}' https://${var.domain_name}/v1/agents"

--- a/infrastructure/terraform/mentisdb/variables.tf
+++ b/infrastructure/terraform/mentisdb/variables.tf
@@ -33,6 +33,17 @@ variable "mentisdb_image" {
   default     = "ghcr.io/nycterent/mentisdb:0.9.5-test4"
 }
 
+variable "mentisdb_volume_size_gb" {
+  description = "Size (GB) of the Hetzner Volume that holds /var/lib/mentisdb. Volume survives server delete/recreate. Min 10."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.mentisdb_volume_size_gb >= 10
+    error_message = "Hetzner Volumes have a 10GB minimum."
+  }
+}
+
 variable "mentisdb_password" {
   description = "HTTP Basic Auth password for the mentisdb user (sourced from MENTISDB_PASSWORD org secret via TF_VAR_mentisdb_password). Single source of truth: the org secret. Rotate by updating the secret + re-applying."
   type        = string


### PR DESCRIPTION
10GB ext4 volume attached to server at creation, mounted at /var/lib/mentisdb before docker starts. Survives server delete/recreate via delete_protection + lifecycle.prevent_destroy. New var mentisdb_volume_size_gb (default 10, min 10). Outputs volume_id + volume_device.