### PR TITLE
fix(ci): strategy-audit jq parens + chimney singular pattern

### DIFF
--- a/.github/workflows/strategy-audit.yml
+++ b/.github/workflows/strategy-audit.yml
@@ -147,13 +147,15 @@ jobs:
           paid_customers="null"
           fetch_status="fetch_failed"
           if curl --fail-with-body --silent --show-error --max-time 15 "$CHIMNEY_URL" -o /tmp/chimney.html; then
-            line=$(grep -i -E 'Paid subscribers' /tmp/chimney.html | head -n 1 || true)
-            extracted=$(printf '%s\n' "$line" | grep -oE '[0-9][0-9,]*' | head -n 1 | tr -d ',' || true)
+            # chimney renders "Paid subscriber" (singular) in <div class="stage-metric">,
+            # with the integer count in the following <div class="stage-status">N</div>.
+            # -A 1 captures the next line so the digit lands in the same grep window.
+            extracted=$(grep -i -A 1 'Paid subscriber' /tmp/chimney.html | grep -oE '[0-9]+' | head -n 1 || true)
             if [ -n "$extracted" ]; then
               paid_customers="$extracted"
               fetch_status="ok"
             else
-              echo "::warning::could not extract Paid subscribers from chimney HTML"
+              echo "::warning::could not extract Paid subscriber count from chimney HTML"
             fi
           else
             echo "::warning::failed to fetch chimney dashboard"
@@ -181,7 +183,7 @@ jobs:
                 ((($delta * 1000) | round) / 10) as $pct |
                 ((if $pct < 0 then -$pct else $pct end) as $pct_abs |
                 (if ($direction == "drop" and $delta <= -$threshold) or ($direction == "grow" and $delta >= $threshold) then true else false end) as $drift |
-                {key:$key,label:$label,baseline:$baseline,current:$current,delta:$delta,pct_abs:$pct_abs,delta_display:(if $pct > 0 then "+" else "" end) + ($pct|tostring) + "%",verdict:(if $drift then "DRIFT" else "OK" end),drift:$drift}))
+                {key:$key,label:$label,baseline:$baseline,current:$current,delta:$delta,pct_abs:$pct_abs,delta_display:((if $pct > 0 then "+" else "" end) + ($pct|tostring) + "%"),verdict:(if $drift then "DRIFT" else "OK" end),drift:$drift}))
               end'
           }
           metric_row paid_customers "Paid customers" drop "$(jq -r '.metrics.paid_customers // null' <<< "$previous")" "$PAID_CUSTOMERS" > /tmp/rows.jsonl


### PR DESCRIPTION
## Summary

Two fixes for `strategy-audit.yml` caught on first scheduled dispatch (run [25282019324](https://github.com/atvirokodosprendimai/ai-pipeline-template/actions/runs/25282019324) failed at the U6 step):

1. **jq parse error in `metric_row()`** — value `(if … end) + ($pct|tostring) + "%"` inside an object literal parses up to the first `+` outside parens and breaks. Wrap the whole concatenation in parens.
2. **Chimney HTML scrape pattern** — was `Paid subscribers` (plural). Dashboard renders singular `Paid subscriber` inside `<div class="stage-metric">` with the count in the next sibling `<div class="stage-status">N</div>`. Switch to `grep -A 1` and extract first integer from the 2-line window.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML still parses.
- jq metric_row tested locally with `baseline=10 current=7 direction=drop threshold=0.25` → `{"delta":-0.3,"delta_display":"-30%","verdict":"DRIFT","drift":true}`.
- Chimney curl + new grep returns `0` (current paid subscriber count).

## Test plan

- [ ] Merge
- [ ] `gh workflow run strategy-audit.yml` — first seeded baseline run
- [ ] Confirm baseline-only PR opens (no drift, first ever entry)
- [ ] Confirm `bot-pr-review-merge.yml` auto-merges the baseline-only PR (no `needs-human` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)