### PR TITLE
fast(tempo): pull cadence forward — daily audit, 30min health, weekly milestones

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -2,7 +2,7 @@ name: Pipeline Health (Self-Healing)
 
 on:
   schedule:
-    - cron: '0 */2 * * *'   # every 2 hours
+    - cron: '*/30 * * * *'   # every 30 minutes
   workflow_dispatch:
     inputs:
       cutoff_override_minutes:

--- a/.github/workflows/strategy-audit.yml
+++ b/.github/workflows/strategy-audit.yml
@@ -2,7 +2,7 @@ name: Strategy Drift Audit
 
 on:
   schedule:
-    - cron: '0 9 1-7 * 1'
+    - cron: '0 9 * * *'
   workflow_dispatch:
     inputs:
       target_repo:
@@ -16,7 +16,7 @@ permissions:
   actions: read
 
 env:
-  DRIFT_THRESHOLD: '0.25'
+  DRIFT_THRESHOLD: '0.10'
   CHIMNEY_URL: 'https://chimney.beerpub.dev/'
 
 jobs:

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -24,6 +24,7 @@ Bet on actually converging autonomously from seed to shipped product, where auto
 - **Lead time spec → merge** — median hours from `needs-triage` issue to merged PR. Source: GitHub PR data. Leading.
 - **Self-heal resolution rate** — `actions_taken / (actions_taken + needs_human_closed)` — fraction healed without escalation. Source: `company/pipeline-health-state.json`. Leading.
 - **Active stuck issues** — open issues at `needs-human` or in retry cooldown >24h. Source: `gh issue list`. Leading.
+- **Cycle time to revenue** — median hours from first commit on a seed product → that seed's first paying customer event. Source: git log + Polar/Stripe webhook timestamps. Lagging — `null` until ≥1 customer exists. Tempo-anchor: target ≤72h.
 
 ## Tracks
 
@@ -47,11 +48,13 @@ _Why it serves the approach:_ converging on code without converging on revenue i
 
 ## Milestones
 
-- **2026-06-30** — wgmesh edge node beta (first seeded product reaches public beta)
-- **2026-08-01** — 1 paying customer (90-day target)
-- **2027-05-03** — 4 customers (Year 1)
-- **2028-05-03** — 42 customers, $10K ARR (Year 2)
-- **2029-05-03** — 420 customers, $100K ARR (Year 3, MSC)
+- **2026-05-10** — first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)
+- **2026-05-17** — wgmesh edge node beta (first seeded product reaches public beta)
+- **2026-05-31** — 1 paying customer
+- **2026-06-14** — 2nd seed product spec'd and entering convergence engine
+- **2026-08-31** — 4 customers ($10K ARR run-rate path)
+- **2027-05-03** — 42 customers, $10K ARR
+- **2028-05-03** — 420 customers, $100K ARR (MSC)
 
 ## Not working on
 


### PR DESCRIPTION
## Summary

Monthly feedback loop on a pre-revenue convergence pipeline = self-defeating. Five tempo changes:

1. **strategy-audit.yml cron** `0 9 1-7 * 1` → `0 9 * * *` (monthly → daily; 30x signal frequency)
2. **DRIFT_THRESHOLD** `0.25` → `0.10` (catch regressions before compounding)
3. **pipeline-health.yml cron** `0 */2 * * *` → `*/30 * * * *` (2hr → 30min operational signal)
4. **STRATEGY.md milestones** rewritten weekly/biweekly through $10K ARR
5. **STRATEGY.md adds Cycle-time-to-revenue metric** — median hours from first commit on seed → first paying customer. Tempo target ≤72h.

## Verification

- `python3 yaml.safe_load` — both workflow files parse OK
- pipeline-health quota math: 48 runs/day × ~1 min = 1440 min/month (free tier = 2000 min/month) ✓
- strategy-audit idempotency layer (PR title `audit: strategy <type> YYYY-MM`) already handles same-day re-fires by editing existing PR body, not creating duplicates

## Deferred to follow-up

Cycle-time-to-revenue metric (#5) is declared in STRATEGY.md but the audit workflow does not yet compute it — returns `null` with `fetch_status: no_customers` until Polar webhook integration lands. Tracked under PR #679 residual finding R3.

## Test plan

- [ ] Merge
- [ ] `gh workflow run strategy-audit.yml` — confirm daily cadence works (no idempotency dupe)
- [ ] Wait for next 30min slot — confirm pipeline-health.yml fires
- [ ] Inspect first audit PR with new 10% threshold — should still be no-drift on identical baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)