### PR TITLE
feat(observability): server-side PostHog instrumentation across pipeline

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -43,6 +43,8 @@ jobs:
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APPROVED_AUTHORS: ${{ github.event.pull_request.user.login }}
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: |
           bash company/scripts/pr-review-merge.sh
 
@@ -86,3 +88,21 @@ jobs:
             -X POST -H 'Content-Type: application/json' \
             -d "$PAYLOAD" "$URL" \
             || { code=$?; echo "::warning::mentisdb append failed (curl exit $code, non-fatal)"; }
+
+      - name: Emit bot_pr_merged to PostHog
+        if: always()
+        env:
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          OUTCOME: ${{ job.status }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PROPS=$(jq -nc \
+            --arg outcome "$OUTCOME" \
+            --arg pr "$PR_NUMBER" \
+            --arg author "$PR_AUTHOR" \
+            --arg title "$PR_TITLE" \
+            '{outcome: $outcome, pr_number: ($pr|tonumber), author: $author, title: $title}')
+          bash company/scripts/posthog-emit.sh bot_pr_merged "${PR_AUTHOR}" "$PROPS"

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -861,3 +861,22 @@ jobs:
             -X POST -H 'Content-Type: application/json' \
             -d "$PAYLOAD" "$URL" \
             || { code=$?; echo "::warning::mentisdb append failed (curl exit $code, non-fatal)"; }
+
+      - name: Emit pipeline_health_run to PostHog
+        if: always()
+        env:
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          OUTCOME: ${{ job.status }}
+        run: |
+          PROPS=$(jq -nc \
+            --arg outcome "$OUTCOME" \
+            --argjson actions "${ACTIONS_TAKEN:-0}" \
+            --argjson errors "${ERRORS:-0}" \
+            --argjson stale_triage "${STALE_TRIAGE_FOUND:-0}" \
+            --argjson stale_copilot "${STALE_COPILOT_FOUND:-0}" \
+            --argjson stale_approved "${STALE_APPROVED_FOUND:-0}" \
+            --argjson needs_human_closed "${NEEDS_HUMAN_CLOSED:-0}" \
+            --arg circuit_breaker "${CIRCUIT_BREAKER_TRIPPED:-false}" \
+            '{outcome: $outcome, actions_taken: $actions, errors: $errors, stale_triage: $stale_triage, stale_copilot: $stale_copilot, stale_approved: $stale_approved, needs_human_closed: $needs_human_closed, circuit_breaker_tripped: ($circuit_breaker == "true")}')
+          bash company/scripts/posthog-emit.sh pipeline_health_run "pipeline-health" "$PROPS"

--- a/.github/workflows/strategy-audit.yml
+++ b/.github/workflows/strategy-audit.yml
@@ -338,3 +338,22 @@ jobs:
             -X POST -H 'Content-Type: application/json' \
             -d "$PAYLOAD" "$URL" \
             || { code=$?; echo "::warning::mentisdb append failed (curl exit $code, non-fatal)"; }
+
+      - name: Emit strategy_audit_run to PostHog
+        if: always() && steps.skip-guard.outputs.skip != 'true'
+        env:
+          POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          OUTCOME: ${{ job.status }}
+          DRIFT_DETECTED: ${{ env.DRIFT_DETECTED || 'false' }}
+        run: |
+          PROPS=$(jq -nc \
+            --arg outcome "$OUTCOME" \
+            --arg drift "$DRIFT_DETECTED" \
+            --arg paid "${PAID_CUSTOMERS:-null}" \
+            --arg auto_ship "${AUTONOMOUS_SHIP_RATE:-null}" \
+            --arg lead "${LEAD_TIME_HOURS:-null}" \
+            --arg heal "${SELF_HEAL_RATE:-0}" \
+            --arg stuck "${ACTIVE_STUCK_ISSUES:-0}" \
+            '{outcome: $outcome, drift_detected: ($drift == "true"), paid_customers: $paid, autonomous_ship_rate: $auto_ship, lead_time_hours: $lead, self_heal_rate: $heal, active_stuck_issues: $stuck}')
+          bash company/scripts/posthog-emit.sh strategy_audit_run "strategy-audit" "$PROPS"

--- a/company/scripts/posthog-emit.sh
+++ b/company/scripts/posthog-emit.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Emit a single event to PostHog (server-side, write-only project key).
+# Non-fatal: failure prints ::warning:: and exits 0.
+#
+# Usage:
+#   posthog-emit.sh <event_name> [<distinct_id>] [<properties_json>]
+#
+# Env:
+#   POSTHOG_PROJECT_KEY  required; phc_... write-only project ingest key
+#   POSTHOG_HOST         optional; defaults to https://eu.i.posthog.com
+set -euo pipefail
+
+EVENT="${1:?event name required}"
+DISTINCT_ID="${2:-${GITHUB_REPOSITORY:-ai-pipeline-template}}"
+# Bash quirk: `${3:-{}}` corrupts a set value with an extra `}` because the
+# parser eats the inner `{}` as part of the default expression. Use explicit
+# branching so a passed JSON object stays intact.
+if [ "${3:-}" = "" ]; then
+  PROPS="{}"
+else
+  PROPS="$3"
+fi
+
+if [ -z "${POSTHOG_PROJECT_KEY:-}" ]; then
+  echo "::warning::POSTHOG_PROJECT_KEY unset, skipping event $EVENT"
+  exit 0
+fi
+
+# Inject standard properties: repo, run_id, run_url, workflow when available.
+# These match the GitHub Actions environment when invoked from a workflow step
+# and are harmlessly null when invoked from a local shell.
+STANDARD_PROPS=$(jq -nc \
+  --arg repo "${GITHUB_REPOSITORY:-}" \
+  --arg run_id "${GITHUB_RUN_ID:-}" \
+  --arg run_url "${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}" \
+  --arg workflow "${GITHUB_WORKFLOW:-}" \
+  --arg ref "${GITHUB_REF_NAME:-}" \
+  '{repo: $repo, run_id: $run_id, run_url: $run_url, workflow: $workflow, ref: $ref}')
+
+MERGED_PROPS=$(jq -nc --argjson std "$STANDARD_PROPS" --argjson custom "$PROPS" '$std + $custom')
+
+PAYLOAD=$(jq -nc \
+  --arg api_key "$POSTHOG_PROJECT_KEY" \
+  --arg event "$EVENT" \
+  --arg distinct_id "$DISTINCT_ID" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson props "$MERGED_PROPS" \
+  '{api_key: $api_key, event: $event, distinct_id: $distinct_id, timestamp: $ts, properties: $props}')
+
+URL="${POSTHOG_HOST:-https://eu.i.posthog.com}/i/v0/e/"
+
+curl --fail-with-body --silent --show-error --max-time 10 \
+  -X POST -H 'Content-Type: application/json' \
+  -d "$PAYLOAD" "$URL" \
+  >/dev/null \
+  || { code=$?; echo "::warning::posthog emit failed for event=$EVENT (curl exit $code, non-fatal)"; }

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -82,6 +82,18 @@ escalate() {
   fi
 
   log_audit "escalated" "$reason"
+
+  # Server-side PostHog event so escalation rate is queryable alongside
+  # bot_pr_merged. Non-fatal — the helper itself swallows curl failures.
+  if [ -x "${SCRIPT_DIR}/posthog-emit.sh" ]; then
+    local escalation_props
+    escalation_props=$(jq -nc \
+      --arg pr "$pr" \
+      --arg reason "$safe_reason" \
+      '{pr_number: ($pr|tonumber), reason: $reason}')
+    bash "${SCRIPT_DIR}/posthog-emit.sh" escalation_posted "pr-review-merge" "$escalation_props" || true
+  fi
+
   check_circuit_breaker
 }
 


### PR DESCRIPTION
## Summary

Wires the four pulse events declared by `ce-product-pulse` into existing workflows via direct HTTP `POST` to PostHog EU ingest. The wizard route was abandoned — it requires a `phx_` personal API key (we have `phc_` write-only project key) and JS-only integrations (we have GitHub Actions + bash).

## Pattern

New helper: `company/scripts/posthog-emit.sh`. Builds payload with standard props (repo, run_id, run_url, workflow, ref) merged with caller-supplied custom props, POSTs to `${POSTHOG_HOST}/i/v0/e/`, swallows curl failures with `::warning::` (non-fatal, mirrors the MentisDB append pattern).

Bash quirk caught + fixed: `${3:-{}}` corrupts a set value with an extra `}` because the parser eats the inner `{}` as part of the default. Use explicit if/else.

## Wired emits

| Event | Where | Props |
|---|---|---|
| `bot_pr_merged` | bot-pr-review-merge.yml end | outcome, pr_number, author, title |
| `escalation_posted` | pr-review-merge.sh escalate() | reason, pr_number |
| `pipeline_health_run` | pipeline-health.yml end | outcome, actions_taken, errors, stale counts, needs_human_closed, circuit_breaker_tripped |
| `strategy_audit_run` | strategy-audit.yml end | outcome, drift_detected, all 5 strategy metrics |

## Verification

- `python3 yaml.safe_load` clean across 3 workflows
- `bash -n` clean for both scripts
- Live emit smoke test against EU ingest: both with and without custom props arg returned 200 OK

## Out of scope

- `bot_pr_opened` event at PR-creation moment (lower value than merged)
- Polar payments integration to populate `cycle_time_to_revenue`
- PostHog dashboard / saved insights creation (UI work)

## Notes

`POSTHOG_PROJECT_KEY` repo secret + `POSTHOG_HOST` repo variable already provisioned (`https://eu.i.posthog.com`). Workflows reference `secrets.POSTHOG_PROJECT_KEY` + `vars.POSTHOG_HOST`.

Per the security memo earlier in this session, the leaked key in conversation context is a `phc_` write-only project key (designed for client-side embed). Practical attack surface = event spoofing, not data theft. User chose to integrate first and rotate after; rotation still pending.

## Test plan

- [ ] Merge
- [ ] Wait for next pipeline-health PR (within 30 min)
- [ ] Verify `bot_pr_merged` event appears in PostHog EU project
- [ ] Verify `pipeline_health_run` event appears with non-zero `actions_taken` if any healing happened
- [ ] Run `gh workflow run strategy-audit.yml` to test `strategy_audit_run` emit on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)