### PR TITLE
fix(ci): use pupabobas App token in bot-pr-review-merge to silence email spam

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -25,6 +25,13 @@ jobs:
       contains(github.event.pull_request.title, 'impl:')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout main (script lives on main, not PR branch)
         uses: actions/checkout@v4
         with:
@@ -32,7 +39,7 @@ jobs:
 
       - name: Autonomous PR review and merge
         env:
-          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APPROVED_AUTHORS: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## Problem

You still got an email after PR #675 fix:
- PR #693 opened by `app/pupabobas` ✓ (the #675 fix worked at the open layer)
- bot-pr-review-merge.yml triggered, Copilot reviewer timed out, posted escalation comment AS `nycterent` (because step uses `secrets.PUSH_TOKEN` PAT)
- comment authoring → auto-subscribed you to thread
- merge → "modified open/close state" email lands

Same root cause as #675, different file.

## Fix

Insert `actions/create-github-app-token@v2` step before checkout. Swap the script step's `GH_TOKEN` from `secrets.PUSH_TOKEN` to `steps.app-token.outputs.token`. 8-line diff.

App perms verified sufficient: contents:write + pull_requests:write are present on pupabobas (org-scoped since 2026-05-02 via PR #675).

## Out of scope

- The Copilot-review-timeout path itself (the script gives up after 360s and escalates). Tempo-relevant — see follow-up: shorten timeout or skip Copilot entirely on bot-authored PRs.
- Other workflows still on PUSH_TOKEN that don't author user-visible artifacts (terraform-deploy, observation-loop, copilot-undraft, etc.). They don't spam.

## Test plan

- [ ] Merge
- [ ] Wait for next pipeline-health PR (every 30 min now)
- [ ] Confirm any comment posted by bot-pr-review-merge.yml is authored by `pupabobas[bot]`, not `nycterent`
- [ ] Confirm no email lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)