### PR TITLE
fix(snapshot-clogs): add jq -s/--slurp (#930 first-dispatch fix)

### DIFF
--- a/.github/scripts/snapshot-clogs.sh
+++ b/.github/scripts/snapshot-clogs.sh
@@ -35,7 +35,11 @@ for repo in "${repos[@]}"; do
     --json number,title,labels,createdAt,updatedAt,url \
     > "$issues_file"
 
-  jq --arg repo "$repo" '
+  # --slurp: collect the two input files into a single array so .[0] is the PR
+  # array and .[1] is the issue array. Without -s, jq processes each document
+  # separately and .[0] indexes into the first PR object, which fails on
+  # `.[0][]` with "Cannot index string with string".
+  jq -s --arg repo "$repo" '
     [
       (.[0][] | {
         repo: $repo,


### PR DESCRIPTION
First post-merge dispatch of `supervisor-rank.yml` (run #25946289909) failed at Snapshot clogs step with `jq: Cannot index string with string "number"`.

Root cause: jq filter expected `.[0]`/`.[1]` to index two slurped arrays but file was passed without `-s`/`--slurp`, so each input was processed as a separate document and `.[0]` indexed into the first PR object instead.

Fix is one flag. End-to-end live-API smoke test passes — produced ranked top-5 over real backlog (31 items across 7-stage taxonomy, 9 unknowns).

Admin-merge per `protect-main` ruleset convention.