### PR TITLE
docs: seed CONCEPTS.md shared domain vocabulary

### DIFF
--- a/.goosehints
+++ b/.goosehints
@@ -15,6 +15,8 @@ __PROJECT_STRUCTURE__
 
 __ARCHITECTURE_NOTES__
 
+- `CONCEPTS.md` (repo root) — shared domain vocabulary (entities, named processes, status concepts); read when orienting to the codebase or before discussing domain concepts.
+
 ## Commercial Focus
 
 When the pipeline is idle, prefer the highest-leverage 2–4 hour task that increases the probability of getting the first paying customer. Bias toward proof of value, offer clarity, onboarding, distribution, and customer delivery readiness over internal polish.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,90 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Relationships
+
+The pipeline converges a Seed into a shipped product by moving work items through stages. An Issue is the root work item; triage produces a Spec, an approved Spec produces an Implementation, and a merged Implementation closes the originating Issue. Stage is carried entirely by the work item's label, so the label *is* the state. Two named loops drive this from opposite ends: the Observation Loop decides *what* work to create, and the Convergence Engine drives each created item *through* to merge and deploy. Self-Healing watches the same items and re-triggers whichever stage has stalled.
+
+## The loops
+
+### Observation Loop
+The daily cycle that collects signals (GitHub activity, infra health, costs, contributions), assesses the company's current state, and creates or closes Issues to pursue the highest-leverage actions. Owns the loop-state it writes and the daily Assessment it emits; it decides *what* enters the pipeline, not how work moves through it.
+
+### Convergence Engine
+The agent loop that drives a single work item through triage → spec → implementation → merge → deploy without a human in the loop. Distinct from the Observation Loop: the Observation Loop chooses work, the Convergence Engine completes it. "Converging" means reaching a finished, deployed product — not merely generating code that still needs babysitting.
+
+### Self-Healing
+Deterministic (code, never LLM) recovery that detects work items stalled too long in a stage and re-triggers the responsible workflow, typically by toggling the stage label off and back on. Before acting it checks for an already-in-flight downstream artifact and skips if work is genuinely progressing. Governed by the Circuit Breaker.
+*Avoid:* pipeline-health (that is the workflow that runs Self-Healing, not the concept).
+
+### Assessment
+The Observation Loop's dated decision record for one run — the state it read, the funnel stage it inferred, and the actions it chose. Each run appends one Assessment to the loop history.
+
+### Supervisor
+The ranking pass that snapshots open work items across repos, classifies each into a pipeline stage, and ranks the worst Clogs by dwell time weighted by how much downstream work they block, then recommends one action per Clog. Read-only: it surfaces and recommends, it does not act.
+
+## Work items
+
+### Issue
+The root unit of pipeline work, carrying its current stage as a GitHub label. An Issue's label determines its position in the pipeline and which agent or workflow acts on it next. An Issue is closed automatically when the Implementation fulfilling it merges.
+
+### Spec
+The design proposal for an Issue, written by the Spec writer during triage and delivered as a spec pull request. A Spec is structurally validated and approved before any code is written against it.
+*Avoid:* spec PR (that is the delivery vehicle; the Spec is the content).
+
+### Implementation
+The code change that fulfills an approved Spec, produced by the Build agent and delivered as an implementation pull request. Reviewed and guardrail-checked before auto-merge; its merge is what closes the originating Issue.
+*Avoid:* impl PR, build.
+
+### Seed
+A product idea the founder plants for the pipeline to converge into a shipped, deployed product. Seeds are the things the pipeline exists to finish and take to revenue; a Seed reaching public beta is a milestone, and each Seed owns its own path to a first paying customer.
+*Avoid:* seed product.
+
+## Stage control and status
+
+### Clog
+A work item stuck in a stage and blocking pipeline flow, severe in proportion to how long it has dwelled and how much downstream work waits on it. The Supervisor's unit of attention: the pipeline's worst Clogs are what get ranked and recommended for action.
+
+### Circuit Breaker
+The safety mechanism that stops Self-Healing from cascading within a single run — once too many recovery actions or errors occur in one run, remaining healing is skipped and a human escalation is raised. Resets at the start of the next run rather than latching into a disabled state.
+
+### Escalation
+The handoff of a work item to a human when automated recovery is exhausted or a safety limit trips, marked by a dedicated needs-human state. An escalated item can be auto-closed later if resolution signals appear.
+*Avoid:* needs-human (that is the label; Escalation is the act).
+
+### Funnel stage
+The company's overall maturity position along a fixed ladder — Foundation, Dogfood, Presence, Reachable, Pipeline, Revenue — inferred each run to decide where leverage is highest. Distinct from a work item's pipeline stage: the Funnel stage describes the whole company, a pipeline stage describes one Issue.
+
+### Function label
+A tag classifying a work item by the business function it serves (development, ops, go-to-market, billing, support, legal) rather than by its pipeline stage. Stage labels and function labels coexist on the same Issue.
+
+## Agent roles
+
+The pipeline defines roles, not tools — any conforming agent can fill a role.
+
+### Spec writer
+The agent role that analyzes a freshly triaged Issue and produces its Spec.
+
+### Build agent
+The agent role that reads an approved Spec and produces the Implementation. Currently defaulted to Goose, but the role is tool-agnostic.
+*Avoid:* Goose (a current implementation of the role, not the role).
+
+### Observer
+The model role that reads collected state during the Observation Loop and produces the Assessment.
+
+## Principles and metrics
+
+### Andon
+The project's foundational stop-the-line principle: when a defect, failing check, or broken build appears, halt and fix the root cause before passing work downstream rather than working around it. Any contributor — human or agent — has both the authority and the obligation to stop the line.
+
+### Autonomous-ship rate
+The share of seeded Specs that reach merge and deploy with zero human intervention — the leading metric for whether the pipeline truly converges without babysitting.
+
+### MSC
+The count of paying subscribers across seeded products — the project's lagging revenue north-star, tracked on the dashboard and excluding subscriptions from unrelated products.
+
+## Flagged ambiguities
+
+- "The loop" had been used for both the work-selection cycle and the work-completion cycle — these are distinct: the **Observation Loop** chooses work, the **Convergence Engine** completes it.
+- "Pipeline stage" (a single Issue's position) and "Funnel stage" (the whole company's maturity) are different ladders; do not conflate them.


### PR DESCRIPTION
## What

Bootstraps `CONCEPTS.md` — the project's shared domain glossary — via `/ce-compound create concepts.md` (routed to ce-compound-refresh's repo-wide bootstrap path).

## Source

Seeded from the declared domain model only: `README.md` (The Full Loop, Agent Roles), `STRATEGY.md` (tracks, metrics), `CONSTITUTION.md` (Andon), `docs/domain/pipeline-state-machine.md`, `company/idle-policy.md`. No terms pulled from beyond the declared model.

## Contents (24 entries, 6 clusters + flagged ambiguities)

- **The loops** — Observation Loop, Convergence Engine, Self-Healing, Assessment, Supervisor
- **Work items** — Issue, Spec, Implementation, Seed
- **Stage control & status** — Clog, Circuit Breaker, Escalation, Funnel stage, Function label
- **Agent roles** — Spec writer, Build agent, Observer
- **Principles & metrics** — Andon, Autonomous-ship rate, MSC
- **Relationships** + **Flagged ambiguities** (Observation Loop ≠ Convergence Engine; pipeline stage ≠ funnel stage)

Glossary-only per vocabulary rules: no file paths, class names, thresholds, or config values — behavior stated, not numbers.

## Discoverability

No root `AGENTS.md`/`CLAUDE.md` exist (repo uses `.goosehints` + `README.md`), so the instruction-file discoverability edit was skipped per skill scope. Consider adding a one-line `CONCEPTS.md` pointer to `.goosehints` or README manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)