### PR TITLE
fix(ci): bot-pr-review-merge author normalization + accept drafts

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -60,7 +60,12 @@ jobs:
         run: |
           set -uo pipefail
 
-          ALLOWED_AUTHORS='["copilot-swe-agent[bot]","Copilot","goose[bot]","pupabobas[bot]","nycterent"]'
+          # Accept both `gh pr list` form (`app/copilot-swe-agent`) AND
+          # `pull_request` event form (`copilot-swe-agent[bot]`). Per
+          # feedback_app_author_identifier_inconsistency.md — same App
+          # surfaces under different identifiers depending on the GitHub
+          # surface; matching exactly one form misses the rest.
+          ALLOWED_AUTHORS='["copilot-swe-agent[bot]","app/copilot-swe-agent","Copilot","goose[bot]","app/goose","pupabobas[bot]","app/pupabobas","nycterent"]'
 
           PRS=$(gh pr list --repo "$TARGET_REPO" \
                   --state open \
@@ -68,15 +73,17 @@ jobs:
                   --json number,title,author,labels,isDraft \
                   --limit 50)
 
+          # Drafts are accepted — Copilot opens spec PRs as drafts, and
+          # Spec Validation has already labeled them `approved-for-build`
+          # by the time we see them. We undraft inline before review.
           ELIGIBLE=$(echo "$PRS" | jq -c --argjson allowed "$ALLOWED_AUTHORS" '
             [ .[]
-              | select(.isDraft | not)
               | select(([.labels[].name] | index("needs-human")) == null)
               | select(
                   ($allowed | index(.author.login)) != null
                   or (.title | startswith("impl:"))
                 )
-              | {number, title, author: (.author.login)}
+              | {number, title, author: (.author.login), isDraft}
             ]')
 
           COUNT=$(echo "$ELIGIBLE" | jq 'length')
@@ -94,10 +101,33 @@ jobs:
             PR_NUMBER=$(echo "$pr_json" | jq -r '.number')
             PR_AUTHOR=$(echo "$pr_json" | jq -r '.author')
             PR_TITLE=$(echo "$pr_json" | jq -r '.title')
-            export PR_NUMBER PR_AUTHOR PR_TITLE
-            export APPROVED_AUTHORS="$PR_AUTHOR"
+            PR_DRAFT=$(echo "$pr_json" | jq -r '.isDraft')
 
-            echo "::group::PR #$PR_NUMBER ($PR_AUTHOR): $PR_TITLE"
+            # Normalize APPROVED_AUTHORS for downstream pr-review-merge.sh:
+            # the script expects the "[bot]" form so its internal allowlist
+            # checks match. If we got the `app/<name>` form from `gh pr list`,
+            # convert to `<name>[bot]`.
+            case "$PR_AUTHOR" in
+              app/*)
+                NORM_AUTHOR="${PR_AUTHOR#app/}[bot]"
+                ;;
+              *)
+                NORM_AUTHOR="$PR_AUTHOR"
+                ;;
+            esac
+
+            export PR_NUMBER PR_AUTHOR PR_TITLE
+            export APPROVED_AUTHORS="$NORM_AUTHOR"
+
+            echo "::group::PR #$PR_NUMBER ($PR_AUTHOR → $NORM_AUTHOR): $PR_TITLE"
+
+            # Undraft inline if needed. `gh pr ready` is idempotent on
+            # already-ready PRs but errors there are non-fatal.
+            if [ "$PR_DRAFT" = "true" ]; then
+              echo "PR is draft, marking ready for review..."
+              gh pr ready "$PR_NUMBER" --repo "$TARGET_REPO" \
+                || echo "::warning::gh pr ready failed for PR #$PR_NUMBER (non-fatal, attempting review-merge anyway)"
+            fi
 
             (
               bash company/scripts/pr-review-merge.sh


### PR DESCRIPTION
## Summary

Follow-up to #757. The first scheduled run of `Bot PR Review and Merge` logged `eligible PRs: 0` while 6 spec PRs sat with `approved-for-build`. Two filter bugs:

1. **Author mismatch.** `gh pr list --json author.login` returns `app/copilot-swe-agent` for App-authored PRs, not `copilot-swe-agent[bot]` (which is the form `pull_request` events emit). My allowlist had only the latter. Same identifier-inconsistency shape as wgmesh #683.

2. **Drafts excluded.** Copilot opens spec PRs as drafts. The separate `Auto-undraft Copilot PRs` workflow is supposed to undraft them but has the same `pull_request: opened` gate problem #757 fixed for review-merge — never runs for outside-collaborator PRs. The 6 specs sat as drafts for 11h.

## Changes

- Allowlist accepts both `<name>[bot]` and `app/<name>` forms for copilot-swe-agent, goose, pupabobas.
- Removed `select(.isDraft | not)` filter — drafts now eligible.
- Per-PR loop normalizes `APPROVED_AUTHORS` env var to `[bot]` form so `pr-review-merge.sh`'s internal allowlist matches.
- New step in loop: `gh pr ready $PR_NUMBER` before review-merge. Errors non-fatal.

This makes `Bot PR Review and Merge` self-contained: it can pick up draft Copilot PRs, undraft, review, merge — without depending on the broken `copilot-undraft.yml`.

## Test plan

- [ ] After merge, manually run `gh workflow run bot-pr-review-merge.yml`.
- [ ] Verify `eligible PRs: 6` (or however many `approved-for-build` PRs exist).
- [ ] Verify each PR is undrafted then merged.
- [ ] Verify per-PR PostHog `bot_pr_merged` events fire.

## Related

- #757 — the schedule-trigger conversion this fixes the filter for.
- Memory: `feedback_app_author_identifier_inconsistency.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)