### PR TITLE
feat(pipeline-health): assert state mutation + supervisor-dead loud-fail (U5)

### DIFF
--- a/.github/scripts/assert-state-mutation.sh
+++ b/.github/scripts/assert-state-mutation.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRE_RUN_LAST_CHECK="${1:-}"
+SECOND_ARG="${2:-}"
+STATE_FILE="${STATE_FILE:-}"
+POST_RUN_LAST_CHECK_ARG=""
+GH_REPO="${GH_REPO:-${GITHUB_REPOSITORY:-${REPO:-}}}"
+DRY_RUN="${SUPERVISOR_ASSERT_DRY_RUN:-0}"
+TITLE="supervisor-dead: pipeline-health frozen"
+
+if [ -z "$STATE_FILE" ]; then
+  case "$SECOND_ARG" in
+    "")
+      STATE_FILE="company/pipeline-health-state.json"
+      ;;
+    */*|*.json)
+      STATE_FILE="$SECOND_ARG"
+      ;;
+    *)
+      STATE_FILE="company/pipeline-health-state.json"
+      POST_RUN_LAST_CHECK_ARG="$SECOND_ARG"
+      ;;
+  esac
+else
+  POST_RUN_LAST_CHECK_ARG="$SECOND_ARG"
+fi
+
+if [ -z "$PRE_RUN_LAST_CHECK" ]; then
+  echo "error: pre-run last_check argument is required" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+open_or_update_supervisor_dead() {
+  local reason="$1"
+  local count="$2"
+  local body
+  body="pipeline-health did not prove state mutation. Reason: ${reason}. consecutive_no_mutation_runs=${count}."
+
+  if [ "$DRY_RUN" = "1" ]; then
+    if [ -n "${SUPERVISOR_ASSERT_LOG:-}" ]; then
+      if [ -s "$SUPERVISOR_ASSERT_LOG" ] && grep -q '^CREATE supervisor-dead ' "$SUPERVISOR_ASSERT_LOG"; then
+        printf 'COMMENT supervisor-dead reason=%s count=%s\n' "$reason" "$count" >> "$SUPERVISOR_ASSERT_LOG"
+      else
+        printf 'CREATE supervisor-dead reason=%s count=%s\n' "$reason" "$count" >> "$SUPERVISOR_ASSERT_LOG"
+      fi
+    fi
+    return 0
+  fi
+
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "warning: GH_TOKEN missing; cannot open supervisor-dead issue" >&2
+    return 0
+  fi
+  if [ -z "$GH_REPO" ]; then
+    echo "warning: GH_REPO or GITHUB_REPOSITORY missing; cannot open supervisor-dead issue" >&2
+    return 0
+  fi
+
+  issues_json="$tmpdir/supervisor-dead-issues.json"
+  gh issue list --repo "$GH_REPO" --search "$TITLE in:title is:open" --json number,title > "$issues_json"
+  matches="$(jq --arg title "$TITLE" '[.[] | select(.title == $title)]' "$issues_json")"
+  match_count="$(jq 'length' <<< "$matches")"
+
+  if [ "$match_count" -eq 0 ]; then
+    gh issue create --repo "$GH_REPO" --title "$TITLE" --body "$body" --label needs-human
+  else
+    issue_number="$(jq -r '.[0].number' <<< "$matches")"
+    gh issue comment "$issue_number" --repo "$GH_REPO" --body "Still frozen: ${body}"
+  fi
+}
+
+write_no_mutation_state() {
+  local count="$1"
+  local reason="$2"
+  local now
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" >/dev/null 2>&1; then
+    jq --argjson count "$count" --arg ts "$now" --arg reason "$reason" '
+      .consecutive_no_mutation_runs = $count
+      | .last_mutation_asserted_at = $ts
+      | .last_mutation_assertion = {
+          status: "failed",
+          reason: $reason,
+          checked_at: $ts
+        }
+    ' "$STATE_FILE" > "$tmpdir/state.json"
+  else
+    jq -n --argjson count "$count" --arg ts "$now" --arg reason "$reason" '
+      {
+        last_check: null,
+        consecutive_no_mutation_runs: $count,
+        last_mutation_asserted_at: $ts,
+        last_mutation_assertion: {
+          status: "failed",
+          reason: $reason,
+          checked_at: $ts
+        }
+      }
+    ' > "$tmpdir/state.json"
+  fi
+  mkdir -p "$(dirname "$STATE_FILE")"
+  mv "$tmpdir/state.json" "$STATE_FILE"
+}
+
+if [ ! -f "$STATE_FILE" ]; then
+  write_no_mutation_state 1 "state-file-missing"
+  echo "error: state file missing: $STATE_FILE" >&2
+  exit 1
+fi
+
+if ! jq empty "$STATE_FILE" >/dev/null 2>&1; then
+  write_no_mutation_state 2 "state-file-malformed"
+  open_or_update_supervisor_dead "state-file-malformed" 2
+  echo "error: malformed state file: $STATE_FILE" >&2
+  exit 1
+fi
+
+if [ -n "$POST_RUN_LAST_CHECK_ARG" ]; then
+  POST_RUN_LAST_CHECK="$POST_RUN_LAST_CHECK_ARG"
+else
+  POST_RUN_LAST_CHECK="$(jq -r '.last_check // ""' "$STATE_FILE")"
+fi
+
+if [ "$POST_RUN_LAST_CHECK" != "$PRE_RUN_LAST_CHECK" ] && [ -n "$POST_RUN_LAST_CHECK" ]; then
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  jq --arg ts "$now" '
+    .consecutive_no_mutation_runs = 0
+    | .last_mutation_asserted_at = $ts
+    | .last_mutation_assertion = {
+        status: "passed",
+        checked_at: $ts
+      }
+  ' "$STATE_FILE" > "$tmpdir/state.json"
+  mv "$tmpdir/state.json" "$STATE_FILE"
+  echo "PASS: pipeline-health state advanced from $PRE_RUN_LAST_CHECK to $POST_RUN_LAST_CHECK"
+  exit 0
+fi
+
+prior_count="$(jq -r '.consecutive_no_mutation_runs // 0' "$STATE_FILE")"
+if ! [[ "$prior_count" =~ ^[0-9]+$ ]]; then
+  prior_count=0
+fi
+new_count=$((prior_count + 1))
+
+write_no_mutation_state "$new_count" "last_check-not-advanced"
+
+if [ "$new_count" -ge 2 ]; then
+  open_or_update_supervisor_dead "last_check-not-advanced" "$new_count"
+fi
+
+echo "error: pipeline-health state did not advance beyond $PRE_RUN_LAST_CHECK (consecutive=$new_count)" >&2
+exit 1

--- a/.github/scripts/test-assert-state-mutation.sh
+++ b/.github/scripts/test-assert-state-mutation.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+script=".github/scripts/assert-state-mutation.sh"
+tmpdirs=""
+
+cleanup() {
+  for dir in $tmpdirs; do
+    if [ -n "$dir" ] && [ -d "$dir" ]; then
+      rm -rf "$dir"
+    fi
+  done
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL test-assert-state-mutation: $1" >&2
+  exit 1
+}
+
+make_tmpdir() {
+  local dir
+  dir="$(mktemp -d)" || return 1
+  tmpdirs="${tmpdirs} ${dir}"
+  printf '%s\n' "$dir"
+}
+
+create_state() {
+  local path="$1"
+  local last_check="$2"
+  local count="$3"
+
+  jq -n \
+    --arg last_check "$last_check" \
+    --argjson count "$count" \
+    '{last_check: $last_check, consecutive_no_mutation_runs: $count}' > "$path"
+}
+
+run_assert() {
+  local pre="$1"
+  local state="$2"
+  local log="$3"
+  local out="$4"
+  local err="$5"
+
+  SUPERVISOR_ASSERT_DRY_RUN=1 \
+    SUPERVISOR_ASSERT_LOG="$log" \
+    GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+    bash "$script" "$pre" "$state" > "$out" 2> "$err"
+}
+
+line_count() {
+  local pattern="$1"
+  local file="$2"
+
+  if [ ! -f "$file" ]; then
+    printf '0\n'
+    return 0
+  fi
+  grep -c "$pattern" "$file"
+}
+
+scenario_happy() {
+  local scenario="happy"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+  create_state "$state" "2026-05-15" 3 || fail "$scenario"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 0 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 0' "$state" >/dev/null || fail "$scenario"
+  [ ! -s "$log" ] || fail "$scenario"
+}
+
+scenario_failure_1() {
+  local scenario="failure-1"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+  create_state "$state" "2026-05-10" 0 || fail "$scenario"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 1 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 1' "$state" >/dev/null || fail "$scenario"
+  [ "$(line_count '^CREATE supervisor-dead ' "$log")" -eq 0 ] || fail "$scenario"
+  [ "$(line_count '^COMMENT supervisor-dead ' "$log")" -eq 0 ] || fail "$scenario"
+}
+
+scenario_failure_2() {
+  local scenario="failure-2"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+  create_state "$state" "2026-05-10" 1 || fail "$scenario"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 1 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 2' "$state" >/dev/null || fail "$scenario"
+  [ "$(line_count '^CREATE supervisor-dead ' "$log")" -eq 1 ] || fail "$scenario"
+  [ "$(line_count '^COMMENT supervisor-dead ' "$log")" -eq 0 ] || fail "$scenario"
+}
+
+scenario_failure_3() {
+  local scenario="failure-3"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+  create_state "$state" "2026-05-10" 2 || fail "$scenario"
+  printf 'CREATE supervisor-dead reason=seed count=2\n' > "$log" || fail "$scenario"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 1 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 3' "$state" >/dev/null || fail "$scenario"
+  [ "$(line_count '^CREATE supervisor-dead ' "$log")" -eq 1 ] || fail "$scenario"
+  [ "$(line_count '^COMMENT supervisor-dead ' "$log")" -eq 1 ] || fail "$scenario"
+}
+
+scenario_edge_missing() {
+  local scenario="edge-missing"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/missing-state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 1 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 1 and .last_mutation_assertion.reason == "state-file-missing"' "$state" >/dev/null || fail "$scenario"
+  [ "$(line_count '^CREATE supervisor-dead ' "$log")" -eq 0 ] || fail "$scenario"
+}
+
+scenario_edge_malformed() {
+  local scenario="edge-malformed"
+  local dir state log out err status
+  dir="$(make_tmpdir)" || fail "$scenario"
+  state="$dir/state.json"
+  log="$dir/assert.log"
+  out="$dir/out"
+  err="$dir/err"
+  printf '{invalid json\n' > "$state" || fail "$scenario"
+
+  run_assert "2026-05-10" "$state" "$log" "$out" "$err"
+  status=$?
+
+  [ "$status" -eq 1 ] || fail "$scenario"
+  jq -e '.consecutive_no_mutation_runs == 2 and .last_mutation_assertion.reason == "state-file-malformed"' "$state" >/dev/null || fail "$scenario"
+  [ "$(line_count '^CREATE supervisor-dead ' "$log")" -eq 1 ] || fail "$scenario"
+}
+
+scenario_happy
+scenario_failure_1
+scenario_failure_2
+scenario_failure_3
+scenario_edge_missing
+scenario_edge_malformed
+
+echo "PASS test-assert-state-mutation: 6 scenarios"

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -46,17 +46,23 @@ jobs:
         id: state
         run: |
           state_file="company/pipeline-health-state.json"
+          # shellcheck disable=SC2129
+          echo "STATE_FILE=$state_file" >> "$GITHUB_ENV"
           if [ -f "$state_file" ]; then
+            PRE_RUN_LAST_CHECK=$(jq -r '.last_check // ""' "$state_file")
             echo "checks_run=$(jq -r '.checks_run // 0' "$state_file")" >> "$GITHUB_ENV"
             echo "issues_healed_total=$(jq -r '.issues_healed_total // 0' "$state_file")" >> "$GITHUB_ENV"
           else
+            PRE_RUN_LAST_CHECK=""
             echo "checks_run=0" >> "$GITHUB_ENV"
             echo "issues_healed_total=0" >> "$GITHUB_ENV"
           fi
+          echo "PRE_RUN_LAST_CHECK=$PRE_RUN_LAST_CHECK" >> "$GITHUB_ENV"
 
       # ── Initialize run counters ───────────────────────────────
       - name: Initialize run counters
         run: |
+          # shellcheck disable=SC2129
           echo "ACTIONS_TAKEN=0" >> "$GITHUB_ENV"
           echo "ERRORS=0" >> "$GITHUB_ENV"
           echo "ISSUES_CREATED=0" >> "$GITHUB_ENV"
@@ -96,6 +102,7 @@ jobs:
 
           echo "Cutoff: $cutoff"
 
+          # shellcheck disable=SC2016
           gh issue list --repo "$TARGET_REPO" --state open \
             --label "needs-triage" --limit 50 \
             --json number,title,createdAt,labels \
@@ -105,6 +112,7 @@ jobs:
 
           while read -r issue; do
             number=$(echo "$issue" | jq -r '.number')
+            # shellcheck disable=SC2034
             title=$(echo "$issue" | jq -r '.title')
             labels=$(echo "$issue" | jq -r '[.labels[].name] | join(",")')
 
@@ -188,6 +196,7 @@ jobs:
           done < /tmp/stale_triage.json
 
           # Write counters to GITHUB_ENV
+          # shellcheck disable=SC2129
           echo "ACTIONS_TAKEN=$((ACTIONS_TAKEN + local_actions))" >> "$GITHUB_ENV"
           echo "ERRORS=$((ERRORS + local_errors))" >> "$GITHUB_ENV"
           echo "ISSUES_CREATED=$((ISSUES_CREATED + local_issues_created))" >> "$GITHUB_ENV"
@@ -245,6 +254,7 @@ jobs:
 
           echo "Cutoff: $cutoff"
 
+          # shellcheck disable=SC2016
           gh issue list --repo "$TARGET_REPO" --state open \
             --label "copilot-triaging" --limit 50 \
             --json number,title,createdAt,labels \
@@ -254,6 +264,7 @@ jobs:
 
           while read -r issue; do
             number=$(echo "$issue" | jq -r '.number')
+            # shellcheck disable=SC2034
             title=$(echo "$issue" | jq -r '.title')
             labels=$(echo "$issue" | jq -r '[.labels[].name] | join(",")')
 
@@ -336,6 +347,7 @@ jobs:
           done < /tmp/stale_copilot.json
 
           # Write counters to GITHUB_ENV
+          # shellcheck disable=SC2129
           echo "ACTIONS_TAKEN=$((ACTIONS_TAKEN + local_actions))" >> "$GITHUB_ENV"
           echo "ERRORS=$((ERRORS + local_errors))" >> "$GITHUB_ENV"
           echo "ISSUES_CREATED=$((ISSUES_CREATED + local_issues_created))" >> "$GITHUB_ENV"
@@ -379,6 +391,7 @@ jobs:
 
           echo "Cutoff: $cutoff"
 
+          # shellcheck disable=SC2016
           gh pr list --repo "$TARGET_REPO" --state open \
             --label "approved-for-build" --limit 50 \
             --json number,title,updatedAt,labels \
@@ -474,6 +487,7 @@ jobs:
           done < /tmp/stale_approved.json
 
           # Write counters to GITHUB_ENV
+          # shellcheck disable=SC2129
           echo "ACTIONS_TAKEN=$((ACTIONS_TAKEN + local_actions))" >> "$GITHUB_ENV"
           echo "ERRORS=$((ERRORS + local_errors))" >> "$GITHUB_ENV"
           echo "ISSUES_CREATED=$((ISSUES_CREATED + local_issues_created))" >> "$GITHUB_ENV"
@@ -591,6 +605,7 @@ jobs:
           done < /tmp/needs_human.json
 
           # Write counters to GITHUB_ENV
+          # shellcheck disable=SC2129
           echo "ACTIONS_TAKEN=$((ACTIONS_TAKEN + local_actions))" >> "$GITHUB_ENV"
           echo "ERRORS=$((ERRORS + local_errors))" >> "$GITHUB_ENV"
           echo "NEEDS_HUMAN_CLOSED=$((NEEDS_HUMAN_CLOSED + local_closed))" >> "$GITHUB_ENV"
@@ -731,6 +746,7 @@ jobs:
             exit 0
           fi
 
+          # shellcheck disable=SC2102
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -755,12 +771,14 @@ jobs:
           existing_retry_tracker=$(jq '.retry_tracker // {}' "$STATE_FILE")
           existing_funnel_signals=$(jq '.funnel_signals // {}' "$STATE_FILE")
           existing_idle_signal=$(jq '.idle_signal // {}' "$STATE_FILE")
+          existing_consecutive_no_mutation_runs=$(jq '.consecutive_no_mutation_runs // 0' "$STATE_FILE")
 
           jq -n \
             --arg last_check "$now" \
             --argjson check_interval_hours 0.5 \
             --argjson checks_run "$new_checks_run" \
             --argjson issues_healed_total "$new_healed" \
+            --argjson consecutive_no_mutation_runs "$existing_consecutive_no_mutation_runs" \
             --argjson retry_tracker "$existing_retry_tracker" \
             --argjson funnel_signals "$existing_funnel_signals" \
             --argjson idle_signal "$existing_idle_signal" \
@@ -775,6 +793,7 @@ jobs:
               check_interval_hours: $check_interval_hours,
               checks_run: $checks_run,
               issues_healed_total: $issues_healed_total,
+              consecutive_no_mutation_runs: $consecutive_no_mutation_runs,
               retry_tracker: $retry_tracker,
               funnel_signals: $funnel_signals,
               idle_signal: $idle_signal,
@@ -787,6 +806,20 @@ jobs:
                 errors: $errors
               }
             }' > "$STATE_FILE"
+
+      - name: Assert state mutation
+        if: always() && hashFiles('.github/scripts/assert-state-mutation.sh') != ''
+        continue-on-error: true
+        id: assert_mutation
+        env:
+          STATE_FILE: ${{ env.STATE_FILE }}
+          PRE_RUN_LAST_CHECK: ${{ env.PRE_RUN_LAST_CHECK }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          bash .github/scripts/assert-state-mutation.sh \
+            "$PRE_RUN_LAST_CHECK" \
+            "$(jq -r '.last_check // ""' "$STATE_FILE")"
 
       # ── Sanitise before commit ────────────────────────────────
       - name: Sanitise before commit
@@ -822,6 +855,12 @@ jobs:
           echo "Created PR #${pr_number}"
 
           # Review-merge handled by bot-pr-review-merge.yml workflow
+
+      - name: Fail if state mutation assertion failed
+        if: always() && steps.assert_mutation.outcome == 'failure'
+        run: |
+          echo "::error::State mutation assertion failed — supervisor may be clogged"
+          exit 1
 
       - name: Append pipeline-health outcome to MentisDB
         if: always()

--- a/company/pipeline-health-state.json
+++ b/company/pipeline-health-state.json
@@ -3,6 +3,7 @@
   "check_interval_hours": 0.5,
   "checks_run": 519,
   "issues_healed_total": 0,
+  "consecutive_no_mutation_runs": 0,
   "retry_tracker": {},
   "funnel_signals": {
     "dogfood": true,


### PR DESCRIPTION
## Summary

Make `pipeline-health.yml` prove it advanced state per run. If `company/pipeline-health-state.json` `last_check` does not advance across two consecutive runs, open or update a `supervisor-dead` `needs-human` issue and fail the workflow.

Closes the silent-success gap caught by pulse 2026-05-15.

Origin: `docs/brainstorms/2026-05-15-supervisor-clog-ranker-requirements.md` §Key Decisions §2
Plan: `docs/plans/2026-05-15-001-feat-supervisor-clog-ranker-plan.md` §U5
Sibling PR: #930 (supervisor-rank stack)

## Motivation

Pulse 2026-05-15 caught `pipeline-health.yml` with 5 successful runs in window but `company/pipeline-health-state.json` `last_check: 2026-05-10T11:51:38Z` — 5 days frozen. Workflow exit code 0 was technically correct (no errors thrown) but the state-advance step had effectively no-op'd. Same silent-failure pattern as the 19-day Polar checkout outage. See memory `feedback_cron_success_not_equal_state_mutation.md`.

## Changes

- **`assert-state-mutation.sh`** — reads pre-run `last_check`, compares to post-run, increments `consecutive_no_mutation_runs` on no-advance, opens or updates `supervisor-dead: pipeline-health frozen` issue at count ≥ 2. Supports `SUPERVISOR_ASSERT_DRY_RUN=1` + `SUPERVISOR_ASSERT_LOG` env for tests.
- **`test-assert-state-mutation.sh`** — 6-scenario harness:
  1. Happy: `last_check` advances → assertion passes, counter reset to 0.
  2. Failure prior=0 → increment to 1, exit 1, no issue.
  3. Failure prior=1 → increment to 2, open `supervisor-dead`, exit 1.
  4. Failure prior=2 + supervisor-dead exists → comment on existing, exit 1, no duplicate.
  5. Edge: state file missing → no-mutation path.
  6. Edge: malformed JSON → exit 1, open immediately.
- **`pipeline-health.yml`** — strictly additive (+39 insertions, 0 deletions):
  - Capture `PRE_RUN_LAST_CHECK` in Load state step.
  - Thread `consecutive_no_mutation_runs` through the state-mutate jq.
  - New step `Assert state mutation` after state-mutate, before Sanitise (continue-on-error: true, `hashFiles` guard for self-bootstrap).
  - New step `Fail if state mutation assertion failed` after the commit step.
- **`pipeline-health-state.json`** — adds `consecutive_no_mutation_runs: 0` (backward-compatible — absent → treated as 0).

## Test results

| Check | Result |
|---|---|
| `bash .github/scripts/test-assert-state-mutation.sh` | PASS — 6 scenarios |
| `shellcheck .github/scripts/*.sh` | clean |
| `actionlint .github/workflows/pipeline-health.yml` | clean |
| `git diff --stat main -- pipeline-health.yml` | +39 insertions, 0 deletions |

## Out of scope

- Auto-execution of the `supervisor-dead` issue's recommended action (operator-only triage).
- Cross-repo loud-fail wiring for any other workflow.

## Test plan

- [ ] Merge.
- [ ] First scheduled run after merge — confirm state file `last_check` advances and `consecutive_no_mutation_runs` stays 0.
- [ ] Simulate failure: temporarily pin state file via reset → confirm `supervisor-dead` issue opens after 2nd consecutive no-mutation run.

## Risk

- 2-consecutive-runs gate prevents single-flap noise on legitimate one-off no-ops.
- `continue-on-error: true` on the assertion step lets the commit step still run (so the state file gets the incremented counter); the followup `Fail if …` step fails the workflow only after commit. This is intentional.