### PR TITLE
fix(ci): bot-pr-review-merge jq scoping for author allowlist match

### DIFF
--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -80,8 +80,7 @@ jobs:
           # `$allowed | index(.author.login)` looks intuitive but jq evaluates
           # `.author.login` against the piped-in value (the $allowed array
           # itself), not the outer PR object — fails with
-          # `Cannot index array with string "author"`. Same kind of scoping
-          # gotcha as feedback_jq_object_literal_concat_parens.md.
+          # `Cannot index array with string "author"`.
           ELIGIBLE=$(echo "$PRS" | jq -c --argjson allowed "$ALLOWED_AUTHORS" '
             [ .[]
               | .author.login as $login

--- a/.github/workflows/bot-pr-review-merge.yml
+++ b/.github/workflows/bot-pr-review-merge.yml
@@ -76,14 +76,21 @@ jobs:
           # Drafts are accepted — Copilot opens spec PRs as drafts, and
           # Spec Validation has already labeled them `approved-for-build`
           # by the time we see them. We undraft inline before review.
+          # NOTE: bind .author.login as $login BEFORE piping into $allowed.
+          # `$allowed | index(.author.login)` looks intuitive but jq evaluates
+          # `.author.login` against the piped-in value (the $allowed array
+          # itself), not the outer PR object — fails with
+          # `Cannot index array with string "author"`. Same kind of scoping
+          # gotcha as feedback_jq_object_literal_concat_parens.md.
           ELIGIBLE=$(echo "$PRS" | jq -c --argjson allowed "$ALLOWED_AUTHORS" '
             [ .[]
+              | .author.login as $login
               | select(([.labels[].name] | index("needs-human")) == null)
               | select(
-                  ($allowed | index(.author.login)) != null
+                  ($allowed | index($login)) != null
                   or (.title | startswith("impl:"))
                 )
-              | {number, title, author: (.author.login), isDraft}
+              | {number, title, author: $login, isDraft}
             ]')
 
           COUNT=$(echo "$ELIGIBLE" | jq 'length')


### PR DESCRIPTION
## Summary

Third fix-forward on `bot-pr-review-merge.yml` (after #757 schedule conversion + #761 author normalization). The allowlist filter was syntactically valid jq but semantically wrong:

```jq
$allowed | index(.author.login)   # WRONG
```

jq evaluates `.author.login` against the value piped in (the `$allowed` array, not the outer PR object) and errors:

```
jq: error (at <stdin>:1): Cannot index array with string "author"
```

Run #25458243241 (post-#761 manual dispatch) failed with this exact error. The 6 spec PRs sat for 13h.

## Fix

Bind `.author.login` as a variable before the pipe:

```jq
.author.login as $login
| select(($allowed | index($login)) != null)
```

Tested locally against the actual `gh pr list` output — returns `[750,749,747,744,743,741]` (correct 6 spec PRs).

Added inline comment explaining the scoping gotcha so the next reader doesn't reintroduce it.

## Test plan

- [ ] After merge, `gh workflow run bot-pr-review-merge.yml`.
- [ ] Run logs `eligible PRs: 6`.
- [ ] Each PR is undrafted then merged.

## Related

- #757 (schedule trigger), #761 (author/draft handling)
- Memory: `feedback_jq_object_literal_concat_parens.md` (sibling jq scoping pitfall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)