### PR TITLE
reframe(outreach): Founding-only $5/mo, strip BGP/anycast vapor

### DIFF
--- a/.github/workflows/rah-bounty-dispatch.yml
+++ b/.github/workflows/rah-bounty-dispatch.yml
@@ -67,9 +67,12 @@ jobs:
           fi
           # Capture both body + status. Print body unconditionally so the
           # operator can see what RAH said, but fail the step if not 2xx.
+          # RAH REST API authenticates via `X-API-Key` header per their docs,
+          # NOT `Authorization: Bearer`. The Bearer form returns 401
+          # `auth_missing` on writes. Discovered 2026-05-09 KPI loop tick.
           status=$(curl -s -o /tmp/rah-resp.json -w "%{http_code}" \
             -X POST "https://rentahuman.ai/api/bounties" \
-            -H "Authorization: Bearer $RAH_KEY" \
+            -H "X-API-Key: $RAH_KEY" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
             -d @/tmp/bounty.json)

--- a/company/bounties/cloudroof-checkout-validation.json
+++ b/company/bounties/cloudroof-checkout-validation.json
@@ -1,21 +1,16 @@
 {
-  "title": "Validate cloudroof.eu Polar checkout end-to-end ($5 sub reimbursed)",
-  "description": "I just shipped Polar checkout CTAs on https://cloudroof.eu (managed WireGuard mesh CDN pilot). Need 1 human to walk the full visitor → paid-subscriber flow and prove the success path works.\n\n**What you do:**\n\n1. Open https://cloudroof.eu in a normal browser (not incognito; cookies allowed).\n2. Scroll to the Pilot Program section near the bottom of the slide deck.\n3. Click the **$5 / month — Founding** tier (left card, 'Become a founding member →' button).\n4. Complete the Polar checkout with your real card. **You will be charged $5/mo.**\n5. After checkout, screenshot the Polar success page (the URL should redirect to chimney.beerpub.dev/?checkout=success).\n6. Screenshot the confirmation email from Polar / Stripe.\n7. Open https://chimney.beerpub.dev/ and screenshot the customer-count widget (top of page, says 'X of 1 customer').\n\n**What you submit (3 screenshots + 1 line):**\n- Polar success-page screenshot\n- Confirmation email screenshot (subject + first 2 lines visible, no need to share full content)\n- Chimney customer-count screenshot\n- One sentence on how the experience felt (good, broken, awkward, etc).\n\n**Reimbursement:** the bounty payout includes $5 to cover the first month's subscription + $5 service fee for your time. After your task is accepted you can cancel the subscription anytime in your Polar account — no obligation past the first month.\n\n**Why this matters:** I haven't manually verified my own checkout flow yet (no real card runs). This bounty tests whether the chain actually works. If it breaks, I'll see exactly where.",
+  "title": "Validate cloudroof Polar checkout end-to-end (sub reimbursed)",
+  "description": "I just shipped checkout buttons on a managed WireGuard mesh CDN landing page. Need 1 human to walk the full visitor → paid-subscriber flow and prove the success path works.\n\n**What you do:**\n\n1. Open the landing page (search 'cloudroof' in your browser; it is the dot-eu domain).\n2. Scroll to the Pilot Program section near the bottom of the slide deck.\n3. Click the **$5 / month — Founding** tier (left card).\n4. Complete the Polar checkout with your real card. **You will be charged $5/mo.**\n5. After checkout, screenshot the Polar success page (it should redirect to the chimney dashboard).\n6. Screenshot the confirmation email from Polar / Stripe.\n7. Open the chimney pipeline dashboard (search 'chimney beerpub') and screenshot the customer-count widget at the top.\n\n**What you submit (3 screenshots + 1 line):**\n- Polar success-page screenshot\n- Confirmation email screenshot (subject + first 2 lines visible, redact personal info if you want)\n- Chimney customer-count screenshot\n- One sentence on how the experience felt (good, broken, awkward, etc).\n\n**Reimbursement:** the bounty payout includes $5 to cover the first month's subscription + $5 service fee for your time. After your task is accepted you can cancel the subscription anytime in your Polar account — no obligation past the first month.\n\n**Why this matters:** I have not manually verified my own checkout flow yet (no real card runs). This bounty tests whether the chain actually works. If it breaks, I will see exactly where.",
   "requirements": [
-    "Must have a real credit card capable of charging $5 USD/EUR",
-    "Must be in a country where Polar.sh accepts customers (most of US/EU; check polar.sh)",
+    "Must have a real credit card capable of charging $5 USD or EUR",
+    "Must be in a country where Polar.sh accepts customers (most of US/EU)",
     "Must complete within 24 hours of acceptance",
     "Comfortable taking screenshots and uploading them"
   ],
-  "startInstructions": "If the cloudroof.eu page does not show 'Pilot Program' or the buttons return errors, screenshot the failure and submit that — the bounty pays out for documenting the broken state too. The whole point is to find out which path is real.",
+  "startInstructions": "If the landing page does not show 'Pilot Program' or the buttons return errors, screenshot the failure and submit that — the bounty pays out for documenting the broken state too. The whole point is to find out which path is real.",
   "skillsNeeded": ["attention to detail", "screenshots", "research"],
   "category": "research-fieldwork",
-  "location": {
-    "city": "",
-    "state": "",
-    "country": "",
-    "isRemoteAllowed": true
-  },
+  "location": {"city": "", "state": "", "country": "", "isRemoteAllowed": true},
   "deadline": "2026-05-15T20:00:00.000Z",
   "estimatedHours": 0.5,
   "estimatedDurationUnit": "hours",

--- a/docs/outreach/2026-05-08-pilot-launch.md
+++ b/docs/outreach/2026-05-08-pilot-launch.md
@@ -1,0 +1,339 @@
+# cloudroof founding sponsor outreach drafts (2026-05-08)
+
+Note: Reframed 2026-05-09 to Founding-only ($5/mo). $20 and $100 higher-tier drafts removed; will re-author once Phase 1 route-control plane is live (per memory/project_cloudroof_path_b_2026_05_09.md).
+
+Single CTA for all channels:
+<https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+
+Core pitch:
+
+> I'm building cloudroof — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = single POP, IPv6-only, no SLA. Looking for 5 founding sponsors at $5/mo to fund the build + shape the roadmap. No production claims yet — explicitly research-grade.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+
+Channels picked:
+1. Discord
+2. Show HN
+3. Reddit x3
+4. Direct email to 5 stargazers
+5. Product Hunt
+
+---
+
+## 1. Discord — `discord.gg/HUApcDn6ra`
+
+Post in `#announcements` or `#general`. Pin only if the server is ready for sponsor discussion.
+
+> **cloudroof founding sponsors**
+>
+> Quick update from the wgmesh side: I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh.
+>
+> Phase 1 is deliberately small: **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get:
+>
+> - name in CONTRIBUTORS/SPONSORS
+> - Discord access
+> - vote on Phase 2 features
+> - first access to the alpha when Phase 1 ships
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Self-hosting wgmesh stays free under MIT. The $5 tier is a small signal that this direction is worth building.
+
+---
+
+## 2. Show HN
+
+Title (<=80 chars):
+
+```
+Show HN: cloudroof — OSS CDN-alternative on wgmesh, research-grade
+```
+
+Submission URL: `https://wgmesh.dev/`
+
+First-comment post-body:
+
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh.
+>
+> wgmesh is the base layer: share a secret, build an encrypted WireGuard mesh. It handles peer discovery, NAT traversal, and relay fallback without a central coordination server.
+>
+> cloudroof is the next experiment on top: Phase 1 is **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get:
+>
+> - name in CONTRIBUTORS/SPONSORS
+> - Discord access
+> - vote on Phase 2 features
+> - first access to the alpha when Phase 1 ships
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> GitHub: github.com/atvirokodosprendimai/wgmesh
+>
+> Happy to discuss wgmesh internals, the Phase 1 constraints, EU merchant-of-record setup, or what would make the alpha useful enough to test.
+
+---
+
+## 3. Reddit
+
+### 3a. r/selfhosted
+
+Title:
+
+```
+Building cloudroof: OSS CDN-alternative on wgmesh, seeking 5 founding sponsors
+```
+
+Body:
+
+> Hey selfhosted,
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh.
+>
+> wgmesh is the open-source base layer:
+>
+> ```
+> brew install atvirokodosprendimai/tap/wgmesh
+> wgmesh join --secret "wgmesh://v1/your-secret"
+> ```
+>
+> Phase 1 for cloudroof is intentionally narrow: **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get:
+>
+> - name in CONTRIBUTORS/SPONSORS
+> - Discord access
+> - vote on Phase 2 features
+> - first access to the alpha when Phase 1 ships
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Code: github.com/atvirokodosprendimai/wgmesh
+>
+> If you self-host public services and want a small, open alternative shaped in public before it claims to be production-ready, I'd value your sponsorship or blunt feedback.
+
+### 3b. r/wireguard
+
+Held until Phase 1 (mesh routing claims not yet implementable).
+
+### 3c. r/homelab
+
+Title:
+
+```
+Building cloudroof for homelab origins: research-grade alpha, $5 founding sponsors
+```
+
+Body:
+
+> Sharing because homelab users are the people I most want shaping this early.
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh.
+>
+> The long-term goal is to make it easier to expose services backed by home servers, NAS boxes, Pis, and small VPSs without handing the entire architecture to a closed platform. But Phase 1 is deliberately small: **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get:
+>
+> - name in CONTRIBUTORS/SPONSORS
+> - Discord access
+> - vote on Phase 2 features
+> - first access to the alpha when Phase 1 ships
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> wgmesh: github.com/atvirokodosprendimai/wgmesh
+>
+> The useful feedback right now: what would Phase 2 need before you'd test it with a non-critical homelab service?
+
+---
+
+## 4. Direct email (5 personalized stargazers)
+
+Send one email per stargazer. Keep the subject, the core status line, and the single Founding checkout. Swap only the personalized paragraph.
+
+**Subject:**
+
+```
+You starred wgmesh — quick note on cloudroof
+```
+
+### 4a. @blinkinglight — mz@9g.lt
+
+> Hey blinkinglight,
+>
+> Saw you starred wgmesh and have already been filing useful issues, so I won't pitch this as "new project exists."
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Why I thought of you: your issue feedback is exactly the kind of practical pressure this needs before it becomes anything public-facing. If the $5 sponsorship makes sense, great; if not, 2-3 blunt sentences on what Phase 2 should prioritize would be just as useful.
+>
+> Thanks,
+> Marty
+
+### 4b. @cablehead / Andy Gayton — andy@thecablelounge.com
+
+> Hey Andy,
+>
+> Saw you starred wgmesh — thanks. Given your work around small, useful infrastructure tools and the Cable Lounge world, I thought this direction might be relevant.
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Why I thought of you: I suspect you would care less about marketing claims and more about whether the underlying network is inspectable, hackable, and honestly scoped. That's exactly the line I'm trying to hold here.
+>
+> Thanks,
+> Marty
+
+### 4c. @sausagenoods / Irem Kuyucu — siren@kernal.eu
+
+> Hey Irem,
+>
+> Saw you starred wgmesh — thanks. Since you're local to Vilnius and working around the Kernal orbit, I wanted to send the early version before posting more widely.
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Why I thought of you: local infrastructure people will spot weak assumptions faster than a broad launch crowd. If the $5 sponsorship fits, great; otherwise I'd value the harshest product-shape feedback.
+>
+> Thanks,
+> Marty
+
+### 4d. @YingliangCai — yingliangcai@ikesy.com
+
+> Hey Yingliang,
+>
+> Saw you starred wgmesh — thanks. Given your work at Ikesy and the Shenzhen infrastructure/software context, I thought the early cloudroof direction might be worth a quick note.
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Why I thought of you: cross-region networking assumptions break quickly once they leave a single EU test environment. If you have a view on what would make this worth testing from your side, that would directly shape Phase 2.
+>
+> Thanks,
+> Marty
+
+### 4e. @XavierBeheydt / Xavier — xavier.beheydt@gmail.com
+
+> Hey Xavier,
+>
+> Saw you starred wgmesh — thanks. Given your open-source engineering work in France, I thought you might care about the EU-based, OSS-first angle here.
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh. Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Why I thought of you: this needs practical open-source users who will push for a small, understandable alpha rather than a polished promise. If you sponsor, you'll help set that bar early.
+>
+> Thanks,
+> Marty
+
+---
+
+## 5. Product Hunt
+
+Submit at: <https://www.producthunt.com/posts/new>
+
+Tagline (<=60 chars):
+
+```
+OSS CDN-alternative on wgmesh, starting research-grade
+```
+
+Description (<=260 chars):
+
+```
+cloudroof is an OSS, EU-based CDN-alternative on wgmesh. Phase 1 is single POP, IPv6-only, no SLA. Seeking 5 founding sponsors at $5/mo to fund the build, vote on Phase 2, and get first alpha access.
+```
+
+Topics: `Developer Tools`, `Networking`, `Self-Hosting`, `Open Source`.
+
+Maker comment:
+
+> Hey PH,
+>
+> I'm building **cloudroof** — an OSS, EU-based CDN-alternative on top of wgmesh.
+>
+> Phase 1 = **single POP, IPv6-only, no SLA**. No production claims yet; this is explicitly research-grade.
+>
+> I'm looking for **5 founding sponsors at $5/mo** to fund the build and shape the roadmap.
+>
+> Founding sponsors get: name in CONTRIBUTORS/SPONSORS, Discord access, vote on Phase 2 features, and first access to the alpha when Phase 1 ships.
+>
+> Honest status: wgmesh is ~25kLOC Go; the global route-control plane is not yet implemented; Phase 1 ETA 2-3 weeks pending co-founder IPv6 /48 ratification.
+>
+> Founding checkout: <https://buy.polar.sh/polar_cl_MIoEXmQ6vlAmJSyoFQsvuNyzSbxtk2OZqacJb1VzxpN>
+>
+> Happy to answer anything about wgmesh, the research-grade scope, or what I'm intentionally not claiming until Phase 1 exists.
+
+---
+
+## Send order recommendation
+
+1. **Now:** Discord + direct email to 5 personalized stargazers. Warmest audience and easiest to correct if feedback exposes wording problems.
+2. **Next morning, 9-10am ET:** Show HN.
+3. **Later that day:** Reddit r/selfhosted, then r/homelab after discussion stabilizes.
+4. **Hold:** r/wireguard until Phase 1 can support the networking claims.
+5. **Day 2:** Product Hunt, only if at least one warm-channel conversation confirms the framing is clear.
+
+If a CTA breaks at any point: stop sending, fix, resume.
+
+## After-send checklist
+
+- [ ] Watch paid sponsor count
+- [ ] Watch GitHub stars as a secondary leading indicator
+- [ ] Save any sponsor or serious feedback exchange to `docs/customers/<handle>.md`


### PR DESCRIPTION
## Summary

- Reframes `docs/outreach/2026-05-08-pilot-launch.md` to Founding-$5-only framing across all 5 channels (Discord, Show HN, Reddit ×3, stargazer emails, Product Hunt). Strips BGP/anycast/edge-node language per Path B no-vapor decision.
- Includes carryover `fix(rah)` commit (`ae59cad`) for X-API-Key header + URL-strip in bounty description (was on `fix/rah-bounty-no-links` parent, never independently PR'd post-#811).

## Why

User picked Path B no-vapor interpretation 2026-05-09: outreach with BGP/anycast claims pulled until Phase 1 BGP plane real, BUT \$5 Founding tier (no infra promises) ships immediately. See `memory/project_cloudroof_path_b_2026_05_09.md` + `memory/project_founding_only_outreach_path_b_compat_2026_05_09.md`.

## Test plan

- [x] git grep -niE 'bgp|anycast|reserved capacity' on outreach doc returns 0 hits
- [x] All 5 channels reframed with single \$5 Founding CTA
- [ ] Operator: send Discord §1 first (warmest, lowest blast radius)

🤖 Codex-executed plan from Opus session