### PR TITLE
chore(ci): pipeline-health PR creation via pupabobas App token

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -20,6 +20,7 @@ jobs:
       github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
       github.event.pull_request.user.login == 'Copilot' ||
       github.event.pull_request.user.login == 'goose[bot]' ||
+      github.event.pull_request.user.login == 'pupabobas[bot]' ||
       github.event.pull_request.user.login == 'nycterent' ||
       contains(github.event.pull_request.title, 'impl:')
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -28,10 +28,17 @@ jobs:
     name: Diagnose → Heal → Report
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       # ── Read current state ────────────────────────────────────
@@ -792,7 +799,7 @@ jobs:
       # ── Commit state via PR ───────────────────────────────────
       - name: Commit state via PR
         env:
-          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "pipeline-health[bot]"
           git config user.email "pipeline-health[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Switch `pipeline-health.yml` PR-creating steps from user PAT (`PUSH_TOKEN`, identity `nycterent`) to org GitHub App `pupabobas`
- Stops user auto-subscription + Copilot review email noise on the ~12-per-day automated heal PRs
- Add `pupabobas[bot]` to `bot-pr-review-merge.yml` author filter so auto-merge still fires

## Scope (deliberately narrow)

- `pipeline-health.yml`: insert `actions/create-github-app-token@v2` step; swap checkout token + `Commit state via PR` `GH_TOKEN`
- 8 cross-repo wgmesh API calls in same workflow keep `PUSH_TOKEN` (App lacks `issues:write`)
- Other 10 workflows using `PUSH_TOKEN` left untouched (none spam user)

## Prereqs (already done)

- Org variable `APP_ID = 2887137` (visibility ALL)
- Org secret `APP_PRIVATE_KEY` (visibility ALL)

## Test plan

- [ ] CI yaml lint passes on this PR
- [ ] Merge, then `gh workflow run pipeline-health.yml`
- [ ] Verify next `heal: pipeline health check` PR opens by `pupabobas[bot]`, not `nycterent`
- [ ] Verify `bot-pr-review-merge.yml` triggers + merges PR
- [ ] Confirm no email after next scheduled cron (every 2h)