### PR TITLE
fix(terraform): revert hcloud_server volumes arg — restore hcloud_volume_attachment

### DIFF
--- a/infrastructure/terraform/mentisdb/main.tf
+++ b/infrastructure/terraform/mentisdb/main.tf
@@ -84,9 +84,9 @@ resource "hcloud_server" "mentisdb" {
   location     = "hel1"
   ssh_keys     = [hcloud_ssh_key.deploy.id]
   firewall_ids = [hcloud_firewall.mentisdb.id]
-  volumes      = [hcloud_volume.mentisdb_data.id]
-  # The volume is attached in the server create request so it is
-  # available before cloud-init runs the docker mount logic.
+  # Volume attached via hcloud_volume_attachment below.
+  # `volumes` argument on hcloud_server is not supported by the
+  # hetznercloud/hcloud provider 1.x — see PR #610 + heal commit.
   user_data = templatefile("${path.module}/cloud-init.sh.tpl", {
     domain_name         = var.domain_name
     letsencrypt_email   = var.letsencrypt_email
@@ -98,6 +98,12 @@ resource "hcloud_server" "mentisdb" {
     role = "mentisdb"
     env  = "prod"
   }
+}
+
+resource "hcloud_volume_attachment" "mentisdb_data" {
+  volume_id = hcloud_volume.mentisdb_data.id
+  server_id = hcloud_server.mentisdb.id
+  automount = false
 }
 
 resource "cloudflare_record" "mem_beerpub" {


### PR DESCRIPTION
## Hot fix

PR #610 (commit 9ef21f7) refactored the mentisdb data-volume attachment from a separate \`hcloud_volume_attachment\` resource into the \`hcloud_server\` block via a \`volumes\` attribute. The \`hetznercloud/hcloud\` provider 1.x does **not** support that attribute, so \`tofu plan\` fails on main:

\`\`\`
Error: Unsupported argument
  on main.tf line 87, in resource \"hcloud_server\" \"mentisdb\":
  87:   volumes      = [hcloud_volume.mentisdb_data.id]
An argument named \"volumes\" is not expected here.
\`\`\`

## Fix

Restore the \`hcloud_volume_attachment\` resource and add an inline comment explaining the provider-version limitation.

## Production state

Plan never applied because the error was at plan stage. \`tfstate\` and the running mentisdb-prod server still match the pre-PR-610 layout (volume attached via the original attachment resource). No live infra change resulted from the broken commit.

## Detected via

\`gh run view 25017350383\` — Terraform Infrastructure Deployment failed on the merge of PR #610.

## Test plan

- [x] tofu fmt clean locally
- [ ] tofu plan succeeds in CI on this branch
- [ ] Post-merge: tofu apply on main succeeds (no diff vs current state expected)