### PR TITLE
fix(ci): normalize App author identifiers in run_guardrails author check

### DIFF
--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -239,10 +239,20 @@ run_guardrails() {
     return 1
   fi
 
+  # gh CLI returns "app/<slug>" for GitHub App authors, while workflow event
+  # payloads pass "<slug>[bot]". Normalize both forms to the bare slug so the
+  # author allowlist match works regardless of which surface produced the name.
+  normalize_login() {
+    local x="${1#app/}"
+    printf '%s' "${x%\[bot\]}"
+  }
+  local author_norm
+  author_norm=$(normalize_login "$author")
+
   local approved_found="false"
   IFS=',' read -ra approved_list <<< "$APPROVED_AUTHORS"
   for approved in "${approved_list[@]}"; do
-    if [[ "$author" == "$approved" ]]; then
+    if [[ "$(normalize_login "$approved")" == "$author_norm" ]]; then
       approved_found="true"
       break
     fi


### PR DESCRIPTION
## Problem

PR #705 (heal: pipeline health check) shipped today with escalation comment despite the auto-state-PR Copilot skip from PR #703:

> ## Escalated to Human Review
> **Reason:** Unknown author: app/pupabobas

The auto-state-PR skip worked (no Copilot timeout). But the next gate — `run_guardrails` author allowlist — flagged the same App as unknown.

## Root cause

Two surfaces report the App author differently:

| Surface | Value |
|---|---|
| Workflow event `github.event.pull_request.user.login` (passed as `APPROVED_AUTHORS` env var) | `pupabobas[bot]` |
| `gh pr view --jq '.author.login'` (read inside script) | `app/pupabobas` |

Exact-string `==` comparison failed → escalate → comment → email.

## Fix

`normalize_login()` strips leading `app/` and trailing `[bot]` from both sides before comparison.

| Input | Normalized |
|---|---|
| `app/pupabobas` | `pupabobas` |
| `pupabobas[bot]` | `pupabobas` |
| `pupabobas` | `pupabobas` |
| `copilot-swe-agent[bot]` | `copilot-swe-agent` |
| `app/copilot-swe-agent` | `copilot-swe-agent` |
| `nycterent` | `nycterent` (unchanged) |

Plain user logins pass through unchanged → manual-PR allowlist behavior unaffected.

## Test plan

- [ ] Merge
- [ ] Wait for next pipeline-health PR (within 30 min)
- [ ] Confirm no `## Escalated to Human Review` comment posted
- [ ] Confirm no `needs-human` label applied
- [ ] Confirm PR auto-merges within ~30s
- [ ] Confirm no email lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)