### PR TITLE
feat(compound): auto-compound learning loop (zero-LLM capture + inert weekly synthesis)

### DIFF
--- a/.github/scripts/compound-queue-append.sh
+++ b/.github/scripts/compound-queue-append.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reads env: PR_NUMBER, PR_TITLE, PR_BODY, ISSUE_NUMBER (may be empty), FILES (newline list), MERGED_AT
+# Appends ONE JSONL line to $1 (default: compound-queue.jsonl)
+# Uses jq -c -n with --arg/--argjson -- NEVER string-concat JSON
+# Keys: pr (number), title, issue (number or null), body_excerpt (first 800 chars of body), files (array), merged_at
+# No network. No secrets in output.
+
+out_path="${1:-compound-queue.jsonl}"
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${PR_TITLE:?PR_TITLE is required}"
+: "${MERGED_AT:?MERGED_AT is required}"
+
+pr_body="${PR_BODY:-}"
+issue_number="${ISSUE_NUMBER:-}"
+files="${FILES:-}"
+body_excerpt="${pr_body:0:800}"
+
+files_json="$(printf '%s' "$files" | jq -R -s 'split("\n") | map(select(length > 0))')"
+
+if [[ -n "$issue_number" ]]; then
+  issue_json="$issue_number"
+else
+  issue_json="null"
+fi
+
+jq -c -n \
+  --argjson pr "$PR_NUMBER" \
+  --arg title "$PR_TITLE" \
+  --argjson issue "$issue_json" \
+  --arg body_excerpt "$body_excerpt" \
+  --argjson files "$files_json" \
+  --arg merged_at "$MERGED_AT" \
+  '{
+    pr: $pr,
+    title: $title,
+    issue: $issue,
+    body_excerpt: $body_excerpt,
+    files: $files,
+    merged_at: $merged_at
+  }' >> "$out_path"

--- a/.github/scripts/compound-render-docs.sh
+++ b/.github/scripts/compound-render-docs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Input $1 = path to LLM JSON response file
+# Expects JSON array of {category, slug, title, tags:[...], date, markdown}
+# Validates category is one of: integration-issues, logic-errors, design-decisions, runtime-errors
+# Writes docs/solutions/<category>/<slug>.md with proper frontmatter then markdown body
+# Strips slug to [a-z0-9-] only (refuse path traversal)
+# Prints list of files written
+# Skips + warns on invalid category or unsafe slug
+
+input_path="${1:?usage: compound-render-docs.sh <llm-json-response>}"
+tmp_array="$(mktemp)"
+tmp_content="$(mktemp)"
+trap 'rm -f "$tmp_array" "$tmp_content"' EXIT
+
+if jq -e 'type == "array"' "$input_path" >/dev/null; then
+  jq '.' "$input_path" > "$tmp_array"
+else
+  jq -r '.choices[0].message.content // empty' "$input_path" > "$tmp_content"
+  # shellcheck disable=SC2016
+  sed -n '/^```json[[:space:]]*$/,/^```[[:space:]]*$/p' "$tmp_content" | sed '1d;$d' > "$tmp_array"
+  if ! jq -e 'type == "array"' "$tmp_array" >/dev/null 2>&1; then
+    jq -e 'type == "array"' "$tmp_content" >/dev/null
+    jq '.' "$tmp_content" > "$tmp_array"
+  fi
+fi
+
+if ! jq -e 'type == "array"' "$tmp_array" >/dev/null; then
+  echo "FAIL: LLM response is not a JSON array" >&2
+  exit 1
+fi
+
+jq -c '.[]' "$tmp_array" | while IFS= read -r entry; do
+  category="$(printf '%s\n' "$entry" | jq -r '.category // ""')"
+  slug="$(printf '%s\n' "$entry" | jq -r '.slug // ""')"
+
+  case "$category" in
+    integration-issues|logic-errors|design-decisions|runtime-errors) ;;
+    *)
+      echo "WARN: skipping invalid category: $category" >&2
+      continue
+      ;;
+  esac
+
+  safe_slug="$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')"
+  if [[ -z "$safe_slug" || "$slug" != "$safe_slug" ]]; then
+    echo "WARN: skipping unsafe slug: $slug" >&2
+    continue
+  fi
+
+  out_dir="docs/solutions/$category"
+  out_file="$out_dir/$safe_slug.md"
+  mkdir -p "$out_dir"
+
+  title="$(printf '%s\n' "$entry" | jq -r '.title // ""')"
+  date="$(printf '%s\n' "$entry" | jq -r '.date // ""')"
+  tags_line="$(printf '%s\n' "$entry" | jq -r '(.tags // []) | map(tostring) | "tags: [" + join(", ") + "]"')"
+  markdown="$(printf '%s\n' "$entry" | jq -r '.markdown // ""')"
+
+  {
+    echo "---"
+    printf 'title: "%s"\n' "${title//\"/\\\"}"
+    printf 'category: %s\n' "$category"
+    printf 'date: %s\n' "$date"
+    printf '%s\n' "$tags_line"
+    echo "---"
+    echo
+    printf '%s\n' "$markdown"
+  } > "$out_file"
+
+  printf '%s\n' "$out_file"
+done

--- a/.github/scripts/compound-render-docs.sh
+++ b/.github/scripts/compound-render-docs.sh
@@ -57,6 +57,11 @@ jq -c '.[]' "$tmp_array" | while IFS= read -r entry; do
   date="$(printf '%s\n' "$entry" | jq -r '.date // ""')"
   tags_line="$(printf '%s\n' "$entry" | jq -r '(.tags // []) | map(tostring) | "tags: [" + join(", ") + "]"')"
   markdown="$(printf '%s\n' "$entry" | jq -r '.markdown // ""')"
+  title="${title//$'\r'/ }"
+  title="${title//$'\n'/ }"
+  if ! [[ "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    date=$(date -u +%F)
+  fi
 
   {
     echo "---"

--- a/.github/scripts/test-compound-queue-append.sh
+++ b/.github/scripts/test-compound-queue-append.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+queue_file="$tmp_dir/compound-queue.jsonl"
+long_body="$(printf 'x%.0s' {1..900})"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+export PR_NUMBER="123"
+export PR_TITLE="Implement Issue #45 compound queue"
+export PR_BODY="$long_body"
+export ISSUE_NUMBER=""
+export FILES=$'.github/workflows/example.yml\nsrc/example.sh'
+export MERGED_AT="2026-06-05T12:34:56Z"
+
+bash "$script_dir/compound-queue-append.sh" "$queue_file"
+
+jq -e . "$queue_file" >/dev/null || fail "appended line is not valid JSON"
+
+[[ "$(jq -r '.pr' "$queue_file")" == "123" ]] || fail "pr mismatch"
+[[ "$(jq -r '.title' "$queue_file")" == "$PR_TITLE" ]] || fail "title mismatch"
+[[ "$(jq -r '.issue == null' "$queue_file")" == "true" ]] || fail "empty ISSUE_NUMBER did not produce null"
+[[ "$(jq -r '.files | length' "$queue_file")" == "2" ]] || fail "files length mismatch"
+[[ "$(jq -r '.files[0]' "$queue_file")" == ".github/workflows/example.yml" ]] || fail "first file mismatch"
+[[ "$(jq -r '.merged_at' "$queue_file")" == "$MERGED_AT" ]] || fail "merged_at mismatch"
+[[ "$(jq -r '.body_excerpt | length' "$queue_file")" == "800" ]] || fail "body_excerpt not truncated to 800 chars"
+
+export PR_NUMBER="124"
+export PR_TITLE="Second PR"
+export PR_BODY="short body"
+export ISSUE_NUMBER="77"
+export FILES="README.md"
+export MERGED_AT="2026-06-05T13:00:00Z"
+
+bash "$script_dir/compound-queue-append.sh" "$queue_file"
+
+[[ "$(wc -l < "$queue_file" | tr -d ' ')" == "2" ]] || fail "second call did not append a second line"
+[[ "$(tail -n 1 "$queue_file" | jq -r '.issue')" == "77" ]] || fail "non-empty ISSUE_NUMBER mismatch"
+
+echo "PASS: compound-queue-append"

--- a/.github/scripts/test-compound-queue-append.sh
+++ b/.github/scripts/test-compound-queue-append.sh
@@ -44,4 +44,16 @@ bash "$script_dir/compound-queue-append.sh" "$queue_file"
 [[ "$(wc -l < "$queue_file" | tr -d ' ')" == "2" ]] || fail "second call did not append a second line"
 [[ "$(tail -n 1 "$queue_file" | jq -r '.issue')" == "77" ]] || fail "non-empty ISSUE_NUMBER mismatch"
 
+export PR_NUMBER="125"
+export PR_TITLE="Leaky PR"
+export PR_BODY="sk-123456789012345678901234"
+export ISSUE_NUMBER=""
+export FILES="src/leak.sh"
+export MERGED_AT="2026-06-05T14:00:00Z"
+
+if printf '%s\n%s\n%s\n' "$PR_TITLE" "$PR_BODY" "$FILES" | bash "$script_dir/../../company/scripts/sanitise.sh" > /dev/null 2>&1; then
+  fail "sanitise gate accepted secret-like PR content"
+fi
+[[ "$(wc -l < "$queue_file" | tr -d ' ')" == "2" ]] || fail "sanitise rejection should prevent append"
+
 echo "PASS: compound-queue-append"

--- a/.github/scripts/test-compound-render-docs.sh
+++ b/.github/scripts/test-compound-render-docs.sh
@@ -78,4 +78,55 @@ grep -Fq 'tags: [logic, synthesis]' "$expected_two" || fail "logic tags frontmat
 grep -Fxq 'docs/solutions/integration-issues/valid-integration.md' "$output" || fail "integration output path missing"
 grep -Fxq 'docs/solutions/logic-errors/valid-logic.md' "$output" || fail "logic output path missing"
 
+newline_fixture="$tmp_dir/newline-title.json"
+newline_output="$tmp_dir/newline-title-output.txt"
+cat > "$newline_fixture" <<'JSON'
+[
+  {
+    "category": "design-decisions",
+    "slug": "newline-title",
+    "title": "First line\nSecond line",
+    "tags": ["frontmatter"],
+    "date": "2026-06-05",
+    "markdown": "## Problem\n\nTitle contained a newline."
+  }
+]
+JSON
+
+(
+  cd "$tmp_dir"
+  bash "$script_dir/compound-render-docs.sh" "$newline_fixture" > "$newline_output"
+)
+
+newline_doc="$tmp_dir/docs/solutions/design-decisions/newline-title.md"
+[[ -f "$newline_doc" ]] || fail "missing newline title doc"
+grep -Fxq 'title: "First line Second line"' "$newline_doc" || fail "title newline was not rendered as single-line YAML"
+[[ "$(sed -n '2p' "$newline_doc")" == 'title: "First line Second line"' ]] || fail "title frontmatter line mismatch"
+[[ "$(sed -n '3p' "$newline_doc")" == 'category: design-decisions' ]] || fail "title newline spilled into next frontmatter line"
+
+invalid_date_fixture="$tmp_dir/invalid-date.json"
+invalid_date_output="$tmp_dir/invalid-date-output.txt"
+cat > "$invalid_date_fixture" <<'JSON'
+[
+  {
+    "category": "runtime-errors",
+    "slug": "invalid-date",
+    "title": "Invalid date",
+    "tags": ["frontmatter"],
+    "date": "not-a-date",
+    "markdown": "## Problem\n\nDate was invalid."
+  }
+]
+JSON
+
+(
+  cd "$tmp_dir"
+  bash "$script_dir/compound-render-docs.sh" "$invalid_date_fixture" > "$invalid_date_output"
+)
+
+invalid_date_doc="$tmp_dir/docs/solutions/runtime-errors/invalid-date.md"
+[[ -f "$invalid_date_doc" ]] || fail "missing invalid date doc"
+rendered_date="$(sed -n '4s/^date: //p' "$invalid_date_doc")"
+[[ "$rendered_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || fail "invalid date did not fall back to YYYY-MM-DD"
+
 echo "PASS: compound-render-docs"

--- a/.github/scripts/test-compound-render-docs.sh
+++ b/.github/scripts/test-compound-render-docs.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture="$tmp_dir/fixture.json"
+output="$tmp_dir/output.txt"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat > "$fixture" <<'JSON'
+[
+  {
+    "category": "integration-issues",
+    "slug": "valid-integration",
+    "title": "Valid integration learning",
+    "tags": ["github-actions", "queue"],
+    "date": "2026-06-05",
+    "markdown": "## Problem\n\nIntegration failed.\n\n## Root Cause\n\nQueue drift."
+  },
+  {
+    "category": "logic-errors",
+    "slug": "valid-logic",
+    "title": "Valid logic learning",
+    "tags": ["logic", "synthesis"],
+    "date": "2026-06-05",
+    "markdown": "## Problem\n\nLogic failed.\n\n## Root Cause\n\nBad assumption."
+  },
+  {
+    "category": "bad-category",
+    "slug": "bad-category",
+    "title": "Bad category",
+    "tags": ["bad"],
+    "date": "2026-06-05",
+    "markdown": "## Problem\n\nShould be skipped."
+  },
+  {
+    "category": "runtime-errors",
+    "slug": "../evil",
+    "title": "Traversal",
+    "tags": ["bad"],
+    "date": "2026-06-05",
+    "markdown": "## Problem\n\nShould be skipped."
+  }
+]
+JSON
+
+(
+  cd "$tmp_dir"
+  bash "$script_dir/compound-render-docs.sh" "$fixture" > "$output"
+)
+
+expected_one="$tmp_dir/docs/solutions/integration-issues/valid-integration.md"
+expected_two="$tmp_dir/docs/solutions/logic-errors/valid-logic.md"
+
+[[ -f "$expected_one" ]] || fail "missing valid integration doc"
+[[ -f "$expected_two" ]] || fail "missing valid logic doc"
+[[ "$(find "$tmp_dir/docs/solutions" -type f | wc -l | tr -d ' ')" == "2" ]] || fail "unexpected number of docs written"
+[[ ! -e "$tmp_dir/docs/solutions/bad-category/bad-category.md" ]] || fail "bad category was written"
+[[ ! -e "$tmp_dir/docs/solutions/runtime-errors/evil.md" ]] || fail "traversal slug was written as sanitized file"
+[[ ! -e "$tmp_dir/evil.md" ]] || fail "traversal escaped output directory"
+
+grep -Fq 'title: "Valid integration learning"' "$expected_one" || fail "integration title frontmatter mismatch"
+grep -Fq 'category: integration-issues' "$expected_one" || fail "integration category frontmatter mismatch"
+grep -Fq 'date: 2026-06-05' "$expected_one" || fail "integration date frontmatter mismatch"
+grep -Fq 'tags: [github-actions, queue]' "$expected_one" || fail "integration tags frontmatter mismatch"
+grep -Fq '## Problem' "$expected_one" || fail "integration markdown missing"
+
+grep -Fq 'title: "Valid logic learning"' "$expected_two" || fail "logic title frontmatter mismatch"
+grep -Fq 'category: logic-errors' "$expected_two" || fail "logic category frontmatter mismatch"
+grep -Fq 'tags: [logic, synthesis]' "$expected_two" || fail "logic tags frontmatter mismatch"
+
+grep -Fxq 'docs/solutions/integration-issues/valid-integration.md' "$output" || fail "integration output path missing"
+grep -Fxq 'docs/solutions/logic-errors/valid-logic.md' "$output" || fail "logic output path missing"
+
+echo "PASS: compound-render-docs"

--- a/.github/workflows/compound-capture.yml
+++ b/.github/workflows/compound-capture.yml
@@ -1,0 +1,67 @@
+name: Compound Capture
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: compound-queue-append
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    if: >-
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.title, 'spec:') &&
+      !contains(github.event.pull_request.title, 'heal:') &&
+      !contains(github.event.pull_request.title, 'loop:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.PUSH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Checkout or create compound queue branch
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin compound-queue >/dev/null 2>&1; then
+            git fetch origin compound-queue:compound-queue
+            git switch compound-queue
+          else
+            git switch -c compound-queue
+            touch compound-queue.jsonl
+            git add compound-queue.jsonl
+            git commit -m "queue: initialize compound queue"
+            git push origin compound-queue
+          fi
+
+      - name: Append merged PR to compound queue
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+        run: |
+          set -euo pipefail
+          ISSUE_NUMBER="$(printf '%s\n' "$PR_TITLE" | grep -oE 'Issue #[0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+          FILES="$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '[.files[].path] | join("\n")')"
+          export ISSUE_NUMBER FILES
+          bash .github/scripts/compound-queue-append.sh compound-queue.jsonl
+
+      - name: Push compound queue
+        run: |
+          set -euo pipefail
+          git add compound-queue.jsonl
+          git commit -m "queue: PR #${{ github.event.pull_request.number }}"
+          git push origin compound-queue

--- a/.github/workflows/compound-capture.yml
+++ b/.github/workflows/compound-capture.yml
@@ -55,13 +55,18 @@ jobs:
         run: |
           set -euo pipefail
           ISSUE_NUMBER="$(printf '%s\n' "$PR_TITLE" | grep -oE 'Issue #[0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
-          FILES="$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '[.files[].path] | join("\n")')"
+          FILES="$(gh pr view "$PR_NUMBER" --json files --jq '[.files[].path] | join("\n")')"
+          if ! printf '%s\n%s\n%s\n' "$PR_TITLE" "$PR_BODY" "$FILES" | bash company/scripts/sanitise.sh > /dev/null; then
+            echo "::error::sanitise.sh rejected PR #$PR_NUMBER content — not appending to compound queue"; exit 1
+          fi
           export ISSUE_NUMBER FILES
           bash .github/scripts/compound-queue-append.sh compound-queue.jsonl
 
       - name: Push compound queue
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           git add compound-queue.jsonl
-          git commit -m "queue: PR #${{ github.event.pull_request.number }}"
+          git commit -m "queue: PR #$PR_NUMBER"
           git push origin compound-queue

--- a/.github/workflows/compound-synthesize.yml
+++ b/.github/workflows/compound-synthesize.yml
@@ -1,0 +1,165 @@
+name: Compound Synthesize
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 6 * * 1'
+  # # Enable weekly synthesis by uncommenting; incurs ~1 model call/week
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+      SYNTHESIS_BRANCH: compound/synthesis-${{ github.run_id }}
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.PUSH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Read compound queue
+        id: queue
+        run: |
+          set -euo pipefail
+          if ! git fetch origin compound-queue:refs/remotes/origin/compound-queue; then
+            echo "queue empty, nothing to synthesize"
+            echo "has_queue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git cat-file -e origin/compound-queue:compound-queue.jsonl 2>/dev/null; then
+            echo "queue empty, nothing to synthesize"
+            echo "has_queue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git show origin/compound-queue:compound-queue.jsonl > /tmp/compound-queue.jsonl
+          if [ ! -s /tmp/compound-queue.jsonl ]; then
+            echo "queue empty, nothing to synthesize"
+            echo "has_queue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_queue=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build synthesis prompt
+        if: steps.queue.outputs.has_queue == 'true'
+        run: |
+          set -euo pipefail
+          today="$(date -u '+%Y-%m-%d')"
+          cat > /tmp/system_prompt.txt <<'SYSEOF'
+          You synthesize reusable engineering lessons from merged implementation PRs.
+          Return ONLY a JSON array. Do not include prose, markdown fences, commentary, or explanations outside the array.
+          Each array item must match this schema:
+          {
+            "category": "integration-issues|logic-errors|design-decisions|runtime-errors",
+            "slug": "lowercase-kebab-case",
+            "title": "Human-readable title",
+            "tags": ["tag-one", "tag-two"],
+            "date": "YYYY-MM-DD",
+            "markdown": "## Problem\n...\n\n## Root Cause\n...\n\n## Solution\n...\n\n## Prevention\n..."
+          }
+          Create one entry per genuinely reusable learning. Return [] if none are worthy.
+          Do not include secrets, credentials, tokens, private URLs, personal data, or sensitive operational details.
+          SYSEOF
+
+          cat > /tmp/user_message.txt <<MSGEOF
+          Today is $today.
+
+          Synthesize reusable engineering learnings from these merged implementation PR queue entries.
+          Ignore entries that do not contain a lesson that should become long-lived documentation.
+
+          ## Queue Entries
+          $(cat /tmp/compound-queue.jsonl)
+          MSGEOF
+
+      - name: Call LLM
+        if: steps.queue.outputs.has_queue == 'true'
+        env:
+          OBSERVER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$OBSERVER_API_KEY" ]; then
+            echo "::error::OPENROUTER_API_KEY is not configured"
+            exit 1
+          fi
+
+          # Call LLM via OpenAI-compatible API
+          jq -n \
+            --rawfile system /tmp/system_prompt.txt \
+            --rawfile user /tmp/user_message.txt \
+            '{
+              model: "anthropic/claude-sonnet-4",
+              max_tokens: 4096,
+              messages: [{role: "system", content: $system}, {role: "user", content: $user}]
+            }' > /tmp/request.json
+
+          # NOTE: Expects OpenAI-compatible chat/completions endpoint.
+          # Use OpenRouter or similar proxy for non-OpenAI providers.
+          http_code=$(curl -s -w '%{http_code}' -o /tmp/llm_response.json \
+            -H "Authorization: Bearer $OBSERVER_API_KEY" \
+            -H "content-type: application/json" \
+            -d @/tmp/request.json \
+            https://openrouter.ai/api/v1/chat/completions)
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            content=$(jq -r '.choices[0].message.content' /tmp/llm_response.json)
+            echo "$content" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/synthesis.json
+            if [ ! -s /tmp/synthesis.json ]; then
+              echo "$content" | jq . > /tmp/synthesis.json 2>/dev/null || echo "$content" > /tmp/synthesis.json
+            fi
+          else
+            api_error=$(jq -r '.error.message // "unknown error"' /tmp/llm_response.json 2>/dev/null || echo "HTTP $http_code")
+            echo "::error::Synthesis LLM returned HTTP $http_code: $api_error"
+            exit 1
+          fi
+
+      - name: Render solution docs
+        if: steps.queue.outputs.has_queue == 'true'
+        id: render
+        run: |
+          set -euo pipefail
+          bash .github/scripts/compound-render-docs.sh /tmp/llm_response.json | tee /tmp/compound-written.txt
+          if [ -s /tmp/compound-written.txt ]; then
+            echo "written=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "written=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push synthesis docs branch and open PR
+        if: steps.queue.outputs.has_queue == 'true' && steps.render.outputs.written == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$SYNTHESIS_BRANCH"
+          git add docs/solutions/
+          git commit -m "docs: synthesize compound learnings"
+          git push origin "$SYNTHESIS_BRANCH"
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$SYNTHESIS_BRANCH" \
+            --title "docs: synthesize compound learnings" \
+            --body "Adds reusable solution notes synthesized from the compound learning queue."
+
+      - name: Truncate compound queue
+        if: steps.queue.outputs.has_queue == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin compound-queue:compound-queue
+          git switch compound-queue
+          : > compound-queue.jsonl
+          git add compound-queue.jsonl
+          git commit -m "queue: truncate after synthesis run ${{ github.run_id }}"
+          git push origin compound-queue

--- a/.github/workflows/compound-synthesize.yml
+++ b/.github/workflows/compound-synthesize.yml
@@ -110,11 +110,7 @@ jobs:
             https://openrouter.ai/api/v1/chat/completions)
 
           if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-            content=$(jq -r '.choices[0].message.content' /tmp/llm_response.json)
-            echo "$content" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/synthesis.json
-            if [ ! -s /tmp/synthesis.json ]; then
-              echo "$content" | jq . > /tmp/synthesis.json 2>/dev/null || echo "$content" > /tmp/synthesis.json
-            fi
+            :
           else
             api_error=$(jq -r '.error.message // "unknown error"' /tmp/llm_response.json 2>/dev/null || echo "HTTP $http_code")
             echo "::error::Synthesis LLM returned HTTP $http_code: $api_error"
@@ -132,6 +128,18 @@ jobs:
           else
             echo "written=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Sanitise rendered solution docs
+        if: steps.queue.outputs.has_queue == 'true' && steps.render.outputs.written == 'true'
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+            if ! bash company/scripts/sanitise.sh < "$f" > /dev/null; then
+              echo "::error::sanitise.sh rejected $f — not publishing synthesized docs"; exit 1
+            fi
+          done < /tmp/compound-written.txt
 
       - name: Push synthesis docs branch and open PR
         if: steps.queue.outputs.has_queue == 'true' && steps.render.outputs.written == 'true'


### PR DESCRIPTION
Move 4 from the compound-engineering session, right-sized for frugality.

## What
- **compound-capture.yml** (ACTIVE, $0) — on every implementation-PR merge, appends one JSONL line to a dedicated long-lived `compound-queue` branch. No LLM, never writes `main`, no PR-pile.
- **compound-synthesize.yml** (INERT) — `workflow_dispatch` only; `schedule:` commented. Reads the queue; **exits 0 with no model call if empty**. Otherwise one `anthropic/claude-sonnet-4` call (copied from observation-loop, same `OPENROUTER_API_KEY` secret) drafts `docs/solutions/<category>/*.md`, opens **one** PR, truncates the queue.
- 2 helper scripts + 2 real (non-dry-run) tests: JSONL correctness, body truncation, null-issue, category allow-list, slug path-traversal stripping.

## Cost
Capture = $0. Synthesis ≤1 model call/week, and only when the queue is non-empty — and it won't run at all until you uncomment the `schedule:` block.

## Verify
`bash .github/scripts/test-compound-queue-append.sh` → PASS; `bash .github/scripts/test-compound-render-docs.sh` → PASS; shellcheck clean; both workflows YAML-valid; `schedule:` confirmed commented.