### PR TITLE
fix(observability): restore posthog-emit.sh from main before invoking

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -869,6 +869,11 @@ jobs:
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
           OUTCOME: ${{ job.status }}
         run: |
+          # The "Commit state via PR" step earlier switched to a
+          # pipeline-health/<date>-<run-id> branch which predates this
+          # helper script. Path-restricted checkout pulls just the helper
+          # from main without changing branch state.
+          git checkout main -- company/scripts/posthog-emit.sh 2>/dev/null || true
           PROPS=$(jq -nc \
             --arg outcome "$OUTCOME" \
             --argjson actions "${ACTIONS_TAKEN:-0}" \

--- a/.github/workflows/strategy-audit.yml
+++ b/.github/workflows/strategy-audit.yml
@@ -347,6 +347,13 @@ jobs:
           OUTCOME: ${{ job.status }}
           DRIFT_DETECTED: ${{ env.DRIFT_DETECTED || 'false' }}
         run: |
+          # Earlier steps switched the working tree to an audit branch
+          # (audit/strategy-baseline-* or audit/strategy-drift-*) which
+          # may predate this script. Path-restricted checkout copies just
+          # the helper from main into the current tree without changing
+          # branch state. `|| true` for older runs where main wasn't
+          # fetched (fetch-depth: 0 makes that unlikely but harmless).
+          git checkout main -- company/scripts/posthog-emit.sh 2>/dev/null || true
           PROPS=$(jq -nc \
             --arg outcome "$OUTCOME" \
             --arg drift "$DRIFT_DETECTED" \


### PR DESCRIPTION
## Bug

PR #712 wired posthog-emit.sh into pipeline-health.yml and strategy-audit.yml. Both workflows switch the working tree to a non-main branch BEFORE the emit step runs:

- pipeline-health.yml → `pipeline-health/<date>-<run-id>` (in "Commit state via PR" step)
- strategy-audit.yml → `audit/strategy-baseline-<date>` or `audit/strategy-drift-<date>` (in "Detect drift, build audit body, manage PR" step)

Those branches predate this commit, so the script doesn't exist on their tree. First run after #712:

```
bash: company/scripts/posthog-emit.sh: No such file or directory
Process completed with exit code 127
```

(run #25338513934)

## Fix

`git checkout main -- company/scripts/posthog-emit.sh 2>/dev/null || true` at the start of each emit step. Path-restricted checkout copies just the helper from main into the current tree without changing branch state. Earlier steps already finished their commits/pushes, so the working tree is otherwise idle — additive checkout is safe.

bot-pr-review-merge.yml is unaffected; its emit step runs on main (no branch switch in that workflow).

## Test plan

- [ ] Merge
- [ ] `gh workflow run strategy-audit.yml` — verify Emit step exits 0 and `strategy_audit_run` event lands in PostHog EU
- [ ] Wait for next pipeline-health cron — verify `pipeline_health_run` event lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)