### PR TITLE
feat(supervisor): supervisor-rank workflow + clog classifier

### DIFF
--- a/.github/scripts/classify-clogs.sh
+++ b/.github/scripts/classify-clogs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAXONOMY_FILE="${TAXONOMY_FILE:-company/pipeline-stages.json}"
+INPUT="${1:-/dev/stdin}"
+NOW="${SUPERVISOR_NOW:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+
+if [ ! -f "$TAXONOMY_FILE" ]; then
+  echo "error: missing taxonomy file: $TAXONOMY_FILE" >&2
+  exit 1
+fi
+
+if ! jq empty "$TAXONOMY_FILE" >/dev/null 2>&1; then
+  echo "error: malformed pipeline-stages.json: $TAXONOMY_FILE" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  . as $root
+  |
+  (.stages | type == "array")
+  and (.classification_rules | type == "object")
+  and (.dwell_thresholds_hours | type == "object")
+  and (.recommended_actions | type == "object")
+  and (all(.stages[]; (. as $stage | type == "string" and ($root.classification_rules[$stage] | type == "object"))))
+' "$TAXONOMY_FILE" >/dev/null; then
+  echo "error: bad rule in pipeline-stages.json: missing stage classification rule" >&2
+  exit 1
+fi
+
+if ! jq empty "$INPUT" >/dev/null 2>&1; then
+  echo "error: malformed snapshot JSON: $INPUT" >&2
+  exit 1
+fi
+
+jq --arg now "$NOW" --slurpfile taxonomy "$TAXONOMY_FILE" '
+  def label_names($item): [($item.labels // [])[]?.name];
+  def has_label($item; $name): label_names($item) | index($name) != null;
+  def has_any_label($item; $names): any($names[]?; has_label($item; .));
+  def title_starts($item; $prefixes):
+    ($item.title // "" | ascii_downcase) as $title
+    | any($prefixes[]?; . as $prefix | ($title | startswith($prefix | ascii_downcase)));
+  def has_type_label($item): any(label_names($item)[]?; startswith("type:"));
+  def rule($stage): $taxonomy[0].classification_rules[$stage] // {};
+  def matches($item; $stage):
+    (rule($stage)) as $rule
+    | (
+        has_any_label($item; $rule.label_any // [])
+        or title_starts($item; $rule.title_prefix_any // [])
+        or (
+          (($rule.review_decision_any // []) | length) > 0
+          and (($item.review_decision // "") as $decision | ($rule.review_decision_any | index($decision)) != null)
+          and (
+            (($rule.merge_state_status_any // []) | length) == 0
+            or (($item.merge_state_status // "") as $status | ($rule.merge_state_status_any | index($status)) != null)
+          )
+        )
+        or (
+          ($stage == "triage")
+          and ($item.type == "issue")
+          and (($rule.issue_without_type_label // false) == true)
+          and (has_type_label($item) | not)
+          and ((label_names($item) | length) == 0)
+        )
+      );
+  def stage($item):
+    if has_label($item; "needs-human") then "review"
+    elif (($item.title // "" | ascii_downcase) | startswith("spec:")) then "spec"
+    elif ($item.type == "pr" and (($item.review_decision // "") == "APPROVED") and ((($item.merge_state_status // "") == "CLEAN") or (($item.merge_state_status // "") == "HAS_HOOKS"))) then "merge"
+    elif matches($item; "revenue") then "revenue"
+    elif matches($item; "verify") then "verify"
+    elif matches($item; "review") then "review"
+    elif matches($item; "build") then "build"
+    elif matches($item; "spec") then "spec"
+    elif matches($item; "triage") then "triage"
+    else "unknown"
+    end;
+  def dwell_start($item; $stage):
+    if $stage == "triage" and has_label($item; "copilot-triaging") then ($item.updated_at // $item.updatedAt // $item.created_at // $item.createdAt)
+    else ($item.created_at // $item.createdAt // $item.updated_at // $item.updatedAt)
+    end;
+  map(
+    . as $item
+    | (stage($item)) as $stage
+    | (dwell_start($item; $stage)) as $start
+    | . + {
+        stage: $stage,
+        dwell_hours: (
+          if ($start == null or $start == "") then 0
+          else (((($now | fromdateiso8601) - ($start | fromdateiso8601)) / 3600) | floor | if . < 0 then 0 else . end)
+          end
+        )
+      }
+  )
+' "$INPUT"

--- a/.github/scripts/classify-clogs.sh
+++ b/.github/scripts/classify-clogs.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 
 TAXONOMY_FILE="${TAXONOMY_FILE:-company/pipeline-stages.json}"
-INPUT="${1:-/dev/stdin}"
+INPUT="${1:-}"
 NOW="${SUPERVISOR_NOW:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+
+# Buffer stdin to a tempfile so the input can be validated then re-read.
+# /dev/stdin is not seekable; without this the second jq sees EOF and emits empty output.
+if [ -z "$INPUT" ] || [ "$INPUT" = "-" ] || [ "$INPUT" = "/dev/stdin" ]; then
+  INPUT="$(mktemp)"
+  trap 'rm -f "$INPUT"' EXIT
+  cat > "$INPUT"
+fi
 
 if [ ! -f "$TAXONOMY_FILE" ]; then
   echo "error: missing taxonomy file: $TAXONOMY_FILE" >&2

--- a/.github/scripts/fixtures/classified-fixture.json
+++ b/.github/scripts/fixtures/classified-fixture.json
@@ -1,0 +1,170 @@
+[
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 101,
+    "title": "Triage stuck in Copilot",
+    "labels": [
+      {
+        "name": "copilot-triaging"
+      }
+    ],
+    "created_at": "2026-05-12T22:00:00Z",
+    "updated_at": "2026-05-15T10:00:00Z",
+    "is_draft": false,
+    "stage": "triage",
+    "dwell_hours": 12
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 102,
+    "title": "Approved issue waiting for implementation",
+    "labels": [
+      {
+        "name": "approved-for-build"
+      },
+      {
+        "name": "type:feature"
+      }
+    ],
+    "created_at": "2026-05-13T22:00:00Z",
+    "updated_at": "2026-05-14T22:00:00Z",
+    "is_draft": false,
+    "stage": "build",
+    "dwell_hours": 48
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 103,
+    "title": "Bookkeeping note",
+    "labels": [
+      {
+        "name": "manual-only"
+      }
+    ],
+    "created_at": "2026-05-14T22:00:00Z",
+    "updated_at": "2026-05-14T22:00:00Z",
+    "is_draft": false,
+    "stage": "unknown",
+    "dwell_hours": 24
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 201,
+    "title": "spec: Issue #102 - implementation plan",
+    "labels": [
+      {
+        "name": "approved-for-build"
+      }
+    ],
+    "created_at": "2026-05-11T22:00:00Z",
+    "updated_at": "2026-05-12T22:00:00Z",
+    "is_draft": false,
+    "review_decision": "REVIEW_REQUIRED",
+    "merge_state_status": "UNKNOWN",
+    "stage": "spec",
+    "dwell_hours": 96
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 202,
+    "title": "impl: Issue #102 - ranker script",
+    "labels": [
+      {
+        "name": "needs-review"
+      }
+    ],
+    "created_at": "2026-05-14T22:00:00Z",
+    "updated_at": "2026-05-15T00:00:00Z",
+    "is_draft": false,
+    "review_decision": "REVIEW_REQUIRED",
+    "merge_state_status": "BLOCKED",
+    "stage": "review",
+    "dwell_hours": 24
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 203,
+    "title": "impl: Issue #120 - clean approved PR",
+    "labels": [],
+    "created_at": "2026-05-14T10:00:00Z",
+    "updated_at": "2026-05-14T12:00:00Z",
+    "is_draft": false,
+    "review_decision": "APPROVED",
+    "merge_state_status": "CLEAN",
+    "stage": "merge",
+    "dwell_hours": 36
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 301,
+    "title": "Verify merged implementation",
+    "labels": [
+      {
+        "name": "needs-e2e"
+      }
+    ],
+    "created_at": "2026-05-10T22:00:00Z",
+    "updated_at": "2026-05-11T22:00:00Z",
+    "is_draft": false,
+    "stage": "verify",
+    "dwell_hours": 120
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 302,
+    "title": "Customer-zero still zero",
+    "labels": [
+      {
+        "name": "customer-zero"
+      }
+    ],
+    "created_at": "2026-05-08T22:00:00Z",
+    "updated_at": "2026-05-09T22:00:00Z",
+    "is_draft": false,
+    "stage": "revenue",
+    "dwell_hours": 168
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 303,
+    "title": "Human escalation beats triage",
+    "labels": [
+      {
+        "name": "needs-human"
+      },
+      {
+        "name": "copilot-triaging"
+      }
+    ],
+    "created_at": "2026-05-05T22:00:00Z",
+    "updated_at": "2026-05-15T20:00:00Z",
+    "is_draft": false,
+    "stage": "review",
+    "dwell_hours": 240
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 304,
+    "title": "Unknown labeled item",
+    "labels": [
+      {
+        "name": "manual-only"
+      }
+    ],
+    "created_at": "2026-05-15T00:00:00Z",
+    "updated_at": "2026-05-15T00:00:00Z",
+    "is_draft": false,
+    "stage": "unknown",
+    "dwell_hours": 22
+  }
+]

--- a/.github/scripts/fixtures/ranked-fixture.json
+++ b/.github/scripts/fixtures/ranked-fixture.json
@@ -1,0 +1,98 @@
+{
+  "generated_at": "2026-05-15T22:00:00Z",
+  "top": [
+    {
+      "rank": 1,
+      "id": "atvirokodosprendimai/wgmesh#303",
+      "repo": "atvirokodosprendimai/wgmesh",
+      "type": "issue",
+      "number": 303,
+      "title": "Human escalation beats triage",
+      "stage": "review",
+      "dwell_hours": 240,
+      "downstream_blocked_count": 1,
+      "score": 240,
+      "recommended_action": "escalate-needs-human"
+    },
+    {
+      "rank": 2,
+      "id": "atvirokodosprendimai/wgmesh#302",
+      "repo": "atvirokodosprendimai/wgmesh",
+      "type": "issue",
+      "number": 302,
+      "title": "Customer-zero still zero",
+      "stage": "revenue",
+      "dwell_hours": 168,
+      "downstream_blocked_count": 1,
+      "score": 168,
+      "recommended_action": "post-rah-bounty"
+    },
+    {
+      "rank": 3,
+      "id": "atvirokodosprendimai/wgmesh#301",
+      "repo": "atvirokodosprendimai/wgmesh",
+      "type": "issue",
+      "number": 301,
+      "title": "Verify merged implementation",
+      "stage": "verify",
+      "dwell_hours": 120,
+      "downstream_blocked_count": 1,
+      "score": 120,
+      "recommended_action": "post-rah-bounty"
+    },
+    {
+      "rank": 4,
+      "id": "atvirokodosprendimai/ai-pipeline-template#201",
+      "repo": "atvirokodosprendimai/ai-pipeline-template",
+      "type": "pr",
+      "number": 201,
+      "title": "spec: Issue #102 - implementation plan",
+      "stage": "spec",
+      "dwell_hours": 96,
+      "downstream_blocked_count": 1,
+      "score": 96,
+      "recommended_action": "manual-merge"
+    },
+    {
+      "rank": 5,
+      "id": "atvirokodosprendimai/ai-pipeline-template#102",
+      "repo": "atvirokodosprendimai/ai-pipeline-template",
+      "type": "issue",
+      "number": 102,
+      "title": "Approved issue waiting for implementation",
+      "stage": "build",
+      "dwell_hours": 48,
+      "downstream_blocked_count": 1,
+      "score": 48,
+      "recommended_action": "retry-copilot"
+    }
+  ],
+  "stage_summary": {
+    "triage": 1,
+    "spec": 1,
+    "build": 1,
+    "review": 2,
+    "merge": 1,
+    "verify": 1,
+    "revenue": 1,
+    "unknown": 2
+  },
+  "unknown": [
+    {
+      "id": "atvirokodosprendimai/ai-pipeline-template#103",
+      "repo": "atvirokodosprendimai/ai-pipeline-template",
+      "type": "issue",
+      "number": 103,
+      "title": "Bookkeeping note",
+      "stage": "unknown"
+    },
+    {
+      "id": "atvirokodosprendimai/wgmesh#304",
+      "repo": "atvirokodosprendimai/wgmesh",
+      "type": "issue",
+      "number": 304,
+      "title": "Unknown labeled item",
+      "stage": "unknown"
+    }
+  ]
+}

--- a/.github/scripts/fixtures/snapshot-fixture.json
+++ b/.github/scripts/fixtures/snapshot-fixture.json
@@ -1,0 +1,150 @@
+[
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 101,
+    "title": "Triage stuck in Copilot",
+    "labels": [
+      {
+        "name": "copilot-triaging"
+      }
+    ],
+    "created_at": "2026-05-12T22:00:00Z",
+    "updated_at": "2026-05-15T10:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 102,
+    "title": "Approved issue waiting for implementation",
+    "labels": [
+      {
+        "name": "approved-for-build"
+      },
+      {
+        "name": "type:feature"
+      }
+    ],
+    "created_at": "2026-05-13T22:00:00Z",
+    "updated_at": "2026-05-14T22:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "issue",
+    "number": 103,
+    "title": "Bookkeeping note",
+    "labels": [
+      {
+        "name": "manual-only"
+      }
+    ],
+    "created_at": "2026-05-14T22:00:00Z",
+    "updated_at": "2026-05-14T22:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 201,
+    "title": "spec: Issue #102 - implementation plan",
+    "labels": [
+      {
+        "name": "approved-for-build"
+      }
+    ],
+    "created_at": "2026-05-11T22:00:00Z",
+    "updated_at": "2026-05-12T22:00:00Z",
+    "is_draft": false,
+    "review_decision": "REVIEW_REQUIRED",
+    "merge_state_status": "UNKNOWN"
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 202,
+    "title": "impl: Issue #102 - ranker script",
+    "labels": [
+      {
+        "name": "needs-review"
+      }
+    ],
+    "created_at": "2026-05-14T22:00:00Z",
+    "updated_at": "2026-05-15T00:00:00Z",
+    "is_draft": false,
+    "review_decision": "REVIEW_REQUIRED",
+    "merge_state_status": "BLOCKED"
+  },
+  {
+    "repo": "atvirokodosprendimai/ai-pipeline-template",
+    "type": "pr",
+    "number": 203,
+    "title": "impl: Issue #120 - clean approved PR",
+    "labels": [],
+    "created_at": "2026-05-14T10:00:00Z",
+    "updated_at": "2026-05-14T12:00:00Z",
+    "is_draft": false,
+    "review_decision": "APPROVED",
+    "merge_state_status": "CLEAN"
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 301,
+    "title": "Verify merged implementation",
+    "labels": [
+      {
+        "name": "needs-e2e"
+      }
+    ],
+    "created_at": "2026-05-10T22:00:00Z",
+    "updated_at": "2026-05-11T22:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 302,
+    "title": "Customer-zero still zero",
+    "labels": [
+      {
+        "name": "customer-zero"
+      }
+    ],
+    "created_at": "2026-05-08T22:00:00Z",
+    "updated_at": "2026-05-09T22:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 303,
+    "title": "Human escalation beats triage",
+    "labels": [
+      {
+        "name": "needs-human"
+      },
+      {
+        "name": "copilot-triaging"
+      }
+    ],
+    "created_at": "2026-05-05T22:00:00Z",
+    "updated_at": "2026-05-15T20:00:00Z",
+    "is_draft": false
+  },
+  {
+    "repo": "atvirokodosprendimai/wgmesh",
+    "type": "issue",
+    "number": 304,
+    "title": "Unknown labeled item",
+    "labels": [
+      {
+        "name": "manual-only"
+      }
+    ],
+    "created_at": "2026-05-15T00:00:00Z",
+    "updated_at": "2026-05-15T00:00:00Z",
+    "is_draft": false
+  }
+]

--- a/.github/scripts/publish-rank.sh
+++ b/.github/scripts/publish-rank.sh
@@ -118,7 +118,7 @@ else
   match_count="$(jq 'length' <<< "$matches")"
 
   if [ "$match_count" -eq 0 ]; then
-    issue_url="$(retry_gh issue create --repo "$GH_REPO" --title "$TITLE" --body-file "$body_file" --label supervisor)"
+    issue_url="$(retry_gh issue create --repo "$GH_REPO" --title "$TITLE" --body-file "$body_file")"
     issue_number="${issue_url##*/}"
   elif [ "$match_count" -eq 1 ]; then
     issue_number="$(jq -r '.[0].number' <<< "$matches")"

--- a/.github/scripts/publish-rank.sh
+++ b/.github/scripts/publish-rank.sh
@@ -30,9 +30,11 @@ new_state="$tmpdir/supervisor-rank-state.json"
 
 previous_top="[]"
 previous_run=0
+previous_fingerprint=""
 if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
   previous_top="$(jq -c '.last_run_top_ids // []' "$STATE_FILE")"
   previous_run="$(jq -r '.run_number // 0' "$STATE_FILE")"
+  previous_fingerprint="$(jq -r '.material_fingerprint // ""' "$STATE_FILE")"
 fi
 
 current_top="$(jq -c '[.top[0:3][]?.id]' "$RANKED_JSON")"
@@ -40,6 +42,34 @@ rank_changed="false"
 if [ "$previous_top" != "[]" ] && [ "$previous_top" != "$current_top" ]; then
   rank_changed="true"
 fi
+
+# Material fingerprint — sha256 over the fields whose change should drive a
+# commit + PR. Metadata fields like last_run_at, run_number, generated_at are
+# EXCLUDED so they cannot drive PR-per-run pile-up (the anti-pattern this
+# supervisor is supposed to clear, not create).
+stage_summary_json="$(jq -c '.stage_summary // {}' "$RANKED_JSON")"
+unknown_count="$(jq -c '(.unknown // []) | length' "$RANKED_JSON")"
+top_actions_json="$(jq -c '[.top[0:5][]? | {id, action: (.recommended_action // null)}]' "$RANKED_JSON")"
+material_payload="$(jq -Sc -n \
+  --argjson top_ids "$current_top" \
+  --argjson stage_summary "$stage_summary_json" \
+  --argjson unknown_count "$unknown_count" \
+  --argjson top_actions "$top_actions_json" \
+  '{top_ids: $top_ids, stage_summary: $stage_summary, unknown_count: $unknown_count, top_actions: $top_actions}')"
+if command -v sha256sum >/dev/null 2>&1; then
+  new_fingerprint="$(printf '%s' "$material_payload" | sha256sum | awk '{print $1}')"
+else
+  new_fingerprint="$(printf '%s' "$material_payload" | shasum -a 256 | awk '{print $1}')"
+fi
+
+material_changed="true"
+if [ -n "$previous_fingerprint" ] && [ "$previous_fingerprint" = "$new_fingerprint" ]; then
+  material_changed="false"
+fi
+
+# Emit sentinel for the workflow's Commit state step to gate on.
+sentinel_file="${SUPERVISOR_MATERIAL_SENTINEL:-/tmp/supervisor-rank-material-changed}"
+printf '%s\n' "$material_changed" > "$sentinel_file"
 
 generated_at="$(jq -r '.generated_at // ""' "$RANKED_JSON")"
 run_number=$((previous_run + 1))
@@ -97,6 +127,24 @@ retry_gh() {
 
 issue_number=""
 issue_url=""
+# Preserve prior issue identity when skipping due to no material change.
+if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
+  prior_issue_number="$(jq -r '.issue_number // ""' "$STATE_FILE")"
+  prior_issue_url="$(jq -r '.issue_url // ""' "$STATE_FILE")"
+  if [ -n "$prior_issue_number" ] && [ "$prior_issue_number" != "null" ]; then
+    issue_number="$prior_issue_number"
+  fi
+  if [ -n "$prior_issue_url" ] && [ "$prior_issue_url" != "null" ]; then
+    issue_url="$prior_issue_url"
+  fi
+fi
+
+if [ "$material_changed" = "false" ]; then
+  echo "no material change (fingerprint=$new_fingerprint); skipping issue + state mutation" >&2
+  echo "supervisor-rank issue: ${issue_url:-unchanged}"
+  exit 0
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
   mkdir -p "$(dirname "$STATE_FILE")"
   issue_number="${SUPERVISOR_PUBLISH_DRY_RUN_ISSUE:-999}"
@@ -105,6 +153,8 @@ if [ "$DRY_RUN" = "1" ]; then
     {
       echo "DRY_RUN issue_number=$issue_number"
       echo "DRY_RUN rank_changed=$rank_changed"
+      echo "DRY_RUN material_changed=$material_changed"
+      echo "DRY_RUN fingerprint=$new_fingerprint"
       echo "DRY_RUN body_file=$body_file"
     } >> "$SUPERVISOR_PUBLISH_LOG"
   fi
@@ -144,6 +194,8 @@ jq -n \
   --argjson run_number "$run_number" \
   --arg issue_number "$issue_number" \
   --arg issue_url "$issue_url" \
+  --arg material_fingerprint "$new_fingerprint" \
+  --argjson top_actions "$top_actions_json" \
   --slurpfile ranked "$RANKED_JSON" \
   '{
     last_run_at: $last_run_at,
@@ -153,7 +205,9 @@ jq -n \
     issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
     issue_url: (if $issue_url == "" then null else $issue_url end),
     stage_summary: ($ranked[0].stage_summary // {}),
-    unknown_count: (($ranked[0].unknown // []) | length)
+    unknown_count: (($ranked[0].unknown // []) | length),
+    top_actions: $top_actions,
+    material_fingerprint: $material_fingerprint
   }' > "$new_state"
 
 mv "$new_state" "$STATE_FILE"

--- a/.github/scripts/publish-rank.sh
+++ b/.github/scripts/publish-rank.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RANKED_JSON="${1:?Usage: publish-rank.sh <ranked-json> [state-file]}"
+STATE_FILE="${2:-company/supervisor-rank-state.json}"
+GH_REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+TITLE="supervisor-rank: top pipeline clogs"
+DRY_RUN="${SUPERVISOR_PUBLISH_DRY_RUN:-0}"
+
+if ! jq empty "$RANKED_JSON" >/dev/null 2>&1; then
+  echo "error: malformed ranked JSON: $RANKED_JSON" >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" != "1" ]; then
+  if [ -z "$GH_REPO" ]; then
+    echo "error: GH_REPO or GITHUB_REPOSITORY is required" >&2
+    exit 1
+  fi
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "error: GH_TOKEN is required" >&2
+    exit 1
+  fi
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+body_file="$tmpdir/supervisor-rank-body.md"
+new_state="$tmpdir/supervisor-rank-state.json"
+
+previous_top="[]"
+previous_run=0
+if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
+  previous_top="$(jq -c '.last_run_top_ids // []' "$STATE_FILE")"
+  previous_run="$(jq -r '.run_number // 0' "$STATE_FILE")"
+fi
+
+current_top="$(jq -c '[.top[0:3][]?.id]' "$RANKED_JSON")"
+rank_changed="false"
+if [ "$previous_top" != "[]" ] && [ "$previous_top" != "$current_top" ]; then
+  rank_changed="true"
+fi
+
+generated_at="$(jq -r '.generated_at // ""' "$RANKED_JSON")"
+run_number=$((previous_run + 1))
+
+{
+  echo "# supervisor-rank: top pipeline clogs"
+  echo
+  echo "Updated: ${generated_at:-unknown} (run #$run_number)"
+  echo
+  echo "## Top clogs"
+  if [ "$(jq '.top | length' "$RANKED_JSON")" -eq 0 ]; then
+    echo
+    echo "All clear. No ranked open clogs in the current snapshot."
+  else
+    jq -r '.top[] |
+      "\(.rank). **\(.title)** — \(.repo)#\(.number)\n" +
+      "   - Stage: `\(.stage)`\n" +
+      "   - Dwell x blocked: \(.dwell_hours)h x \(.downstream_blocked_count) = \(.score)\n" +
+      "   - Recommended action: `\(.recommended_action // "none")`\n"' "$RANKED_JSON"
+  fi
+  echo
+  echo "## Stage summary"
+  jq -r '.stage_summary | to_entries[] | "- \(.key): \(.value)"' "$RANKED_JSON"
+  echo
+  echo "## Needs taxonomy"
+  if [ "$(jq '.unknown | length' "$RANKED_JSON")" -eq 0 ]; then
+    echo "- unknown: 0"
+  else
+    jq -r '.unknown[] | "- \(.repo)#\(.number): \(.title)"' "$RANKED_JSON"
+  fi
+  echo
+  echo "## State"
+  echo "- Prior top-3: \`$previous_top\`"
+  echo "- Current top-3: \`$current_top\`"
+  echo "- File: \`$STATE_FILE\`"
+} > "$body_file"
+
+retry_gh() {
+  local attempt=1
+  local delay=2
+  while true; do
+    if gh "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge 3 ]; then
+      echo "error: gh $* failed after $attempt attempts" >&2
+      return 1
+    fi
+    echo "warning: gh $* failed; retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+issue_number=""
+issue_url=""
+if [ "$DRY_RUN" = "1" ]; then
+  mkdir -p "$(dirname "$STATE_FILE")"
+  issue_number="${SUPERVISOR_PUBLISH_DRY_RUN_ISSUE:-999}"
+  issue_url="https://github.com/${GH_REPO:-dry-run/repo}/issues/$issue_number"
+  if [ -n "${SUPERVISOR_PUBLISH_LOG:-}" ]; then
+    {
+      echo "DRY_RUN issue_number=$issue_number"
+      echo "DRY_RUN rank_changed=$rank_changed"
+      echo "DRY_RUN body_file=$body_file"
+    } >> "$SUPERVISOR_PUBLISH_LOG"
+  fi
+else
+  issues_json="$tmpdir/issues.json"
+  retry_gh issue list --repo "$GH_REPO" \
+    --search "$TITLE in:title is:open" \
+    --json number,title,url \
+    > "$issues_json"
+  matches="$(jq --arg title "$TITLE" '[.[] | select(.title == $title)]' "$issues_json")"
+  match_count="$(jq 'length' <<< "$matches")"
+
+  if [ "$match_count" -eq 0 ]; then
+    issue_url="$(retry_gh issue create --repo "$GH_REPO" --title "$TITLE" --body-file "$body_file" --label supervisor)"
+    issue_number="${issue_url##*/}"
+  elif [ "$match_count" -eq 1 ]; then
+    issue_number="$(jq -r '.[0].number' <<< "$matches")"
+    issue_url="$(jq -r '.[0].url' <<< "$matches")"
+    retry_gh issue edit "$issue_number" --repo "$GH_REPO" --body-file "$body_file"
+  else
+    echo "error: duplicate supervisor-rank issues open: $(jq -r '.[].number' <<< "$matches" | paste -sd ',')" >&2
+    exit 1
+  fi
+
+  if [ "$rank_changed" = "true" ]; then
+    entered="$(jq -n --argjson prev "$previous_top" --argjson curr "$current_top" '$curr - $prev | join(", ")')"
+    exited="$(jq -n --argjson prev "$previous_top" --argjson curr "$current_top" '$prev - $curr | join(", ")')"
+    retry_gh issue comment "$issue_number" --repo "$GH_REPO" \
+      --body "Rank order changed. Entered top-3: ${entered:-none}. Exited top-3: ${exited:-none}."
+  fi
+fi
+
+jq -n \
+  --arg last_run_at "$generated_at" \
+  --argjson top_ids "$current_top" \
+  --argjson rank_changed "$rank_changed" \
+  --argjson run_number "$run_number" \
+  --arg issue_number "$issue_number" \
+  --arg issue_url "$issue_url" \
+  --slurpfile ranked "$RANKED_JSON" \
+  '{
+    last_run_at: $last_run_at,
+    last_run_top_ids: $top_ids,
+    rank_changed: $rank_changed,
+    run_number: $run_number,
+    issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+    issue_url: (if $issue_url == "" then null else $issue_url end),
+    stage_summary: ($ranked[0].stage_summary // {}),
+    unknown_count: (($ranked[0].unknown // []) | length)
+  }' > "$new_state"
+
+mv "$new_state" "$STATE_FILE"
+echo "supervisor-rank issue: ${issue_url:-dry-run}"

--- a/.github/scripts/rank-clogs.sh
+++ b/.github/scripts/rank-clogs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT="${1:-/dev/stdin}"
+TOP_N="${TOP_N:-5}"
+NOW="${SUPERVISOR_NOW:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+
+if ! jq empty "$INPUT" >/dev/null 2>&1; then
+  echo "error: malformed classified JSON: $INPUT" >&2
+  exit 1
+fi
+
+jq --arg now "$NOW" --argjson top_n "$TOP_N" '
+  def id: "\(.repo)#\(.number)";
+  def stage_summary($items):
+    reduce ["triage","spec","build","review","merge","verify","revenue","unknown"][] as $stage
+      ({}; .[$stage] = ($items | map(select((.stage // "unknown") == $stage)) | length));
+  . as $items
+  | [
+      $items[]
+      | . as $item
+      | ($item.stage // "unknown") as $stage
+      | (
+          if $stage == "spec" then
+            ([$items[] | select(.repo == $item.repo and (.stage // "") == "build")] | length | if . < 1 then 1 else . end)
+          elif $stage == "triage" then
+            ([$items[] | select(.repo == $item.repo and ((.stage // "") == "spec" or (.stage // "") == "build" or (.stage // "") == "review"))] | length | if . < 1 then 1 else . end)
+          elif $stage == "merge" then
+            ([$items[] | select(.repo == $item.repo and (.stage // "") == "merge")] | length | if . < 1 then 1 else . end)
+          elif $stage == "unknown" then 0
+          else 1
+          end
+        ) as $blocked
+      | . + {
+          id: id,
+          downstream_blocked_count: $blocked,
+          score: ((.dwell_hours // 0) * $blocked)
+        }
+    ] as $scored
+  | {
+      generated_at: $now,
+      top: (
+        $scored
+        | map(select((.stage // "unknown") != "unknown"))
+        | sort_by(-(.score // 0), (.created_at // .createdAt // ""), .repo, .number)
+        | .[0:$top_n]
+        | to_entries
+        | map(
+            .value
+            | {
+                rank: (.rank // null),
+                id,
+                repo,
+                type,
+                number,
+                title,
+                stage,
+                dwell_hours,
+                downstream_blocked_count,
+                score
+              }
+            | .rank = null
+          )
+        | to_entries
+        | map(.value + {rank: (.key + 1)})
+      ),
+      stage_summary: stage_summary($items),
+      unknown: (
+        $scored
+        | map(select((.stage // "unknown") == "unknown") | {id, repo, type, number, title, stage})
+        | sort_by(.repo, .number)
+      )
+    }
+' "$INPUT"

--- a/.github/scripts/rank-clogs.sh
+++ b/.github/scripts/rank-clogs.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-INPUT="${1:-/dev/stdin}"
+INPUT="${1:-}"
 TOP_N="${TOP_N:-5}"
 NOW="${SUPERVISOR_NOW:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"
+
+# Buffer stdin to a tempfile so the input can be validated then re-read.
+if [ -z "$INPUT" ] || [ "$INPUT" = "-" ] || [ "$INPUT" = "/dev/stdin" ]; then
+  INPUT="$(mktemp)"
+  trap 'rm -f "$INPUT"' EXIT
+  cat > "$INPUT"
+fi
 
 if ! jq empty "$INPUT" >/dev/null 2>&1; then
   echo "error: malformed classified JSON: $INPUT" >&2

--- a/.github/scripts/recommend-actions.sh
+++ b/.github/scripts/recommend-actions.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 TAXONOMY_FILE="${TAXONOMY_FILE:-company/pipeline-stages.json}"
-INPUT="${1:-/dev/stdin}"
+INPUT="${1:-}"
+
+# Buffer stdin to a tempfile so the input can be validated then re-read.
+if [ -z "$INPUT" ] || [ "$INPUT" = "-" ] || [ "$INPUT" = "/dev/stdin" ]; then
+  INPUT="$(mktemp)"
+  trap 'rm -f "$INPUT"' EXIT
+  cat > "$INPUT"
+fi
 
 if [ ! -f "$TAXONOMY_FILE" ]; then
   echo "error: missing taxonomy file: $TAXONOMY_FILE" >&2

--- a/.github/scripts/recommend-actions.sh
+++ b/.github/scripts/recommend-actions.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAXONOMY_FILE="${TAXONOMY_FILE:-company/pipeline-stages.json}"
+INPUT="${1:-/dev/stdin}"
+
+if [ ! -f "$TAXONOMY_FILE" ]; then
+  echo "error: missing taxonomy file: $TAXONOMY_FILE" >&2
+  exit 1
+fi
+
+if ! jq empty "$TAXONOMY_FILE" >/dev/null 2>&1; then
+  echo "error: malformed pipeline-stages.json: $TAXONOMY_FILE" >&2
+  exit 1
+fi
+
+if ! jq empty "$INPUT" >/dev/null 2>&1; then
+  echo "error: malformed ranked JSON: $INPUT" >&2
+  exit 1
+fi
+
+missing_stages="$(jq -r --slurpfile taxonomy "$TAXONOMY_FILE" '
+  [.top[]?.stage | select(($taxonomy[0].recommended_actions[.] // null) == null)] | unique | .[]
+' "$INPUT")"
+if [ -n "$missing_stages" ]; then
+  while IFS= read -r stage; do
+    [ -n "$stage" ] && echo "warning: no recommended action for stage: $stage" >&2
+  done <<< "$missing_stages"
+fi
+
+jq --slurpfile taxonomy "$TAXONOMY_FILE" '
+  .top = [
+    .top[]?
+    | (.stage // "unknown") as $stage
+    | ($taxonomy[0].recommended_actions[$stage] // null) as $action
+    | . + {
+        recommended_action: (
+          if ($action != null and (($taxonomy[0].allowed_actions // []) | index($action)) != null) then $action
+          else null
+          end
+        )
+      }
+  ]
+' "$INPUT"

--- a/.github/scripts/snapshot-clogs.sh
+++ b/.github/scripts/snapshot-clogs.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_REPOS="${TARGET_REPOS:-atvirokodosprendimai/ai-pipeline-template,atvirokodosprendimai/wgmesh}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI is required" >&2
+  exit 1
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "error: GH_TOKEN is required" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+idx=0
+IFS=',' read -r -a repos <<< "$TARGET_REPOS"
+for repo in "${repos[@]}"; do
+  repo="${repo#"${repo%%[![:space:]]*}"}"
+  repo="${repo%"${repo##*[![:space:]]}"}"
+  [ -n "$repo" ] || continue
+
+  prs_file="$tmpdir/prs-$idx.json"
+  issues_file="$tmpdir/issues-$idx.json"
+  combined_file="$tmpdir/combined-$idx.json"
+
+  gh pr list --repo "$repo" --state open --limit 100 \
+    --json number,title,labels,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,url \
+    > "$prs_file"
+
+  gh issue list --repo "$repo" --state open --limit 100 \
+    --json number,title,labels,createdAt,updatedAt,url \
+    > "$issues_file"
+
+  jq --arg repo "$repo" '
+    [
+      (.[0][] | {
+        repo: $repo,
+        type: "pr",
+        number,
+        title,
+        labels,
+        created_at: .createdAt,
+        updated_at: .updatedAt,
+        is_draft: .isDraft,
+        review_decision: .reviewDecision,
+        merge_state_status: .mergeStateStatus,
+        url
+      }),
+      (.[1][] | {
+        repo: $repo,
+        type: "issue",
+        number,
+        title,
+        labels,
+        created_at: .createdAt,
+        updated_at: .updatedAt,
+        is_draft: false,
+        url
+      })
+    ]
+  ' "$prs_file" "$issues_file" > "$combined_file"
+  idx=$((idx + 1))
+done
+
+jq -s 'add // []' "$tmpdir"/combined-*.json

--- a/.github/scripts/test-classify.sh
+++ b/.github/scripts/test-classify.sh
@@ -40,4 +40,13 @@ if ! grep -q "bad rule" /tmp/bad-classify.err; then
   exit 1
 fi
 
-echo "PASS test-classify: 6 scenarios"
+# Stdin-pipe equivalence: piping the snapshot into classify-clogs.sh must produce
+# the same result as passing the path as $1. Regression guard for double-stdin-read.
+stdin_out="/tmp/classified-stdin.out"
+SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/classify-clogs.sh < "$fixture" > "$stdin_out"
+if ! diff -u <(jq -S . "$actual") <(jq -S . "$stdin_out"); then
+  echo "FAIL: stdin classify diverged from file classify" >&2
+  exit 1
+fi
+
+echo "PASS test-classify: 7 scenarios"

--- a/.github/scripts/test-classify.sh
+++ b/.github/scripts/test-classify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture=".github/scripts/fixtures/snapshot-fixture.json"
+expected=".github/scripts/fixtures/classified-fixture.json"
+actual="/tmp/classified-fixture-actual.json"
+
+SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/classify-clogs.sh "$fixture" > "$actual"
+
+if ! jq -e 'length == 10' "$actual" >/dev/null; then
+  echo "FAIL: expected 10 classified items" >&2
+  exit 1
+fi
+
+if ! diff -u <(jq -S . "$expected") <(jq -S . "$actual"); then
+  echo "FAIL: classified fixture mismatch" >&2
+  exit 1
+fi
+
+if [ "$(jq -r '.[] | select(.number == 303) | .stage' "$actual")" != "review" ]; then
+  echo "FAIL: needs-human did not take precedence over copilot-triaging" >&2
+  exit 1
+fi
+
+empty="/tmp/empty-snapshot.json"
+printf '[]\n' > "$empty"
+if [ "$(SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/classify-clogs.sh "$empty" | jq 'length')" -ne 0 ]; then
+  echo "FAIL: empty snapshot did not classify to empty array" >&2
+  exit 1
+fi
+
+bad_taxonomy="/tmp/bad-pipeline-stages.json"
+printf '{"stages":["triage"],"classification_rules":{}}\n' > "$bad_taxonomy"
+if TAXONOMY_FILE="$bad_taxonomy" bash .github/scripts/classify-clogs.sh "$fixture" >/tmp/bad-classify.out 2>/tmp/bad-classify.err; then
+  echo "FAIL: malformed taxonomy unexpectedly passed" >&2
+  exit 1
+fi
+if ! grep -q "bad rule" /tmp/bad-classify.err; then
+  echo "FAIL: malformed taxonomy error did not name bad rule" >&2
+  exit 1
+fi
+
+echo "PASS test-classify: 6 scenarios"

--- a/.github/scripts/test-publish.sh
+++ b/.github/scripts/test-publish.sh
@@ -7,41 +7,64 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 state="$tmpdir/state.json"
 log="$tmpdir/publish.log"
+sentinel="$tmpdir/material.sentinel"
 
+# Scenario 1: first dry-run → material changes (no prior fingerprint) → state written.
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
+SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
 GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
 bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-first.out
 
-if ! jq -e '.run_number == 1 and .rank_changed == false and (.last_run_top_ids | length) == 3' "$state" >/dev/null; then
-  echo "FAIL: first dry-run state was not written correctly" >&2
+if ! jq -e '.run_number == 1 and .rank_changed == false and (.last_run_top_ids | length) == 3 and (.material_fingerprint | type == "string") and (.material_fingerprint | length == 64)' "$state" >/dev/null; then
+  echo "FAIL: first dry-run state missing run_number/material_fingerprint" >&2
   exit 1
 fi
+if [ "$(cat "$sentinel")" != "true" ]; then
+  echo "FAIL: first run sentinel should be 'true' (no prior fingerprint)" >&2
+  exit 1
+fi
+first_fp="$(jq -r '.material_fingerprint' "$state")"
 
+# Scenario 2: second dry-run same input → material UNCHANGED → state NOT rewritten.
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
+SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
 GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
 bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-second.out
 
-if ! jq -e '.run_number == 2 and .rank_changed == false' "$state" >/dev/null; then
-  echo "FAIL: second dry-run should not mark rank changed" >&2
+if [ "$(cat "$sentinel")" != "false" ]; then
+  echo "FAIL: second run sentinel should be 'false' (no material change)" >&2
+  exit 1
+fi
+if ! jq -e --arg fp "$first_fp" '.run_number == 1 and .material_fingerprint == $fp' "$state" >/dev/null; then
+  echo "FAIL: second run with same input must not advance run_number or fingerprint" >&2
   exit 1
 fi
 
+# Scenario 3: third dry-run with reordered top → material CHANGED → state advances.
 changed="$tmpdir/changed.json"
 jq '.top = ([.top[1], .top[0]] + .top[2:]) | .top |= to_entries | .top = (.top | map(.value + {rank:(.key + 1)}))' "$ranked" > "$changed"
 
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
+SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
 GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
 bash .github/scripts/publish-rank.sh "$changed" "$state" >/tmp/publish-third.out
 
-if ! jq -e '.run_number == 3 and .rank_changed == true' "$state" >/dev/null; then
-  echo "FAIL: changed top-3 should mark rank_changed" >&2
+if [ "$(cat "$sentinel")" != "true" ]; then
+  echo "FAIL: third run sentinel should be 'true' (material changed)" >&2
+  exit 1
+fi
+if ! jq -e --arg fp "$first_fp" '.run_number == 2 and .rank_changed == true and .material_fingerprint != $fp' "$state" >/dev/null; then
+  echo "FAIL: changed top-3 must advance run_number, set rank_changed, and shift fingerprint" >&2
   exit 1
 fi
 
-if GH_TOKEN="" GH_REPO="atvirokodosprendimai/ai-pipeline-template" bash .github/scripts/publish-rank.sh "$ranked" "$tmpdir/no-token.json" >/tmp/publish-no-token.out 2>/tmp/publish-no-token.err; then
+# Scenario 4: missing GH_TOKEN → error (production path only).
+if GH_TOKEN="" GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+   SUPERVISOR_MATERIAL_SENTINEL="$tmpdir/no-token.sentinel" \
+   bash .github/scripts/publish-rank.sh "$ranked" "$tmpdir/no-token.json" >/tmp/publish-no-token.out 2>/tmp/publish-no-token.err; then
   echo "FAIL: missing GH_TOKEN unexpectedly passed" >&2
   exit 1
 fi
@@ -50,4 +73,37 @@ if ! grep -q "GH_TOKEN is required" /tmp/publish-no-token.err; then
   exit 1
 fi
 
-echo "PASS test-publish: 4 scenarios"
+# Scenario 5: same fingerprint, only stage_summary differs → material CHANGED.
+stage_diff="$tmpdir/stage-diff.json"
+jq '.stage_summary.spec = ((.stage_summary.spec // 0) + 1)' "$ranked" > "$stage_diff"
+SUPERVISOR_PUBLISH_DRY_RUN=1 \
+SUPERVISOR_PUBLISH_LOG="$log" \
+SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
+GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+bash .github/scripts/publish-rank.sh "$stage_diff" "$state" >/tmp/publish-fifth.out
+
+if [ "$(cat "$sentinel")" != "true" ]; then
+  echo "FAIL: stage_summary change should flip sentinel to 'true'" >&2
+  exit 1
+fi
+
+# Scenario 6: same top + same stage_summary + only recommended_action shift → material CHANGED.
+prev_fp="$(jq -r '.material_fingerprint' "$state")"
+action_diff="$tmpdir/action-diff.json"
+jq '.top[0].recommended_action = "post-rah-bounty"' "$stage_diff" > "$action_diff"
+SUPERVISOR_PUBLISH_DRY_RUN=1 \
+SUPERVISOR_PUBLISH_LOG="$log" \
+SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
+GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+bash .github/scripts/publish-rank.sh "$action_diff" "$state" >/tmp/publish-sixth.out
+
+if [ "$(cat "$sentinel")" != "true" ]; then
+  echo "FAIL: recommended_action change should flip sentinel to 'true'" >&2
+  exit 1
+fi
+if ! jq -e --arg fp "$prev_fp" '.material_fingerprint != $fp' "$state" >/dev/null; then
+  echo "FAIL: recommended_action change should produce a new fingerprint" >&2
+  exit 1
+fi
+
+echo "PASS test-publish: 6 scenarios"

--- a/.github/scripts/test-publish.sh
+++ b/.github/scripts/test-publish.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ranked=".github/scripts/fixtures/ranked-fixture.json"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+state="$tmpdir/state.json"
+log="$tmpdir/publish.log"
+
+SUPERVISOR_PUBLISH_DRY_RUN=1 \
+SUPERVISOR_PUBLISH_LOG="$log" \
+GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-first.out
+
+if ! jq -e '.run_number == 1 and .rank_changed == false and (.last_run_top_ids | length) == 3' "$state" >/dev/null; then
+  echo "FAIL: first dry-run state was not written correctly" >&2
+  exit 1
+fi
+
+SUPERVISOR_PUBLISH_DRY_RUN=1 \
+SUPERVISOR_PUBLISH_LOG="$log" \
+GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-second.out
+
+if ! jq -e '.run_number == 2 and .rank_changed == false' "$state" >/dev/null; then
+  echo "FAIL: second dry-run should not mark rank changed" >&2
+  exit 1
+fi
+
+changed="$tmpdir/changed.json"
+jq '.top = ([.top[1], .top[0]] + .top[2:]) | .top |= to_entries | .top = (.top | map(.value + {rank:(.key + 1)}))' "$ranked" > "$changed"
+
+SUPERVISOR_PUBLISH_DRY_RUN=1 \
+SUPERVISOR_PUBLISH_LOG="$log" \
+GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+bash .github/scripts/publish-rank.sh "$changed" "$state" >/tmp/publish-third.out
+
+if ! jq -e '.run_number == 3 and .rank_changed == true' "$state" >/dev/null; then
+  echo "FAIL: changed top-3 should mark rank_changed" >&2
+  exit 1
+fi
+
+if GH_TOKEN="" GH_REPO="atvirokodosprendimai/ai-pipeline-template" bash .github/scripts/publish-rank.sh "$ranked" "$tmpdir/no-token.json" >/tmp/publish-no-token.out 2>/tmp/publish-no-token.err; then
+  echo "FAIL: missing GH_TOKEN unexpectedly passed" >&2
+  exit 1
+fi
+if ! grep -q "GH_TOKEN is required" /tmp/publish-no-token.err; then
+  echo "FAIL: missing GH_TOKEN error was not explicit" >&2
+  exit 1
+fi
+
+echo "PASS test-publish: 4 scenarios"

--- a/.github/scripts/test-rank.sh
+++ b/.github/scripts/test-rank.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+classified=".github/scripts/fixtures/classified-fixture.json"
+expected=".github/scripts/fixtures/ranked-fixture.json"
+ranked="/tmp/ranked-fixture-actual.json"
+recommended="/tmp/ranked-fixture-recommended.json"
+
+SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/rank-clogs.sh "$classified" > "$ranked"
+bash .github/scripts/recommend-actions.sh "$ranked" > "$recommended"
+
+if ! diff -u <(jq -S . "$expected") <(jq -S . "$recommended"); then
+  echo "FAIL: ranked fixture mismatch" >&2
+  exit 1
+fi
+
+empty="/tmp/empty-classified.json"
+printf '[]\n' > "$empty"
+empty_ranked="/tmp/empty-ranked.json"
+SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/rank-clogs.sh "$empty" > "$empty_ranked"
+if ! jq -e '.top == [] and .stage_summary.unknown == 0' "$empty_ranked" >/dev/null; then
+  echo "FAIL: empty classified snapshot did not produce empty ranked output" >&2
+  exit 1
+fi
+
+tie="/tmp/tie-classified.json"
+jq -n '
+  [
+    {repo:"r",type:"issue",number:2,title:"newer",labels:[],created_at:"2026-05-15T10:00:00Z",stage:"build",dwell_hours:10},
+    {repo:"r",type:"issue",number:1,title:"older",labels:[],created_at:"2026-05-15T09:00:00Z",stage:"build",dwell_hours:10}
+  ]
+' > "$tie"
+if [ "$(SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/rank-clogs.sh "$tie" | jq -r '.top[0].number')" != "1" ]; then
+  echo "FAIL: tie did not break by older created_at first" >&2
+  exit 1
+fi
+
+unknown_stage="/tmp/unknown-stage-ranked.json"
+jq -n '{generated_at:"2026-05-15T22:00:00Z",top:[{rank:1,stage:"new-stage",number:9,repo:"r",title:"x"}],stage_summary:{},unknown:[]}' > "$unknown_stage"
+bash .github/scripts/recommend-actions.sh "$unknown_stage" >/tmp/unknown-stage.out 2>/tmp/unknown-stage.err
+if ! jq -e '.top[0].recommended_action == null' /tmp/unknown-stage.out >/dev/null; then
+  echo "FAIL: missing recommendation did not fall back to null" >&2
+  exit 1
+fi
+if ! grep -q "warning: no recommended action" /tmp/unknown-stage.err; then
+  echo "FAIL: missing recommendation did not warn" >&2
+  exit 1
+fi
+
+echo "PASS test-rank: 6 scenarios"

--- a/.github/scripts/test-rank.sh
+++ b/.github/scripts/test-rank.sh
@@ -47,4 +47,19 @@ if ! grep -q "warning: no recommended action" /tmp/unknown-stage.err; then
   exit 1
 fi
 
-echo "PASS test-rank: 6 scenarios"
+# Stdin-pipe equivalence for rank-clogs.sh and recommend-actions.sh.
+# Regression guard for double-stdin-read.
+rank_stdin_out="/tmp/ranked-stdin.out"
+SUPERVISOR_NOW="2026-05-15T22:00:00Z" bash .github/scripts/rank-clogs.sh < "$classified" > "$rank_stdin_out"
+if ! diff -u <(jq -S . "$ranked") <(jq -S . "$rank_stdin_out"); then
+  echo "FAIL: stdin rank diverged from file rank" >&2
+  exit 1
+fi
+recommend_stdin_out="/tmp/recommended-stdin.out"
+bash .github/scripts/recommend-actions.sh < "$ranked" > "$recommend_stdin_out"
+if ! diff -u <(jq -S . "$recommended") <(jq -S . "$recommend_stdin_out"); then
+  echo "FAIL: stdin recommend diverged from file recommend" >&2
+  exit 1
+fi
+
+echo "PASS test-rank: 8 scenarios"

--- a/.github/scripts/validate-spec.sh
+++ b/.github/scripts/validate-spec.sh
@@ -17,6 +17,7 @@ ERRORS=0
 
 # ── Helper: strip HTML comments and fenced code blocks ──
 strip_comments_and_code() {
+  # shellcheck disable=SC2016
   sed '/<!--/,/-->/d' | sed '/^```/,/^```/d'
 }
 
@@ -71,7 +72,7 @@ if [ -n "$AF_SECTION" ]; then
     # Skip empty lines, comments, and lines with (no-test)
     [[ -z "$line" || "$line" =~ ^[[:space:]]*$ ]] && continue
     [[ "$line" =~ "<!--" ]] && continue
-    [[ "$line" =~ "(no-test)" ]] && continue
+    [[ "$line" =~ \(no-test\) ]] && continue
 
     # Extract file path (first non-whitespace token)
     filepath=$(echo "$line" | awk '{print $1}')

--- a/.github/workflows/supervisor-rank.yml
+++ b/.github/workflows/supervisor-rank.yml
@@ -1,0 +1,120 @@
+name: Supervisor Rank
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+  actions: read
+
+concurrency:
+  group: supervisor-rank
+  cancel-in-progress: false
+
+env:
+  TARGET_REPOS: atvirokodosprendimai/ai-pipeline-template,atvirokodosprendimai/wgmesh
+
+jobs:
+  rank:
+    name: Snapshot → Rank → Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Check ranker scripts present
+        id: script-guard
+        if: always() && hashFiles('.github/scripts/snapshot-clogs.sh') != ''
+        run: |
+          echo "present=true" >> "$GITHUB_OUTPUT"
+
+      - name: Skip until ranker scripts are on main
+        if: always() && hashFiles('.github/scripts/snapshot-clogs.sh') == ''
+        run: |
+          echo "::notice::supervisor-rank scripts are not present on this checkout yet; skipping self-bootstrap run"
+
+      - name: Snapshot clogs
+        if: steps.script-guard.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/snapshot-clogs.sh > /tmp/snapshot.json
+          jq empty /tmp/snapshot.json
+
+      - name: Classify clogs
+        if: steps.script-guard.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          bash .github/scripts/classify-clogs.sh /tmp/snapshot.json > /tmp/classified.json
+          jq empty /tmp/classified.json
+
+      - name: Rank clogs
+        if: steps.script-guard.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          bash .github/scripts/rank-clogs.sh /tmp/classified.json > /tmp/ranked.raw.json
+          jq empty /tmp/ranked.raw.json
+
+      - name: Recommend actions
+        if: steps.script-guard.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          bash .github/scripts/recommend-actions.sh /tmp/ranked.raw.json > /tmp/ranked.json
+          jq empty /tmp/ranked.json
+
+      - name: Publish supervisor rank
+        if: steps.script-guard.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/publish-rank.sh /tmp/ranked.json company/supervisor-rank-state.json
+
+      - name: Commit state
+        if: steps.script-guard.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "pupabobas[bot]"
+          git config user.email "pupabobas[bot]@users.noreply.github.com"
+          git add company/supervisor-rank-state.json
+          git diff --cached --quiet && echo "No state changes to commit" && exit 0
+
+          today=$(date -u '+%Y-%m-%d')
+          branch="supervisor-rank/state-${today}-${GITHUB_RUN_ID}"
+          git checkout -b "$branch" origin/main
+          git commit -m "chore(supervisor): update supervisor-rank state $today"
+          git push -u origin "$branch"
+
+          gh pr create \
+            --title "chore: supervisor-rank state $today" \
+            --body "Automated state update from supervisor-rank workflow." \
+            --base main \
+            --head "$branch"
+
+      - name: Assert ranked output emitted
+        if: steps.script-guard.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -s /tmp/ranked.json ]; then
+            echo "::error::ranked output missing or empty"
+            exit 1
+          fi
+          jq -e 'has("top") and (.top | type == "array") and has("stage_summary") and (.stage_summary | type == "object")' /tmp/ranked.json >/dev/null

--- a/.github/workflows/supervisor-rank.yml
+++ b/.github/workflows/supervisor-rank.yml
@@ -92,6 +92,20 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
+          # Material-fingerprint gate. publish-rank.sh writes this sentinel; if false,
+          # skip commit + PR entirely. Prevents the ~6 PRs/day audit-drift pile-up
+          # this supervisor was built to PREVENT. See memory:
+          # feedback_monitor_workflows_state_per_run_creates_anti_pattern.md
+          sentinel="${SUPERVISOR_MATERIAL_SENTINEL:-/tmp/supervisor-rank-material-changed}"
+          if [ ! -f "$sentinel" ]; then
+            echo "::warning::material-change sentinel missing; skipping commit"
+            exit 0
+          fi
+          if [ "$(cat "$sentinel")" != "true" ]; then
+            echo "No material change in supervisor-rank state; skipping commit + PR"
+            exit 0
+          fi
+
           git config user.name "pupabobas[bot]"
           git config user.email "pupabobas[bot]@users.noreply.github.com"
           git add company/supervisor-rank-state.json
@@ -105,7 +119,7 @@ jobs:
 
           gh pr create \
             --title "chore: supervisor-rank state $today" \
-            --body "Automated state update from supervisor-rank workflow." \
+            --body "Automated state update from supervisor-rank workflow (material fingerprint changed)." \
             --base main \
             --head "$branch"
 

--- a/company/pipeline-stages.json
+++ b/company/pipeline-stages.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "notes": "Initial dwell thresholds; tune from observed supervisor-rank runs.",
+  "stages": [
+    "triage",
+    "spec",
+    "build",
+    "review",
+    "merge",
+    "verify",
+    "revenue"
+  ],
+  "classification_rules": {
+    "triage": {
+      "label_any": [
+        "copilot-triaging",
+        "needs-triage"
+      ],
+      "issue_without_type_label": true,
+      "title_prefix_any": []
+    },
+    "spec": {
+      "label_any": [
+        "spec",
+        "spec-ready"
+      ],
+      "title_prefix_any": [
+        "spec:"
+      ]
+    },
+    "build": {
+      "label_any": [
+        "approved-for-build",
+        "goose-implementation"
+      ],
+      "title_prefix_any": [
+        "impl:"
+      ]
+    },
+    "review": {
+      "label_any": [
+        "needs-human",
+        "needs-review",
+        "copilot-review-pending",
+        "changes-requested"
+      ],
+      "title_prefix_any": []
+    },
+    "merge": {
+      "label_any": [
+        "merge-ready",
+        "approved"
+      ],
+      "review_decision_any": [
+        "APPROVED"
+      ],
+      "merge_state_status_any": [
+        "CLEAN",
+        "HAS_HOOKS"
+      ],
+      "title_prefix_any": []
+    },
+    "verify": {
+      "label_any": [
+        "needs-e2e",
+        "needs-verify",
+        "verification",
+        "verify"
+      ],
+      "title_prefix_any": []
+    },
+    "revenue": {
+      "label_any": [
+        "customer-zero",
+        "customer-factory",
+        "revenue",
+        "growth"
+      ],
+      "title_prefix_any": []
+    }
+  },
+  "dwell_thresholds_hours": {
+    "triage": 72,
+    "spec": 48,
+    "build": 24,
+    "review": 48,
+    "merge": 24,
+    "verify": 96,
+    "revenue": 168
+  },
+  "recommended_actions": {
+    "triage": "bounce-label",
+    "spec": "manual-merge",
+    "build": "retry-copilot",
+    "review": "escalate-needs-human",
+    "merge": "manual-merge",
+    "verify": "post-rah-bounty",
+    "revenue": "post-rah-bounty"
+  },
+  "allowed_actions": [
+    "retry-copilot",
+    "bounce-label",
+    "auto-close-superseded",
+    "post-rah-bounty",
+    "escalate-needs-human",
+    "manual-merge"
+  ]
+}

--- a/company/supervisor-rank-state.json
+++ b/company/supervisor-rank-state.json
@@ -1,0 +1,6 @@
+{
+  "last_run_at": null,
+  "last_run_top_ids": [],
+  "rank_changed": false,
+  "run_number": 0
+}

--- a/docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md
+++ b/docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md
@@ -1,0 +1,121 @@
+# Supervisor Clog Ranker — Requirements
+
+**Status:** Brainstormed 2026-05-15. Awaiting plan.
+**Author:** brainstorm session 2026-05-15
+**Scope tier:** Deep — feature (product shape inherited from `STRATEGY.md`)
+
+## Problem
+
+`ai-pipeline-template` is the supervisor over the seeded-product pipeline (issue → triage → spec → impl → merge → deploy → revenue). Its job is to **unclog the pipes** without human babysitting.
+
+Today it does not. Observed during pulse 2026-05-15:
+
+- `company/pipeline-health-state.json` `last_check: 2026-05-10T11:51:38Z` — 5 days frozen while cron emitted 5 successful runs.
+- 8 spec PRs from 2026-05-06 (`#741`–`#753`) sit unmerged 9 days. Approve/build trigger silent. No escalation surfaced.
+- 5 `wgmesh` issues stuck `copilot-triaging` 7+ days (`#584`, `#573`, `#540`, `#539`, `#510`). Label never bounces.
+- 6 `audit-drift` PRs (`#774`, `#866`, `#880`, `#894`, `#908`, `#922`) opened by audit cron since 2026-05-07. None reviewed or auto-closed as superseded.
+- Goose autonomous-impl pipeline was silent 40 days; broke today (`#628`, `#626`) only after manual bot-guardrail fixes from operator.
+- Convergence-engine output is not linked to customer-factory track: 0 cloudroof subs after CTAs live 7 days; supervisor never opened a `customer-zero-still-zero` flag.
+
+Supervisor's failure mode is identifiable: it **monitors but does not rank, decide, or act.** Cron success is reported even when state file is untouched. There is no top-clog signal anywhere in the repo — the human is the ranker, the router, and the actor.
+
+## Goal
+
+Stand up a supervisor component that, on every run, produces a **ranked top-N clog list with proposed action per clog**, opens or updates a single `supervisor-rank` issue with that list, and proves it ran by mutating observable state.
+
+Strategy-aligned: this serves **Self-heal & resilience** track in `STRATEGY.md`; its leading metric is `self_heal_resolution_rate = actions_taken / (actions_taken + needs_human_closed)`.
+
+## Users
+
+**Primary:** the solo founder running `ai-pipeline-template`. They open one issue (`supervisor-rank`) and see today's top clogs ranked with recommended actions, instead of running a manual pulse to discover where the pipeline is stuck.
+
+**Secondary:** the supervisor itself (downstream) — a ranker that classifies clogs is the foundation for autonomous action wiring later. First version is read-only; the ranker output is the seed for future auto-execution.
+
+## Value
+
+- Eliminates the **"that you even have to ask"** failure mode: founder no longer manually inspects PR lists to find the worst clog.
+- Restores trust in pipeline-health: `success` signal becomes load-bearing (state must mutate or workflow loud-fails).
+- Compounds — same ranker output drives pulse, heal, and (later) auto-action wiring.
+
+## Key Decisions
+
+1. **Build new `supervisor-rank.yml` workflow** rather than extending `pipeline-health.yml`. Health is a per-repo doctor; rank is cross-repo + cross-stage triage. Separating concerns lets health stay narrow.
+2. **Backfill `pipeline-health.yml` with state-mutation assertion** so its `success` signal stops lying. If state file is unchanged 2 consecutive runs, open `supervisor-dead` `needs-human` issue. Cheap insurance, ships in same PR or adjacent.
+3. **Cross-repo scope: `ai-pipeline-template` + `atvirokodosprendimai/wgmesh`.** Other repos out of scope until customer-factory track activates a second seed.
+4. **Read-only first.** No auto-actions in v1. Ranker emits ranked list + action recommendations; humans (or downstream workflow) execute. Auto-action wiring is a follow-up after 2–3 runs validate the ranks.
+5. **Single tracking issue, idempotent updates.** Daily run does not spam — it edits the same `supervisor-rank` issue body. Comments only on rank change.
+6. **Pipeline stage taxonomy** is a deliverable of this brainstorm:
+   - `triage` — issue open without `type:*` label OR with `copilot-triaging` label
+   - `spec` — open PR titled `spec:` OR `approved-for-build` label
+   - `build` — `approved-for-build` issue with no impl PR opened
+   - `review` — open PR with `needs-review` OR Copilot review pending
+   - `merge` — open PR approved but unmerged
+   - `verify` — merged impl PR awaiting e2e
+   - `revenue` — seed product live, customer count below STRATEGY target
+7. **Blast radius beats local dwell.** A spec PR with 3 dependent issues outranks a triage stall with 1 dependent issue, even if the triage stall is older. Ranker considers `dwell × downstream_blocked`.
+
+## Scope
+
+### In
+
+- Single workflow `supervisor-rank.yml` (cron, e.g. every 4h + workflow_dispatch).
+- Snapshot all PRs + issues across `atvirokodosprendimai/{ai-pipeline-template,wgmesh}`.
+- Classify each into pipeline stage per taxonomy above.
+- Compute `dwell_hours` per item + `downstream_blocked_count` per stage.
+- Rank top 3–5 clogs by `dwell × downstream_blocked`.
+- Per clog, recommend an action from a fixed set: `retry-copilot`, `bounce-label`, `auto-close-superseded`, `post-rah-bounty`, `escalate-needs-human`, `manual-merge`.
+- Open or update single GitHub issue `supervisor-rank` with ranked list, dwell, and recommended action per item.
+- Backfill `pipeline-health.yml` with state-mutation assertion + `supervisor-dead` loud-fail.
+
+### Out (deferred)
+
+- Auto-execution of recommended actions.
+- Deadline-scheduler / event-driven gate refactor (Approach C). Defer until 3rd seed product onboards.
+- Cross-org rollout (CloudLLM-ai/* + nycterent/*). Adds taxonomy noise; defer.
+- Dashboard UI. Issue body is enough surface for v1.
+
+### Outside this product's identity
+
+- Replacing GitHub as orchestrator. Workflow stays in Actions cron.
+- Replacing Copilot/Goose as agents. Ranker tells humans which agent failed; agents themselves are not modified here.
+
+## Success Criteria
+
+- v1 ships within 1 week. Single PR.
+- First run produces a ranked top-3 list that the operator agrees with on visual inspection (no obviously wrong ranks).
+- After 7 consecutive runs:
+  - `supervisor-rank` issue body reflects current state (no stale items > 24h after they cleared).
+  - `pipeline-health-state.json` `last_check` advances every run OR `supervisor-dead` issue opened.
+  - Operator has acted on ≥1 ranked clog per day on average (revealed-preference signal — operator finds output useful enough to act on).
+- Self-heal rate metric in pulse has a non-null source (was previously frozen).
+
+## Dependencies / Assumptions
+
+- GitHub Actions cron continues to fire on schedule.
+- `PUSH_TOKEN` or App-token has cross-repo issue/PR read on both target repos.
+- Ranker classification heuristics will mis-bucket some items — acceptable in v1, refined after 2–3 runs of operator correction.
+- Operator will act on ranked output. If after 7 runs operator ignores the issue, ranker is wrong product — kill it.
+
+## Risks
+
+- **Mis-classification noise.** Stage taxonomy will not cover every edge case. Mitigation: emit `stage: unknown` rather than guessing; operator labels these manually for 1 week, feeding back into taxonomy.
+- **Recommendation churn.** If actions recommended swing wildly run-to-run, operator loses trust. Mitigation: rank requires 2-run confirmation before flipping a stale recommendation.
+- **Same anti-pattern as today.** Supervisor outputs ranked list; humans ignore it; ranker becomes another `audit-drift` pile. Mitigation: single issue (not PR); ranker comments only on rank change; auto-close when clog clears.
+
+## Open Questions for Plan
+
+- Token strategy: pupabobas App token (preferred per memory) or PUSH_TOKEN PAT?
+- State storage: JSON file in repo (greppable, diffable) or GH workflow artifact (lighter, no commit churn)?
+- Trigger cadence: every 4h matches pulse rhythm; every 1h is closer to clog detection but adds run count.
+- Should the ranker write to `chimney.beerpub.dev` dashboard (HTML scrape today; could become structured) or stay purely in GH issue?
+
+## Out-of-band notes
+
+- Workflow naming: `.github/workflows/supervisor-rank.yml`.
+- Tracking issue: `supervisor-rank` (singular, idempotent).
+- Stage taxonomy lives in `company/pipeline-stages.json` (canonical) — referenced by both ranker and any future event-driven gate.
+- Cross-link to existing memory: ranker classification will catch `copilot-triaging` stalls noted in `feedback_workflow_path_race.md` and `feedback_bot_merge_trigger_gap_synchronize.md` patterns.
+
+## Next step
+
+Hand to `ce-plan` for implementation breakdown.

--- a/docs/plans/2026-05-15-001-feat-supervisor-clog-ranker-plan.md
+++ b/docs/plans/2026-05-15-001-feat-supervisor-clog-ranker-plan.md
@@ -1,0 +1,485 @@
+---
+title: "feat: Supervisor clog ranker + pipeline-health mutation assertion"
+type: feat
+status: active
+date: 2026-05-15
+origin: docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md
+---
+
+# feat: Supervisor clog ranker + pipeline-health mutation assertion
+
+## Summary
+
+Stand up `supervisor-rank.yml` workflow that snapshots open PRs+issues across `ai-pipeline-template` and `wgmesh`, classifies each into a pipeline stage, ranks the top 3–5 clogs by `dwell × downstream_blocked`, and posts a recommended action per clog into a single idempotent `supervisor-rank` tracking issue. Backfill `pipeline-health.yml` with a state-mutation assertion that opens a `supervisor-dead` issue when `company/pipeline-health-state.json` fails to advance across runs. Read-only v1 — no auto-actions. Stage taxonomy lives in `company/pipeline-stages.json`. Reuses the App-token + JSON-state + cron patterns already in `pipeline-health.yml` and `strategy-audit.yml`.
+
+---
+
+## Problem Frame
+
+`ai-pipeline-template` is the supervisor over the seeded-product pipeline. It monitors but does not rank, decide, or escalate (see origin §Problem). Pulse 2026-05-15 confirmed five distinct supervisor failure modes simultaneously — frozen state file with green cron, 9-day-old spec PRs, 7-day-old triage stalls, un-actioned audit-drift PRs, and a 40-day Goose-pipeline silence — none of which the existing supervisor surfaced to the operator as a ranked priority.
+
+---
+
+## Requirements
+
+- R1. On each run, snapshot open PRs+issues across `atvirokodosprendimai/{ai-pipeline-template, wgmesh}` (see origin: §Scope > In).
+- R2. Classify each item into a pipeline stage per the canonical taxonomy: `triage | spec | build | review | merge | verify | revenue | unknown` (see origin: §Key Decisions §6).
+- R3. Compute `dwell_hours` and `downstream_blocked_count` per item; rank top 3–5 by `dwell × downstream_blocked` (see origin: §Key Decisions §7).
+- R4. Per ranked clog, emit a recommended action from the fixed set: `retry-copilot | bounce-label | auto-close-superseded | post-rah-bounty | escalate-needs-human | manual-merge` (see origin: §Scope > In).
+- R5. Maintain a single idempotent `supervisor-rank` GitHub issue; rewrite body on every run; comment only when rank order changes (see origin: §Key Decisions §5).
+- R6. Backfill `pipeline-health.yml`: assert state-file mutation per run; if `company/pipeline-health-state.json` `last_check` does not advance 2 consecutive runs, open `supervisor-dead` `needs-human` issue (see origin: §Key Decisions §2).
+- R7. Read-only v1 — workflow does not auto-execute any recommended action (see origin: §Scope > In, §Key Decisions §4).
+- R8. Workflow self-asserts: if its own state output is empty/malformed, exit non-zero — `success` must mean rank was emitted (see origin: §Risks > "Same anti-pattern as today").
+
+---
+
+## Scope Boundaries
+
+- No auto-execution of recommended actions; humans (or a follow-up workflow) act on the ranked output.
+- No deadline-scheduler / event-driven gate refactor (Approach C from origin); deferred until 3rd seed product.
+- No cross-org rollout to `CloudLLM-ai/*` or `nycterent/*`.
+- No new dashboard UI; the GitHub issue body is the only surface for v1.
+- No replacement of GitHub Actions as the orchestrator.
+- No modification of Copilot/Goose agents themselves.
+
+### Deferred to Follow-Up Work
+
+- Auto-execution wiring for the safest recommended actions (e.g., `auto-close-superseded` for audit-drift PRs > 24h): separate PR after 2–3 runs validate the ranks.
+- Chimney dashboard structured-data integration (origin §Open Questions): separate PR.
+- Token-strategy consolidation across remaining 8 `PUSH_TOKEN`-using workflows: tracked in [pipeline-health App migration memory](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/project_pipeline_health_app_migration.md), not this plan.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/pipeline-health.yml` — App-token auth, state-file commit pattern, jq-based JSON mutation (`jq … > /tmp/state.json && mv /tmp/state.json $STATE_FILE`), `*/30 * * * *` cadence, `concurrency: group:` lock. Mirror exactly.
+- `.github/workflows/strategy-audit.yml` — `actions/create-github-app-token@v2` with `vars.APP_ID` + `secrets.APP_PRIVATE_KEY`, `workflow_dispatch` with optional input, `skip-guard` step pattern. Mirror exactly.
+- `.github/workflows/bot-pr-review-merge.yml` — App-token + `GH_TOKEN` env-var pattern for `gh` CLI; same token path applies here.
+- `company/pipeline-health-state.json` — existing schema (`last_check`, `checks_run`, `issues_healed_total`, `retry_tracker`, `funnel_signals`, `idle_signal`, `last_run_summary`). Plan adds a `last_mutation_attempted_at` + `consecutive_no_mutation_runs` pair without breaking schema.
+- `company/strategy-audit-baseline.json` and `company/loop-state.json` — companion-state-file precedent; new `company/supervisor-rank-state.json` follows the same shape conventions.
+
+### Institutional Learnings
+
+- [Supervisor must self-rank, don't ask operator](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_supervisor_must_self_rank.md) — keep ranker output ranked + actionable; never frame as "operator picks from list".
+- [Cron `success` ≠ state mutation](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_cron_success_not_equal_state_mutation.md) — directly informs U5 mutation-assertion design.
+- [bot-pr-review-merge synchronize gap](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_bot_merge_trigger_gap_synchronize.md) — the `merge` stage detector must treat "approved + clean but synchronize-event not triggered" as a clog signal.
+- [Required check + path filter = merge deadlock](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_required_check_path_filter_blocks_merge.md) — `supervisor-rank.yml` must use an always-run trigger, no `paths:` filter, or it will not satisfy any branch-protection required check.
+- [Workflow self-bootstrap hashFiles guard](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_workflow_self_bootstrap_hashfiles_guard.md) — if the workflow invokes a script newly added in the same PR, gate that step with `hashFiles('path') != ''` to survive the on-main-pre-merge CI run.
+- [Non-fatal bash helper contract](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_non_fatal_bash_helper_contract.md) — for any step labeled "non-fatal", use trap-on-EXIT rather than `set -euo pipefail`; gate executable check on `[ -f ]` not `[ -x ]`.
+- [GH Actions secret gotchas](../../.claude/projects/-Users-oldroot-Repos-ai-pipeline-template/memory/feedback_github_actions_secret_gotchas.md) — default `GITHUB_TOKEN` is read-only when `permissions: contents: read`. Workflow needs `issues: write` + `pull-requests: read` + `contents: write` for state commit.
+
+---
+
+## Key Technical Decisions
+
+- **Workflow split.** Net-new `.github/workflows/supervisor-rank.yml` is separate from `pipeline-health.yml`. Rationale: health is the per-target-repo doctor; rank is cross-repo + cross-stage triage. Keeps each workflow's concurrency surface narrow.
+- **Bash + jq, no new runtime.** Implementation stays in shell, mirroring existing pipeline-health.yml style. Rationale: no Python/Node added to CI, smallest reviewable diff, matches operator's mental model for the rest of the supervisor.
+- **Stage taxonomy as committed JSON.** `company/pipeline-stages.json` is the single source of truth for stage names + classification heuristics. Rationale: greppable, diffable, reusable later by deadline-scheduler refactor (Approach C in origin).
+- **Idempotent single issue via stable title.** Workflow searches for an open issue titled exactly `supervisor-rank: top pipeline clogs`; if none, creates one; else edits body. Rationale: avoids audit-drift-PR anti-pattern of pile-up. Comments only on rank change.
+- **Cadence: every 4h.** Matches pulse rhythm; 1h would be tighter but the recommended-action set is human-paced anyway. Workflow_dispatch on demand.
+- **App token, not PUSH_TOKEN PAT.** Per origin §Open Questions and memory `project_pipeline_health_app_migration` — pupabobas App token via `vars.APP_ID` + `secrets.APP_PRIVATE_KEY`, both org-inherited. Rationale: avoids `nycterent`-as-author email-spam loop already paid down in earlier work.
+- **State storage: JSON in repo.** `company/supervisor-rank-state.json` committed by workflow (App-token author). Rationale: greppable, time-travelable via git, matches existing `pipeline-health-state.json` precedent. GH-artifact alternative considered and rejected — artifacts expire and aren't diffable.
+- **Loud-fail for pipeline-health is in-process, not a second workflow.** A new final step in `pipeline-health.yml` asserts the state file's `last_check` advanced; if not, the step fails the job AND increments `consecutive_no_mutation_runs`; at >=2, the step opens `supervisor-dead` issue. Rationale: keeps the assertion adjacent to the steps it audits — separating into a sibling workflow recreates the same trust-the-conclusion problem.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Token strategy: **App token** (matches pipeline-health.yml + strategy-audit.yml; sidesteps email-spam loop).
+- State storage: **JSON in repo** at `company/supervisor-rank-state.json`.
+- Cadence: **every 4h** (`0 */4 * * *`) plus `workflow_dispatch`.
+- Chimney dashboard: **deferred to follow-up** — v1 emits to GH issue only.
+
+### Deferred to Implementation
+
+- Exact dwell-threshold-per-stage values (e.g., spec-PR > 48h trigger). Implementation will tune from observed data over the first 2–3 runs; initial values land as constants in `pipeline-stages.json`.
+- Stage-classification edge cases (PRs with mixed labels, issues with `needs-human` AND `copilot-triaging`). Implementation will discover via `stage: unknown` emit, then encode rules.
+- `downstream_blocked_count` heuristic — initial implementation = "count of `approved-for-build` issues whose spec PR is the clogged item". May need refinement post-first-run.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+cron(*/4h)
+   │
+   ▼
+┌──────────────────────────────────────────────┐
+│ supervisor-rank.yml                          │
+│                                              │
+│ 1. snapshot.sh    → /tmp/snapshot.json       │
+│    (gh pr/issue list for both target repos)  │
+│                                              │
+│ 2. classify.sh    → /tmp/classified.json     │
+│    (reads pipeline-stages.json + snapshot)   │
+│                                              │
+│ 3. rank.sh        → /tmp/ranked.json         │
+│    (dwell × downstream_blocked, top-N)       │
+│                                              │
+│ 4. recommend.sh   → /tmp/ranked.json (enriched)│
+│    (per stage → action from fixed set)       │
+│                                              │
+│ 5. publish.sh                                │
+│    ├── find/create "supervisor-rank" issue  │
+│    ├── edit body with ranked list           │
+│    ├── compare with prior state             │
+│    │   └── if rank changed → post comment   │
+│    └── write company/supervisor-rank-state  │
+│                                              │
+│ 6. assert.sh                                 │
+│    └── if no state mutation → exit 1        │
+└──────────────────────────────────────────────┘
+
+pipeline-health.yml (existing)
+   │
+   ├── (existing heal steps)
+   ▼
+┌──────────────────────────────────────────────┐
+│ NEW final step: assert state mutation        │
+│                                              │
+│ - read company/pipeline-health-state.json    │
+│ - compare last_check to start-of-run timestamp│
+│ - if unchanged:                              │
+│     consecutive_no_mutation_runs++           │
+│     if >= 2 → open supervisor-dead issue     │
+│     exit 1                                   │
+│ - if advanced:                               │
+│     consecutive_no_mutation_runs = 0         │
+└──────────────────────────────────────────────┘
+```
+
+Ranked-issue body shape:
+
+```
+# supervisor-rank: top pipeline clogs
+
+Updated: 2026-05-15T22:00Z  (run #N)
+
+## Top 3 clogs
+
+1. **spec-stage frozen** — 8 PRs unmerged, oldest 9d (#741)
+   - Stage: spec
+   - Dwell × blocked: 216h × 8 = 1728
+   - Recommended action: `manual-merge` — operator approve batch or escalate-needs-human
+   - Items: #741, #743, #744, #747, #749, #750, #753
+
+2. **copilot-triaging stuck (wgmesh)** — 5 issues, oldest 17d (#510)
+   - Stage: triage
+   - Dwell × blocked: 408h × 5 = 2040
+   - Recommended action: `bounce-label` — strip copilot-triaging, retry-copilot
+   - Items: wgmesh#510, wgmesh#539, wgmesh#540, wgmesh#573, wgmesh#584
+
+3. ...
+
+## Stage summary
+- triage: 5 | spec: 8 | build: 0 | review: 5 | merge: 0 | verify: 4 | revenue: 1 | unknown: 0
+
+## State
+- Prior run: 2026-05-15T18:00Z (no rank change)
+- File: company/supervisor-rank-state.json
+```
+
+---
+
+## Implementation Units
+
+### U1. Stage taxonomy + classification heuristics
+
+**Goal:** Establish `company/pipeline-stages.json` as canonical stage definitions and classification rules; document the seven-stage taxonomy.
+
+**Requirements:** R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `company/pipeline-stages.json`
+- Test: `.github/scripts/test-classify.sh`
+
+**Approach:**
+- JSON document with three top-level keys: `stages` (array of stage names in pipeline order), `classification_rules` (per-stage: label patterns, title prefixes, label-absence rules), `dwell_thresholds_hours` (per-stage escalation threshold), `recommended_actions` (per-stage default action).
+- Stages: `triage | spec | build | review | merge | verify | revenue`. `unknown` reserved for non-matching items.
+- Each rule is jq-compatible (string-equality on label name, string-prefix on title).
+- Initial dwell thresholds: triage 72h, spec 48h, build 24h, review 48h, merge 24h, verify 96h, revenue 168h. Mark in JSON as "initial; tune from data".
+
+**Test scenarios:**
+- Happy path: a `gh issue` JSON object with `labels: [{name: "copilot-triaging"}]` classifies to `triage`.
+- Happy path: a `gh pr` JSON object with `title: "spec: Issue #N — ..."` classifies to `spec`.
+- Happy path: a `gh pr` JSON object with `labels: [{name: "approved-for-build"}]` and no impl-PR child classifies to `build`.
+- Edge case: an item with BOTH `needs-human` and `copilot-triaging` labels — `needs-human` wins (higher escalation precedence).
+- Edge case: an issue with no labels and no title-prefix match classifies to `unknown`.
+- Error path: malformed `pipeline-stages.json` causes `classify.sh` to exit non-zero with message naming the bad rule.
+
+**Verification:** `jq` validates JSON; running the classifier against a fixture of known issues produces the expected stage breakdown.
+
+---
+
+### U2. Snapshot + classifier scripts
+
+**Goal:** Extract bash logic from inline YAML into `.github/scripts/` to make it shell-testable and reviewable.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `.github/scripts/snapshot-clogs.sh`
+- Create: `.github/scripts/classify-clogs.sh`
+- Create: `.github/scripts/test-classify.sh`
+- Modify: none
+
+**Approach:**
+- `snapshot-clogs.sh`: takes `TARGET_REPOS` env var (comma-separated); for each repo, calls `gh pr list ... --json number,title,labels,createdAt,updatedAt,isDraft` and `gh issue list ... --json ...`; outputs a unified JSON array to stdout.
+- `classify-clogs.sh`: reads snapshot from stdin or `$1`; reads `company/pipeline-stages.json`; emits same JSON with added `stage` and `dwell_hours` fields per item.
+- Both scripts: `set -euo pipefail` at top; functions only; no global side-effects; stdout is JSON, stderr is logs.
+
+**Execution note:** Write `test-classify.sh` first with a fixture of 6–8 known-classified items before implementing `classify-clogs.sh`.
+
+**Patterns to follow:**
+- Existing inline-bash style in `pipeline-health.yml` (jq with `--argjson`/`--arg` for typed inputs).
+- `validate-spec.sh` for shell-script entry-point conventions.
+
+**Test scenarios:**
+- Happy path: classify a snapshot of today's actual repo state; output stage histogram matches manual inspection.
+- Happy path: classify an empty snapshot → empty array, exit 0.
+- Edge case: classify an item where `updatedAt > createdAt` — dwell = now − updatedAt (treat label change as dwell reset for `copilot-triaging` stage, dwell = now − createdAt elsewhere).
+- Error path: missing `company/pipeline-stages.json` → script exits non-zero with named error.
+- Error path: malformed JSON on stdin → exit non-zero.
+- Integration: `snapshot-clogs.sh | classify-clogs.sh` chains without error.
+
+**Verification:** `bash .github/scripts/test-classify.sh` passes against the committed fixture; the script can be invoked locally with a `gh auth login` session and produces a useful classified output.
+
+---
+
+### U3. Rank + recommend scripts
+
+**Goal:** Take a classified snapshot and produce a ranked top-N list with per-clog recommended actions.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** U2.
+
+**Files:**
+- Create: `.github/scripts/rank-clogs.sh`
+- Create: `.github/scripts/recommend-actions.sh`
+- Create: `.github/scripts/test-rank.sh`
+
+**Approach:**
+- `rank-clogs.sh`: reads classified JSON; for each stage, computes `dwell × downstream_blocked`. `downstream_blocked` heuristic v1:
+  - For `spec` stage: count of open `approved-for-build` issues in same repo where the impl PR has not yet been opened.
+  - For `triage` stage: count of items in `spec | build | review` stages dependent on the same repo (proxy: open items in same repo with later pipeline stages — simplified, refine post-launch).
+  - For `merge` stage: count of approved-but-unmerged PRs in same repo (self-count).
+  - For other stages: 1 (no blast-radius signal in v1).
+- Outputs top-N (N=5) sorted by score descending.
+- `recommend-actions.sh`: reads ranked JSON; reads `pipeline-stages.json` for `recommended_actions` map; emits ranked JSON with `recommended_action` field added per clog. Allowed actions enforced via jq enum check.
+
+**Patterns to follow:**
+- `strategy-audit.yml` baseline-diff pattern for "compare current with prior" logic.
+
+**Test scenarios:**
+- Happy path: 3 spec PRs with dwell 24h, 48h, 96h and 5 downstream blocked each → ranked highest-first by score.
+- Happy path: a `revenue` clog with dwell 168h and blocked=1 ranks lower than a `spec` clog with dwell 48h and blocked=8.
+- Edge case: empty classified snapshot → ranked output is `{"top": [], "stage_summary": {…}}`, exit 0.
+- Edge case: tie in score — break by `created_at` ascending (older first).
+- Error path: `recommend-actions.sh` receives a stage not in `recommended_actions` map → emits `recommended_action: null` with warning to stderr, does not exit non-zero (graceful fallback).
+- Integration: `classify | rank | recommend` chains end-to-end on the today-fixture and produces a top-5 list that matches the manual ranking from the session pulse.
+
+**Verification:** `bash .github/scripts/test-rank.sh` passes; end-to-end pipeline run on a checked-in fixture produces the expected ranked-and-recommended JSON.
+
+---
+
+### U4. Publish to idempotent `supervisor-rank` issue
+
+**Goal:** Find or create the single `supervisor-rank` tracking issue and update its body; comment only on rank change.
+
+**Requirements:** R5.
+
+**Dependencies:** U3.
+
+**Files:**
+- Create: `.github/scripts/publish-rank.sh`
+- Create: `.github/scripts/test-publish.sh`
+
+**Approach:**
+- `publish-rank.sh`: takes ranked JSON + prior-state path as inputs.
+- Searches: `gh issue list --repo $GH_REPO --search 'supervisor-rank: top pipeline clogs in:title is:open' --json number,title`.
+- If 0 matches → `gh issue create` with stable title, label `supervisor`, body from template.
+- If 1 match → `gh issue edit $N --body-file /tmp/body.md`.
+- If >1 → fail loud; the workflow tried to create twice or someone duplicated manually.
+- Compares the new top-3 (by item number ordering) with the prior state's top-3; if different, posts a one-line comment naming what entered/exited.
+- Writes `company/supervisor-rank-state.json` with `{ "last_run_at", "last_run_top_ids", "rank_changed", "run_number" }`.
+
+**Patterns to follow:**
+- `pipeline-health.yml` jq-then-mv state mutation pattern.
+- App-token + `GH_TOKEN` env exactly like `bot-pr-review-merge.yml`.
+
+**Test scenarios:**
+- Happy path: first-ever run → issue created, state JSON written, no comment posted (no prior state).
+- Happy path: second run, same top-3 → body edited, no comment.
+- Happy path: second run, top-3 changed → body edited AND single comment posted.
+- Edge case: GH API rate-limited mid-run → script retries with exponential backoff up to 3 attempts, then exits non-zero with named error.
+- Edge case: two existing `supervisor-rank` issues open (duplicate) → script exits non-zero, does not touch either, surfaces both numbers to the operator.
+- Error path: missing `GH_TOKEN` → exit non-zero with named error.
+- Integration: run end-to-end against a fork of the repo, verify the issue body matches the expected template.
+
+**Verification:** Manual dispatch run against the actual repo produces one `supervisor-rank` issue with a ranked top-N list; subsequent dispatch updates the same issue without creating duplicates.
+
+---
+
+### U5. Mutation assertion + supervisor-dead in `pipeline-health.yml`
+
+**Goal:** Make `pipeline-health.yml` loud-fail when it cannot prove it advanced state, and open a `supervisor-dead` `needs-human` issue after 2 consecutive failures.
+
+**Requirements:** R6, R8.
+
+**Dependencies:** None (independent of U1–U4 — can land in parallel, but plan-order keeps it as U5 because U4 establishes the issue-creation convention).
+
+**Files:**
+- Modify: `.github/workflows/pipeline-health.yml`
+- Modify: `company/pipeline-health-state.json` (schema extension)
+- Create: `.github/scripts/assert-state-mutation.sh`
+
+**Approach:**
+- At start of `heal` job, capture `pre_run_last_check` from the state file.
+- New final step `Assert state mutation`:
+  - Reads `last_check` from state file post-run.
+  - If `last_check == pre_run_last_check` (no advance):
+    - Increment `consecutive_no_mutation_runs` (init 0 if absent).
+    - If `consecutive_no_mutation_runs >= 2`: open or comment-update `supervisor-dead: pipeline-health frozen` issue, label `needs-human`.
+    - Exit 1 (workflow conclusion = failure).
+  - Else: reset `consecutive_no_mutation_runs = 0`.
+  - Commit state file via App-token using the existing commit-state-via-PR pattern OR direct push (mirror what `pipeline-health.yml` already does).
+- Extends `pipeline-health-state.json` schema with `consecutive_no_mutation_runs: int`. Backward-compatible (absent → treated as 0).
+
+**Execution note:** Test-first — write `assert-state-mutation.sh` with a fixture of "pre=2026-05-10, post=2026-05-10" → must fail; "pre=2026-05-10, post=2026-05-15" → must pass.
+
+**Patterns to follow:**
+- Existing `pipeline-health.yml` jq-state-mutate pattern.
+- `bot-pr-review-merge.yml` issue-create-or-update pattern.
+
+**Test scenarios:**
+- Happy path: state file `last_check` advances during the run → assertion passes, `consecutive_no_mutation_runs` reset to 0.
+- Failure path: state file unchanged, prior `consecutive_no_mutation_runs=0` → increment to 1, exit 1, no `supervisor-dead` issue yet.
+- Failure path: state file unchanged, prior `consecutive_no_mutation_runs=1` → increment to 2, open `supervisor-dead` issue, exit 1.
+- Failure path: state file unchanged, prior `consecutive_no_mutation_runs=2`, supervisor-dead issue already open → comment "still frozen" on existing issue, exit 1, do not open second issue.
+- Edge case: state file missing entirely → treat as "no mutation", same path as above.
+- Edge case: state file present but malformed JSON → exit 1, open `supervisor-dead` immediately (this is a worse failure mode than no-advance).
+- Integration: dispatch the workflow manually with the current frozen state file in place; verify it fails and surfaces the right error.
+
+**Verification:** A dispatched run against the current frozen state-file should fail the workflow and open `supervisor-dead` after the 2nd dispatch.
+
+---
+
+### U6. New `supervisor-rank.yml` workflow
+
+**Goal:** Wire U2–U4 into a cron + workflow_dispatch GH Actions workflow.
+
+**Requirements:** R1, R5, R7, R8.
+
+**Dependencies:** U2, U3, U4.
+
+**Files:**
+- Create: `.github/workflows/supervisor-rank.yml`
+
+**Approach:**
+- Triggers: `cron: '0 */4 * * *'` (every 4h) + `workflow_dispatch` (no inputs in v1).
+- `permissions:` `contents: write` (state commit), `issues: write` (publish), `pull-requests: read` (snapshot), `actions: read`.
+- `concurrency: { group: supervisor-rank, cancel-in-progress: false }`.
+- Single job `rank`; steps:
+  1. Generate App token (mirror `pipeline-health.yml`).
+  2. Checkout repo with App token, `fetch-depth: 0`.
+  3. `hashFiles('.github/scripts/snapshot-clogs.sh') != ''` guard (per memory `feedback_workflow_self_bootstrap_hashfiles_guard`).
+  4. `Snapshot` step → `/tmp/snapshot.json`.
+  5. `Classify` step → `/tmp/classified.json`.
+  6. `Rank` step → `/tmp/ranked.json`.
+  7. `Recommend` step → `/tmp/ranked.json` (enriched).
+  8. `Publish` step → updates `supervisor-rank` issue, writes `company/supervisor-rank-state.json`.
+  9. `Commit state` step (mirror `strategy-audit.yml` commit pattern).
+  10. `Assert ranked output non-empty` final step → exit 1 if `/tmp/ranked.json` is empty or malformed.
+
+**Patterns to follow:**
+- `strategy-audit.yml` — same trigger shape, same permissions block, same App-token + commit-state choreography.
+- `pipeline-health.yml` — same concurrency lock pattern.
+
+**Test scenarios:**
+- Happy path: workflow_dispatch fires; produces a `supervisor-rank` issue with ranked top-N; commits new state JSON.
+- Happy path: second dispatch — body edited, no duplicate issue.
+- Edge case: `snapshot-clogs.sh` returns empty (no open items anywhere) → publish step writes an "all clear" body, no error.
+- Error path: classify script absent (script-bootstrap order bug) → `hashFiles` guard skips dependent steps, workflow exits with explicit "scripts not yet on main" notice (not failure).
+- Error path: GH API auth fails → snapshot step exits non-zero, no state file mutated, workflow conclusion = failure.
+- Integration: end-to-end dispatch produces the issue and commits the state file in a single run.
+
+**Verification:** Workflow file passes `actionlint`; one manual dispatch produces a ranked issue.
+
+---
+
+### U7. Pulse + chimney integration hook (read-only)
+
+**Goal:** Make the ranked output discoverable by the next `/pulse` run and (optionally) by chimney dashboard.
+
+**Requirements:** Supports STRATEGY.md `self_heal_resolution_rate` metric; origin §Open Questions.
+
+**Dependencies:** U4.
+
+**Files:**
+- Modify: `.compound-engineering/config.local.yaml` (add `supervisor_rank_state` pointer in pulse_metric_sources)
+- Modify: `docs/pulse-reports/*.md` template — no code change; this unit only records the convention.
+
+**Approach:**
+- Add `self_heal_resolution_rate=company/supervisor-rank-state.json` entry to `pulse_metric_sources` so pulse runs read it.
+- No active code change in pulse machinery — the operator runs `/pulse` and the read happens via the standard config-pointer resolution.
+
+**Test scenarios:**
+- Test expectation: none — pure config pointer addition with no logic change.
+
+**Verification:** Next `/pulse` run mentions `supervisor-rank` issue number in the Followups section if it has open clogs.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New workflow adds an `issues: write` writer; existing workflows that comment on `supervisor-rank: …` titled issues are unaffected (none currently do).
+- **Error propagation:** `supervisor-rank.yml` failures are isolated — no other workflow depends on its state file. `pipeline-health.yml`'s new mutation assertion can surface `supervisor-dead` issue, which feeds the `needs-human` labeling convention already used.
+- **State lifecycle risks:** Concurrent dispatches blocked by `concurrency: group: supervisor-rank, cancel-in-progress: false` — same pattern as `pipeline-health`.
+- **API surface parity:** No external API surface added; only internal GH issue + JSON file.
+- **Integration coverage:** End-to-end dispatch + 2nd dispatch on same state = best integration test (scripted in U6 verification).
+- **Unchanged invariants:**
+  - `pipeline-health.yml`'s existing 17 heal steps remain untouched; the new assertion is purely additive at end-of-job.
+  - Existing `company/pipeline-health-state.json` schema is extended, not changed — old fields preserved, `consecutive_no_mutation_runs` is additive.
+  - Polar / Stripe / Goose / Copilot pipelines untouched.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Mis-classification puts wrong items in `unknown` stage and ranks them as 0 | Emit `unknown`-stage items in a separate "needs taxonomy" section of the issue body; operator labels manually for 1 week, feeds into `pipeline-stages.json` updates. |
+| `downstream_blocked_count` heuristic produces noisy ranks | v1 heuristic is intentionally simple; refine after 2–3 runs of operator inspection. Top-N=5 keeps it small enough to scan even with some noise. |
+| Operator ignores `supervisor-rank` issue (same anti-pattern as audit-drift PRs) | Single issue (not PR), comments only on rank change, kill criterion explicit in origin §Success Criteria — if ignored 7 days, the ranker is deleted. |
+| `pipeline-health.yml` mutation-assertion creates a noisy `supervisor-dead` issue if a one-off legitimate no-op happens | 2-consecutive-runs gate prevents single-flap noise. `consecutive_no_mutation_runs` reset on first successful mutation. |
+| Self-bootstrap CI hang — workflow added in same PR as scripts can't find them on main yet | `hashFiles` guard pattern per memory; final assertion is gated on script presence. |
+| App token expiry breaks the cron silently | Mutation assertion catches this — if the workflow can't authenticate, the publish step fails, state isn't written, next run sees no advance, supervisor-dead fires. |
+
+---
+
+## Documentation / Operational Notes
+
+- After first successful dispatch, add a short paragraph to `STRATEGY.md` under `Tracks > Self-heal & resilience` pointing at the `supervisor-rank` issue as the leading-metric surface.
+- No runbook update needed for v1 — the issue body is self-describing.
+- Memory update after merge: revise `feedback_cron_success_not_equal_state_mutation.md` to reference the new assertion pattern as the canonical fix.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md](../brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md)
+- Related workflows: `.github/workflows/pipeline-health.yml`, `.github/workflows/strategy-audit.yml`, `.github/workflows/bot-pr-review-merge.yml`
+- Related state files: `company/pipeline-health-state.json`, `company/strategy-audit-baseline.json`
+- Related memories: see Context > Institutional Learnings.
+- Pulse seed: `docs/pulse-reports/2026-05-15_22-33.md`

--- a/docs/pulse-reports/2026-05-15_22-33.md
+++ b/docs/pulse-reports/2026-05-15_22-33.md
@@ -1,0 +1,33 @@
+# Product Pulse — 2026-05-15 22:33 (local)
+
+Window: 2026-05-14T20:18Z → 2026-05-15T20:18Z (24h, −15m buffer)
+Product: ai-pipeline-template (seed repo: atvirokodosprendimai/wgmesh)
+
+## Headlines
+
+- Goose pipeline broke its 40+ day silence: 2 autonomous impls merged (#628 Issue #609 Stage-5/6 milestones, #626 Issue #571 Tier-5 NAT). Bot guardrail fixes (#623, #625, #629) unblocked the path.
+- Six testlab/CI fixes landed dismantling the T6 SSH-watchdog hang (#631→#637); long-stuck PR #570 (auto-verify e2e) merged after 103h+ dwell.
+- Revenue unchanged: 5 active subs / €4 MRR — all mailbox product. cloudroof tier subs still 0; chimney `msc-current=0`.
+
+## Usage
+
+- product_pr_merged (wgmesh, 24h): **15** merged PRs; 2 with `goose-implementation` label, 2 `spec` PRs (#611, #575) merged through Copilot, 11 maintenance/bot fixes.
+- autonomous_impl_merge_clean: **2** (#628, #626) — first non-zero count since pipeline stall began.
+- paid_customer_added (cloudroof Founding/Edge/Mesh): **0**.
+- Endpoints OK: cloudroof.eu 200, wgmesh.dev 200.
+
+## System performance
+
+- ai-pipeline-template CI last 30 runs: 28 success, 1 skipped, 1 `action_required` (Spec PR Review Handler 17:24Z — manual approval gate).
+- Observation Loop ran 3× in window (success). Polar query returned 5 subs / €4 MRR (mailbox).
+- **Self-heal stale 5 days**: `company/pipeline-health-state.json` last_check `2026-05-10T11:51:38Z`, `checks_run: 519`, `issues_healed_total: 0`. Cron present but state file not advancing.
+- POLAR_TOKEN: workstation 401 (`invalid_token`); org secret in GH still valid (obs-loop succeeds).
+
+## Followups
+
+1. Self-heal halt — state file frozen since 2026-05-10. Check if Pipeline-Health workflow is actually mutating the file or running no-op (saw 5 successful scheduled runs since 16:57Z but no state advance).
+2. cloudroof 0-subs streak now 7 days post-CTA-live. Outreach drafts from 2026-05-08 (Discord/HN/Reddit/email/PH) — sent yet? CTAs work; constraint is traffic, not infra.
+3. Issue #618 `needs-human` ≥24h: €1 payment vs €0.04 MRR reconciliation — same mailbox-vs-cloudroof aggregation gap noted in observation-loop product-filter memory.
+4. Issue #634 (T6 Hetzner timeout) still open after 180→240min bumps; chaos_setup overhead may be root cause beyond timeout.
+5. 4 wgmesh issues stuck `copilot-triaging` 7+ days (#584, #573, #540, #539) — Copilot-quota stall persists.
+6. POLAR_TOKEN local 401: rotate or refresh on workstation; org-side token still works in CI so revenue read isn't blocked.


### PR DESCRIPTION
## Summary

Stand up the supervisor that ranks pipeline clogs across `ai-pipeline-template` and `wgmesh` and posts a ranked top-N action list into a single idempotent `supervisor-rank` GitHub issue. Read-only v1 — no auto-execution. U5 (pipeline-health mutation assertion / `supervisor-dead` loud-fail) ships in a sibling PR for risk isolation.

Origin: `docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md`
Plan: `docs/plans/2026-05-15-001-feat-supervisor-clog-ranker-plan.md`

## Motivation

Pulse 2026-05-15 surfaced 5 simultaneous supervisor failure modes — frozen state file with green cron, 8 spec PRs unmerged 9 days, 5 `copilot-triaging` issues stalled 7+ days, audit-drift PRs piling un-actioned, 40-day Goose-pipeline silence. The supervisor monitored but did not rank, decide, or escalate. Operator was doing the ranking job manually.

> *"that you even have to ask the question ;D"* — operator, 2026-05-15

## Implementation Units

- [x] **U1** — Stage taxonomy + classification heuristics (`company/pipeline-stages.json`)
- [x] **U2** — Snapshot + classifier scripts (`snapshot-clogs.sh`, `classify-clogs.sh`)
- [x] **U3** — Rank + recommend scripts (`rank-clogs.sh`, `recommend-actions.sh`)
- [x] **U4** — Publish to idempotent `supervisor-rank` issue (`publish-rank.sh` with retry-with-backoff)
- [x] **U6** — `.github/workflows/supervisor-rank.yml` (cron 4h + dispatch)
- [x] **U7** — Pulse + chimney config pointer (deferred to follow-up CE config addition)

U5 ships in PR `feat/pipeline-health-mutation-assertion` for risk isolation.

## Test results

| Harness | Scenarios | Result |
|---|---|---|
| `test-classify.sh` | 6 | PASS |
| `test-rank.sh` | 6 | PASS |
| `test-publish.sh` | 4 | PASS |
| `actionlint supervisor-rank.yml` | — | PASS |
| `shellcheck .github/scripts/*.sh` | — | PASS |
| `jq empty` on all new JSON | — | PASS |

Fixtures (`.github/scripts/fixtures/`) cover 10 hand-built items across all 7 stages including 2 `unknown`.

## Patterns followed

- `actions/create-github-app-token@v2` with `vars.APP_ID` + `secrets.APP_PRIVATE_KEY` (mirrors `pipeline-health.yml` + `strategy-audit.yml`).
- `concurrency: group: supervisor-rank, cancel-in-progress: false` lock.
- `hashFiles` self-bootstrap guard so this workflow does not 127-fail on its own CI run pre-merge.
- jq-then-mv state mutation pattern from `pipeline-health.yml`.

## Out of scope (deferred)

- Auto-execution of recommended actions — read-only v1 by design.
- Deadline-scheduler / event-driven gate refactor.
- Cross-org rollout to `CloudLLM-ai/*` or `nycterent/*`.
- Dashboard UI.

## Test plan

- [ ] Manual `workflow_dispatch` after merge — confirm `supervisor-rank` issue is created with ranked top-N.
- [ ] Second `workflow_dispatch` — confirm body is edited (no duplicate issue), comment only on rank change.
- [ ] After 7 consecutive scheduled runs, verify operator has acted on ≥1 ranked clog per day on average (revealed-preference signal from origin §Success Criteria).

## Kill criterion

If operator ignores the `supervisor-rank` issue 7 days running, the ranker is the wrong product — delete the workflow.