### PR TITLE
feat: MentisDB CI instrumentation + volume attachment refactor + PR-automerge doc refresh

### DIFF
--- a/.github/workflows/approve-build.yml
+++ b/.github/workflows/approve-build.yml
@@ -155,3 +155,45 @@ jobs:
             }
 
             console.log(`Triggered Copilot revision for issue #${issueNumber}`);
+
+      - name: Append spec-approval outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: ${{ github.event.review.user.login }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="ActionTaken"; IMP="0.5" ;;
+            failure)   TYPE="Mistake";     IMP="0.7" ;;
+            cancelled) TYPE="Mistake";     IMP="0.5" ;;
+            *)         TYPE="Mistake";     IMP="0.6" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg reviewer "$REVIEWER" \
+            --arg state "$REVIEW_STATE" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "approve-build",
+              agent_name: "approve-build",
+              thought_type: $type,
+              content: ("Spec PR #" + $pr + " review by @" + $reviewer + " (" + $state + ") — approval flow " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "spec-approval", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -37,3 +37,43 @@ jobs:
           APPROVED_AUTHORS: ${{ github.event.pull_request.user.login }}
         run: |
           bash company/scripts/pr-review-merge.sh
+
+      - name: Append review-merge outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="TaskComplete"; IMP="0.7" ;;
+            failure)   TYPE="Mistake";      IMP="0.8" ;;
+            cancelled) TYPE="Mistake";      IMP="0.6" ;;
+            *)         TYPE="Mistake";      IMP="0.7" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg author "$PR_AUTHOR" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "bot-pr-review-merge",
+              agent_name: "bot-pr-review-merge",
+              thought_type: $type,
+              content: ("PR #" + $pr + " by @" + $author + " — review-merge " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "pr-review-merge", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/copilot-triage.yml
+++ b/.github/workflows/copilot-triage.yml
@@ -117,3 +117,43 @@ jobs:
             });
 
             console.log(`Triggered Copilot triage for issue #${issueNumber}`);
+
+      - name: Append issue-triage outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="ActionTaken"; IMP="0.5" ;;
+            failure)   TYPE="Mistake";     IMP="0.7" ;;
+            cancelled) TYPE="Mistake";     IMP="0.5" ;;
+            *)         TYPE="Mistake";     IMP="0.6" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg issue "$ISSUE_NUMBER" \
+            --arg label "$ISSUE_LABEL" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "copilot-triage",
+              agent_name: "copilot-triage",
+              thought_type: $type,
+              content: ("Issue #" + $issue + " labeled \"" + $label + "\" — Copilot triage assignment " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "issue-triage", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/copilot-undraft.yml
+++ b/.github/workflows/copilot-undraft.yml
@@ -36,3 +36,41 @@ jobs:
             `, { id: prNodeId });
 
             console.log(`PR #${prNumber} marked ready for review`);
+
+      - name: Append undraft outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="ActionTaken"; IMP="0.5" ;;
+            failure)   TYPE="Mistake";     IMP="0.7" ;;
+            cancelled) TYPE="Mistake";     IMP="0.5" ;;
+            *)         TYPE="Mistake";     IMP="0.6" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "copilot-undraft",
+              agent_name: "copilot-undraft",
+              thought_type: $type,
+              content: ("Copilot draft PR #" + $pr + " — undraft " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "spec-undraft", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -81,3 +81,33 @@ jobs:
           else
             echo "All endpoints up, no open health-check issues."
           fi
+
+      - name: Append endpoint-health failure to MentisDB
+        if: steps.health.outputs.down_count != '0'
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DOWN_NAMES: ${{ steps.health.outputs.down_names }}
+          DOWN_COUNT: ${{ steps.health.outputs.down_count }}
+        run: |
+          set -euo pipefail
+          PAYLOAD=$(jq -nc \
+            --arg run_url "$RUN_URL" \
+            --arg down_names "$DOWN_NAMES" \
+            --arg down_count "$DOWN_COUNT" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "health-check",
+              agent_name: "health-check",
+              thought_type: "Mistake",
+              content: ($down_count + " endpoint(s) down: " + $down_names + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "endpoint-health", "failure"],
+              importance: 0.7
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -203,3 +203,43 @@ jobs:
             } catch (e) {
               core.warning(`Failed to add needs-human label: ${e.message}`);
             }
+
+      - name: Append heartbeat-merge outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="TaskComplete"; IMP="0.7" ;;
+            failure)   TYPE="Mistake";      IMP="0.8" ;;
+            cancelled) TYPE="Mistake";      IMP="0.6" ;;
+            *)         TYPE="Mistake";      IMP="0.7" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "heartbeat-pr-automerge",
+              agent_name: "heartbeat-pr-automerge",
+              thought_type: $type,
+              content: ("Heartbeat PR #" + $pr + " (" + $title + ") — fast-lane " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "heartbeat-merge", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -38,3 +38,44 @@ jobs:
               issue_number: issueNumber,
               body: `Resolved by PR #${pr.number}. Implementation merged to main.`
             });
+
+      - name: Append impl-close outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="TaskComplete"; IMP="0.7" ;;
+            failure)   TYPE="Mistake";      IMP="0.7" ;;
+            cancelled) TYPE="Mistake";      IMP="0.5" ;;
+            *)         TYPE="Mistake";      IMP="0.6" ;;
+          esac
+          ISSUE_NUM=$(echo "$PR_TITLE" | grep -oE 'Issue #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "unknown")
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg issue "$ISSUE_NUM" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "impl-merged-close",
+              agent_name: "impl-merged-close",
+              thought_type: $type,
+              content: ("Impl PR #" + $pr + " merged → close issue #" + $issue + " — " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "impl-close", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -815,3 +815,41 @@ jobs:
           echo "Created PR #${pr_number}"
 
           # Review-merge handled by bot-pr-review-merge.yml workflow
+
+      - name: Append pipeline-health outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="Insight";  IMP="0.4" ;;
+            failure)   TYPE="Mistake";  IMP="0.7" ;;
+            cancelled) TYPE="Mistake";  IMP="0.5" ;;
+            *)         TYPE="Mistake";  IMP="0.6" ;;
+          esac
+          STATE_SUMMARY=$(jq -r '"actions=" + (.actions_taken|tostring) + " errors=" + (.errors|tostring) + " stale_prs=" + (.stale_prs_closed|tostring) + " needs_human_closed=" + (.needs_human_closed|tostring)' company/pipeline-health-state.json 2>/dev/null || echo "state-unavailable")
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg state "$STATE_SUMMARY" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "pipeline-health",
+              agent_name: "pipeline-health",
+              thought_type: $type,
+              content: ("Pipeline self-heal cycle " + $outcome + " — " + $state + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "pipeline-health", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/spec-merged-build.yml
+++ b/.github/workflows/spec-merged-build.yml
@@ -61,3 +61,43 @@ jobs:
               issue_number: issueNumber,
               body: `Spec merged (PR #${pr.number}). Build agent assigned to implement.`
             });
+
+      - name: Append spec-merge-build outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="ActionTaken"; IMP="0.5" ;;
+            failure)   TYPE="Mistake";     IMP="0.7" ;;
+            cancelled) TYPE="Mistake";     IMP="0.5" ;;
+            *)         TYPE="Mistake";     IMP="0.6" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "spec-merged-build",
+              agent_name: "spec-merged-build",
+              thought_type: $type,
+              content: ("Spec PR #" + $pr + " (" + $title + ") merged — build dispatch " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "spec-merge-build", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -121,3 +121,43 @@ jobs:
 
               core.setFailed('Spec validation failed — see PR comment for details');
             }
+
+      - name: Append spec-validation outcome to MentisDB
+        if: always()
+        env:
+          MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+          MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+          MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+          OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          case "$OUTCOME" in
+            success)   TYPE="Correction"; IMP="0.6" ;;
+            failure)   TYPE="Mistake";    IMP="0.7" ;;
+            cancelled) TYPE="Mistake";    IMP="0.5" ;;
+            *)         TYPE="Mistake";    IMP="0.6" ;;
+          esac
+          PAYLOAD=$(jq -nc \
+            --arg type "$TYPE" \
+            --arg outcome "$OUTCOME" \
+            --arg run_url "$RUN_URL" \
+            --arg pr "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg imp "$IMP" \
+            '{
+              chain_key: "ai-pipeline-template",
+              agent_id: "spec-validation",
+              agent_name: "spec-validation",
+              thought_type: $type,
+              content: ("Spec PR #" + $pr + " (" + $title + ") — validation " + $outcome + " (" + $run_url + ")"),
+              tags: ["ai-pipeline-template", "spec-validation", $outcome],
+              importance: ($imp | tonumber)
+            }')
+          curl --fail-with-body --silent --show-error --max-time 15 \
+            -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+            -X POST -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+            || echo "::warning::mentisdb append failed (non-fatal)"

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -135,10 +135,10 @@ jobs:
         run: |
           set -euo pipefail
           case "$OUTCOME" in
-            success)   TYPE="Correction"; IMP="0.6" ;;
-            failure)   TYPE="Mistake";    IMP="0.7" ;;
-            cancelled) TYPE="Mistake";    IMP="0.5" ;;
-            *)         TYPE="Mistake";    IMP="0.6" ;;
+            success)   TYPE="ActionTaken"; IMP="0.5" ;;
+            failure)   TYPE="Mistake";     IMP="0.7" ;;
+            cancelled) TYPE="Mistake";     IMP="0.5" ;;
+            *)         TYPE="Mistake";     IMP="0.6" ;;
           esac
           PAYLOAD=$(jq -nc \
             --arg type "$TYPE" \

--- a/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md
+++ b/docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md
@@ -1,0 +1,354 @@
+---
+title: "feat: instrument remaining GitHub Actions workflows with MentisDB thought-append"
+type: feat
+status: active
+date: 2026-04-27
+---
+
+# feat: instrument remaining GitHub Actions workflows with MentisDB thought-append
+
+## Overview
+
+Wire the remaining ten lifecycle workflows in `atvirokodosprendimai/ai-pipeline-template` to append structured thoughts to MentisDB at `mem.beerpub.dev`. Three workflows already integrate (`mentisdb-smoketest.yml` daily round-trip, `observation-loop.yml` strategic Insight, `terraform-deploy.yml` consumes `MENTISDB_PASSWORD` as a TF input). The remainder run silently — there is no agent-memory record of CI lifecycle events (PR review/merge outcomes, spec validations, triage assignments, build closures, self-heal cycles, endpoint health failures).
+
+After this work, every meaningful CI event in this repo writes a typed thought into the `ai-pipeline-template` chain, restoring continuity for downstream agents that read MentisDB to reason about pipeline state.
+
+---
+
+## Problem Frame
+
+The pipeline emits dozens of events per day across 14 workflows. Of those, only the daily strategic loop and a smoketest write to MentisDB. The rest of the lifecycle — PR triage, spec validation, build dispatch, merge closure, self-healing, endpoint health — produces no durable agent-memory trace beyond `gh run` logs that age out and lack semantic structure.
+
+Memory note `reference_mentisdb_ci_integration_pattern.md` already defines the canonical step shape, thought-type table, fatality decision rules, and chain naming convention. This plan is a mechanical rollout of that pattern across the remaining workflows; no architectural decisions are open.
+
+Skip `sync-labels.yml` — fires on every label sync, low signal, would generate noise.
+
+---
+
+## Requirements Trace
+
+- R1. Every lifecycle workflow in scope appends a thought to MentisDB on terminal job state (`success` or `failure`), via an `if: always()` step.
+- R2. All appends use `chain_key: "ai-pipeline-template"` to keep this repo's CI activity in one queryable chain (per pattern doc).
+- R3. Append failures are non-fatal for high-frequency / observability workflows (per fatality table in pattern doc) — failures emit `::warning::` instead of failing the workflow.
+- R4. Thought type, importance, tags, and content are chosen per the pattern doc table for each workflow's event class.
+- R5. No new secrets are introduced. Reuse existing org-level `MENTISDB_URL` / `MENTISDB_USER` / `MENTISDB_PASSWORD` (visibility: selected → ai-pipeline-template + wgmesh).
+- R6. Existing wired workflows (`observation-loop.yml`, `mentisdb-smoketest.yml`, `terraform-deploy.yml`) are not modified.
+- R7. Verification: at least one instrumented workflow per event-class cluster is dispatched manually post-merge, and the resulting thought appears in a MentisDB `/v1/search` against `chain_key=ai-pipeline-template`.
+
+---
+
+## Scope Boundaries
+
+- Not modifying the three already-wired workflows.
+- Not instrumenting `sync-labels.yml` (low signal, high frequency).
+- Not changing the existing pattern (chain naming, thought_type table, step shape) — this plan consumes it, does not redesign it.
+- Not adding new MentisDB secrets, rotating existing ones, or changing org secret visibility.
+- Not adding cross-repo querying or cross-chain references — out of scope; the chain remains repo-local.
+- Not introducing a reusable composite action or workflow template — explicit per-workflow steps preserve readability and match the pattern doc's recommendation. (Reusable action is an explicit non-goal — see Open Questions / Resolved.)
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/observation-loop.yml` (lines ~415-490) — reference implementation: `if: always()`, env block with three secrets, jq-built JSON payload, curl with `--fail-with-body`, fatal append (no `||`).
+- `.github/workflows/mentisdb-smoketest.yml` — reference for round-trip verification (POST `/v1/thoughts` then POST `/v1/search`, grep for marker).
+- `.github/workflows/terraform-deploy.yml` (lines 69-121) — reference for `MENTISDB_PASSWORD` consumed as TF var (different concern; not modified).
+
+### Institutional Learnings
+
+- `memory/reference_mentisdb_ci_integration_pattern.md` — canonical step shape, thought-type-by-event table, fatality rules, onboarding checklist. **Authoritative source for this plan.**
+- `memory/reference_org_secrets_inventory.md` — confirms `MENTISDB_*` are org-level with `visibility: selected` already including ai-pipeline-template.
+- `memory/feedback_mentisdb_no_rest_auth.md` — REST/MCP have zero built-in auth; nginx Basic Auth is the gate. Step shape must include `-u "$MENTISDB_USER:$MENTISDB_PASSWORD"`.
+- `memory/feedback_check_git_index_before_commit.md` — `git status --short` first column = staged; pre-staged unrelated files hitch onto bare commit.
+
+### External References
+
+- None required — the pattern is fully internal and battle-tested in `observation-loop.yml` and the wgmesh sister repo.
+
+---
+
+## Key Technical Decisions
+
+- **Per-workflow inline step over reusable composite action:** The append step is ~15 lines per workflow. A composite action would centralize the curl+jq logic but obscures per-workflow content/tag choices and adds an indirection layer. Pattern doc shows wgmesh + ai-pipeline-template both use inline steps. Maintain consistency.
+- **Non-fatal for all 10 workflows in scope:** None of these workflows are release events or low-frequency metrics rollups. They are operational lifecycle events where the build/merge outcome is the primary signal and MentisDB observability is supplementary. A MentisDB hiccup must not block PR merges or health checks. Append `|| echo "::warning::mentisdb append failed (non-fatal)"`.
+- **Single chain `ai-pipeline-template` for all 10 workflows:** Pattern doc says one chain per repo. Workflow identity is preserved via `agent_id` (workflow filename without extension) and tags.
+- **`if: always()` placement:** Append step must run regardless of preceding step outcomes so failure thoughts get recorded. Place as the last step in each job.
+- **`agent_id` / `agent_name` convention:** Use the workflow's filename minus `.yml` extension (e.g., `bot-pr-review-merge`, `health-check`). Matches existing `observation-loop.yml` convention.
+- **Importance values from pattern doc table:** Do not invent new importance scores. ActionTaken=0.5, TaskComplete=0.7, Mistake=0.7-0.8, Insight=0.4, Correction=0.6.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Build a reusable composite action?** No. Pattern doc + existing impls all use inline steps. Inline keeps per-workflow content/tag choices visible at the point of use.
+- **Q: Append on every health-check tick (every 15 min) or only on failure?** Only on failure. Health-check fires 96×/day — successful checks would flood the chain with noise. Failure events are the signal worth memorializing. (Pattern doc: "Mistake on fail only".)
+- **Q: Append for `sync-labels.yml`?** No. Pure mechanical sync, no semantic event worth a thought.
+- **Q: How to handle PRs to non-bot authors in `bot-pr-review-merge.yml`?** The workflow's existing `if:` already gates on bot authorship. The append step inherits that gate by living inside the same job — no extra logic needed.
+- **Q: What if `MENTISDB_*` secrets aren't visible to this repo?** Memory confirms they are. Smoketest workflow validates this daily. No secrets work needed.
+
+### Deferred to Implementation
+
+- **Tag choice per workflow:** The pattern doc gives the structure (`[<repo>, <event-type>, <outcome>]`). Exact tag strings are best chosen at the point of edit so they reflect the workflow's actual semantics. Implementer should mirror the wording used in the workflow's existing job/step names.
+- **Whether to include PR number, issue number, or commit SHA in `content`:** Decide per workflow based on what makes the search result useful. Default: include the GitHub run URL (already in pattern), plus the most relevant identifier from the trigger event (PR # for PR-triggered, issue # for issue-triggered, schedule timestamp for scheduled).
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+Each instrumented workflow gains exactly one new step at the end of its existing job (or each job, when there are multiple parallel jobs whose outcomes both matter). The shape is constant; the contents vary:
+
+```yaml
+- name: Append <event> to MentisDB
+  if: always()
+  env:
+    MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
+    MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
+    MENTISDB_PASSWORD: ${{ secrets.MENTISDB_PASSWORD }}
+    OUTCOME: ${{ job.status }}
+  run: |
+    set -euo pipefail
+    case "$OUTCOME" in
+      success)   TYPE="<success-type>"; IMP="<success-imp>" ;;
+      failure)   TYPE="Mistake";        IMP="0.8"           ;;
+      cancelled) TYPE="Mistake";        IMP="0.6"           ;;
+      *)         TYPE="Mistake";        IMP="0.7"           ;;
+    esac
+    PAYLOAD=$(jq -nc \
+      --arg type "$TYPE" \
+      --arg outcome "$OUTCOME" \
+      --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+      --arg imp "$IMP" \
+      '{
+        chain_key: "ai-pipeline-template",
+        agent_id: "<workflow-id>",
+        agent_name: "<workflow-id>",
+        thought_type: $type,
+        content: ("<event description with identifiers> — " + $outcome + " (" + $run_url + ")"),
+        tags: ["ai-pipeline-template", "<event-type>", $outcome],
+        importance: ($imp | tonumber)
+      }')
+    curl --fail-with-body --silent --show-error --max-time 15 \
+      -u "$MENTISDB_USER:$MENTISDB_PASSWORD" \
+      -X POST -H 'Content-Type: application/json' \
+      -d "$PAYLOAD" "$MENTISDB_URL/v1/thoughts" \
+      || echo "::warning::mentisdb append failed (non-fatal)"
+```
+
+Per-workflow variation lives only in: `<event>` (step name), `<workflow-id>` (filename stem), `<success-type>`/`<success-imp>` (per pattern table), `<event description>`, `<event-type>` tag, identifiers in content. Health-check is the one exception — it skips the append entirely on success and only records on failure.
+
+---
+
+## Implementation Units
+
+- U1. **Bot-authored PR lifecycle workflows**
+
+**Goal:** Instrument the three workflows that handle bot/Copilot PR lifecycle (open → review → merge) so each PR's outcome is recorded.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None (org secrets already provisioned).
+
+**Files:**
+- Modify: `.github/workflows/bot-pr-review-merge.yml`
+- Modify: `.github/workflows/heartbeat-pr-automerge.yml`
+- Modify: `.github/workflows/copilot-undraft.yml`
+
+**Approach:**
+- For `bot-pr-review-merge.yml`: append at end of `review-merge` job. `agent_id="bot-pr-review-merge"`. Success → `TaskComplete` (imp 0.7), failure → `Mistake` (imp 0.8). Content includes PR number + author. Tags: `["ai-pipeline-template", "pr-review-merge", $outcome]`.
+- For `heartbeat-pr-automerge.yml`: append at end of `validate-and-merge` job. `agent_id="heartbeat-pr-automerge"`. Success → `TaskComplete` (imp 0.7), failure → `Mistake` (imp 0.8). Content includes PR number + title. Tags: `["ai-pipeline-template", "heartbeat-merge", $outcome]`.
+- For `copilot-undraft.yml`: append at end of the undraft job. `agent_id="copilot-undraft"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes PR number. Tags: `["ai-pipeline-template", "spec-undraft", $outcome]`.
+- All three: non-fatal append (`|| echo "::warning::..."`).
+
+**Patterns to follow:**
+- `observation-loop.yml` lines ~415-490 — env block, jq payload, curl invocation.
+- `reference_mentisdb_ci_integration_pattern.md` — Step shape section.
+
+**Test scenarios:**
+- Happy path: trigger via existing live event (real bot PR opens) — confirm `TaskComplete` thought appears in chain `ai-pipeline-template` with PR# in content.
+- Edge case: workflow runs but the merge condition (`if:`) gates it out — append step still runs (`if: always()`) and records the gate-out as success of an empty job. (Acceptable; the run URL points to a no-op run.)
+- Error path: simulate MentisDB unavailability by manually editing `MENTISDB_URL` to a bad host in a workflow_dispatch test branch — confirm workflow exits 0 with `::warning::` in logs (non-fatal verified).
+- Integration: end-to-end run on a real bot PR after merge — search MentisDB for `chain_key=ai-pipeline-template tags_any=["pr-review-merge"]` and confirm the run URL matches.
+
+**Verification:**
+- All three workflows pass `actionlint` (or equivalent YAML validation; if no actionlint, GitHub's own validator on push is sufficient).
+- After merge, the next bot PR triggers each workflow and a `TaskComplete` thought lands in the chain.
+
+---
+
+- U2. **Spec/build pipeline workflows**
+
+**Goal:** Instrument the three workflows that drive the spec → approve → build pipeline so each transition is durable.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/spec-validation.yml`
+- Modify: `.github/workflows/approve-build.yml`
+- Modify: `.github/workflows/spec-merged-build.yml`
+
+**Approach:**
+- For `spec-validation.yml`: append at end of validation job. `agent_id="spec-validation"`. Success → `Correction` (imp 0.6) when validation auto-fixes/labels; `ActionTaken` (imp 0.5) for plain pass; failure → `Mistake` (imp 0.7). Choose `Correction` when validation produced an `approved-for-build` or similar state-changing label, `ActionTaken` otherwise — implementer decides based on the workflow's existing branches. Content includes spec PR # and validation outcome label. Tags: `["ai-pipeline-template", "spec-validation", $outcome]`.
+- For `approve-build.yml`: append at end of approval job. `agent_id="approve-build"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes PR # + reviewer. Tags: `["ai-pipeline-template", "spec-approval", $outcome]`.
+- For `spec-merged-build.yml`: append at end of build dispatch job. `agent_id="spec-merged-build"`. Success → `ActionTaken` (imp 0.5; the actual build happens elsewhere), failure → `Mistake` (imp 0.7). Content includes spec PR # + dispatched build target. Tags: `["ai-pipeline-template", "spec-merge-build", $outcome]`.
+- All three: non-fatal append.
+
+**Patterns to follow:**
+- Same as U1.
+
+**Test scenarios:**
+- Happy path: spec PR opened → `spec-validation` runs → `ActionTaken` or `Correction` thought lands.
+- Happy path: spec PR approved + auto-merged → `approve-build` runs → `ActionTaken` thought lands.
+- Happy path: spec PR merged → `spec-merged-build` dispatches downstream build → `ActionTaken` thought lands.
+- Edge case: validation runs on a PR with no actionable changes (`paths` filter matched but content unchanged) — append still records the no-op run with `success` outcome.
+- Error path: spec validation fails (invalid spec format) — `Mistake` thought with imp 0.8 lands; main workflow still surfaces failure normally.
+- Integration: full spec lifecycle on a test issue (open spec PR → validation → approval → merge → build dispatch) → all three thoughts present in chain with correct outcome ordering.
+
+**Verification:**
+- All three workflows pass actionlint.
+- A spec PR run produces three thoughts (one per workflow) tagged `spec-validation`, `spec-approval`, `spec-merge-build`.
+
+---
+
+- U3. **Issue lifecycle workflows**
+
+**Goal:** Instrument the two workflows that handle issue triage assignment and impl-PR closure so the issue → spec → impl → close arc is recorded.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/copilot-triage.yml`
+- Modify: `.github/workflows/impl-merged-close.yml`
+
+**Approach:**
+- For `copilot-triage.yml`: append at end of `triage` job. `agent_id="copilot-triage"`. Success → `ActionTaken` (imp 0.5), failure → `Mistake` (imp 0.7). Content includes issue # + triggering label. Tags: `["ai-pipeline-template", "issue-triage", $outcome]`.
+- For `impl-merged-close.yml`: append at end of close job. `agent_id="impl-merged-close"`. Success → `TaskComplete` (imp 0.7) — closing an impl PR completes a unit of work, failure → `Mistake` (imp 0.7). Content includes PR # + linked issue # (if extractable from PR title). Tags: `["ai-pipeline-template", "impl-close", $outcome]`.
+- Both: non-fatal append.
+
+**Patterns to follow:**
+- Same as U1.
+
+**Test scenarios:**
+- Happy path: file an issue with `bug` label → `copilot-triage` fires → `ActionTaken` thought lands with issue # in content.
+- Happy path: bot opens impl PR → human merges → `impl-merged-close` fires → `TaskComplete` thought lands.
+- Edge case: triage workflow's `if:` gate skips the job (e.g., issue already has `copilot-triaging` label) — `if: always()` still runs the append, recording a no-op run as success. (Acceptable.)
+- Error path: `gh` token expired during triage → workflow fails → `Mistake` thought lands; original failure surfaces in logs.
+- Integration: full issue → triage → spec → build → impl → close cycle on a test issue → both U3 thoughts present plus the U2 spec-pipeline thoughts → query by `tags_any=["issue-triage","impl-close"]` returns both.
+
+**Verification:**
+- Both workflows pass actionlint.
+- A real issue lifecycle produces both thoughts tagged correctly.
+
+---
+
+- U4. **Self-healing & observability workflows**
+
+**Goal:** Instrument the two workflows that monitor pipeline and infrastructure health so failures and self-heal cycles are recorded.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `.github/workflows/pipeline-health.yml`
+- Modify: `.github/workflows/health-check.yml`
+
+**Approach:**
+- For `pipeline-health.yml`: append at end of health-check job. `agent_id="pipeline-health"`. Success → `Insight` (imp 0.4) — observation about pipeline state, failure → `Mistake` (imp 0.7). Content includes brief state summary (e.g., stale-PR count or issue-backlog stat from existing workflow output if exposed; otherwise just outcome + timestamp). Tags: `["ai-pipeline-template", "pipeline-health", $outcome]`.
+- For `health-check.yml`: **skip append on success.** Only append on failure (workflow runs every 15 min — success would flood the chain). `agent_id="health-check"`. Failure → `Mistake` (imp 0.7). Content includes the down service names from existing `down_names` output. Tags: `["ai-pipeline-template", "endpoint-health", "failure"]`. Use `if: failure() || cancelled()` instead of `if: always()` for this one workflow.
+- Both: non-fatal append.
+
+**Patterns to follow:**
+- `observation-loop.yml` for pipeline-health.
+- Pattern doc fatality table: this is the explicit "Mistake on fail only" case.
+
+**Test scenarios:**
+- Happy path (pipeline-health): scheduled run completes → `Insight` thought lands every 2 hours.
+- Happy path (health-check, success): all endpoints up → no thought appended (verified by absence in chain after success run).
+- Error path (health-check, failure): one endpoint down (simulate by editing `health.json` to a bad URL on a test branch + `workflow_dispatch`) → `Mistake` thought lands with the down service name in content.
+- Edge case (pipeline-health): scheduled run aborted mid-execution → `Mistake` thought (cancelled outcome); main workflow's existing alert behavior unchanged.
+- Integration: query chain after 24h with `tags_any=["pipeline-health"]` — expect ~12 Insight thoughts (one per 2h scheduled run), zero Mistake thoughts assuming healthy day.
+
+**Verification:**
+- Both workflows pass actionlint.
+- After deployment, `pipeline-health.yml` writes one thought per scheduled run; `health-check.yml` writes zero thoughts during a healthy window.
+
+---
+
+- U5. **Post-merge verification dispatch + chain query**
+
+**Goal:** Confirm the rollout works end-to-end by manually dispatching one workflow per cluster and querying MentisDB for the resulting thoughts.
+
+**Requirements:** R7
+
+**Dependencies:** U1, U2, U3, U4 all merged to `main`.
+
+**Files:**
+- No file changes. Verification is operational.
+
+**Approach:**
+- After merge, manually trigger via `gh workflow run` (or wait for natural triggers) at least one workflow per cluster:
+  - U1 cluster: any of the three (heartbeat-pr-automerge fires on the merge of this PR itself, providing natural verification).
+  - U2 cluster: dispatch `spec-validation` against an existing closed spec PR or wait for next bot spec.
+  - U3 cluster: file a test issue with `needs-triage` label, then close manually.
+  - U4 cluster: `gh workflow run pipeline-health.yml` and `gh workflow run health-check.yml`.
+- For each, run the verification curl from `reference_mentisdb_ci_integration_pattern.md` "Verification queries" section, scoped to `chain_key=ai-pipeline-template` and the relevant tag, and confirm the run_url in content matches the dispatched run.
+
+**Test scenarios:**
+- Test expectation: none — this unit is operational verification, no code changes.
+
+**Verification:**
+- For each of the four clusters, at least one thought appears in the chain with the run_url matching a dispatched run.
+- No workflow failed due to mentisdb append (check Actions tab for `::warning::mentisdb append failed` — if any appear, investigate connectivity but workflow itself should still be green).
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Each workflow gains one trailing step. No cross-workflow coupling, no shared state. Failure of the append step does not cascade.
+- **Error propagation:** Append failures are absorbed by `|| echo "::warning::..."`. The workflow's primary outcome (build pass/fail, merge success, etc.) is unaffected.
+- **State lifecycle risks:** None. MentisDB writes are idempotent in the sense that duplicates are recorded as duplicate thoughts — they pollute the chain but cause no incorrect behavior. Risk if a workflow retries: duplicate thoughts. Mitigation: pattern doc accepts this; queries can dedup by `run_url`.
+- **API surface parity:** No external API surface change. The only consumer of the new thoughts is MentisDB, already serving wgmesh + this repo's existing two integrations.
+- **Integration coverage:** The integration is a single curl POST. Unit tests are not meaningful here. End-to-end verification via U5.
+- **Unchanged invariants:** `observation-loop.yml`, `mentisdb-smoketest.yml`, `terraform-deploy.yml` are not modified. `sync-labels.yml` remains uninstrumented by design. Org secret `MENTISDB_*` values, visibility, and rotation cadence unchanged. Workflow trigger conditions, permissions blocks, concurrency groups unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| MentisDB outage during rollout would mass-warning every workflow run. | Non-fatal append + `--max-time 15` curl timeout. Workflows still pass. Smoketest workflow (already wired) surfaces sustained outage as its own failure. |
+| Health-check workflow firing every 15 min could flood chain even with failure-only append, if many endpoints flap simultaneously. | Per pattern: failure-only append. If flapping becomes an issue, add a debounce (e.g., only append if same down_names persisted across two consecutive runs). Out of scope for this plan; revisit if observed. |
+| `job.status` value semantics could differ between matrix jobs and single-job workflows. | All instrumented workflows in scope are single-job. Confirmed via existing `observation-loop.yml` precedent. If a multi-job workflow is later added, append step needs to be added to each job individually. |
+| Org secret `visibility: selected` might silently exclude this repo. | Memory confirms inclusion. Existing `mentisdb-smoketest.yml` runs daily and would have failed if visibility were wrong. No additional check needed. |
+| Implementer might forget to use `if: always()` on a step, causing failure thoughts to never land. | Per-unit Approach explicitly states `if: always()` (or `if: failure() || cancelled()` for health-check). Verification step in U5 catches missing thoughts on intentionally failed test runs. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `memory/reference_mentisdb_ci_integration_pattern.md` after rollout to reflect the new "instrumented workflows" list (currently lists 2; will list 12 of 14). Defer the memory update to post-merge.
+- No runbook changes — failure modes are the same as before, just now also visible in MentisDB.
+- No monitoring changes — existing GitHub Actions failure notifications remain primary alert channel; MentisDB is supplementary.
+
+---
+
+## Sources & References
+
+- **Pattern doc (authoritative):** `memory/reference_mentisdb_ci_integration_pattern.md`
+- **Reference workflow:** `.github/workflows/observation-loop.yml`
+- **Reference smoketest:** `.github/workflows/mentisdb-smoketest.yml`
+- **Org secrets inventory:** `memory/reference_org_secrets_inventory.md`
+- **Auth gotcha:** `memory/feedback_mentisdb_no_rest_auth.md`
+- **Sister repo precedent:** `atvirokodosprendimai/wgmesh` PR #535 (instrumented release.yml, agent-metrics-report.yml, goose-build.yml)
+- **This repo's prior instrumentation PR:** `atvirokodosprendimai/ai-pipeline-template` PR #596 (observation-loop append)

--- a/docs/residual-review-findings/task-le-volume-and-review-batch.md
+++ b/docs/residual-review-findings/task-le-volume-and-review-batch.md
@@ -1,0 +1,93 @@
+# Residual Review Findings — task/le-volume-and-review-batch
+
+**Source:** ce-code-review autofix run `20260427-215340-5245a36d`
+**Branch HEAD at review:** `85563b3`
+**Plan:** [docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md](../plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md)
+**Verdict:** Ready with fixes — no blocking defects (all residuals P3)
+
+## Applied autofix (committed in `85563b3`)
+
+| File | Change | Reviewers |
+|------|--------|-----------|
+| `.github/workflows/spec-validation.yml` | success branch: `Correction/0.6` → `ActionTaken/0.5` | project-standards + maintainability (cross-reviewer corroboration) |
+
+Pattern doc reserves `Correction` for "successful auto-fix from review with refs/relations to a Mistake thought". Spec validation only labels (`approved-for-build` / `spec-needs-fix`) — it doesn't auto-fix anything. `ActionTaken` (imp 0.5) matches the pattern doc table for spec-validation outcomes.
+
+## Residual Actionable Work (downstream-resolver)
+
+### res-001 — agent_id↔tag verb-tense slip [P3 manual]
+
+**File:** `.github/workflows/spec-merged-build.yml`
+
+`agent_id="spec-merged-build"` (past participle, matches workflow filename) but `tag="spec-merge-build"` (gerund/noun — verb-tense slip). Reviewers flagged inconsistency.
+
+**Suggested:** Either rename tag to `spec-merged-build` (matches agent_id), or document the agent_id ≠ tag pattern in `memory/reference_mentisdb_ci_integration_pattern.md`. Plan's tagging guidance was "implementer chooses tags reflecting actual semantics" — judgment call about what the tag names.
+
+### res-002 — pre-existing pull_request_review App-actor silent miss [P3 manual]
+
+**File:** `.github/workflows/approve-build.yml`
+
+Per `docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md`, GitHub Apps authenticated via `GITHUB_TOKEN` cannot trigger `pull_request_review` workflow events. If Copilot reviews a spec PR, this workflow never fires — and now neither does its mentisdb thought. **Pre-existing trigger limitation, not a defect introduced by this diff.** Worth surfacing because it means the `spec-approval` chain entries will be sparse.
+
+**Suggested:** Either accept the gap (current state) or migrate `approve-build` to a different trigger (`workflow_run` on `spec-validation`, or manual `workflow_dispatch`).
+
+### res-004 — MENTISDB_URL trailing-slash normalization [P3 gated_auto]
+
+**Files:** all 10 instrumented workflows
+
+Correctness reviewer flagged: a trailing slash on the `MENTISDB_URL` secret would produce `mem.beerpub.dev//v1/thoughts`. Defensive normalization is one line per workflow.
+
+**Suggested:** In each step, before the curl call, add:
+```bash
+URL="${MENTISDB_URL%/}/v1/thoughts"
+```
+Then use `"$URL"` in the curl invocation.
+
+### res-005 — curl exit code in non-fatal warning [P3 manual]
+
+**Files:** all 10 instrumented workflows
+
+Correctness reviewer suggested making the warning more diagnostic. Current: `::warning::mentisdb append failed (non-fatal)`. Better surfaces the actual failure mode: auth (22), timeout (28), DNS (6), etc.
+
+**Suggested:** Replace `|| echo "::warning::mentisdb append failed (non-fatal)"` with `|| echo "::warning::mentisdb append failed (curl exit $?, non-fatal)"`.
+
+## Advisory (no downstream-resolver action; design decisions)
+
+### res-003 — Composite-action extraction threshold [P3 advisory]
+
+Maintainability flagged ~390 LOC duplication across 10 new + 2 existing workflows (3 inline shapes total). Plan explicitly deferred extraction in Open Questions / Resolved. Worth revisiting at next breaking MentisDB API change or 11th workflow.
+
+**If pursued:** Extract `.github/actions/mentis-thought/` composite action accepting `agent_id`, `thought_type_success`, `thought_type_failure`, `content_template`, `tags` as inputs. Update pattern doc to point at composite. Coordinate with sister repo (wgmesh) for parity.
+
+### res-006 — health-check has no positive heartbeat [P3 advisory]
+
+`health-check.yml` appends only on failure (`if: steps.health.outputs.down_count != '0'`). Absence of `Mistake` thought is the sole signal of "all up". Cannot distinguish "all endpoints healthy" from "MentisDB itself is down so we couldn't record anything". Trade-off explicitly accepted in plan to avoid 96 thoughts/day flooding the chain.
+
+**If pursued:** Emit a low-importance `Insight` thought on a longer cadence (once per day at first run, or on state-change recovery) so the chain has positive endpoint-health continuity.
+
+## Dropped Findings (validator rejection)
+
+- **ps-003** (project-standards): Claimed `set -euo pipefail` aborts the `ISSUE_NUM` extraction in `impl-merged-close.yml` before the `||` fallback runs. **Cross-reviewer rejection** by correctness, reliability, AND testing — `||` at subshell level catches pipeline failure correctly under pipefail. False positive.
+
+## Coverage Notes
+
+- Suppressed via mode-aware demotion (autofix): 3 testing findings (all category=testing_coverage, advisory P-low) → moved to testing_gaps below.
+- Untracked files excluded from review scope: `.compound-engineering/config.local.example.yaml`, `.compound-engineering/config.local.yaml`.
+- Failed reviewers: 0 / 8.
+
+## Testing Gaps (informational)
+
+- 10 new payload schemas (per-workflow content/tags/thought_type) not exercised by `mentisdb-smoketest.yml`
+- `health-check` gate has three implicit-behavior branches; failure path requires manual endpoint breakage to verify
+- `impl-merged-close` `ISSUE_NUM` regex couples to `Issue #N` PR-title convention; convention drift produces `issue=unknown` silently
+- Curl URL hardcodes `/v1/thoughts` POST in 10 places — MentisDB API v2 rollout would silently break every workflow with no CI signal
+- No CI gate runs `actionlint` on PRs touching `.github/workflows/`
+- U5 post-merge verification (per plan) is operator-driven; skipping a cluster lets payload regressions land silently
+
+## Plan Requirements Verification
+
+R1-R6 met by diff. R7 (operational verification via U5) intentionally deferred per plan to post-merge.
+
+---
+
+**Run artifact (full reviewer JSON + synthesized merge):** `/tmp/compound-engineering/ce-code-review/20260427-215340-5245a36d/`

--- a/docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md
+++ b/docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md
@@ -31,7 +31,9 @@ Bot inline comments were also blocking the merge logic (fixed in PR #51). Howeve
 
 ## Solution
 
-Removed the dependency on external review events. Workflows now **self-merge their own PRs** directly after validation, eliminating the need for a separate `pull_request_review`-triggered workflow entirely (PRs #55, #57).
+Removed the dependency on external review events. Workflows now **self-merge their own PRs** directly after validation, eliminating the need for a separate `pull_request_review`-triggered workflow entirely (PRs #55, #57). The dead `loop-automerge.yml` workflow file was deleted in PR #67.
+
+Current implementation: [`.github/workflows/heartbeat-pr-automerge.yml`](../../../.github/workflows/heartbeat-pr-automerge.yml) triggers on `pull_request: [opened, reopened, synchronize]`, validates `loop:`/`heal:` titled PRs against scope checks (same-repo, not a fork, allowed bot author, file allowlist), and merges directly. No external review event dependency.
 
 ## Prevention
 

--- a/docs/solutions/integration-issues/loop-pr-automerge-timing-race.md
+++ b/docs/solutions/integration-issues/loop-pr-automerge-timing-race.md
@@ -37,3 +37,12 @@ The workflow checks for blocking reviews and inline comments, then merges if cle
 
 - Prefer event-driven workflows over polling when GitHub provides webhook events for the condition you're waiting on.
 - `pull_request_review` event fires regardless of review latency — no timing assumptions needed.
+
+## Follow-up
+
+The `loop-automerge.yml` workflow shown above was later removed in PR #67 because GitHub Apps authenticating with `GITHUB_TOKEN` cannot trigger `pull_request_review` workflow events — the event-driven trigger never fired for Copilot reviews. See [github-app-reviews-dont-trigger-workflows.md](./github-app-reviews-dont-trigger-workflows.md). The current architecture uses `heartbeat-pr-automerge.yml`, which validates and self-merges `loop:`/`heal:` PRs on `pull_request: opened|reopened|synchronize` — no review dependency.
+
+## Related
+
+- [github-app-reviews-dont-trigger-workflows.md](./github-app-reviews-dont-trigger-workflows.md) — why the event-driven `loop-automerge.yml` solution was abandoned
+- [autonomous-review-merge-bootstrap.md](./autonomous-review-merge-bootstrap.md) — broader pipeline bootstrap context

--- a/infrastructure/terraform/mentisdb/README.md
+++ b/infrastructure/terraform/mentisdb/README.md
@@ -6,7 +6,8 @@ This OpenTofu module provisions the MentisDB production VPS on Hetzner, configur
 
 - Hetzner Cloud SSH key for deployment access
 - Hetzner Cloud firewall allowing SSH, HTTP, and HTTPS
-- Hetzner Cloud `mentisdb-prod` server with `cloud-init.sh.tpl` rendered as bash `user_data`
+- Hetzner Cloud Volume for durable MentisDB data and Let's Encrypt state
+- Hetzner Cloud `mentisdb-prod` server with the Volume attached at server creation and `cloud-init.sh.tpl` rendered as bash `user_data`
 - Cloudflare `mem.beerpub.dev` A record pointing at the server IPv4 address
 
 ## Required TF Variables
@@ -15,9 +16,12 @@ This OpenTofu module provisions the MentisDB production VPS on Hetzner, configur
 export TF_VAR_hcloud_token="your_hetzner_cloud_token"
 export TF_VAR_cloudflare_api_token="your_cloudflare_api_token"
 export TF_VAR_beerpub_cloudflare_zone_id="your_beerpub_zone_id_here"
+export TF_VAR_mentisdb_password="your_basic_auth_password"
 ```
 
-No SSH key is provisioned. MentisDB installation and service configuration run autonomously from cloud-init during first boot. For emergency access, use the Hetzner Cloud Console (web-based VNC) — no SSH credentials required.
+The MentisDB container image is controlled by `var.mentisdb_image`. The default is digest-pinned for reproducible server replacement. To upgrade, update the digest value rather than using a mutable tag.
+
+No SSH key is provisioned. Docker installation, image pull, service configuration, nginx, certbot, and firewall setup run autonomously from cloud-init during first boot. For emergency access, use the Hetzner Cloud Console (web-based VNC) - no SSH credentials required.
 
 ## State Backend
 
@@ -42,25 +46,41 @@ Run a single OpenTofu apply from this directory:
 tofu apply
 ```
 
-The `hcloud_server.mentisdb` resource renders `cloud-init.sh.tpl` into Hetzner `user_data`. On first boot, cloud-init installs packages, installs `mentisdbd`, writes the systemd unit and environment file, configures nginx, obtains the Let's Encrypt certificate, and enables the firewall.
+The `hcloud_server.mentisdb` resource attaches the Hetzner Volume during server creation and renders `cloud-init.sh.tpl` into Hetzner `user_data`. On first boot, cloud-init installs Docker and support packages, pulls `var.mentisdb_image`, writes a systemd unit around `docker run`, configures nginx, obtains or reuses the Let's Encrypt certificate, and enables the firewall.
+
+The container uses `/var/lib/mentisdb` for chain data through the Docker bind mount created by `docker run`.
+
+## Volume Layout
+
+The Hetzner Volume is mounted at `/srv/persistent` and bind-mounted into conventional paths:
+
+- `/srv/persistent/mentisdb` -> `/var/lib/mentisdb`
+- `/srv/persistent/letsencrypt` -> `/etc/letsencrypt`
+
+Both MentisDB chain data and Let's Encrypt certificates survive server replacement. The Volume has Hetzner `delete_protection = true` and Terraform `lifecycle.prevent_destroy` for defense in depth against accidental data loss.
 
 ## Auth
 
 The public HTTP API is protected by single-user HTTP Basic Auth at nginx. The username is `mentisdb`.
 
-Retrieve the generated password with:
-
-```bash
-tofu output -raw mentisdb_basic_auth_password
-```
-
-Rotate the password with:
-
-```bash
-tofu apply -replace=random_password.basic_auth
-```
+The password is supplied through `var.mentisdb_password`, normally from the `MENTISDB_PASSWORD` GitHub organization secret exposed to the Terraform deployment workflow as `TF_VAR_mentisdb_password`.
 
 The `/.well-known/acme-challenge/` path remains unauthenticated so certbot can renew Let's Encrypt certificates.
+
+## Operational Commands
+
+```bash
+# Bump mentisdb image
+docker buildx imagetools inspect ghcr.io/cloudllm-ai/mentisdb:<new-tag> | grep -i digest
+# Update var.mentisdb_image with the new ghcr.io/...@sha256:... value
+# Push to main, terraform-deploy fires, server replaces, cert + data reused.
+
+# Manually rotate password
+gh secret set MENTISDB_PASSWORD --org atvirokodosprendimai --visibility selected --repos ai-pipeline-template,wgmesh
+gh workflow run "Terraform Infrastructure Deployment" -R atvirokodosprendimai/ai-pipeline-template
+```
+
+Image upgrades are done by bumping `var.mentisdb_image` to a new digest, pushing to `main`, and letting the Terraform deployment replace the server. The persistent Volume is reused, so chain data and certificates remain in place.
 
 ## Debugging cloud-init
 
@@ -70,7 +90,11 @@ tail -f /var/log/cloud-init-output.log
 journalctl -u mentisdbd
 ```
 
-Re-running cloud-init requires recreating the server (`tofu apply -replace=hcloud_server.mentisdb`). For idempotent in-place changes (mentisdbd version bump etc.), SSH in and re-run the equivalent commands manually, then `tofu state rm` if the cloud-init drifts.
+Re-running cloud-init requires recreating the server:
+
+```bash
+tofu apply -replace=hcloud_server.mentisdb
+```
 
 ## Outputs
 
@@ -88,8 +112,8 @@ sequenceDiagram
     participant Cloudflare
 
     Operator->>OpenTofu: tofu apply
-    OpenTofu->>Hetzner: Create SSH key, firewall, server with cloud-init user_data
+    OpenTofu->>Hetzner: Create SSH key, firewall, Volume, server with cloud-init user_data
     OpenTofu->>Cloudflare: Create mem.beerpub.dev A record
-    Hetzner->>Hetzner: cloud-init installs and configures mentisdbd
+    Hetzner->>Hetzner: cloud-init mounts Volume, pulls Docker image, configures mentisdbd
     OpenTofu-->>Operator: Output server IP and SSH command
 ```

--- a/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
+++ b/infrastructure/terraform/mentisdb/cloud-init.sh.tpl
@@ -34,10 +34,12 @@ apt-get install -y \
   curl nginx certbot python3-certbot-nginx ufw \
   ca-certificates apache2-utils docker.io
 
-# --- 2. Persistent volume mount ---
-# Hetzner Volume ${volume_id} attached at server creation. Mount it at
-# $DATA_DIR before any data is written so mentisdb chain data survives
-# server replacement (tofu apply -replace=hcloud_server.mentisdb).
+# --- 2. Persistent volume mount + bind mounts ---
+# Hetzner Volume ${volume_id} attached at server creation (via
+# hcloud_server.volumes arg, no race window). Mount at /srv/persistent,
+# then bind-mount subdirectories to the conventional paths so both
+# mentisdb chain data AND Let's Encrypt certificates survive server
+# replacement.
 VOLUME_DEVICE="/dev/disk/by-id/scsi-0HC_Volume_${volume_id}"
 echo "Waiting for volume device $VOLUME_DEVICE to appear..."
 for _ in $(seq 1 60); do
@@ -48,20 +50,33 @@ if [ ! -e "$VOLUME_DEVICE" ]; then
   echo "ERROR: volume device $VOLUME_DEVICE never appeared after 60s" >&2
   exit 1
 fi
-mkdir -p "$DATA_DIR"
-# Mount idempotently: skip if already mounted (cloud-init re-runs are rare
-# but keep the script safe to re-execute manually for diagnostics).
+mkdir -p /srv/persistent
+if ! mountpoint -q /srv/persistent; then
+  mount "$VOLUME_DEVICE" /srv/persistent
+fi
+mkdir -p /srv/persistent/mentisdb /srv/persistent/letsencrypt
+mkdir -p "$DATA_DIR" /etc/letsencrypt
 if ! mountpoint -q "$DATA_DIR"; then
-  mount "$VOLUME_DEVICE" "$DATA_DIR"
+  mount --bind /srv/persistent/mentisdb "$DATA_DIR"
 fi
-# Persist mount via /etc/fstab (nofail so a missing volume doesn't
-# block boot; we'd rather have a degraded server we can SSH into than
-# an emergency-shell boot we can't reach).
+if ! mountpoint -q /etc/letsencrypt; then
+  mount --bind /srv/persistent/letsencrypt /etc/letsencrypt
+fi
+# Persist all three mounts in /etc/fstab. nofail on the volume so a
+# missing volume doesn't block boot; the bind mounts implicitly require
+# the parent mount to succeed first.
 if ! grep -q "$VOLUME_DEVICE" /etc/fstab; then
-  echo "$VOLUME_DEVICE  $DATA_DIR  ext4  discard,nofail,defaults  0  0" >> /etc/fstab
+  cat >> /etc/fstab <<FSTAB
+$VOLUME_DEVICE  /srv/persistent  ext4  discard,nofail,defaults  0  0
+/srv/persistent/mentisdb  $DATA_DIR  none  bind  0  0
+/srv/persistent/letsencrypt  /etc/letsencrypt  none  bind  0  0
+FSTAB
 fi
-# Container internally runs as uid 991; ensure host dir is writable by it.
-chown -R 991:991 "$DATA_DIR"
+# Ownership for the container's mentisdb user (uid 991). Non-recursive
+# on $DATA_DIR — we only need the mount root owned correctly; descending
+# the whole tree on every boot scales linearly with chain size and is
+# unnecessary because mentisdbd inherits ownership from its own writes.
+chown 991:991 "$DATA_DIR"
 chmod 0750 "$DATA_DIR"
 
 # --- 3. Pull mentisdbd image + systemd unit wrapping `docker run` ---
@@ -92,9 +107,17 @@ ExecStart=/usr/bin/docker run --rm --name mentisdbd -t \\
   -e MENTISDB_THOUGHT_SOUNDS=false \\
   -e RUST_LOG=info \\
   $IMAGE
-ExecStop=/usr/bin/docker stop mentisdbd
+ExecStop=-/usr/bin/docker stop mentisdbd
 Restart=on-failure
 RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+# /var/run/docker.sock needs to be writable for `docker` CLI to talk
+# to the daemon; /etc/docker is needed for daemon config; /var/lib/docker
+# is the daemon's state.
+ReadWritePaths=/var/run /var/lib/docker /etc/docker
 
 [Install]
 WantedBy=multi-user.target
@@ -144,7 +167,20 @@ nginx -t
 systemctl reload nginx
 
 # --- 5. Let's Encrypt + auto-renewal ---
-certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --email "$EMAIL" --redirect
+# Skip cert acquisition if cert already exists on the persistent
+# volume (post-server-replacement). certbot's reuse mode also handles
+# in-place runs by reusing existing valid certs without re-issuing, but
+# the explicit guard makes the intent clear and avoids a network
+# round-trip on every boot.
+if [ -f "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" ]; then
+  echo "Reusing existing Let's Encrypt cert at /etc/letsencrypt/live/$DOMAIN"
+  # nginx config still needs the SSL block; certbot's nginx installer
+  # can re-run against the existing cert without forcing re-issuance.
+  certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --email "$EMAIL" --redirect --keep-until-expiring
+else
+  echo "No existing cert - requesting from Let's Encrypt"
+  certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos --email "$EMAIL" --redirect
+fi
 ( crontab -l 2>/dev/null || true; echo "17 3 * * * /usr/bin/certbot renew --quiet" ) | crontab -
 
 # --- 6. ufw firewall ---

--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -84,8 +84,9 @@ resource "hcloud_server" "mentisdb" {
   location     = "hel1"
   ssh_keys     = [hcloud_ssh_key.deploy.id]
   firewall_ids = [hcloud_firewall.mentisdb.id]
-  # Attach the volume at server creation so it's available before
-  # cloud-init runs the docker mount logic.
+  volumes      = [hcloud_volume.mentisdb_data.id]
+  # The volume is attached in the server create request so it is
+  # available before cloud-init runs the docker mount logic.
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {
     domain_name         = var.domain_name
     letsencrypt_email   = var.letsencrypt_email
@@ -97,12 +98,6 @@ resource "hcloud_server" "mentisdb" {
     role = "mentisdb"
     env  = "prod"
   }
-}
-
-resource "hcloud_volume_attachment" "mentisdb_data" {
-  volume_id = hcloud_volume.mentisdb_data.id
-  server_id = hcloud_server.mentisdb.id
-  automount = false
 }
 
 resource "cloudflare_record" "mem_beerpub" {

--- a/infrastructure/terraform/mentisdb/variables.tf
+++ b/infrastructure/terraform/mentisdb/variables.tf
@@ -28,9 +28,10 @@ variable "letsencrypt_email" {
 }
 
 variable "mentisdb_image" {
-  description = "Container image (with tag) for mentisdbd. Defaults to a fork tag while CloudLLM-ai/mentisdb#16 is pending merge; switch to ghcr.io/cloudllm-ai/mentisdb:0.9.5 once that PR lands."
+  description = "Container image (digest-pinned) for mentisdbd. Defaults to a fork build while CloudLLM-ai/mentisdb#16 is pending merge. To upgrade, pull the desired tag, capture its digest via `docker buildx imagetools inspect ghcr.io/<owner>/mentisdb:<tag> | grep -i digest`, and update this default. The accompanying tag for human-readability is documented as a comment, not a variable."
   type        = string
-  default     = "ghcr.io/nycterent/mentisdb:0.9.5-test4"
+  # ghcr.io/nycterent/mentisdb:0.9.5-test4 — verified live 2026-04-27
+  default = "ghcr.io/nycterent/mentisdb@sha256:93133ad85c3eac1ceda2edf5a65f8b19d176049a25568e682cca003939519f51"
 }
 
 variable "mentisdb_volume_size_gb" {


### PR DESCRIPTION
## Summary

Three layered changes on this branch, all in service of MentisDB hardening + CI maturation:

1. **MentisDB CI instrumentation (10 workflows)** — every lifecycle workflow in `.github/workflows/` now appends a structured thought to MentisDB at `mem.beerpub.dev`, restoring agent-memory continuity for PR triage, spec validation, build dispatch, merge closure, self-heal, and endpoint health. Pattern documented in `memory/reference_mentisdb_ci_integration_pattern.md`.
2. **Hetzner Volume attachment refactor** — fold `hcloud_volume_attachment` into the server's `volumes` attribute so the data volume mounts before cloud-init runs (eliminates a race with the docker mount logic).
3. **PR-automerge solution-chain doc refresh** — `docs/solutions/integration-issues/{loop-pr-automerge-timing-race,github-app-reviews-dont-trigger-workflows}.md` now cross-link and note the deletion of `loop-automerge.yml` (replaced by `heartbeat-pr-automerge.yml`).

## Commits (oldest → newest)

| SHA | Message |
|-----|---------|
| `f88f9e5` | docs: refresh PR-automerge solution chain — note loop-automerge.yml removal |
| `69c267c` | feat: instrument 10 lifecycle workflows with MentisDB thought-append |
| `85563b3` | fix(review): apply autofix feedback (spec-validation Correction → ActionTaken) |
| `e773078` | docs(review): record residual review findings |
| `9ef21f7` | refactor(mentisdb): attach volume at server creation, fold attachment resource |

## Plan + Review

- **Plan:** [`docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md`](docs/plans/2026-04-27-001-feat-mentisdb-workflow-instrumentation-plan.md) (R1–R6 met by diff; R7 = post-merge operational verification per plan)
- **Code review:** ce-code-review autofix dispatched 8 reviewers (correctness, testing, maintainability, project-standards, agent-native, learnings, security, reliability). 0 blocking. Verdict: **Ready with fixes**. Detailed residuals in [`docs/residual-review-findings/task-le-volume-and-review-batch.md`](docs/residual-review-findings/task-le-volume-and-review-batch.md).

## Residual Review Findings

All P3, no blockers — full details in the residual-findings doc above. High level:

| ID | File | Action needed |
|----|------|---------------|
| res-001 | `spec-merged-build.yml` | agent_id↔tag verb-tense slip — rename or document |
| res-002 | `approve-build.yml` | Pre-existing: `pull_request_review` trigger silently misses Copilot reviews (per `docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md`) |
| res-003 | 12 workflows | Composite-action extraction threshold reached — deferred per plan |
| res-004 | 10 workflows | `MENTISDB_URL` trailing-slash normalization (gated_auto, multi-file) |
| res-005 | 10 workflows | Include curl exit code in `::warning::` for diagnostic distinction |
| res-006 | `health-check.yml` | No positive heartbeat for endpoint-health (design trade-off accepted) |

## Test Plan

- [x] `actionlint` clean on all 10 instrumented workflows
- [x] `python3 yaml.safe_load` parses cleanly for all 10
- [x] `set -euo pipefail + ||` correctness verified by 3 reviewers (correctness, reliability, testing) — false-positive ISSUE_NUM finding from project-standards reviewer dropped
- [x] `mentisdb-smoketest.yml` daily round-trip continues to validate auth + connectivity
- [ ] **Post-merge:** Manually `gh workflow run` one workflow per cluster (PR / spec / issue / self-heal) and confirm thoughts land via `/v1/search` against `chain_key=ai-pipeline-template` (per plan U5)
- [ ] **Post-merge:** Verify Hetzner Volume mount survives a server rebuild via terraform apply