### PR TITLE
fix(ci): heartbeat auto-merge — add audit fast-lane, retry on merge race

### DIFF
--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -182,7 +182,7 @@ jobs:
               sleep "$backoff"
               continue
             fi
-            echo "::error::gh pr merge failed with non-retryable error: $out"
+            echo "::error::gh pr merge failed with non-retryable error (full output above)"
             exit 1
           done
           echo "::error::gh pr merge exhausted $max_attempts attempts"

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -176,6 +176,10 @@ jobs:
               exit 0
             fi
             echo "$out"
+            if echo "$out" | grep -qiE "already merged|already closed|pull request is closed|state.*merged"; then
+              echo "::notice::PR #$PR_NUMBER is already merged/closed by another run; treating as success."
+              exit 0
+            fi
             if echo "$out" | grep -qiE "Merge already in progress|merge_in_progress|Pull Request is in unstable status|Base branch was modified"; then
               backoff=$((attempts * 10))
               echo "::notice::Transient merge race on attempt $attempts; retrying in ${backoff}s"

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -181,6 +181,10 @@ jobs:
               exit 0
             fi
             if echo "$out" | grep -qiE "Merge already in progress|merge_in_progress|Pull Request is in unstable status|Base branch was modified"; then
+              if [ "$attempts" -ge "$max_attempts" ]; then
+                echo "::notice::Transient merge race on attempt $attempts; no retries remain — falling through to exhaustion"
+                continue
+              fi
               backoff=$((attempts * 10))
               echo "::notice::Transient merge race on attempt $attempts; retrying in ${backoff}s"
               sleep "$backoff"

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -16,8 +16,10 @@ concurrency:
 jobs:
   validate-and-merge:
     if: >-
-      startsWith(github.event.pull_request.title, 'loop: ') ||
-      startsWith(github.event.pull_request.title, 'heal: ')
+      (startsWith(github.event.pull_request.title, 'loop: ') ||
+       startsWith(github.event.pull_request.title, 'heal: ') ||
+       startsWith(github.event.pull_request.title, 'audit: ')) &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-human')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
@@ -76,6 +78,9 @@ jobs:
             heal:*)
               expected_branch='^pipeline-health/'
               ;;
+            audit:*)
+              expected_branch='^audit/strategy-(baseline|drift)-'
+              ;;
             *)
               echo "::error::PR title does not match heartbeat prefixes: $PR_TITLE"
               exit 1
@@ -89,7 +94,7 @@ jobs:
 
           for path in "${changed_files[@]}"; do
             case "$path" in
-              company/loop-state.json|company/pipeline-health-state.json|company/audit-log.jsonl)
+              company/loop-state.json|company/pipeline-health-state.json|company/audit-log.jsonl|company/strategy-audit-baseline.json)
                 ;;
               company/loop-history/*.md)
                 ;;
@@ -121,7 +126,7 @@ jobs:
 
           for path in "${changed_files[@]}"; do
             case "$path" in
-              company/loop-state.json|company/pipeline-health-state.json)
+              company/loop-state.json|company/pipeline-health-state.json|company/strategy-audit-baseline.json)
                 jq empty "$path"
                 ;;
               company/audit-log.jsonl)
@@ -155,14 +160,33 @@ jobs:
             fi
           done
 
-      - name: Merge heartbeat PR (admin bypass)
+      - name: Merge heartbeat PR (admin bypass, retry on race)
         env:
           GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
           TARGET_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" --squash --delete-branch --admin
+          attempts=0
+          max_attempts=5
+          while [ "$attempts" -lt "$max_attempts" ]; do
+            attempts=$((attempts + 1))
+            if out=$(gh pr merge "$PR_NUMBER" --repo "$TARGET_REPO" --squash --delete-branch --admin 2>&1); then
+              echo "Merged PR #$PR_NUMBER on attempt $attempts"
+              exit 0
+            fi
+            echo "$out"
+            if echo "$out" | grep -qiE "Merge already in progress|merge_in_progress|Pull Request is in unstable status|Base branch was modified"; then
+              backoff=$((attempts * 10))
+              echo "::notice::Transient merge race on attempt $attempts; retrying in ${backoff}s"
+              sleep "$backoff"
+              continue
+            fi
+            echo "::error::gh pr merge failed with non-retryable error: $out"
+            exit 1
+          done
+          echo "::error::gh pr merge exhausted $max_attempts attempts"
+          exit 1
 
       - name: Comment on validation failure
         if: failure()

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   validate-and-merge:
     if: >-
-      (startsWith(github.event.pull_request.title, 'loop: ') ||
-       startsWith(github.event.pull_request.title, 'heal: ') ||
-       startsWith(github.event.pull_request.title, 'audit: strategy baseline')) &&
-      !contains(github.event.pull_request.labels.*.name, 'needs-human')
+      startsWith(github.event.pull_request.title, 'loop: ') ||
+      startsWith(github.event.pull_request.title, 'heal: ') ||
+      (startsWith(github.event.pull_request.title, 'audit: strategy baseline') &&
+       !contains(github.event.pull_request.labels.*.name, 'needs-human'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -18,7 +18,7 @@ jobs:
     if: >-
       (startsWith(github.event.pull_request.title, 'loop: ') ||
        startsWith(github.event.pull_request.title, 'heal: ') ||
-       startsWith(github.event.pull_request.title, 'audit: ')) &&
+       startsWith(github.event.pull_request.title, 'audit: strategy baseline')) &&
       !contains(github.event.pull_request.labels.*.name, 'needs-human')
     runs-on: ubuntu-latest
     steps:
@@ -78,8 +78,8 @@ jobs:
             heal:*)
               expected_branch='^pipeline-health/'
               ;;
-            audit:*)
-              expected_branch='^audit/strategy-(baseline|drift)-'
+            'audit: strategy baseline'*)
+              expected_branch='^audit/strategy-baseline-'
               ;;
             *)
               echo "::error::PR title does not match heartbeat prefixes: $PR_TITLE"


### PR DESCRIPTION
## Summary

- Add `audit:` prefix to heartbeat auto-merge fast-lane; explicitly gate on `!needs-human` so drift-detected audit PRs stay human-gated
- Extend title→branch case and file whitelist to cover `company/strategy-audit-baseline.json`
- Wrap `gh pr merge` in a retry loop (5 attempts, linear backoff) matching the four known transient GraphQL race errors

## Background

Two production bugs surfaced via pulse 2026-05-08:

1. **Audit PRs unsupported.** `audit:` strategy-baseline PRs (no-drift) fall through to the default `REVIEW_REQUIRED` gate because the workflow `if:` only matched `loop:` and `heal:`. PRs #790, #774, #754, #704 stuck indefinitely.

2. **Merge race.** `gh pr merge --admin` has no retry. When a parallel run holds the GraphQL serialization lock, the call exits 1 and the `Comment on validation failure` step slaps `needs-human`. PRs #647 (7d), #715 (3d), #758 (1d) all failed this way after passing all validation.

**Constraint preserved:** `audit:` PRs that have the `needs-human` label (drift detected, set by `strategy-audit.yml`) continue to skip auto-merge and stay human-gated.

## Test plan

- [ ] Confirm `yamllint` / `actionlint` passes on the edited file (CI)
- [ ] Wait for next `heal:` cron — verify auto-merge succeeds on first or retry attempt
- [ ] Confirm today's `audit:` PR #790 auto-merges once this workflow lands on main
- [ ] Confirm a drift-detected `audit:` PR (with `needs-human`) is NOT auto-merged
