### PR TITLE
fix(ci): polar-discovery — diagnostic mode without -f flag

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -42,7 +42,7 @@ jobs:
             atvirokodosprendimai/lighthouse-go
             atvirokodosprendimai/chimney
             atvirokodosprendimai/coroot-cicd
-            atvirokodosprendimai/creu
+            atvirokodosprendimai/cloudroof-eu
             atvirokodosprendimai/dns-server
             atvirokodosprendimai/tvcentras
             atvirokodosprendimai/homebrew-tap

--- a/.github/workflows/polar-discovery.yml
+++ b/.github/workflows/polar-discovery.yml
@@ -24,7 +24,7 @@ jobs:
           POLAR_TOKEN: ${{ secrets.POLAR_TOKEN }}
           POLAR_ORG: atvirokodosprendimai
         run: |
-          set -euo pipefail
+          set -uo pipefail
           if [ -z "$POLAR_TOKEN" ]; then
             echo "::error::POLAR_TOKEN not configured"
             exit 1
@@ -32,9 +32,35 @@ jobs:
           API="https://api.polar.sh"
           AUTH="Authorization: Bearer $POLAR_TOKEN"
 
-          # 1. Resolve org id
-          org=$(curl -sf -H "$AUTH" -H "Accept: application/json" \
-            "$API/v1/organizations/?slug=$POLAR_ORG")
+          # Token-validity probe: /v1/users/me — should always 200 if token is valid.
+          echo "==== /v1/users/me (token-validity probe) ===="
+          curl -s -o /tmp/me.json -w "HTTP %{http_code}\n" -H "$AUTH" -H "Accept: application/json" "$API/v1/users/me"
+          jq '. | {email, id, accepted_terms_of_service}' /tmp/me.json 2>/dev/null || cat /tmp/me.json
+
+          echo ""
+          echo "==== /v1/organizations/ (orgs visible to token) ===="
+          curl -s -o /tmp/orgs.json -w "HTTP %{http_code}\n" -H "$AUTH" -H "Accept: application/json" "$API/v1/organizations/?limit=20"
+          jq '.items // . | map({id, slug, name, profile_settings: (.profile_settings // {})}) // .' /tmp/orgs.json 2>/dev/null || cat /tmp/orgs.json
+
+          echo ""
+          echo "==== /v1/organizations/?slug=$POLAR_ORG (org by slug) ===="
+          curl -s -o /tmp/org.json -w "HTTP %{http_code}\n" -H "$AUTH" -H "Accept: application/json" "$API/v1/organizations/?slug=$POLAR_ORG"
+          jq '.' /tmp/org.json 2>/dev/null || cat /tmp/org.json
+
+          # If we got an org id from any of the above, use it for products
+          org_id=$(jq -r '.items[0].id // empty' /tmp/orgs.json 2>/dev/null)
+          if [ -z "$org_id" ]; then
+            org_id=$(jq -r '.items[0].id // empty' /tmp/org.json 2>/dev/null)
+          fi
+          if [ -z "$org_id" ]; then
+            echo "::warning::No org id resolved; products step skipped."
+            exit 0
+          fi
+          echo ""
+          echo "Resolved org_id: $org_id"
+
+          # 1. Resolve org id (kept for parity with original; just use $org_id we already found)
+          org="$(cat /tmp/org.json)"
           org_id=$(echo "$org" | jq -r '.items[0].id // empty')
           org_slug=$(echo "$org" | jq -r '.items[0].slug // empty')
           org_pub=$(echo "$org" | jq -r '.items[0].profile_settings // {}')

--- a/.github/workflows/polar-discovery.yml
+++ b/.github/workflows/polar-discovery.yml
@@ -1,0 +1,99 @@
+name: Polar Discovery (one-shot)
+
+# One-shot diagnostic: lists Polar org products + each product's prices and
+# any public/checkout URL fields. Used 2026-05-08 to discover correct public
+# checkout URL pattern after `polar.sh/checkout?productId=<uuid>` and
+# `polar.sh/<org>` were both returning 404.
+#
+# Trigger: workflow_dispatch only. No schedule.
+# Output: full product JSON in workflow log + a sanitized summary in the
+# job summary so checkout URLs are easy to copy without secrets leaking.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect Polar org + products
+        env:
+          POLAR_TOKEN: ${{ secrets.POLAR_TOKEN }}
+          POLAR_ORG: atvirokodosprendimai
+        run: |
+          set -euo pipefail
+          if [ -z "$POLAR_TOKEN" ]; then
+            echo "::error::POLAR_TOKEN not configured"
+            exit 1
+          fi
+          API="https://api.polar.sh"
+          AUTH="Authorization: Bearer $POLAR_TOKEN"
+
+          # 1. Resolve org id
+          org=$(curl -sf -H "$AUTH" -H "Accept: application/json" \
+            "$API/v1/organizations/?slug=$POLAR_ORG")
+          org_id=$(echo "$org" | jq -r '.items[0].id // empty')
+          org_slug=$(echo "$org" | jq -r '.items[0].slug // empty')
+          org_pub=$(echo "$org" | jq -r '.items[0].profile_settings // {}')
+          if [ -z "$org_id" ]; then
+            echo "::error::Could not resolve org slug $POLAR_ORG"
+            echo "Org payload:"; echo "$org" | jq '.'
+            exit 1
+          fi
+          echo "Org id: $org_id"
+          echo "Org slug: $org_slug"
+          echo "Org profile settings: $org_pub"
+
+          # 2. List products (include archived for completeness, then filter)
+          prods=$(curl -sf -H "$AUTH" -H "Accept: application/json" \
+            "$API/v1/products/?organization_id=$org_id&limit=50")
+          n=$(echo "$prods" | jq '.items | length')
+          echo "Product count: $n"
+          echo "$prods" | jq '.items[] | {
+            id, name, slug, is_recurring, is_archived,
+            description: (.description // "" | .[0:120]),
+            prices: [.prices[] | {id, amount_type, price_amount, price_currency, recurring_interval, type}],
+            benefits: [.benefits[]?.id],
+            checkout_links_url: .checkout_links_url,
+            checkout_url: .checkout_url
+          }'
+
+          # 3. Try canonical checkout-link generation per product
+          echo ""
+          echo "==== Checkout-link probe per product ===="
+          for product_id in $(echo "$prods" | jq -r '.items[].id'); do
+            echo ""
+            echo "Product: $product_id"
+            # Polar v1: POST /v1/checkout-links/ with product_id binds a public link
+            link=$(curl -sf -X GET -H "$AUTH" -H "Accept: application/json" \
+              "$API/v1/checkout-links/?product_id=$product_id&limit=10" \
+              || echo '{"items":[]}')
+            echo "  Existing links:"
+            echo "$link" | jq -r '.items[] | "    \(.id) → \(.url) (active=\(.success_url // "—"))"' || echo "    (none)"
+          done
+
+          # 4. Job summary with the URL pattern that's likely live
+          {
+            echo "## Polar discovery summary"
+            echo ""
+            echo "**Org:** \`$org_slug\` (id \`$org_id\`)"
+            echo ""
+            echo "### Products"
+            echo "$prods" | jq -r '.items[] | "- **\(.name)** (\(.id), archived=\(.is_archived)) — slug \`\(.slug // "none")\`"'
+            echo ""
+            echo "### Existing public checkout-link URLs"
+            for product_id in $(echo "$prods" | jq -r '.items[].id'); do
+              link=$(curl -sf -X GET -H "$AUTH" -H "Accept: application/json" \
+                "$API/v1/checkout-links/?product_id=$product_id&limit=10" \
+                || echo '{"items":[]}')
+              n=$(echo "$link" | jq '.items | length')
+              if [ "$n" -gt 0 ]; then
+                pname=$(echo "$prods" | jq -r --arg pid "$product_id" '.items[] | select(.id==$pid) | .name')
+                echo "- $pname:"
+                echo "$link" | jq -r '.items[] | "  - \(.url)"'
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -570,7 +570,14 @@ main() {
       comment_count="$first_thread_count"
       log_audit "inline_no_settling_needed" "First sample > 0; skipping settling window"
     else
+      # Validate INLINE_GRACE_SECONDS as a non-negative integer. Anything
+      # else (empty, "90s", "0.5", garbage) falls back to the default to
+      # avoid `[[ -gt ]]` errors and `sleep` failures under set -e.
       local inline_grace_seconds="${INLINE_GRACE_SECONDS:-90}"
+      if ! [[ "$inline_grace_seconds" =~ ^[0-9]+$ ]]; then
+        echo "::warning::INLINE_GRACE_SECONDS='${inline_grace_seconds}' is not a non-negative integer; falling back to 90s"
+        inline_grace_seconds=90
+      fi
       if [[ "$inline_grace_seconds" -gt 0 ]]; then
         sleep "$inline_grace_seconds"
       fi
@@ -582,7 +589,11 @@ main() {
       fi
     fi
 
-    log_audit "review_detected" "Review found, ${comment_count} unresolved threads"
+    # Distinct audit action so this entry is not confused with the
+    # `review_detected` entry emitted by poll_for_review when the review
+    # record first appears. (Round-2 finding: same action name was
+    # ambiguous for log/metric consumers.)
+    log_audit "review_settled" "Review settled, ${comment_count} unresolved threads after grace window"
     local retry_count=0
 
     while [[ "$comment_count" -gt 0 ]] && [[ "$retry_count" -lt "$MAX_RETRY_COUNT" ]]; do

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -559,8 +559,17 @@ main() {
     # Round-2 fixes addressed: command-substitution exit under set -e
     # (`|| true` after each call), skip-sleep on first>0, and use second
     # sample as latest source-of-truth instead of MAX.
-    local comment_count first_thread_count
-    first_thread_count=$(check_unresolved_threads "$PR_NUMBER" || true)
+    # Round-4 fix: capture both stdout AND exit code from
+    # check_unresolved_threads. On API failure the function echoes "0"
+    # and returns non-zero — masking that with `|| true` and proceeding
+    # with comment_count=0 would let an unsafe merge through when thread
+    # state is actually unknown. Escalate instead.
+    local comment_count first_thread_count first_rc
+    first_thread_count=$(check_unresolved_threads "$PR_NUMBER") && first_rc=0 || first_rc=$?
+    if [[ "$first_rc" -ne 0 ]]; then
+      escalate "$PR_NUMBER" "Failed to fetch review threads on first sample (rc=${first_rc}) — cannot verify clean state safely"
+      exit 0
+    fi
     first_thread_count="${first_thread_count:-0}"
     log_audit "inline_settling_first" "First sample: ${first_thread_count} unresolved threads"
 
@@ -581,7 +590,13 @@ main() {
       if [[ "$inline_grace_seconds" -gt 0 ]]; then
         sleep "$inline_grace_seconds"
       fi
-      comment_count=$(check_unresolved_threads "$PR_NUMBER" || true)
+      # Same explicit rc capture as the first sample.
+      local second_rc
+      comment_count=$(check_unresolved_threads "$PR_NUMBER") && second_rc=0 || second_rc=$?
+      if [[ "$second_rc" -ne 0 ]]; then
+        escalate "$PR_NUMBER" "Failed to fetch review threads on second sample (rc=${second_rc}) — cannot verify clean state safely"
+        exit 0
+      fi
       comment_count="${comment_count:-0}"
       log_audit "inline_settling_second" "Second sample after ${inline_grace_seconds}s: ${comment_count} unresolved threads"
       if [[ "$comment_count" -gt 0 ]]; then

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -538,9 +538,40 @@ main() {
       exit 0
     fi
 
-    # T1.2: Check for inline review comments + retry loop
-    local comment_count
-    comment_count=$(check_unresolved_threads "$PR_NUMBER")
+    # T1.2: Inline-settling grace period.
+    #
+    # Copilot's review submission is two-phase: it posts the summary review
+    # FIRST (creating a record with state COMMENTED that satisfies
+    # poll_for_review's reviews_count > 0 check), THEN posts inline comments
+    # which land as reviewThreads. Sampling threads immediately after the
+    # summary lands races the inline comments — the script sees 0 unresolved
+    # threads, passes guardrails, and merges. The inline comments arrive
+    # too late. PR #577 (wgmesh) hit exactly this in 2026-05-08 (13 inline
+    # findings posted ~24 minutes after summary; PR was already merged).
+    #
+    # Mitigation: sample reviewThreads twice across a settling window and
+    # take the MAX. This preserves the COMMENTED-with-0-threads = clean
+    # path for legitimate fast-merges (no inline comments ever land), while
+    # closing the race for the slow-inline path. Tunable via INLINE_GRACE_SECONDS.
+    local comment_count first_thread_count second_thread_count
+    first_thread_count=$(check_unresolved_threads "$PR_NUMBER")
+    log_audit "inline_settling_first" "First sample: ${first_thread_count} unresolved threads"
+
+    local inline_grace_seconds="${INLINE_GRACE_SECONDS:-90}"
+    if [[ "$inline_grace_seconds" -gt 0 ]]; then
+      sleep "$inline_grace_seconds"
+    fi
+
+    second_thread_count=$(check_unresolved_threads "$PR_NUMBER")
+    log_audit "inline_settling_second" "Second sample after ${inline_grace_seconds}s: ${second_thread_count} unresolved threads"
+
+    if [[ "$second_thread_count" -gt "$first_thread_count" ]]; then
+      comment_count="$second_thread_count"
+      log_audit "inline_late_arrival" "Inline comments arrived during settling window (${first_thread_count} → ${second_thread_count}); using max"
+    else
+      comment_count="$first_thread_count"
+    fi
+
     log_audit "review_detected" "Review found, ${comment_count} unresolved threads"
     local retry_count=0
 

--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -549,27 +549,37 @@ main() {
     # too late. PR #577 (wgmesh) hit exactly this in 2026-05-08 (13 inline
     # findings posted ~24 minutes after summary; PR was already merged).
     #
-    # Mitigation: sample reviewThreads twice across a settling window and
-    # take the MAX. This preserves the COMMENTED-with-0-threads = clean
-    # path for legitimate fast-merges (no inline comments ever land), while
-    # closing the race for the slow-inline path. Tunable via INLINE_GRACE_SECONDS.
-    local comment_count first_thread_count second_thread_count
-    first_thread_count=$(check_unresolved_threads "$PR_NUMBER")
+    # Mitigation: take a first sample. If it shows 0 threads, sleep and
+    # re-sample — the second sample is the source of truth (it is the
+    # latest reading; if threads were resolved during the window, the
+    # second sample correctly reflects 0). If the first sample already
+    # shows >0 threads, the race is moot — skip the sleep and proceed.
+    # Tunable via INLINE_GRACE_SECONDS (default 90s; set 0 to disable).
+    #
+    # Round-2 fixes addressed: command-substitution exit under set -e
+    # (`|| true` after each call), skip-sleep on first>0, and use second
+    # sample as latest source-of-truth instead of MAX.
+    local comment_count first_thread_count
+    first_thread_count=$(check_unresolved_threads "$PR_NUMBER" || true)
+    first_thread_count="${first_thread_count:-0}"
     log_audit "inline_settling_first" "First sample: ${first_thread_count} unresolved threads"
 
-    local inline_grace_seconds="${INLINE_GRACE_SECONDS:-90}"
-    if [[ "$inline_grace_seconds" -gt 0 ]]; then
-      sleep "$inline_grace_seconds"
-    fi
-
-    second_thread_count=$(check_unresolved_threads "$PR_NUMBER")
-    log_audit "inline_settling_second" "Second sample after ${inline_grace_seconds}s: ${second_thread_count} unresolved threads"
-
-    if [[ "$second_thread_count" -gt "$first_thread_count" ]]; then
-      comment_count="$second_thread_count"
-      log_audit "inline_late_arrival" "Inline comments arrived during settling window (${first_thread_count} → ${second_thread_count}); using max"
-    else
+    if [[ "$first_thread_count" -gt 0 ]]; then
+      # Race is moot — inline comments already visible. Skip the settling
+      # window so retry/escalation is not delayed.
       comment_count="$first_thread_count"
+      log_audit "inline_no_settling_needed" "First sample > 0; skipping settling window"
+    else
+      local inline_grace_seconds="${INLINE_GRACE_SECONDS:-90}"
+      if [[ "$inline_grace_seconds" -gt 0 ]]; then
+        sleep "$inline_grace_seconds"
+      fi
+      comment_count=$(check_unresolved_threads "$PR_NUMBER" || true)
+      comment_count="${comment_count:-0}"
+      log_audit "inline_settling_second" "Second sample after ${inline_grace_seconds}s: ${comment_count} unresolved threads"
+      if [[ "$comment_count" -gt 0 ]]; then
+        log_audit "inline_late_arrival" "Inline comments arrived during settling window (0 → ${comment_count})"
+      fi
     fi
 
     log_audit "review_detected" "Review found, ${comment_count} unresolved threads"

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -24,7 +24,7 @@ You observe signals from all repos. Issues are created in **wgmesh** (primary pr
 | **chimney** | GitHub API caching proxy / pipeline dashboard (chimney.beerpub.dev) |
 | **ai-pipeline-template** | This repo — observation loop, system prompt, state, Goose pipeline |
 | **coroot-cicd** | Observability infrastructure (Coroot deployment) |
-| **creu** | creu.lt — related web property |
+| **cloudroof-eu** | cloudroof.eu landing source — Cloudflare Workers, customer-facing CDN sales page (renamed from `creu` 2026-05-08) |
 | **dns-server** | Custom DNS server |
 | **tvcentras** | tvcentras.lt — related web property |
 | **homebrew-tap** | Homebrew formula distribution for wgmesh |


### PR DESCRIPTION
First run of `polar-discovery.yml` (run #25575864008) exited 22 because `curl -f` suppressed the response body. Could not see WHY the org-by-slug query returned non-2xx.

Switches to HTTP-code + body capture without `-f`, probes `/v1/users/me` first to confirm token validity, lists all orgs visible to the token, then tries the slug query.

Companion to the 2026-05-08 KPI loop investigation: `polar.sh/atvirokodosprendimai` returns 404 + observation-loop has been silently logging 'Could not resolve Polar organization ID' — root cause unknown until this discovery output lands.

🤖 Pulse-driven, KPI loop tick 2