### PR TITLE
fix(supervisor-rank): collapse duplicate clog issues via List API + self-healing reconcile

### DIFF
--- a/.github/scripts/publish-rank.sh
+++ b/.github/scripts/publish-rank.sh
@@ -161,7 +161,8 @@ if [ "$DRY_RUN" = "1" ]; then
 else
   issues_json="$tmpdir/issues.json"
   retry_gh issue list --repo "$GH_REPO" \
-    --search "$TITLE in:title is:open" \
+    --state open \
+    --limit 500 \
     --json number,title,url \
     > "$issues_json"
   matches="$(jq --arg title "$TITLE" '[.[] | select(.title == $title)]' "$issues_json")"
@@ -170,13 +171,24 @@ else
   if [ "$match_count" -eq 0 ]; then
     issue_url="$(retry_gh issue create --repo "$GH_REPO" --title "$TITLE" --body-file "$body_file")"
     issue_number="${issue_url##*/}"
-  elif [ "$match_count" -eq 1 ]; then
-    issue_number="$(jq -r '.[0].number' <<< "$matches")"
-    issue_url="$(jq -r '.[0].url' <<< "$matches")"
-    retry_gh issue edit "$issue_number" --repo "$GH_REPO" --body-file "$body_file"
   else
-    echo "error: duplicate supervisor-rank issues open: $(jq -r '.[].number' <<< "$matches" | paste -sd ',')" >&2
-    exit 1
+    canonical_issue="$(jq -c --arg prior "$issue_number" '
+      if ($prior != "" and any(.[]; (.number | tostring) == $prior)) then
+        .[] | select((.number | tostring) == $prior)
+      else
+        min_by(.number)
+      end
+    ' <<< "$matches")"
+    issue_number="$(jq -r '.number' <<< "$canonical_issue")"
+    issue_url="$(jq -r '.url' <<< "$canonical_issue")"
+    retry_gh issue edit "$issue_number" --repo "$GH_REPO" --body-file "$body_file"
+
+    if [ "$match_count" -gt 1 ]; then
+      while IFS= read -r duplicate_issue_number; do
+        retry_gh issue close "$duplicate_issue_number" --repo "$GH_REPO" \
+          --comment "Closing duplicate supervisor-rank issue; canonical tracked in #${issue_number}."
+      done < <(jq -r --arg canonical "$issue_number" '.[] | select((.number | tostring) != $canonical) | .number' <<< "$matches")
+    fi
   fi
 
   if [ "$rank_changed" = "true" ]; then

--- a/.github/scripts/test-publish.sh
+++ b/.github/scripts/test-publish.sh
@@ -202,4 +202,21 @@ assert_gh_count "$record" "issue edit 10" 1
 assert_gh_count "$record" "issue close 22" 1
 assert_gh_count "$record" "issue close 37" 1
 
-echo "PASS test-publish: 9 scenarios"
+# Scenario 10: regression guard — dedup must look up open issues via the List API
+# (--state), never the Search API (--search). The Search API is eventually-consistent
+# and mis-tokenizes the colon in "supervisor-rank:" → 0 matches → create-every-run was
+# the root cause of the duplicate-issue flood. See
+# feedback_gh_issue_dedup_search_api_floods. Without this, the suite would still pass
+# if publish-rank.sh regressed back to --search.
+if ! grep -qF -- "--state" "$record"; then
+  echo "FAIL: dedup must query open issues via the List API (--state); none recorded" >&2
+  cat "$record" >&2
+  exit 1
+fi
+if grep -qF -- "--search" "$record"; then
+  echo "FAIL: dedup must NOT use the Search API (--search) — root cause of the dup flood" >&2
+  cat "$record" >&2
+  exit 1
+fi
+
+echo "PASS test-publish: 10 scenarios"

--- a/.github/scripts/test-publish.sh
+++ b/.github/scripts/test-publish.sh
@@ -9,11 +9,88 @@ state="$tmpdir/state.json"
 log="$tmpdir/publish.log"
 sentinel="$tmpdir/material.sentinel"
 
+repo="atvirokodosprendimai/ai-pipeline-template"
+
+make_gh_shim() {
+  local shim_dir="$1"
+  mkdir -p "$shim_dir"
+  cat > "$shim_dir/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  first=1
+  for arg in "$@"; do
+    if [ "$first" -eq 1 ]; then
+      first=0
+    else
+      printf ' '
+    fi
+    printf '%q' "$arg"
+  done
+  printf '\n'
+} >> "$GH_RECORD"
+
+case "$1 $2" in
+  "issue list")
+    cat "$GH_ISSUES_JSON"
+    ;;
+  "issue create")
+    echo "https://github.com/${GH_REPO}/issues/777"
+    ;;
+  "issue edit"|"issue close"|"issue comment")
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$shim_dir/gh"
+}
+
+run_production_dedup_case() {
+  local case_name="$1"
+  local issues_payload="$2"
+  local state_file="$tmpdir/${case_name}-state.json"
+  local record_file="$tmpdir/${case_name}-gh.log"
+  local issues_file="$tmpdir/${case_name}-issues.json"
+  local shim_dir="$tmpdir/${case_name}-bin"
+  local sentinel_file="$tmpdir/${case_name}-sentinel"
+
+  printf '%s\n' "$issues_payload" > "$issues_file"
+  : > "$record_file"
+  make_gh_shim "$shim_dir"
+
+  GH_TOKEN="test-token" \
+  GH_REPO="$repo" \
+  GH_RECORD="$record_file" \
+  GH_ISSUES_JSON="$issues_file" \
+  SUPERVISOR_MATERIAL_SENTINEL="$sentinel_file" \
+  PATH="$shim_dir:$PATH" \
+  bash .github/scripts/publish-rank.sh "$ranked" "$state_file" > "$tmpdir/${case_name}.out"
+
+  printf '%s\n' "$record_file"
+}
+
+assert_gh_count() {
+  local record_file="$1"
+  local pattern="$2"
+  local expected="$3"
+  local actual
+  actual="$(grep -c -F "$pattern" "$record_file" || true)"
+  if [ "$actual" -ne "$expected" ]; then
+    echo "FAIL: expected $expected gh invocations matching '$pattern', got $actual" >&2
+    cat "$record_file" >&2
+    exit 1
+  fi
+}
+
 # Scenario 1: first dry-run → material changes (no prior fingerprint) → state written.
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
 SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
-GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+GH_REPO="$repo" \
 bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-first.out
 
 if ! jq -e '.run_number == 1 and .rank_changed == false and (.last_run_top_ids | length) == 3 and (.material_fingerprint | type == "string") and (.material_fingerprint | length == 64)' "$state" >/dev/null; then
@@ -30,7 +107,7 @@ first_fp="$(jq -r '.material_fingerprint' "$state")"
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
 SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
-GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+GH_REPO="$repo" \
 bash .github/scripts/publish-rank.sh "$ranked" "$state" >/tmp/publish-second.out
 
 if [ "$(cat "$sentinel")" != "false" ]; then
@@ -49,7 +126,7 @@ jq '.top = ([.top[1], .top[0]] + .top[2:]) | .top |= to_entries | .top = (.top |
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
 SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
-GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+GH_REPO="$repo" \
 bash .github/scripts/publish-rank.sh "$changed" "$state" >/tmp/publish-third.out
 
 if [ "$(cat "$sentinel")" != "true" ]; then
@@ -62,7 +139,7 @@ if ! jq -e --arg fp "$first_fp" '.run_number == 2 and .rank_changed == true and 
 fi
 
 # Scenario 4: missing GH_TOKEN → error (production path only).
-if GH_TOKEN="" GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+if GH_TOKEN="" GH_REPO="$repo" \
    SUPERVISOR_MATERIAL_SENTINEL="$tmpdir/no-token.sentinel" \
    bash .github/scripts/publish-rank.sh "$ranked" "$tmpdir/no-token.json" >/tmp/publish-no-token.out 2>/tmp/publish-no-token.err; then
   echo "FAIL: missing GH_TOKEN unexpectedly passed" >&2
@@ -79,7 +156,7 @@ jq '.stage_summary.spec = ((.stage_summary.spec // 0) + 1)' "$ranked" > "$stage_
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
 SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
-GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+GH_REPO="$repo" \
 bash .github/scripts/publish-rank.sh "$stage_diff" "$state" >/tmp/publish-fifth.out
 
 if [ "$(cat "$sentinel")" != "true" ]; then
@@ -94,7 +171,7 @@ jq '.top[0].recommended_action = "post-rah-bounty"' "$stage_diff" > "$action_dif
 SUPERVISOR_PUBLISH_DRY_RUN=1 \
 SUPERVISOR_PUBLISH_LOG="$log" \
 SUPERVISOR_MATERIAL_SENTINEL="$sentinel" \
-GH_REPO="atvirokodosprendimai/ai-pipeline-template" \
+GH_REPO="$repo" \
 bash .github/scripts/publish-rank.sh "$action_diff" "$state" >/tmp/publish-sixth.out
 
 if [ "$(cat "$sentinel")" != "true" ]; then
@@ -106,4 +183,23 @@ if ! jq -e --arg fp "$prev_fp" '.material_fingerprint != $fp' "$state" >/dev/nul
   exit 1
 fi
 
-echo "PASS test-publish: 6 scenarios"
+# Scenario 7: production dedup with 0 open matches creates one issue.
+record="$(run_production_dedup_case "prod-zero-matches" '[]')"
+assert_gh_count "$record" "issue create" 1
+assert_gh_count "$record" "issue edit" 0
+assert_gh_count "$record" "issue close" 0
+
+# Scenario 8: production dedup with 1 open match edits the existing issue.
+record="$(run_production_dedup_case "prod-one-match" '[{"number":42,"title":"supervisor-rank: top pipeline clogs","url":"https://github.com/atvirokodosprendimai/ai-pipeline-template/issues/42"}]')"
+assert_gh_count "$record" "issue create" 0
+assert_gh_count "$record" "issue edit 42" 1
+assert_gh_count "$record" "issue close" 0
+
+# Scenario 9: production dedup with 3 open matches reconciles to the lowest issue number.
+record="$(run_production_dedup_case "prod-three-matches" '[{"number":37,"title":"supervisor-rank: top pipeline clogs","url":"https://github.com/atvirokodosprendimai/ai-pipeline-template/issues/37"},{"number":10,"title":"supervisor-rank: top pipeline clogs","url":"https://github.com/atvirokodosprendimai/ai-pipeline-template/issues/10"},{"number":22,"title":"supervisor-rank: top pipeline clogs","url":"https://github.com/atvirokodosprendimai/ai-pipeline-template/issues/22"}]')"
+assert_gh_count "$record" "issue create" 0
+assert_gh_count "$record" "issue edit 10" 1
+assert_gh_count "$record" "issue close 22" 1
+assert_gh_count "$record" "issue close 37" 1
+
+echo "PASS test-publish: 9 scenarios"


### PR DESCRIPTION
## Problem
`supervisor-rank` opened a fresh `supervisor-rank: top pipeline clogs` issue every ~4h run — **30–100+ duplicates** open on the public repo.

## Root cause
`publish-rank.sh` dedup used the eventually-consistent GitHub **Search API** with a colon-bearing free-text title (`supervisor-rank: ... in:title is:open`). Search returned 0 matches → the `match_count==0` create branch ran every time. The `>1` hard-fail never fired because search never surfaced the dupes. The dedup path was also **untested** — `test-publish.sh` only exercised the `DRY_RUN` short-circuit.

## Fix
- Swap Search API → strongly-consistent **List API** (`--state open --limit 500`).
- Replace the `>1` hard-fail with **self-healing reconcile**: edit the canonical issue (state-file `issue_number` if present, else lowest number) and close the rest with a pointer comment. The next real run auto-collapses the existing flood to one issue.
- Add real (non-dry-run) dedup tests stubbing `gh`: 0→create, 1→edit, 3→reconcile.

## Tests
```
bash .github/scripts/test-publish.sh   # PASS test-publish: 9 scenarios
bash -n .github/scripts/publish-rank.sh # clean
shellcheck publish-rank.sh test-publish.sh # clean
```

Relates to memory: monitor-workflow issue-per-run anti-pattern; untested-glue-steps.