### PR TITLE
ci: PII policy check workflow for outreach/customers paths

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,12 +39,13 @@ for f in "${staged[@]}"; do
   [ -f "$f" ] || continue
 
   # Hard block: ANY content under docs/customers/.
-  # Subtree is reserved policy-banned namespace.
+  # Subtree is reserved policy-banned namespace by THIS hook (on top of
+  # company/system-prompt.md, which only bans customer names/emails/payment
+  # details directly — that part is upstream policy).
   if [[ "$f" =~ ^docs/customers/ ]]; then
     printf 'BLOCKED: %s\n' "$f" >&2
     printf '  docs/customers/** is a policy-banned subtree. Customer/sponsor\n' >&2
-    printf '  exchanges go to private operator notes (1Password / encrypted file).\n' >&2
-    printf '  See company/system-prompt.md Public/private boundary.\n\n' >&2
+    printf '  exchanges go to private operator notes (1Password / encrypted file).\n\n' >&2
     fail=1
     continue
   fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,9 +18,10 @@ set -euo pipefail
 # Restrict scope to the same path policy as the workflow
 PATHS_REGEX='^docs/(outreach|customers)/'
 
-# Files staged for THIS commit
+# Files staged for THIS commit. Include rename/copy/type-change so a file
+# can't sneak into a restricted path via mv (consistent with workflow + pre-push).
 mapfile -t staged < <(
-  git diff --cached --name-only --diff-filter=AM \
+  git diff --cached --name-only --diff-filter=ACMRT \
     | grep -E "$PATHS_REGEX" \
     || true
 )

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,27 +29,45 @@ if [ "${#staged[@]}" -eq 0 ]; then
   exit 0
 fi
 
-email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
-allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+# Patterns via ENVIRON — awk -v strips backslashes (\. → . over-matches)
+export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+export ALLOW_PATTERN='^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$'
 
 fail=0
 for f in "${staged[@]}"; do
   [ -f "$f" ] || continue
 
-  # Block any handle-keyed customer file
-  if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
+  # Hard block: ANY content under docs/customers/.
+  # Subtree is reserved policy-banned namespace.
+  if [[ "$f" =~ ^docs/customers/ ]]; then
     printf 'BLOCKED: %s\n' "$f" >&2
-    printf '  docs/customers/<handle>.md is policy-banned. Sponsor/customer\n' >&2
+    printf '  docs/customers/** is a policy-banned subtree. Customer/sponsor\n' >&2
     printf '  exchanges go to private operator notes (1Password / encrypted file).\n' >&2
     printf '  See company/system-prompt.md Public/private boundary.\n\n' >&2
     fail=1
     continue
   fi
 
-  # Email scan against the staged content (not just working tree)
+  # Email scan against the staged content (not just working tree).
+  # Extract emails individually so per-line allow-list filtering can't
+  # drop a disallowed email sharing a line with an allow-listed one.
   hits=$(git show ":$f" 2>/dev/null \
-         | grep -nE "$email_pattern" \
-         | grep -vE "$allow_pattern" \
+         | awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
+                {
+                  line = $0
+                  while (match(line, pat)) {
+                    m = substr(line, RSTART, RLENGTH)
+                    printf "%d:%s\n", NR, m
+                    line = substr(line, RSTART + RLENGTH)
+                  }
+                }' \
+         | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
+                    {
+                      email = $2
+                      pos = index(email, "@")
+                      domain = substr(email, pos)
+                      if (domain !~ allow) print
+                    }' \
          || true)
 
   if [ -n "$hits" ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Local pre-commit gate. Same checks as .github/workflows/pii-policy-check.yml
+# but fires BEFORE content reaches GitHub object store.
+#
+# Setup: git config core.hooksPath .githooks  (or run .githooks/setup.sh)
+#
+# Bypass (do not use without operator approval): git commit --no-verify
+#
+# Why both this AND the workflow:
+# - Workflow = required status check on PR; unbypassable but reactive (content
+#   already pushed to a branch on GitHub).
+# - Hook = local; bypassable but stops content from ever leaving the machine.
+# - Agent-dispatched commits (Codex/Aider/etc) need both: hook catches if env
+#   ran setup; workflow catches if hook was bypassed or env wasn't configured.
+
+set -euo pipefail
+
+# Restrict scope to the same path policy as the workflow
+PATHS_REGEX='^docs/(outreach|customers)/'
+
+# Files staged for THIS commit
+mapfile -t staged < <(
+  git diff --cached --name-only --diff-filter=AM \
+    | grep -E "$PATHS_REGEX" \
+    || true
+)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+
+fail=0
+for f in "${staged[@]}"; do
+  [ -f "$f" ] || continue
+
+  # Block any handle-keyed customer file
+  if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
+    printf 'BLOCKED: %s\n' "$f" >&2
+    printf '  docs/customers/<handle>.md is policy-banned. Sponsor/customer\n' >&2
+    printf '  exchanges go to private operator notes (1Password / encrypted file).\n' >&2
+    printf '  See company/system-prompt.md Public/private boundary.\n\n' >&2
+    fail=1
+    continue
+  fi
+
+  # Email scan against the staged content (not just working tree)
+  hits=$(git show ":$f" 2>/dev/null \
+         | grep -nE "$email_pattern" \
+         | grep -vE "$allow_pattern" \
+         || true)
+
+  if [ -n "$hits" ]; then
+    fail=1
+    printf 'BLOCKED: %s\n' "$f" >&2
+    printf '  PII boundary violation — email address(es) detected:\n' >&2
+    printf '%s\n' "$hits" | sed 's/^/    /' >&2
+    printf '  Redact, OR move content to a private operator system.\n\n' >&2
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  printf 'pre-commit: PII policy check failed. Commit aborted.\n' >&2
+  printf 'Bypass (only with operator approval): git commit --no-verify\n' >&2
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,8 +15,9 @@ remote="$1"
 url="$2"
 
 PATHS_REGEX='^docs/(outreach|customers)/'
-email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
-allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+# Patterns via ENVIRON — awk -v strips backslashes (\. → . over-matches)
+export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+export ALLOW_PATTERN='^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$'
 
 # stdin format per githooks(5): <local_ref> <local_sha> <remote_ref> <remote_sha>
 fail=0
@@ -36,9 +37,10 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     range="${remote_sha}..${local_sha}"
   fi
 
-  # Files in policy-restricted paths touched by this push
+  # Files in policy-restricted paths touched by this push.
+  # Include rename/copy/type-change so renames into the path can't bypass.
   mapfile -t files < <(
-    git diff --name-only --diff-filter=AM "$range" 2>/dev/null \
+    git diff --name-only --diff-filter=ACMRT "$range" 2>/dev/null \
       | grep -E "$PATHS_REGEX" \
       || true
   )
@@ -46,18 +48,33 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   [ "${#files[@]}" -eq 0 ] && continue
 
   for f in "${files[@]}"; do
-    # Hard block on customer-handle path
-    if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
+    # Hard block: ANY content under docs/customers/.
+    if [[ "$f" =~ ^docs/customers/ ]]; then
       printf 'BLOCKED in push %s..%s: %s\n' "${remote_sha:0:7}" "${local_sha:0:7}" "$f" >&2
-      printf '  docs/customers/<handle>.md is policy-banned.\n\n' >&2
+      printf '  docs/customers/** is a policy-banned subtree.\n\n' >&2
       fail=1
       continue
     fi
 
-    # Inspect the file content at the push tip (not working tree)
+    # Inspect file content at push tip. Extract emails individually +
+    # apply allow-list per-match.
     hits=$(git show "${local_sha}:${f}" 2>/dev/null \
-           | grep -nE "$email_pattern" \
-           | grep -vE "$allow_pattern" \
+           | awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
+                  {
+                    line = $0
+                    while (match(line, pat)) {
+                      m = substr(line, RSTART, RLENGTH)
+                      printf "%d:%s\n", NR, m
+                      line = substr(line, RSTART + RLENGTH)
+                    }
+                  }' \
+           | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
+                      {
+                        email = $2
+                        pos = index(email, "@")
+                        domain = substr(email, pos)
+                        if (domain !~ allow) print
+                      }' \
            || true)
 
     if [ -n "$hits" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,12 +27,35 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  # Determine the diff range. New branch (remote_sha = 0000...) means scan
-  # local_sha against its merge-base with origin/HEAD; otherwise diff range
-  # is remote_sha..local_sha
+  # Determine the diff range.
+  #
+  # New-branch case (remote_sha all zeros): scan local_sha back to its
+  # nearest existing ancestor on the remote being pushed to. Resolve the
+  # base by trying, in order:
+  #   1. ${local_ref}@{upstream} — upstream of the ref being pushed (NOT
+  #      the currently-checked-out branch's @{u}, which is what plain
+  #      `@{u}` resolves to and would be wrong when pushing a non-checked-
+  #      out branch).
+  #   2. <remote>/HEAD — default branch on the remote being pushed to.
+  #   3. <remote>/main — fallback if HEAD ref is unset.
+  # Then merge-base local_sha against that to find the divergence point.
+  #
+  # Existing-branch update: range is simply remote_sha..local_sha.
   if [[ "$remote_sha" =~ ^0+$ ]]; then
-    base=$(git merge-base "$local_sha" "$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo origin/HEAD)" 2>/dev/null || git rev-parse "${local_sha}^" 2>/dev/null || echo "")
-    range="${base:+$base..}$local_sha"
+    upstream=$(git rev-parse --abbrev-ref "${local_ref}@{u}" 2>/dev/null \
+               || git rev-parse --abbrev-ref "${remote}/HEAD" 2>/dev/null \
+               || echo "${remote}/main")
+    base=$(git merge-base "$local_sha" "$upstream" 2>/dev/null \
+           || git rev-parse "${local_sha}^" 2>/dev/null \
+           || echo "")
+    if [ -z "$base" ] || [ "$base" = "$local_sha" ]; then
+      # No ancestor on remote (truly initial commit on a new repo): diff
+      # against git's well-known empty-tree object so every file is "added".
+      empty_tree=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+      range="${empty_tree}..${local_sha}"
+    else
+      range="${base}..${local_sha}"
+    fi
   else
     range="${remote_sha}..${local_sha}"
   fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -96,9 +96,14 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     # Files this specific commit touched (A/C/M/R/T) under a restricted path.
     # -M emits both old+new path on rename, so renames-out-of restricted are
     # also captured for content scan via the source path.
+    # -m makes diff-tree emit a MERGE commit's diff against each parent;
+    # without it a clean merge yields NO paths, so PII pulled in (or resolved
+    # during conflict resolution) at a merge commit would be missed. -m can
+    # list a path once per parent, so dedupe with sort -u.
     mapfile -t commit_files < <(
-      git diff-tree --no-commit-id --name-only -r -M --diff-filter=ACMRT "$commit" 2>/dev/null \
+      git diff-tree --no-commit-id --name-only -r -M -m --diff-filter=ACMRT "$commit" 2>/dev/null \
         | grep -E "$PATHS_REGEX" \
+        | sort -u \
         || true
     )
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -70,20 +70,12 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     range="${remote_sha}..${local_sha}"
   fi
 
-  # Union of policy-restricted file paths touched anywhere in the push range.
-  # Include rename/copy/type-change so renames into the path can't bypass.
-  mapfile -t files < <(
-    git diff --name-only --diff-filter=ACMRT "$range" 2>/dev/null \
-      | grep -E "$PATHS_REGEX" \
-      || true
-  )
-
-  [ "${#files[@]}" -eq 0 ] && continue
-
-  # All commits in the push range. We scan EACH commit's blob for each
-  # restricted-path file separately so PII committed-then-removed within
-  # the range is still caught — once it lands in a pushed commit object,
-  # it's recoverable via SHA URL even if a later commit deletes the file.
+  # All commits in the push range. We collect restricted-path files
+  # PER-COMMIT (via git diff-tree on each commit) so that files that
+  # existed in a restricted path in an intermediate commit but were
+  # renamed/moved OUT before local_sha are still scanned. The endpoint-
+  # diff approach (git diff base..head) would miss the commit-then-move
+  # bypass.
   #
   # Special-case the empty-tree base (no verified ancestor on remote):
   # rev-list can't take a tree as the left side of `..`, so list ALL
@@ -101,7 +93,18 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   [ "${#commits[@]}" -eq 0 ] && continue
 
   for commit in "${commits[@]}"; do
-    for f in "${files[@]}"; do
+    # Files this specific commit touched (A/C/M/R/T) under a restricted path.
+    # -M emits both old+new path on rename, so renames-out-of restricted are
+    # also captured for content scan via the source path.
+    mapfile -t commit_files < <(
+      git diff-tree --no-commit-id --name-only -r -M --diff-filter=ACMRT "$commit" 2>/dev/null \
+        | grep -E "$PATHS_REGEX" \
+        || true
+    )
+
+    [ "${#commit_files[@]}" -eq 0 ] && continue
+
+    for f in "${commit_files[@]}"; do
       # Hard block: ANY content under docs/customers/ at any commit in range.
       if [[ "$f" =~ ^docs/customers/ ]]; then
         if git cat-file -e "${commit}:${f}" 2>/dev/null; then
@@ -113,7 +116,8 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
         continue
       fi
 
-      # Inspect file content at THIS commit. Skip if file did not exist there.
+      # Inspect file content at THIS commit. Skip if file did not exist there
+      # (rename-out cases where source path no longer resolves at this commit).
       content=$(git cat-file -p "${commit}:${f}" 2>/dev/null) || continue
       [ -z "$content" ] && continue
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Last-line local defense before content hits GitHub.
+#
+# Scans the diff being pushed (across all commits in the push range) against
+# the same policy as pre-commit. Catches:
+# - hook-bypassed commits (--no-verify)
+# - commits made before this hook existed
+# - stale local branches with PII that someone forgot about
+#
+# Bypass: git push --no-verify   (do NOT use without operator approval)
+
+set -euo pipefail
+
+remote="$1"
+url="$2"
+
+PATHS_REGEX='^docs/(outreach|customers)/'
+email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+
+# stdin format per githooks(5): <local_ref> <local_sha> <remote_ref> <remote_sha>
+fail=0
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  # Skip branch deletions (local_sha = 0000...)
+  if [[ "$local_sha" =~ ^0+$ ]]; then
+    continue
+  fi
+
+  # Determine the diff range. New branch (remote_sha = 0000...) means scan
+  # local_sha against its merge-base with origin/HEAD; otherwise diff range
+  # is remote_sha..local_sha
+  if [[ "$remote_sha" =~ ^0+$ ]]; then
+    base=$(git merge-base "$local_sha" "$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo origin/HEAD)" 2>/dev/null || git rev-parse "${local_sha}^" 2>/dev/null || echo "")
+    range="${base:+$base..}$local_sha"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+
+  # Files in policy-restricted paths touched by this push
+  mapfile -t files < <(
+    git diff --name-only --diff-filter=AM "$range" 2>/dev/null \
+      | grep -E "$PATHS_REGEX" \
+      || true
+  )
+
+  [ "${#files[@]}" -eq 0 ] && continue
+
+  for f in "${files[@]}"; do
+    # Hard block on customer-handle path
+    if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
+      printf 'BLOCKED in push %s..%s: %s\n' "${remote_sha:0:7}" "${local_sha:0:7}" "$f" >&2
+      printf '  docs/customers/<handle>.md is policy-banned.\n\n' >&2
+      fail=1
+      continue
+    fi
+
+    # Inspect the file content at the push tip (not working tree)
+    hits=$(git show "${local_sha}:${f}" 2>/dev/null \
+           | grep -nE "$email_pattern" \
+           | grep -vE "$allow_pattern" \
+           || true)
+
+    if [ -n "$hits" ]; then
+      fail=1
+      printf 'BLOCKED in push %s..%s: %s\n' "${remote_sha:0:7}" "${local_sha:0:7}" "$f" >&2
+      printf '  PII boundary violation — email(s) at %s:\n' "$f" >&2
+      printf '%s\n' "$hits" | sed 's/^/    /' >&2
+      printf '  Redact in a new commit, OR rewrite history before pushing.\n\n' >&2
+    fi
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  printf 'pre-push: PII policy check failed. Push aborted.\n' >&2
+  printf 'Bypass (only with operator approval): git push --no-verify\n' >&2
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,27 +30,37 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   # Determine the diff range.
   #
   # New-branch case (remote_sha all zeros): scan local_sha back to its
-  # nearest existing ancestor on the remote being pushed to. Resolve the
-  # base by trying, in order:
-  #   1. ${local_ref}@{upstream} — upstream of the ref being pushed (NOT
-  #      the currently-checked-out branch's @{u}, which is what plain
-  #      `@{u}` resolves to and would be wrong when pushing a non-checked-
-  #      out branch).
+  # nearest VERIFIED ancestor on the remote being pushed to. Resolution
+  # order, picking the first that `git rev-parse --verify` accepts:
+  #   1. ${local_ref}@{upstream} — upstream of the ref being pushed
+  #      (NOT @{u} alone, which resolves to the currently-checked-out
+  #      branch's upstream — wrong when pushing a non-checked-out branch).
   #   2. <remote>/HEAD — default branch on the remote being pushed to.
-  #   3. <remote>/main — fallback if HEAD ref is unset.
-  # Then merge-base local_sha against that to find the divergence point.
+  #   3. <remote>/main — bare fallback if HEAD symref is unset.
+  # If NONE verify (e.g. brand-new repo with no remote), use git's empty-
+  # tree object as the base so the entire history of local_sha is in range.
+  # Skipping straight to ${local_sha}^ would only catch the LAST commit
+  # and miss earlier PII committed-then-removed across the new branch.
   #
   # Existing-branch update: range is simply remote_sha..local_sha.
   if [[ "$remote_sha" =~ ^0+$ ]]; then
-    upstream=$(git rev-parse --abbrev-ref "${local_ref}@{u}" 2>/dev/null \
-               || git rev-parse --abbrev-ref "${remote}/HEAD" 2>/dev/null \
-               || echo "${remote}/main")
-    base=$(git merge-base "$local_sha" "$upstream" 2>/dev/null \
-           || git rev-parse "${local_sha}^" 2>/dev/null \
-           || echo "")
+    upstream=""
+    for cand in "${local_ref}@{u}" "${remote}/HEAD" "${remote}/main"; do
+      if git rev-parse --verify --quiet "$cand" >/dev/null 2>&1; then
+        upstream="$cand"
+        break
+      fi
+    done
+
+    if [ -n "$upstream" ]; then
+      base=$(git merge-base "$local_sha" "$upstream" 2>/dev/null || echo "")
+    else
+      base=""
+    fi
+
     if [ -z "$base" ] || [ "$base" = "$local_sha" ]; then
-      # No ancestor on remote (truly initial commit on a new repo): diff
-      # against git's well-known empty-tree object so every file is "added".
+      # No verified ancestor on remote: scan from git's well-known empty-
+      # tree object so every commit on local_sha is in range.
       empty_tree=4b825dc642cb6eb9a060e54bf8d69288fbee4904
       range="${empty_tree}..${local_sha}"
     else
@@ -60,7 +70,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     range="${remote_sha}..${local_sha}"
   fi
 
-  # Files in policy-restricted paths touched by this push.
+  # Union of policy-restricted file paths touched anywhere in the push range.
   # Include rename/copy/type-change so renames into the path can't bypass.
   mapfile -t files < <(
     git diff --name-only --diff-filter=ACMRT "$range" 2>/dev/null \
@@ -70,43 +80,73 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
 
   [ "${#files[@]}" -eq 0 ] && continue
 
-  for f in "${files[@]}"; do
-    # Hard block: ANY content under docs/customers/.
-    if [[ "$f" =~ ^docs/customers/ ]]; then
-      printf 'BLOCKED in push %s..%s: %s\n' "${remote_sha:0:7}" "${local_sha:0:7}" "$f" >&2
-      printf '  docs/customers/** is a policy-banned subtree.\n\n' >&2
-      fail=1
-      continue
-    fi
+  # All commits in the push range. We scan EACH commit's blob for each
+  # restricted-path file separately so PII committed-then-removed within
+  # the range is still caught — once it lands in a pushed commit object,
+  # it's recoverable via SHA URL even if a later commit deletes the file.
+  #
+  # Special-case the empty-tree base (no verified ancestor on remote):
+  # rev-list can't take a tree as the left side of `..`, so list ALL
+  # commits reachable from local_sha instead.
+  empty_tree=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+  base_for_revlist="${range%..*}"
+  head_for_revlist="${range##*..}"
 
-    # Inspect file content at push tip. Extract emails individually +
-    # apply allow-list per-match.
-    hits=$(git show "${local_sha}:${f}" 2>/dev/null \
-           | awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
-                  {
-                    line = $0
-                    while (match(line, pat)) {
-                      m = substr(line, RSTART, RLENGTH)
-                      printf "%d:%s\n", NR, m
-                      line = substr(line, RSTART + RLENGTH)
-                    }
-                  }' \
-           | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
-                      {
-                        email = $2
-                        pos = index(email, "@")
-                        domain = substr(email, pos)
-                        if (domain !~ allow) print
-                      }' \
-           || true)
+  if [ "$base_for_revlist" = "$empty_tree" ]; then
+    mapfile -t commits < <(git rev-list "$head_for_revlist" 2>/dev/null)
+  else
+    mapfile -t commits < <(git rev-list "${base_for_revlist}..${head_for_revlist}" 2>/dev/null)
+  fi
 
-    if [ -n "$hits" ]; then
-      fail=1
-      printf 'BLOCKED in push %s..%s: %s\n' "${remote_sha:0:7}" "${local_sha:0:7}" "$f" >&2
-      printf '  PII boundary violation — email(s) at %s:\n' "$f" >&2
-      printf '%s\n' "$hits" | sed 's/^/    /' >&2
-      printf '  Redact in a new commit, OR rewrite history before pushing.\n\n' >&2
-    fi
+  [ "${#commits[@]}" -eq 0 ] && continue
+
+  for commit in "${commits[@]}"; do
+    for f in "${files[@]}"; do
+      # Hard block: ANY content under docs/customers/ at any commit in range.
+      if [[ "$f" =~ ^docs/customers/ ]]; then
+        if git cat-file -e "${commit}:${f}" 2>/dev/null; then
+          printf 'BLOCKED in push %s..%s: commit %s contains %s\n' \
+            "${remote_sha:0:7}" "${local_sha:0:7}" "${commit:0:7}" "$f" >&2
+          printf '  docs/customers/** is a policy-banned subtree.\n\n' >&2
+          fail=1
+        fi
+        continue
+      fi
+
+      # Inspect file content at THIS commit. Skip if file did not exist there.
+      content=$(git cat-file -p "${commit}:${f}" 2>/dev/null) || continue
+      [ -z "$content" ] && continue
+
+      hits=$(printf '%s\n' "$content" \
+             | awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
+                    {
+                      line = $0
+                      while (match(line, pat)) {
+                        m = substr(line, RSTART, RLENGTH)
+                        printf "%d:%s\n", NR, m
+                        line = substr(line, RSTART + RLENGTH)
+                      }
+                    }' \
+             | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
+                        {
+                          email = $2
+                          pos = index(email, "@")
+                          domain = substr(email, pos)
+                          if (domain !~ allow) print
+                        }' \
+             || true)
+
+      if [ -n "$hits" ]; then
+        fail=1
+        printf 'BLOCKED in push %s..%s: commit %s, file %s\n' \
+          "${remote_sha:0:7}" "${local_sha:0:7}" "${commit:0:7}" "$f" >&2
+        printf '  Email(s) at this commit:\n' >&2
+        printf '%s\n' "$hits" | sed 's/^/    /' >&2
+        printf '  Even if a later commit removed the file, the bad commit\n' >&2
+        printf '  remains in pushed history. Squash or interactive-rebase\n' >&2
+        printf '  to remove the offending commit before pushing.\n\n' >&2
+      fi
+    done
   done
 done
 

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -2,7 +2,13 @@
 # One-shot setup: wire git to use .githooks/ for client-side policy hooks.
 #
 # Usage:
-#   .githooks/setup.sh
+#   bash .githooks/setup.sh
+#
+# Invocation via `bash` is the documented form because some clones / file
+# systems can strip the +x bit, in which case `.githooks/setup.sh` (without
+# `bash`) would fail with "Permission denied". `bash <path>` always works.
+# After this script runs, `chmod +x` is applied to the hook scripts so
+# subsequent direct invocations also work.
 #
 # Idempotent. Run after fresh clone, or as part of any agent (Codex/Aider/etc)
 # bootstrap. CI does NOT run this — workflow-level enforcement lives in

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -32,4 +32,12 @@ chmod +x .githooks/pre-commit .githooks/pre-push
 printf 'githooks: configured\n'
 printf '  core.hooksPath = .githooks\n'
 printf '  enabled hooks:\n'
-ls -1 .githooks/ | grep -vE '^(setup\.sh|README\.md)$' | sed 's/^/    /'
+# Listing is non-fatal: under `set -euo pipefail`, a `grep` that finds
+# no matches exits non-zero and would kill an already-successful setup.
+# Trap that case with `|| true` so the configure step's success is never
+# undone by a cosmetic listing failure.
+{
+  ls -1 .githooks/ \
+    | grep -vE '^(setup\.sh|README\.md)$' \
+    | sed 's/^/    /'
+} || true

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# One-shot setup: wire git to use .githooks/ for client-side policy hooks.
+#
+# Usage:
+#   .githooks/setup.sh
+#
+# Idempotent. Run after fresh clone, or as part of any agent (Codex/Aider/etc)
+# bootstrap. CI does NOT run this — workflow-level enforcement lives in
+# .github/workflows/pii-policy-check.yml as the unbypassable required check.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf 'setup: not inside a git repo\n' >&2
+  exit 1
+}
+
+cd "$repo_root"
+
+# Wire core.hooksPath
+git config core.hooksPath .githooks
+
+# Ensure scripts are executable (clones may strip the +x bit on some FSes)
+chmod +x .githooks/pre-commit .githooks/pre-push
+
+printf 'githooks: configured\n'
+printf '  core.hooksPath = .githooks\n'
+printf '  enabled hooks:\n'
+ls -1 .githooks/ | grep -vE '^(setup\.sh|README\.md)$' | sed 's/^/    /'

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -84,16 +84,21 @@ jobs:
           echo "Inspecting ${#commits[@]} commit(s) in range ${BASE_SHA:0:7}..${HEAD_SHA:0:7}"
           echo
 
-          # Encode workflow-command parameter values per
-          # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-setting-an-error-message
-          # i.e. URL-encode `%`, `\r`, `\n`. Filenames in the repo can come
-          # from any user-controlled diff, so escape before injecting into
-          # `::error file=...,line=...::` annotations.
+          # Encode workflow-command PROPERTY values per the actions/toolkit
+          # `escapeProperty` rules
+          # (https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts):
+          # %->%25, CR->%0D, LF->%0A, AND the property separators :->%3A , ->%2C.
+          # `%` MUST be escaped first so the later replacements aren't re-encoded.
+          # Filenames come from user-controlled diffs, so a name containing `,`
+          # or `:` would otherwise break the annotation or inject extra
+          # `file=`/`line=` properties.
           gh_escape() {
             local s="$1"
             s="${s//%/%25}"
             s="${s//$'\r'/%0D}"
             s="${s//$'\n'/%0A}"
+            s="${s//:/%3A}"
+            s="${s//,/%2C}"
             printf '%s' "$s"
           }
 
@@ -112,9 +117,15 @@ jobs:
             # Files this specific commit added/modified/renamed/copied/type-changed
             # under a restricted path. Captures BOTH renames-into and renames-out-of
             # by emitting both source + dest paths via -M / --name-only.
+            #
+            # -m makes diff-tree emit the diff of a MERGE commit against each
+            # parent; without it a clean merge yields NO paths, so PII pulled in
+            # (or resolved during conflict resolution) at a merge commit would be
+            # invisible. -m can list a path once per parent, so dedupe with sort -u.
             mapfile -t commit_files < <(
-              git diff-tree --no-commit-id --name-only -r -M --diff-filter=ACMRT "$commit" \
+              git diff-tree --no-commit-id --name-only -r -M -m --diff-filter=ACMRT "$commit" \
                 | grep -E '^docs/(outreach|customers)/' \
+                | sort -u \
                 || true
             )
 
@@ -162,13 +173,18 @@ jobs:
               if [ -n "$hits" ]; then
                 fail=1
                 ef="$(gh_escape "$f")"
+                # IMPORTANT: never echo the matched email VALUE. Actions logs
+                # on a public repo are public; printing the address would
+                # re-expose the very PII this gate exists to keep off public
+                # surfaces. Report line numbers + a count only.
                 while IFS= read -r line; do
                   lineno=$(printf '%s' "$line" | cut -d: -f1)
                   # lineno is digits from cut output; no need to escape
                   echo "::error file=${ef},line=${lineno}::commit ${commit:0:7} contains an email address in this path. This workflow's stricter rule (on top of company/system-prompt.md customer-PII ban) forbids ANY email here, since the path historically accumulated third-party recipient PII."
                 done <<< "$hits"
-                echo "    commit ${commit:0:7} matches in $f:"
-                printf '      %s\n' "$hits"
+                hit_count=$(printf '%s\n' "$hits" | grep -c . || true)
+                hit_lines=$(printf '%s\n' "$hits" | cut -d: -f1 | paste -sd, -)
+                echo "    commit ${commit:0:7}: ${hit_count} disallowed email(s) in $f at line(s): ${hit_lines}"
               fi
             done
           done

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -1,0 +1,109 @@
+name: PII Policy Check
+
+# Blocks merge of any PR that introduces email addresses or handle-keyed
+# customer files in policy-restricted paths. Per company/system-prompt.md
+# "Public/private boundary": names + emails forbidden in docs/outreach/
+# and docs/customers/. PII for sponsor/customer exchanges goes to private
+# operator notes (off-repo).
+#
+# Catches the same class of incident as 2026-05-09 PR #820 (5 stargazer
+# emails landed on public main 9 minutes before manual remediation).
+#
+# Why this and not GitGuardian / Trufflehog / Gitleaks: those tools are
+# secret-focused (API keys, tokens, creds). Email addresses are noisy
+# globally and benign in CHANGELOG/fixtures. Path-scoped grep is the
+# right blast radius for this policy.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/outreach/**'
+      - 'docs/customers/**'
+
+permissions:
+  contents: read
+
+jobs:
+  pii-policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan changed files in policy-restricted paths
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Resolve files in this PR that touch policy-restricted paths
+          mapfile -t files < <(
+            git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD" \
+              | grep -E '^docs/(outreach|customers)/' \
+              || true
+          )
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No policy-restricted paths touched in this PR. PASS."
+            exit 0
+          fi
+
+          echo "Scanning ${#files[@]} file(s):"
+          printf '  - %s\n' "${files[@]}"
+          echo
+
+          fail=0
+
+          # Email regex with allow-list for known-benign forms
+          # (example.com is RFC 2606 reserved; noreply.github.com is GH bot)
+          email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+          allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+
+          for f in "${files[@]}"; do
+            [ -f "$f" ] || continue
+
+            # 1. Block any handle-keyed customer file outright
+            if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
+              echo "::error file=${f}::docs/customers/<handle>.md is policy-banned. Sponsor/customer exchanges go to private operator notes (1Password, encrypted file). See company/system-prompt.md Public/private boundary."
+              fail=1
+              continue
+            fi
+
+            # 2. Email scan (filtered)
+            hits=$(grep -nE "$email_pattern" "$f" \
+                   | grep -vE "$allow_pattern" \
+                   || true)
+
+            if [ -n "$hits" ]; then
+              fail=1
+              while IFS= read -r line; do
+                lineno=$(printf '%s' "$line" | cut -d: -f1)
+                echo "::error file=${f},line=${lineno}::PII boundary violation — email address detected. company/system-prompt.md forbids names/emails in this path."
+              done <<< "$hits"
+              echo "    matches in $f:"
+              printf '      %s\n' "$hits"
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo
+            echo "PII policy check FAILED. Redact and re-push, OR move the offending content to a private operator system."
+            exit 1
+          fi
+
+          echo "PII policy check PASSED for all changed files."
+
+      - name: Note on names + handles (manual review)
+        if: always()
+        run: |
+          cat <<'EOF'
+          Heads-up: this check enforces email policy via regex.
+          Full names + GitHub handles attached to recipient sections are
+          ALSO banned by company/system-prompt.md but are not regex-detectable
+          without high false-positive cost. Reviewer must confirm visually
+          on any PR touching docs/outreach/** that recipient sections are
+          keyed by anonymous letter (Stargazer A-E) or similar, not by
+          name/handle/email.
+          EOF

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -42,17 +42,31 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          # Explicit head SHA (not the synthetic merge ref). On
+          # `pull_request` events the default checkout is the merge of
+          # base+head, which makes commit-range calculations inconsistent
+          # vs. what the user actually pushed.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Scan policy-restricted paths across ALL commits in PR range
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"
-          if [ -z "$BASE_SHA" ]; then
-            echo "::error::could not resolve merge-base of origin/${BASE_REF} and HEAD"
+          # Ensure the base commit is fetched locally (fetch-depth: 0 is
+          # usually enough, but explicit fetch is cheap and bulletproofs
+          # against shallow-clone edge cases).
+          git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::could not resolve base SHA ${BASE_SHA}"
+            exit 1
+          fi
+          if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::could not resolve head SHA ${HEAD_SHA}"
             exit 1
           fi
 
@@ -62,13 +76,26 @@ jobs:
           # restricted path in an intermediate commit but were renamed/moved
           # OUT before HEAD are still scanned. The endpoint-diff approach
           # would miss the commit-then-move-out bypass.
-          mapfile -t commits < <(git rev-list "${BASE_SHA}..HEAD")
+          mapfile -t commits < <(git rev-list "${BASE_SHA}..${HEAD_SHA}")
           if [ "${#commits[@]}" -eq 0 ]; then
             echo "No commits in range. PASS."
             exit 0
           fi
-          echo "Inspecting ${#commits[@]} commit(s) in range ${BASE_SHA:0:7}..HEAD"
+          echo "Inspecting ${#commits[@]} commit(s) in range ${BASE_SHA:0:7}..${HEAD_SHA:0:7}"
           echo
+
+          # Encode workflow-command parameter values per
+          # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-setting-an-error-message
+          # i.e. URL-encode `%`, `\r`, `\n`. Filenames in the repo can come
+          # from any user-controlled diff, so escape before injecting into
+          # `::error file=...,line=...::` annotations.
+          gh_escape() {
+            local s="$1"
+            s="${s//%/%25}"
+            s="${s//$'\r'/%0D}"
+            s="${s//$'\n'/%0A}"
+            printf '%s' "$s"
+          }
 
           # Email regex with allow-list for known-benign forms.
           # example.com is RFC 2606 reserved.
@@ -101,7 +128,8 @@ jobs:
               # later commit deleted it.
               if [[ "$f" =~ ^docs/customers/ ]]; then
                 if git cat-file -e "${commit}:${f}" 2>/dev/null; then
-                  echo "::error file=${f}::commit ${commit:0:7} contains a file under docs/customers/** — that subtree is a policy-banned namespace (this workflow's rule, on top of company/system-prompt.md customer-PII ban). Customer/sponsor exchanges go to private operator notes."
+                  ef="$(gh_escape "$f")"
+                  echo "::error file=${ef}::commit ${commit:0:7} contains a file under docs/customers/** — that subtree is a policy-banned namespace (this workflow's rule, on top of company/system-prompt.md customer-PII ban). Customer/sponsor exchanges go to private operator notes."
                   fail=1
                 fi
                 continue
@@ -133,9 +161,11 @@ jobs:
 
               if [ -n "$hits" ]; then
                 fail=1
+                ef="$(gh_escape "$f")"
                 while IFS= read -r line; do
                   lineno=$(printf '%s' "$line" | cut -d: -f1)
-                  echo "::error file=${f},line=${lineno}::commit ${commit:0:7} contains an email address in this path. This workflow's stricter rule (on top of company/system-prompt.md customer-PII ban) forbids ANY email here, since the path historically accumulated third-party recipient PII."
+                  # lineno is digits from cut output; no need to escape
+                  echo "::error file=${ef},line=${lineno}::commit ${commit:0:7} contains an email address in this path. This workflow's stricter rule (on top of company/system-prompt.md customer-PII ban) forbids ANY email here, since the path historically accumulated third-party recipient PII."
                 done <<< "$hits"
                 echo "    commit ${commit:0:7} matches in $f:"
                 printf '      %s\n' "$hits"

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -18,11 +18,14 @@ name: PII Policy Check
 # globally and benign in CHANGELOG/fixtures. Path-scoped grep is the
 # right blast radius for content-policy boundaries.
 
+# Runs on EVERY PR (no path filter). When configured as a required status
+# check, GitHub waits for *some* completion before allowing merge — a
+# path-filtered workflow that doesn't trigger on a given PR will leave the
+# status indefinitely "expected" and block merge. The in-script check below
+# exits 0 immediately when no policy-restricted paths are touched, so the
+# cost of always-running is one cheap diff invocation.
 on:
   pull_request:
-    paths:
-      - 'docs/outreach/**'
-      - 'docs/customers/**'
 
 permissions:
   contents: read
@@ -62,7 +65,10 @@ jobs:
           fail=0
 
           # Email regex with allow-list for known-benign forms.
-          # example.com is RFC 2606 reserved; *.noreply.github.com is GitHub bot.
+          # example.com is RFC 2606 reserved.
+          # noreply.github.com is GitHub system mail.
+          # users.noreply.github.com is the per-user GitHub privacy domain.
+          # The allow-list pattern matches these THREE domains exactly (anchored).
           # Patterns are passed via ENVIRON to avoid awk's -v backslash stripping
           # (which would turn `\.` into `.` and over-match across whitespace).
           export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -1,18 +1,22 @@
 name: PII Policy Check
 
-# Blocks merge of any PR that introduces email addresses or handle-keyed
-# customer files in policy-restricted paths. Per company/system-prompt.md
-# "Public/private boundary": names + emails forbidden in docs/outreach/
-# and docs/customers/. PII for sponsor/customer exchanges goes to private
-# operator notes (off-repo).
+# Path-scoped pre-merge gate enforcing a STRICTER subset of the repo-wide
+# Public/private boundary defined in company/system-prompt.md. The repo-wide
+# rule forbids names/emails everywhere in this public repo; this workflow
+# adds an automated enforcement floor on the two paths most likely to
+# accumulate PII (docs/outreach/, docs/customers/), where prior incidents
+# landed (2026-05-09 PR #820: 5 stargazer emails on public main 9 min before
+# manual remediation).
 #
-# Catches the same class of incident as 2026-05-09 PR #820 (5 stargazer
-# emails landed on public main 9 minutes before manual remediation).
+# The whole docs/customers/** subtree is policy-banned regardless of file
+# name — that path is reserved as an unused namespace so it can't accrete
+# customer-keyed content. Operator stores sponsor/customer exchanges in
+# private notes (1Password / encrypted file).
 #
 # Why this and not GitGuardian / Trufflehog / Gitleaks: those tools are
 # secret-focused (API keys, tokens, creds). Email addresses are noisy
 # globally and benign in CHANGELOG/fixtures. Path-scoped grep is the
-# right blast radius for this policy.
+# right blast radius for content-policy boundaries.
 
 on:
   pull_request:
@@ -38,9 +42,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Resolve files in this PR that touch policy-restricted paths
+          # Include rename (R) + copy (C) + type-change (T) in addition to
+          # add (A) + modify (M) so a renamed file can't bypass scanning.
           mapfile -t files < <(
-            git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD" \
+            git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
               | grep -E '^docs/(outreach|customers)/' \
               || true
           )
@@ -56,25 +61,47 @@ jobs:
 
           fail=0
 
-          # Email regex with allow-list for known-benign forms
-          # (example.com is RFC 2606 reserved; noreply.github.com is GH bot)
-          email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
-          allow_pattern='@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)'
+          # Email regex with allow-list for known-benign forms.
+          # example.com is RFC 2606 reserved; *.noreply.github.com is GitHub bot.
+          # Patterns are passed via ENVIRON to avoid awk's -v backslash stripping
+          # (which would turn `\.` into `.` and over-match across whitespace).
+          export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+          export ALLOW_PATTERN='^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$'
 
           for f in "${files[@]}"; do
             [ -f "$f" ] || continue
 
-            # 1. Block any handle-keyed customer file outright
-            if [[ "$f" =~ ^docs/customers/.+\.md$ ]]; then
-              echo "::error file=${f}::docs/customers/<handle>.md is policy-banned. Sponsor/customer exchanges go to private operator notes (1Password, encrypted file). See company/system-prompt.md Public/private boundary."
+            # 1. Hard block: ANY content under docs/customers/. Subtree is
+            # reserved as a policy-banned namespace (no customer-keyed files,
+            # no handle-keyed files, no readme that would invite content).
+            # Operator stores customer exchanges in private notes.
+            if [[ "$f" =~ ^docs/customers/ ]]; then
+              echo "::error file=${f}::docs/customers/** is a policy-banned subtree. Customer/sponsor exchanges go to private operator notes (1Password / encrypted file). See company/system-prompt.md Public/private boundary."
               fail=1
               continue
             fi
 
-            # 2. Email scan (filtered)
-            hits=$(grep -nE "$email_pattern" "$f" \
-                   | grep -vE "$allow_pattern" \
-                   || true)
+            # 2. Email scan. Extract every email match individually so
+            # per-line allow-list filtering can't drop a disallowed email
+            # sharing a line with an allow-listed one.
+            #
+            # awk extracts each match with its line number, then the
+            # allow-list filter compares the @domain part exactly.
+            hits=$(awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
+            {
+              line = $0
+              while (match(line, pat)) {
+                m = substr(line, RSTART, RLENGTH)
+                printf "%d:%s\n", NR, m
+                line = substr(line, RSTART + RLENGTH)
+              }
+            }' -- "$f" | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
+            {
+              email = $2
+              pos = index(email, "@")
+              domain = substr(email, pos)
+              if (domain !~ allow) print
+            }' || true)
 
             if [ -n "$hits" ]; then
               fail=1
@@ -99,11 +126,11 @@ jobs:
         if: always()
         run: |
           cat <<'EOF'
-          Heads-up: this check enforces email policy via regex.
-          Full names + GitHub handles attached to recipient sections are
-          ALSO banned by company/system-prompt.md but are not regex-detectable
-          without high false-positive cost. Reviewer must confirm visually
-          on any PR touching docs/outreach/** that recipient sections are
-          keyed by anonymous letter (Stargazer A-E) or similar, not by
+          Heads-up: this check enforces email policy via regex on emails only.
+          Full names + GitHub handles attached to recipient sections are also
+          banned by company/system-prompt.md but are not regex-detectable
+          without prohibitive false-positive cost. Reviewer must confirm
+          visually on any PR touching docs/outreach/** that recipient sections
+          are keyed by anonymous letter (Stargazer A-E) or similar, not by
           name/handle/email.
           EOF

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -1,17 +1,22 @@
 name: PII Policy Check
 
-# Path-scoped pre-merge gate enforcing a STRICTER subset of the repo-wide
-# Public/private boundary defined in company/system-prompt.md. The repo-wide
-# rule forbids names/emails everywhere in this public repo; this workflow
-# adds an automated enforcement floor on the two paths most likely to
-# accumulate PII (docs/outreach/, docs/customers/), where prior incidents
-# landed (2026-05-09 PR #820: 5 stargazer emails on public main 9 min before
-# manual remediation).
+# Path-scoped pre-merge gate. ENFORCES THIS WORKFLOW'S OWN STRICTER RULE on
+# top of the upstream policy in company/system-prompt.md.
 #
-# The whole docs/customers/** subtree is policy-banned regardless of file
-# name — that path is reserved as an unused namespace so it can't accrete
-# customer-keyed content. Operator stores sponsor/customer exchanges in
-# private notes (1Password / encrypted file).
+# Upstream policy (system-prompt.md "Public/private boundary"): NEVER write
+# customer names, emails, payment details to this public repo.
+#
+# This workflow's stricter, path-scoped extension:
+# 1. docs/outreach/** must contain no email addresses (third-party stargazer,
+#    customer, or otherwise) except a small allow-list of RFC-reserved + GH-bot
+#    domains. The 2026-05-09 PR #820 incident landed 5 stargazer emails on
+#    public main 9 min before manual remediation; that's the threat model
+#    this rule defends against, regardless of whether those people are
+#    "customers" by upstream definition.
+# 2. docs/customers/** is a reserved policy-banned namespace (no files at all)
+#    so the subtree can't accrete handle-keyed customer content. Customer/
+#    sponsor exchanges live in private operator notes (1Password, encrypted
+#    file) — that part IS upstream policy.
 #
 # Why this and not GitGuardian / Trufflehog / Gitleaks: those tools are
 # secret-focused (API keys, tokens, creds). Email addresses are noisy
@@ -39,16 +44,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Scan changed files in policy-restricted paths
+      - name: Scan policy-restricted paths across ALL commits in PR range
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
 
+          BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::could not resolve merge-base of origin/${BASE_REF} and HEAD"
+            exit 1
+          fi
+
+          # Union of policy-restricted files touched anywhere in the PR range.
           # Include rename (R) + copy (C) + type-change (T) in addition to
-          # add (A) + modify (M) so a renamed file can't bypass scanning.
+          # add (A) + modify (M) so a renamed file can't bypass.
           mapfile -t files < <(
-            git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
+            git diff --name-only --diff-filter=ACMRT "${BASE_SHA}..HEAD" \
               | grep -E '^docs/(outreach|customers)/' \
               || true
           )
@@ -58,8 +70,19 @@ jobs:
             exit 0
           fi
 
-          echo "Scanning ${#files[@]} file(s):"
+          echo "Scanning ${#files[@]} file path(s) across all commits in ${BASE_SHA:0:7}..HEAD:"
           printf '  - %s\n' "${files[@]}"
+          echo
+
+          # All commits in the PR range. We scan each commit's blob for each
+          # restricted-path file separately so that PII committed-then-removed
+          # within the range is still caught (it survives in pushed history).
+          mapfile -t commits < <(git rev-list "${BASE_SHA}..HEAD")
+          if [ "${#commits[@]}" -eq 0 ]; then
+            echo "No commits in range. PASS."
+            exit 0
+          fi
+          echo "Inspecting ${#commits[@]} commit(s) in range."
           echo
 
           fail=0
@@ -68,75 +91,78 @@ jobs:
           # example.com is RFC 2606 reserved.
           # noreply.github.com is GitHub system mail.
           # users.noreply.github.com is the per-user GitHub privacy domain.
-          # The allow-list pattern matches these THREE domains exactly (anchored).
-          # Patterns are passed via ENVIRON to avoid awk's -v backslash stripping
-          # (which would turn `\.` into `.` and over-match across whitespace).
+          # Patterns via ENVIRON to avoid awk -v backslash-stripping.
           export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
           export ALLOW_PATTERN='^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$'
 
-          for f in "${files[@]}"; do
-            [ -f "$f" ] || continue
+          for commit in "${commits[@]}"; do
+            for f in "${files[@]}"; do
 
-            # 1. Hard block: ANY content under docs/customers/. Subtree is
-            # reserved as a policy-banned namespace (no customer-keyed files,
-            # no handle-keyed files, no readme that would invite content).
-            # Operator stores customer exchanges in private notes.
-            if [[ "$f" =~ ^docs/customers/ ]]; then
-              echo "::error file=${f}::docs/customers/** is a policy-banned subtree. Customer/sponsor exchanges go to private operator notes (1Password / encrypted file). See company/system-prompt.md Public/private boundary."
-              fail=1
-              continue
-            fi
+              # 1. Hard block: ANY content under docs/customers/ at ANY commit.
+              # If the commit ADDED a file under that prefix, fail — even if a
+              # later commit deleted it.
+              if [[ "$f" =~ ^docs/customers/ ]]; then
+                if git cat-file -e "${commit}:${f}" 2>/dev/null; then
+                  echo "::error file=${f}::commit ${commit:0:7} contains a file under docs/customers/** — that subtree is a policy-banned namespace (this workflow's rule, on top of company/system-prompt.md customer-PII ban). Customer/sponsor exchanges go to private operator notes."
+                  fail=1
+                fi
+                continue
+              fi
 
-            # 2. Email scan. Extract every email match individually so
-            # per-line allow-list filtering can't drop a disallowed email
-            # sharing a line with an allow-listed one.
-            #
-            # awk extracts each match with its line number, then the
-            # allow-list filter compares the @domain part exactly.
-            hits=$(awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
-            {
-              line = $0
-              while (match(line, pat)) {
-                m = substr(line, RSTART, RLENGTH)
-                printf "%d:%s\n", NR, m
-                line = substr(line, RSTART + RLENGTH)
-              }
-            }' -- "$f" | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
-            {
-              email = $2
-              pos = index(email, "@")
-              domain = substr(email, pos)
-              if (domain !~ allow) print
-            }' || true)
+              # 2. Email scan against the file content AT THIS COMMIT. Skip
+              # silently if the file didn't exist at this commit.
+              content=$(git cat-file -p "${commit}:${f}" 2>/dev/null) || continue
+              [ -z "$content" ] && continue
 
-            if [ -n "$hits" ]; then
-              fail=1
-              while IFS= read -r line; do
-                lineno=$(printf '%s' "$line" | cut -d: -f1)
-                echo "::error file=${f},line=${lineno}::PII boundary violation — email address detected. company/system-prompt.md forbids names/emails in this path."
-              done <<< "$hits"
-              echo "    matches in $f:"
-              printf '      %s\n' "$hits"
-            fi
+              hits=$(printf '%s\n' "$content" \
+                | awk 'BEGIN { pat = ENVIRON["EMAIL_PATTERN"] }
+                       {
+                         line = $0
+                         while (match(line, pat)) {
+                           m = substr(line, RSTART, RLENGTH)
+                           printf "%d:%s\n", NR, m
+                           line = substr(line, RSTART + RLENGTH)
+                         }
+                       }' \
+                | awk -F: 'BEGIN { allow = ENVIRON["ALLOW_PATTERN"] }
+                           {
+                             email = $2
+                             pos = index(email, "@")
+                             domain = substr(email, pos)
+                             if (domain !~ allow) print
+                           }' \
+                || true)
+
+              if [ -n "$hits" ]; then
+                fail=1
+                while IFS= read -r line; do
+                  lineno=$(printf '%s' "$line" | cut -d: -f1)
+                  echo "::error file=${f},line=${lineno}::commit ${commit:0:7} contains an email address in this path. This workflow's stricter rule (on top of company/system-prompt.md customer-PII ban) forbids ANY email here, since the path historically accumulated third-party recipient PII."
+                done <<< "$hits"
+                echo "    commit ${commit:0:7} matches in $f:"
+                printf '      %s\n' "$hits"
+              fi
+            done
           done
 
           if [ "$fail" -ne 0 ]; then
             echo
-            echo "PII policy check FAILED. Redact and re-push, OR move the offending content to a private operator system."
+            echo "PII policy check FAILED. Redact and re-push (history will need to be rewritten if PII was committed-then-removed within the range — squash or interactive-rebase before push), OR move the offending content to a private operator system."
             exit 1
           fi
 
-          echo "PII policy check PASSED for all changed files."
+          echo "PII policy check PASSED across all commits in range."
 
       - name: Note on names + handles (manual review)
         if: always()
         run: |
           cat <<'EOF'
           Heads-up: this check enforces email policy via regex on emails only.
-          Full names + GitHub handles attached to recipient sections are also
-          banned by company/system-prompt.md but are not regex-detectable
-          without prohibitive false-positive cost. Reviewer must confirm
-          visually on any PR touching docs/outreach/** that recipient sections
-          are keyed by anonymous letter (Stargazer A-E) or similar, not by
-          name/handle/email.
+          Full names + GitHub handles attached to recipient sections are NOT
+          regex-detected (FP cost is prohibitive). They are banned in
+          docs/outreach/** by THIS workflow's policy (not by upstream
+          company/system-prompt.md, which only bans customer names/emails/
+          payment details directly). Reviewer must confirm visually on any
+          PR touching docs/outreach/** that recipient sections are keyed by
+          anonymous letter (Stargazer A-E) or similar, not by name/handle.
           EOF

--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -56,36 +56,19 @@ jobs:
             exit 1
           fi
 
-          # Union of policy-restricted files touched anywhere in the PR range.
-          # Include rename (R) + copy (C) + type-change (T) in addition to
-          # add (A) + modify (M) so a renamed file can't bypass.
-          mapfile -t files < <(
-            git diff --name-only --diff-filter=ACMRT "${BASE_SHA}..HEAD" \
-              | grep -E '^docs/(outreach|customers)/' \
-              || true
-          )
-
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No policy-restricted paths touched in this PR. PASS."
-            exit 0
-          fi
-
-          echo "Scanning ${#files[@]} file path(s) across all commits in ${BASE_SHA:0:7}..HEAD:"
-          printf '  - %s\n' "${files[@]}"
-          echo
-
-          # All commits in the PR range. We scan each commit's blob for each
-          # restricted-path file separately so that PII committed-then-removed
-          # within the range is still caught (it survives in pushed history).
+          # All commits in the PR range. We collect restricted-path files
+          # PER-COMMIT (via git diff-tree on each commit) rather than from
+          # the endpoint diff (BASE..HEAD), so files that existed in a
+          # restricted path in an intermediate commit but were renamed/moved
+          # OUT before HEAD are still scanned. The endpoint-diff approach
+          # would miss the commit-then-move-out bypass.
           mapfile -t commits < <(git rev-list "${BASE_SHA}..HEAD")
           if [ "${#commits[@]}" -eq 0 ]; then
             echo "No commits in range. PASS."
             exit 0
           fi
-          echo "Inspecting ${#commits[@]} commit(s) in range."
+          echo "Inspecting ${#commits[@]} commit(s) in range ${BASE_SHA:0:7}..HEAD"
           echo
-
-          fail=0
 
           # Email regex with allow-list for known-benign forms.
           # example.com is RFC 2606 reserved.
@@ -95,8 +78,23 @@ jobs:
           export EMAIL_PATTERN='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
           export ALLOW_PATTERN='^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$'
 
+          fail=0
+          any_restricted_seen=0
+
           for commit in "${commits[@]}"; do
-            for f in "${files[@]}"; do
+            # Files this specific commit added/modified/renamed/copied/type-changed
+            # under a restricted path. Captures BOTH renames-into and renames-out-of
+            # by emitting both source + dest paths via -M / --name-only.
+            mapfile -t commit_files < <(
+              git diff-tree --no-commit-id --name-only -r -M --diff-filter=ACMRT "$commit" \
+                | grep -E '^docs/(outreach|customers)/' \
+                || true
+            )
+
+            [ "${#commit_files[@]}" -eq 0 ] && continue
+            any_restricted_seen=1
+
+            for f in "${commit_files[@]}"; do
 
               # 1. Hard block: ANY content under docs/customers/ at ANY commit.
               # If the commit ADDED a file under that prefix, fail — even if a
@@ -151,7 +149,11 @@ jobs:
             exit 1
           fi
 
-          echo "PII policy check PASSED across all commits in range."
+          if [ "$any_restricted_seen" -eq 0 ]; then
+            echo "No policy-restricted paths touched in any commit in range. PASS."
+          else
+            echo "PII policy check PASSED across all commits in range."
+          fi
 
       - name: Note on names + handles (manual review)
         if: always()


### PR DESCRIPTION
## Summary

Path-scoped pre-merge gate + local hooks blocking the 2026-05-09 PR #820 incident class. Defense in depth: pre-commit + pre-push + workflow + agent-prompt discipline.

Triggers (workflow) on PRs touching:
- `docs/outreach/**`
- `docs/customers/**`

Three checks across all layers:

1. **Email regex** — `[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}` with allow-list for `example.com`, `noreply.github.com`, `users.noreply.github.com`. Per-match extraction (not per-line) so a disallowed email on the same line as an allow-listed one is still caught.

2. **Hard block on any content under `docs/customers/`** — entire subtree is policy-banned regardless of file name. Sponsor/customer exchanges go to private operator notes (1Password / encrypted file).

3. **Rename-aware** — `--diff-filter=ACMRT` so renames into restricted paths can't bypass.

## Files

| File | Purpose | Bypassable |
|---|---|---|
| `.github/workflows/pii-policy-check.yml` | CI required-status-check (path-triggered) | only via admin merge |
| `.githooks/pre-commit` | local block before commit lands | `--no-verify` |
| `.githooks/pre-push` | local block on push (catches `--no-verify` on commit) | `--no-verify` |
| `.githooks/setup.sh` | wires `git config core.hooksPath .githooks` | manual setup required per clone |

## Why not GitGuardian / TruffleHog / Gitleaks

Those are secret-focused (API keys, tokens, creds). Email addresses are noisy globally + benign in CHANGELOG/fixtures. Path-scoped grep matches the actual policy boundary in `company/system-prompt.md`. Cheaper, narrower, no service dependency. See `memory/reference_pii_vs_secret_detection_tooling.md`.

## What this does NOT catch

- Full names + GitHub handles attached to recipient sections (regex FP cost prohibitive). Workflow emits explicit reviewer reminder.
- Phone numbers, physical addresses, other PII forms (out of current threat model — emails are the leaked attribute on PR #820).
- Encoded/obfuscated emails (e.g. `foo [at] bar [dot] com`). Acceptable: not the threat we just hit.

## Test plan

- [x] Local smoke (round 0): `spammer@evil.com` matches; `foo@example.com` allow-listed
- [x] Round 1 Copilot review: 5 findings addressed (rename bypass, customer subtree scope, per-line allow-list FN, grep path injection, header policy scoping)
- [x] Bonus bug: awk `-v` backslash stripping causing regex over-match — fixed via ENVIRON
- [x] Round 1 smoke: mixed-line `legit@example.com and disallowed@spam.net and good@noreply.github.com` → only `disallowed@spam.net` flagged
- [ ] Wait for round 2 Copilot review
- [ ] After merge: open follow-up PR touching `docs/outreach/...` with deliberate fake email; confirm gate fails

🤖 Hardening from 2026-05-09 PII incident