### PR TITLE
feat(pipeline): weekly goal-sprint step (ideate→plan→emit-spec)

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -1,0 +1,64 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Work delegation (Codex) ---
+
+# work_delegate: codex           # codex | false (default: false)
+# work_delegate_consent: true    # true | false (default: false)
+# work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
+# work_delegate_decision: auto   # auto | ask (default: auto)
+# work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+
+# --- Product Pulse (ce-product-pulse) ---
+#
+# 2026-05-06 correction: pulse_primary_event was bot_pr_merged, which
+# counted heal:/loop: maintenance PRs in this meta-pipeline repo as
+# product convergence. STRATEGY.md says convergence happens in the
+# SEEDED PRODUCT repo (atvirokodosprendimai/wgmesh). Repointed events
+# accordingly. See docs/pulse-reports/2026-05-06_05-30-corrected.md
+# for the incident.
+
+pulse_product_name: ai-pipeline-template
+# pulse_seed_product_repo identifies where actual product convergence
+# is measured. NOT used by the upstream ce-product-pulse skill yet,
+# but consumed by the corrected pulse generation in this repo.
+pulse_seed_product_repo: atvirokodosprendimai/wgmesh
+pulse_primary_event: product_pr_merged
+pulse_value_event: autonomous_impl_merge_clean
+pulse_completion_events: paid_customer_added
+pulse_quality_scoring: false
+pulse_analytics_source: github-pr-data
+pulse_tracing_source: github-actions
+pulse_payments_source: polar
+pulse_db_enabled: false
+pulse_lookback_default: 24h
+# Per-metric source notes:
+#   autonomous_ship_rate  = impl: PRs merged in seed repo with no escalation_posted events
+#   lead_time_hours       = median(spec_pr_opened_at → impl_pr_merged_at) per Issue #N
+#   spec_coverage         = (issues with spec PR) / (open issues in seed repo)
+#   active_stuck_issues   = needs-human OR copilot-triaging >24h OR retry cooldown >24h
+#   self_heal_rate        = company/pipeline-health-state.json on this repo (issues_healed_total/checks_run)
+#   paid_customers        = chimney HTML scrape (until Polar webhook integration)
+#   cycle_time_to_revenue = pending Polar integration; null today
+#   pr_processing_rate    = goal-aligned-terminal / dispositioned. PROCESSED = merged
+#                           OR closed-with-written-reason that cites the goal. Bulk-close
+#                           with no reason does NOT count as processed — it is discard.
+#                           Open PRs are not "processed"; they are work-in-flight or dwell.
+#   pr_dwell_violations   = open PRs older than pulse_pr_processing_sla_days with no
+#                           review/merge action — the unprocessed-defect count.
+pulse_metric_sources: paid_customers=chimney-html,autonomous_ship_rate=seed-repo-pr-data,lead_time_hours=seed-repo-pr-data,spec_coverage=seed-repo-pr-data,self_heal_rate=company/pipeline-health-state.json,active_stuck_issues=seed-repo-issues,cycle_time_to_revenue=polar,supervisor_rank_state=company/supervisor-rank-state.json,pr_processing_rate=meta-repo-pr-data,pr_dwell_violations=meta-repo-pr-data
+pulse_pending_metrics: cycle_time_to_revenue,spec_coverage
+# --- PR-processing KPI (added 2026-06-05) ---
+# Intent: open PRs must be ACTED ON per the goal, never bulk-closed to clear backlog.
+# Every disposition needs a goal-aligned reason. Dwelling = defect, not idle.
+pulse_pr_processing_kpi: enabled
+pulse_pr_processing_sla_days: 7
+
+goal_sprint_enabled: true
+goal_sprint_cadence: weekly
+goal_sprint_seed_repo_source: pulse_seed_product_repo
+# goal-sprint step: weekly LLM-driven ideation that emits one spec issue into
+# the autonomous builder chain (atvirokodosprendimai/wgmesh or pulse_seed_product_repo).
+# Triggered every Monday 07:00 UTC. Anti-flood: only emits when fingerprint changes.

--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -1,5 +1,6 @@
 # Compound Engineering -- local config
-# Copy to .compound-engineering/config.local.yaml in your project root.
+# This file is committed in-repo and consumed by workflows at CI runtime
+# (for example, goal-sprint reads pulse_seed_product_repo).
 # All settings are optional. Invalid values fall through to defaults.
 
 # --- Work delegation (Codex) ---

--- a/.github/workflows/goal-sprint.yml
+++ b/.github/workflows/goal-sprint.yml
@@ -1,0 +1,209 @@
+name: Goal Sprint
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print the generated sprint JSON without emitting issues or state PRs.
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: goal-sprint
+  cancel-in-progress: false
+
+env:
+  OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  OBSERVER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  HAS_APP_CREDS: ${{ secrets.APP_ID != '' && secrets.APP_PRIVATE_KEY != '' }}
+
+jobs:
+  sprint:
+    name: Ideate -> Plan -> Emit Spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: env.HAS_APP_CREDS == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Select GitHub token
+        run: |
+          token="${{ steps.app-token.outputs.token }}"
+          if [ -z "$token" ]; then
+            token="${{ secrets.PUSH_TOKEN }}"
+          fi
+          if [ -z "$token" ]; then
+            echo "::error::No GitHub App token or PUSH_TOKEN available"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "GH_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Read seed repository
+        run: |
+          seed_repo=$(python3 - <<'PY'
+          from pathlib import Path
+          path = Path(".compound-engineering/config.local.yaml")
+          value = ""
+          if path.exists():
+              for line in path.read_text().splitlines():
+                  stripped = line.strip()
+                  if stripped.startswith("pulse_seed_product_repo:"):
+                      value = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+          print(value)
+          PY
+          )
+          if [ -z "$seed_repo" ]; then
+            echo "::error::pulse_seed_product_repo missing from .compound-engineering/config.local.yaml"
+            exit 1
+          fi
+          echo "SEED_REPO=$seed_repo" >> "$GITHUB_ENV"
+          echo "Using seed repo: $seed_repo"
+
+      - name: Build goal sprint context
+        run: scripts/goal-sprint/build-context.sh
+
+      - name: Call LLM (or generate stub)
+        env:
+          OBSERVER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -z "$OBSERVER_API_KEY" ]; then
+            echo "::warning::Observer API key not set — generating stub goal sprint."
+            today=$(date -u '+%Y-%m-%d')
+            cat > /tmp/goal_sprint.json <<STUBEOF
+          {
+            "ideas": [
+              {"title": "Set OpenRouter API key for weekly goal sprint", "rationale": "The sprint loop cannot produce grounded weekly specs until the model key is configured.", "impact": "Unblocks recurring goal-directed spec generation.", "effort": "small", "metric": "autonomous_ship_rate"},
+              {"title": "Validate seed repo goal-sprint labels", "rationale": "Issue emission depends on stable downstream labels.", "impact": "Reduces stuck issues from label routing failures.", "effort": "small", "metric": "active_stuck_issues"},
+              {"title": "Dry-run the goal-sprint workflow", "rationale": "Confirms the weekly context and JSON contract before live emission.", "impact": "Improves spec_coverage without flooding the issue board.", "effort": "small", "metric": "spec_coverage"},
+              {"title": "Review first generated sprint issue", "rationale": "Human calibration prevents the first autonomous issue from drifting from STRATEGY.md.", "impact": "Improves pr_processing_rate by starting from a clear spec.", "effort": "small", "metric": "pr_processing_rate"},
+              {"title": "Connect emitted specs to builder chain", "rationale": "The sprint has value only when the emitted issue enters the autonomous builder path.", "impact": "Improves autonomous_ship_rate.", "effort": "medium", "metric": "autonomous_ship_rate"}
+            ],
+            "top": {
+              "title": "Set OpenRouter API key for weekly goal sprint",
+              "problem": "The goal-sprint workflow is installed but cannot call the LLM until OPENROUTER_API_KEY is configured.",
+              "acceptance_criteria": ["OPENROUTER_API_KEY is present in repository secrets", "A dry-run emits valid goal sprint JSON", "No seed repo issue is created during dry-run"],
+              "build_sequence": ["Add OPENROUTER_API_KEY to repository secrets", "Run workflow_dispatch with dry_run=true", "Inspect /tmp/goal_sprint.json in logs"],
+              "class": "needs-human",
+              "labels": ["goal-sprint", "needs-human"]
+            },
+            "fingerprint": "set-openrouter-api-key-weekly-goal-sprint"
+          }
+          STUBEOF
+          else
+            # Call LLM via OpenAI-compatible API
+            jq -n \
+              --rawfile system company/goal-sprint-system-prompt.md \
+              --rawfile user /tmp/goal_sprint_user.txt \
+              '{
+                model: "anthropic/claude-sonnet-4",
+                max_tokens: 4096,
+                messages: [{role: "system", content: $system}, {role: "user", content: $user}]
+              }' > /tmp/request.json
+
+            # NOTE: Expects OpenAI-compatible chat/completions endpoint.
+            # Use OpenRouter or similar proxy for non-OpenAI providers.
+            http_code=$(curl -s -w '%{http_code}' -o /tmp/llm_response.json \
+              -H "Authorization: Bearer $OBSERVER_API_KEY" \
+              -H "content-type: application/json" \
+              -d @/tmp/request.json \
+              https://openrouter.ai/api/v1/chat/completions)
+
+            if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+              content=$(jq -r '.choices[0].message.content' /tmp/llm_response.json)
+              echo "$content" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/goal_sprint.json
+              if [ ! -s /tmp/goal_sprint.json ]; then
+                echo "$content" | jq . > /tmp/goal_sprint.json 2>/dev/null || echo "$content" > /tmp/goal_sprint.json
+              fi
+            else
+              api_error=$(jq -r '.error.message // "unknown error"' /tmp/llm_response.json 2>/dev/null || echo "HTTP $http_code")
+              echo "::warning::Observer LLM returned HTTP $http_code: $api_error — falling back to stub."
+              today=$(date -u '+%Y-%m-%d')
+              jq -n --arg title "Fix goal sprint LLM access" --arg err "$api_error" '{
+                ideas: [
+                  {title: $title, rationale: ("LLM call failed: " + $err), impact: "Unblocks weekly goal-sprint specs", effort: "small", metric: "autonomous_ship_rate"},
+                  {title: "Run goal sprint dry-run after access fix", rationale: "Validates the JSON contract before issue emission", impact: "Protects spec_coverage quality", effort: "small", metric: "spec_coverage"},
+                  {title: "Inspect seed repo label routing", rationale: "Confirms emitted specs enter the right queue", impact: "Reduces active_stuck_issues", effort: "small", metric: "active_stuck_issues"},
+                  {title: "Review current sprint state file", rationale: "Ensures the fingerprint gate is not blocking real changes", impact: "Improves pr_processing_rate", effort: "small", metric: "pr_processing_rate"},
+                  {title: "Check latest pulse report freshness", rationale: "The model needs current metrics for useful ranking", impact: "Improves autonomous_ship_rate", effort: "small", metric: "autonomous_ship_rate"}
+                ],
+                top: {
+                  title: $title,
+                  problem: ("Goal sprint could not call the LLM: " + $err),
+                  acceptance_criteria: ["OPENROUTER_API_KEY works for OpenRouter chat completions", "goal-sprint dry-run produces valid strict JSON", "No issue is emitted while dry_run=true"],
+                  build_sequence: ["Verify OPENROUTER_API_KEY", "Run goal-sprint workflow with dry_run=true", "Confirm JSON extraction succeeds"],
+                  class: "needs-human",
+                  labels: ["goal-sprint", "needs-human"]
+                },
+                fingerprint: "fix-goal-sprint-llm-access"
+              }' > /tmp/goal_sprint.json
+            fi
+          fi
+          jq empty /tmp/goal_sprint.json || { echo "::error::Invalid /tmp/goal_sprint.json"; exit 1; }
+
+      - name: Fingerprint goal sprint
+        run: scripts/goal-sprint/fingerprint.sh
+
+      - name: Dry-run output
+        if: ${{ (github.event.inputs.dry_run || 'false') == 'true' }}
+        run: |
+          cat /tmp/goal_sprint.json
+          exit 0
+
+      - name: Emit goal sprint issue
+        if: ${{ (github.event.inputs.dry_run || 'false') != 'true' }}
+        run: |
+          if [ ! -f /tmp/goal-sprint-material-changed ]; then
+            echo "::error::goal-sprint material-change sentinel missing"
+            exit 1
+          fi
+          if [ "$(cat /tmp/goal-sprint-material-changed)" = "true" ]; then
+            scripts/goal-sprint/emit.sh
+          else
+            echo "No material goal-sprint change; skipping issue emission"
+          fi
+
+      - name: Commit state
+        if: ${{ (github.event.inputs.dry_run || 'false') != 'true' }}
+        run: |
+          if [ ! -f /tmp/goal-sprint-material-changed ]; then
+            echo "::warning::material-change sentinel missing; skipping commit"
+            exit 0
+          fi
+          if [ "$(cat /tmp/goal-sprint-material-changed)" != "true" ]; then
+            echo "No material change in goal-sprint state; skipping commit + PR"
+            exit 0
+          fi
+
+          git config user.name "pupabobas[bot]"
+          git config user.email "pupabobas[bot]@users.noreply.github.com"
+          git add company/goal-sprint-state.json
+          git diff --cached --quiet && echo "No state changes to commit" && exit 0
+
+          today=$(date -u '+%Y-%m-%d')
+          branch="goal-sprint/${today}-${GITHUB_RUN_ID}"
+          top_title=$(jq -r '.top.title // "weekly goal sprint"' /tmp/goal_sprint.json)
+          git checkout -b "$branch"
+          git commit -m "chore(goal-sprint): update state $today"
+          git push -u origin "$branch"
+
+          gh pr create \
+            --title "goal-sprint: ${top_title} ${today}" \
+            --body "Automated weekly goal-sprint state update." \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/goal-sprint.yml
+++ b/.github/workflows/goal-sprint.yml
@@ -155,6 +155,11 @@ jobs:
             fi
           fi
           jq empty /tmp/goal_sprint.json || { echo "::error::Invalid /tmp/goal_sprint.json"; exit 1; }
+          goal_sprint_content="$(cat /tmp/goal_sprint.json)"
+          if ! printf '%s' "$goal_sprint_content" | bash company/scripts/sanitise.sh > /dev/null; then
+            echo "::error::sanitise.sh rejected /tmp/goal_sprint.json"
+            exit 1
+          fi
 
       - name: Fingerprint goal sprint
         run: scripts/goal-sprint/fingerprint.sh
@@ -192,6 +197,11 @@ jobs:
 
           git config user.name "pupabobas[bot]"
           git config user.email "pupabobas[bot]@users.noreply.github.com"
+          state_content="$(cat company/goal-sprint-state.json)"
+          if ! printf '%s' "$state_content" | bash company/scripts/sanitise.sh > /dev/null; then
+            echo "::error::sanitise.sh rejected company/goal-sprint-state.json"
+            exit 1
+          fi
           git add company/goal-sprint-state.json
           git diff --cached --quiet && echo "No state changes to commit" && exit 0
 

--- a/company/goal-sprint-state.json
+++ b/company/goal-sprint-state.json
@@ -1,0 +1,1 @@
+{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }

--- a/company/goal-sprint-system-prompt.md
+++ b/company/goal-sprint-system-prompt.md
@@ -23,7 +23,7 @@ Process:
    - acceptance_criteria: testable list.
    - build_sequence: ordered implementation steps.
    - class: exactly "needs-human" only for things that cannot be contracted via the internet (physical presence, wet signatures, irreversible decisions with no undo path), or exactly "automatable" for everything else, including GTM/outreach/CTA/sales/account-setup that can be contracted via the internet and should be automated or posted as a RAH bounty instead of marked needs-human.
-   - labels: issue labels relevant to routing.
+   - labels: optional downstream routing labels; only labels that already exist in the seed repo are applied.
 
 Emit strict JSON inside one triple-backtick json fence. Do not include prose before or after the fence.
 

--- a/company/goal-sprint-system-prompt.md
+++ b/company/goal-sprint-system-prompt.md
@@ -1,0 +1,55 @@
+You are the weekly goal-sprint planner for an autonomous product pipeline.
+
+In one pass, read the provided goal, current metrics, latest pulse report, loop state, and prior goal-sprint fingerprint. Produce one practical bet for the coming week.
+
+Process:
+
+1. IDEATE exactly 5 grounded, goal-advancing moves.
+   - Each idea must plausibly move a STRATEGY.md key metric.
+   - Do not propose vanity work, generic "improve docs" filler, vague cleanup, or work that cannot be tied to a metric.
+   - Prefer concrete moves that can become a focused issue.
+
+2. RANK the 5 ideas by impact toward the goal divided by effort.
+   - Pick the single top idea only.
+   - Bias for action. One bet per week.
+
+3. PLAN the winning idea into a concrete spec.
+   - title: short issue-ready title.
+   - problem: the specific problem or opportunity.
+   - acceptance_criteria: testable list.
+   - build_sequence: ordered implementation steps.
+   - class: exactly "automatable" for code/PR work the pipeline can ship, or exactly "needs-human" for acquisition/ops work such as outreach, CTA, sales, account setup, or external decisions.
+   - labels: issue labels relevant to routing.
+
+Emit strict JSON inside one triple-backtick json fence. Do not include prose before or after the fence.
+
+The JSON must have exactly this shape:
+
+```json
+{
+  "ideas": [
+    {
+      "title": "str",
+      "rationale": "str",
+      "impact": "str",
+      "effort": "str",
+      "metric": "str"
+    }
+  ],
+  "top": {
+    "title": "str",
+    "problem": "str",
+    "acceptance_criteria": ["str"],
+    "build_sequence": ["str"],
+    "class": "automatable",
+    "labels": ["str"]
+  },
+  "fingerprint": "<stable slug of top.title>"
+}
+```
+
+Additional constraints:
+- The ideas array must contain exactly 5 items.
+- The fingerprint must be a stable lowercase slug of top.title, using hyphens.
+- The top.class value must be either "automatable" or "needs-human".
+- Avoid repeating the prior fingerprint unless it is still clearly the best non-duplicate move.

--- a/company/goal-sprint-system-prompt.md
+++ b/company/goal-sprint-system-prompt.md
@@ -2,6 +2,10 @@ You are the weekly goal-sprint planner for an autonomous product pipeline.
 
 In one pass, read the provided goal, current metrics, latest pulse report, loop state, and prior goal-sprint fingerprint. Produce one practical bet for the coming week.
 
+Output is committed to a PUBLIC repo and published as GitHub issues.
+NEVER include: secrets, customer PII, exact revenue/invoice amounts.
+sanitise.sh is a backstop — do not rely on it to filter sensitive content you should not emit.
+
 Process:
 
 1. IDEATE exactly 5 grounded, goal-advancing moves.
@@ -18,7 +22,7 @@ Process:
    - problem: the specific problem or opportunity.
    - acceptance_criteria: testable list.
    - build_sequence: ordered implementation steps.
-   - class: exactly "automatable" for code/PR work the pipeline can ship, or exactly "needs-human" for acquisition/ops work such as outreach, CTA, sales, account setup, or external decisions.
+   - class: exactly "needs-human" only for things that cannot be contracted via the internet (physical presence, wet signatures, irreversible decisions with no undo path), or exactly "automatable" for everything else, including GTM/outreach/CTA/sales/account-setup that can be contracted via the internet and should be automated or posted as a RAH bounty instead of marked needs-human.
    - labels: issue labels relevant to routing.
 
 Emit strict JSON inside one triple-backtick json fence. Do not include prose before or after the fence.
@@ -52,4 +56,5 @@ Additional constraints:
 - The ideas array must contain exactly 5 items.
 - The fingerprint must be a stable lowercase slug of top.title, using hyphens.
 - The top.class value must be either "automatable" or "needs-human".
+- Contractable human work such as outreach, sales, and sign-ups is "automatable", not "needs-human".
 - Avoid repeating the prior fingerprint unless it is still clearly the best non-duplicate move.

--- a/scripts/goal-sprint/build-context.sh
+++ b/scripts/goal-sprint/build-context.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# non-fatal by design — missing optional inputs must not abort context assembly (see repo bash-helper contract).
 set -uo pipefail
 trap 'status=$?; echo "WARN: build-context command failed near line $LINENO (status $status)" >&2; true' ERR
 
@@ -12,7 +13,7 @@ out="/tmp/goal_sprint_user.txt"
 
   echo "## STRATEGY.md"
   if [ -f STRATEGY.md ]; then
-    cat STRATEGY.md
+    cat STRATEGY.md || true
   else
     echo "STRATEGY.md not found."
   fi
@@ -22,7 +23,7 @@ out="/tmp/goal_sprint_user.txt"
   latest_pulse="$(ls -1 docs/pulse-reports/*.md 2>/dev/null | sort | tail -1 || true)"
   if [ -n "${latest_pulse:-}" ] && [ -f "$latest_pulse" ]; then
     echo "Source: $latest_pulse"
-    cat "$latest_pulse"
+    cat "$latest_pulse" || true
   else
     echo "No pulse report found."
   fi
@@ -31,9 +32,9 @@ out="/tmp/goal_sprint_user.txt"
   echo "## Loop State"
   if [ -f company/loop-state.json ]; then
     if command -v jq >/dev/null 2>&1; then
-      jq . company/loop-state.json || cat company/loop-state.json
+      jq . company/loop-state.json || cat company/loop-state.json || true
     else
-      cat company/loop-state.json
+      cat company/loop-state.json || true
     fi
   else
     echo "company/loop-state.json not found."
@@ -46,7 +47,7 @@ out="/tmp/goal_sprint_user.txt"
       prior="$(jq -r '.last_fingerprint // ""' company/goal-sprint-state.json 2>/dev/null || true)"
       echo "${prior:-none}"
     else
-      cat company/goal-sprint-state.json
+      cat company/goal-sprint-state.json || true
     fi
   else
     echo "none"

--- a/scripts/goal-sprint/build-context.sh
+++ b/scripts/goal-sprint/build-context.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -uo pipefail
+trap 'status=$?; echo "WARN: build-context command failed near line $LINENO (status $status)" >&2; true' ERR
+
+out="/tmp/goal_sprint_user.txt"
+
+{
+  echo "# Goal Sprint Context"
+  echo ""
+  echo "Generated at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo ""
+
+  echo "## STRATEGY.md"
+  if [ -f STRATEGY.md ]; then
+    cat STRATEGY.md
+  else
+    echo "STRATEGY.md not found."
+  fi
+  echo ""
+
+  echo "## Latest Pulse Report"
+  latest_pulse="$(ls -1 docs/pulse-reports/*.md 2>/dev/null | sort | tail -1 || true)"
+  if [ -n "${latest_pulse:-}" ] && [ -f "$latest_pulse" ]; then
+    echo "Source: $latest_pulse"
+    cat "$latest_pulse"
+  else
+    echo "No pulse report found."
+  fi
+  echo ""
+
+  echo "## Loop State"
+  if [ -f company/loop-state.json ]; then
+    if command -v jq >/dev/null 2>&1; then
+      jq . company/loop-state.json || cat company/loop-state.json
+    else
+      cat company/loop-state.json
+    fi
+  else
+    echo "company/loop-state.json not found."
+  fi
+  echo ""
+
+  echo "## Prior Goal Sprint Fingerprint"
+  if [ -f company/goal-sprint-state.json ]; then
+    if command -v jq >/dev/null 2>&1; then
+      prior="$(jq -r '.last_fingerprint // ""' company/goal-sprint-state.json 2>/dev/null || true)"
+      echo "${prior:-none}"
+    else
+      cat company/goal-sprint-state.json
+    fi
+  else
+    echo "none"
+  fi
+} > "$out"
+
+if [ ! -s "$out" ]; then
+  echo "Goal sprint context unavailable; proceed from STRATEGY.md when present." > "$out"
+fi
+
+echo "Wrote $out ($(wc -c < "$out" | tr -d ' ') bytes)"

--- a/scripts/goal-sprint/emit.sh
+++ b/scripts/goal-sprint/emit.sh
@@ -19,6 +19,21 @@ keywords_from_title() {
     head -5 || true
 }
 
+normalise_title() {
+  printf '%s\n' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g'
+}
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+  repo_root="$GITHUB_WORKSPACE"
+else
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)" || fail "failed to resolve repo root"
+fi
+SANITISE="$repo_root/company/scripts/sanitise.sh"
+[ -f "$SANITISE" ] || fail "$SANITISE not found"
+
 [ -f "$sentinel" ] || fail "$sentinel not found"
 if [ "$(cat "$sentinel")" != "true" ]; then
   echo "SKIP: material change sentinel is not true"
@@ -50,13 +65,21 @@ if [ "$fingerprint" = "$last" ]; then
   exit 0
 fi
 
-issue_json="$(gh issue list --repo "$seed_repo" --state all --json title)" || fail "failed to list seed repo issues"
+issue_json="$(gh issue list --repo "$seed_repo" --state all --limit 200 --json title)" || fail "failed to list seed repo issues"
 all_titles="/tmp/goal-sprint-all-titles.txt"
 printf '%s\n' "$issue_json" | jq -r '.[].title // empty' > "$all_titles" || fail "failed to parse seed repo issue titles"
 
 keywords="$(keywords_from_title "$title")"
+title_exact="$(normalise_title "$title")"
 match_count=0
 while IFS= read -r existing_title; do
+  if [ -z "$keywords" ]; then
+    if [ "$(normalise_title "$existing_title")" = "$title_exact" ]; then
+      match_count=$((match_count + 1))
+      break
+    fi
+    continue
+  fi
   existing_lower="$(printf '%s\n' "$existing_title" | tr '[:upper:]' '[:lower:]')"
   hits=0
   for kw in $keywords; do
@@ -99,6 +122,12 @@ if [ "$class" = "automatable" ]; then
   labels="${labels},needs-triage"
 else
   labels="${labels},needs-human"
+fi
+
+BODY="$(cat "$body_file")"
+if ! printf '%s' "$title $BODY" | bash "$SANITISE" > /dev/null 2>&1; then
+  echo "::error:: sanitise.sh rejected issue content"
+  exit 1
 fi
 
 issue_url="$(gh issue create --repo "$seed_repo" --title "$title" --body-file "$body_file" --label "$labels")" || fail "failed to create goal-sprint issue"

--- a/scripts/goal-sprint/emit.sh
+++ b/scripts/goal-sprint/emit.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -uo pipefail
+trap 'status=$?; echo "WARN: emit command failed near line $LINENO (status $status)" >&2; true' ERR
+
+json="/tmp/goal_sprint.json"
+sentinel="/tmp/goal-sprint-material-changed"
+state_file="company/goal-sprint-state.json"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+keywords_from_title() {
+  printf '%s\n' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    tr -cs 'a-z0-9' '\n' |
+    grep -v -E '^(the|a|an|in|on|for|to|of|and|or|is|set|add|configure|verify|check|update|review|approve|implement|basic|define|fix|enable|goal|sprint)$' |
+    head -5 || true
+}
+
+[ -f "$sentinel" ] || fail "$sentinel not found"
+if [ "$(cat "$sentinel")" != "true" ]; then
+  echo "SKIP: material change sentinel is not true"
+  exit 0
+fi
+
+[ -f "$json" ] || fail "$json not found"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+seed_repo="${SEED_REPO:-}"
+[ -n "$seed_repo" ] || fail "SEED_REPO is required"
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+
+fingerprint="$(jq -r '.top.fingerprint // .fingerprint // ""' "$json")" || fail "failed to read fingerprint"
+title="$(jq -r '.top.title // ""' "$json")" || fail "failed to read top.title"
+problem="$(jq -r '.top.problem // ""' "$json")" || fail "failed to read top.problem"
+class="$(jq -r '.top.class // ""' "$json")" || fail "failed to read top.class"
+
+[ -n "$fingerprint" ] && [ "$fingerprint" != "null" ] || fail "fingerprint missing"
+[ -n "$title" ] && [ "$title" != "null" ] || fail "top.title missing"
+[ "$class" = "automatable" ] || [ "$class" = "needs-human" ] || fail "top.class must be automatable or needs-human"
+
+last=""
+if [ -f "$state_file" ]; then
+  last="$(jq -r '.last_fingerprint // ""' "$state_file" 2>/dev/null || true)"
+fi
+if [ "$fingerprint" = "$last" ]; then
+  echo "SKIP: duplicate detected"
+  exit 0
+fi
+
+issue_json="$(gh issue list --repo "$seed_repo" --state all --json title)" || fail "failed to list seed repo issues"
+all_titles="/tmp/goal-sprint-all-titles.txt"
+printf '%s\n' "$issue_json" | jq -r '.[].title // empty' > "$all_titles" || fail "failed to parse seed repo issue titles"
+
+keywords="$(keywords_from_title "$title")"
+match_count=0
+while IFS= read -r existing_title; do
+  existing_lower="$(printf '%s\n' "$existing_title" | tr '[:upper:]' '[:lower:]')"
+  hits=0
+  for kw in $keywords; do
+    if printf '%s\n' "$existing_lower" | grep -q "$kw"; then
+      hits=$((hits + 1))
+    fi
+  done
+  if [ "$hits" -ge 2 ]; then
+    match_count=$((match_count + 1))
+    break
+  fi
+done < "$all_titles"
+
+if [ "$match_count" != "0" ]; then
+  echo "SKIP: duplicate detected"
+  exit 0
+fi
+
+body_file="/tmp/goal-sprint-issue-body.md"
+{
+  echo "## Problem"
+  echo ""
+  echo "$problem"
+  echo ""
+  echo "## Acceptance Criteria"
+  jq -r '.top.acceptance_criteria[]? | "- " + .' "$json" || fail "failed to read acceptance criteria"
+  echo ""
+  echo "## Build Sequence"
+  jq -r '.top.build_sequence[]? | "- " + .' "$json" || fail "failed to read build sequence"
+  if [ "$class" = "needs-human" ]; then
+    echo ""
+    echo "## Escalation"
+    echo ""
+    echo "Autonomy ladder: attempt via pipeline -> Codex -> RAH bounty -> operator."
+  fi
+} > "$body_file"
+
+labels="goal-sprint"
+if [ "$class" = "automatable" ]; then
+  labels="${labels},needs-triage"
+else
+  labels="${labels},needs-human"
+fi
+
+issue_url="$(gh issue create --repo "$seed_repo" --title "$title" --body-file "$body_file" --label "$labels")" || fail "failed to create goal-sprint issue"
+issue_number="$(printf '%s\n' "$issue_url" | grep -Eo '/issues/[0-9]+' | tail -1 | tr -cd '0-9' || true)"
+
+if [ ! -f "$state_file" ]; then
+  mkdir -p "$(dirname "$state_file")"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$state_file"
+fi
+
+week="$(date -u '+%G-W%V')"
+entry="$(jq -n \
+  --arg week "$week" \
+  --arg fingerprint "$fingerprint" \
+  --arg title "$title" \
+  --arg class "$class" \
+  --arg issue_url "$issue_url" \
+  --arg issue_number "$issue_number" \
+  --argjson ideas "$(jq '.ideas' "$json")" \
+  '{
+    week: $week,
+    fingerprint: $fingerprint,
+    title: $title,
+    class: $class,
+    ideas: $ideas,
+    issue: {
+      number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+      url: $issue_url
+    }
+  }')" || fail "failed to build ledger entry"
+
+jq \
+  --arg fingerprint "$fingerprint" \
+  --arg week "$week" \
+  --arg issue_url "$issue_url" \
+  --arg issue_number "$issue_number" \
+  --argjson entry "$entry" \
+  '.last_fingerprint = $fingerprint
+   | .last_week = $week
+   | .ledger = ((.ledger // []) + [$entry])
+   | .last_issue = {
+       number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+       url: $issue_url
+     }' "$state_file" > /tmp/goal-sprint-state.json || fail "failed to update goal sprint state"
+mv /tmp/goal-sprint-state.json "$state_file" || fail "failed to write $state_file"
+
+echo "Created goal-sprint issue: ${issue_url:-unknown}"

--- a/scripts/goal-sprint/emit.sh
+++ b/scripts/goal-sprint/emit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-set -uo pipefail
-trap 'status=$?; echo "WARN: emit command failed near line $LINENO (status $status)" >&2; true' ERR
+set -euo pipefail
+trap 'status=$?; echo "ERROR: emit command failed near line $LINENO (status $status)" >&2; exit "$status"' ERR
 
 json="/tmp/goal_sprint.json"
 sentinel="/tmp/goal-sprint-material-changed"
@@ -9,6 +9,22 @@ state_file="company/goal-sprint-state.json"
 fail() {
   echo "ERROR: $*" >&2
   exit 1
+}
+
+fail_contract() {
+  echo "::error:: $*" >&2
+  exit 1
+}
+
+validate_top_array() {
+  field="$1"
+  if ! jq -e --arg field "$field" \
+    '(.top[$field] | type) == "array"
+     and (.top[$field]
+       | map(select(type == "string") | gsub("^\\s+|\\s+$"; "") | select(length > 0))
+       | length > 0)' "$json" >/dev/null; then
+    fail_contract "top.$field must be an array with at least 1 non-empty item"
+  fi
 }
 
 keywords_from_title() {
@@ -55,6 +71,8 @@ class="$(jq -r '.top.class // ""' "$json")" || fail "failed to read top.class"
 [ -n "$fingerprint" ] && [ "$fingerprint" != "null" ] || fail "fingerprint missing"
 [ -n "$title" ] && [ "$title" != "null" ] || fail "top.title missing"
 [ "$class" = "automatable" ] || [ "$class" = "needs-human" ] || fail "top.class must be automatable or needs-human"
+validate_top_array "acceptance_criteria"
+validate_top_array "build_sequence"
 
 last=""
 if [ -f "$state_file" ]; then
@@ -105,10 +123,18 @@ body_file="/tmp/goal-sprint-issue-body.md"
   echo "$problem"
   echo ""
   echo "## Acceptance Criteria"
-  jq -r '.top.acceptance_criteria[]? | "- " + .' "$json" || fail "failed to read acceptance criteria"
+  jq -r '.top.acceptance_criteria[]
+    | strings
+    | gsub("^\\s+|\\s+$"; "")
+    | select(length > 0)
+    | "- " + .' "$json" || fail "failed to read acceptance criteria"
   echo ""
   echo "## Build Sequence"
-  jq -r '.top.build_sequence[]? | "- " + .' "$json" || fail "failed to read build sequence"
+  jq -r '.top.build_sequence[]
+    | strings
+    | gsub("^\\s+|\\s+$"; "")
+    | select(length > 0)
+    | "- " + .' "$json" || fail "failed to read build sequence"
   if [ "$class" = "needs-human" ]; then
     echo ""
     echo "## Escalation"
@@ -117,12 +143,33 @@ body_file="/tmp/goal-sprint-issue-body.md"
   fi
 } > "$body_file"
 
-labels="goal-sprint"
 if [ "$class" = "automatable" ]; then
-  labels="${labels},needs-triage"
+  class_label="needs-triage"
 else
-  labels="${labels},needs-human"
+  class_label="needs-human"
 fi
+
+existing_labels_file="/tmp/goal-sprint-existing-labels.txt"
+gh label list --repo "$seed_repo" --limit 200 --json name -q '.[].name' > "$existing_labels_file" || fail "failed to list seed repo labels"
+
+base_labels_file="/tmp/goal-sprint-base-labels.txt"
+contract_labels_file="/tmp/goal-sprint-contract-labels.txt"
+labels_file="/tmp/goal-sprint-labels.txt"
+printf '%s\n%s\n' "goal-sprint" "$class_label" > "$base_labels_file"
+cp "$base_labels_file" "$labels_file"
+jq -r '.top.labels[]? | strings | gsub("^\\s+|\\s+$"; "") | select(length > 0)' "$json" > "$contract_labels_file" || fail "failed to read top.labels"
+while IFS= read -r label; do
+  [ -n "$label" ] || continue
+  if grep -Fxq "$label" "$labels_file"; then
+    continue
+  fi
+  if grep -Fxq "$label" "$existing_labels_file"; then
+    printf '%s\n' "$label" >> "$labels_file"
+  else
+    echo "::warning:: dropping unknown top.labels entry: $label" >&2
+  fi
+done < "$contract_labels_file"
+labels="$(paste -sd, "$labels_file")" || fail "failed to assemble labels"
 
 BODY="$(cat "$body_file")"
 if ! printf '%s' "$title $BODY" | bash "$SANITISE" > /dev/null 2>&1; then

--- a/scripts/goal-sprint/fingerprint.sh
+++ b/scripts/goal-sprint/fingerprint.sh
@@ -20,6 +20,12 @@ keywords_from_slug() {
     head -5 || true
 }
 
+normalise_title() {
+  printf '%s\n' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g'
+}
+
 [ -f "$json" ] || fail "$json not found"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
@@ -41,13 +47,23 @@ seed_repo="${SEED_REPO:-}"
 [ -n "$seed_repo" ] || fail "SEED_REPO is required"
 command -v gh >/dev/null 2>&1 || fail "gh is required"
 
-open_json="$(gh issue list --repo "$seed_repo" --label goal-sprint --state open --json title)" || fail "failed to list open goal-sprint issues"
+open_json="$(gh issue list --repo "$seed_repo" --label goal-sprint --state open --limit 200 --json title)" || fail "failed to list open goal-sprint issues"
 open_titles="/tmp/goal-sprint-open-titles.txt"
 printf '%s\n' "$open_json" | jq -r '.[].title // empty' > "$open_titles" || fail "failed to parse open issue titles"
 
 keywords="$(keywords_from_slug "$fingerprint")"
+fingerprint_exact="$(normalise_title "$fingerprint")"
+fingerprint_title_exact="$(normalise_title "$(printf '%s\n' "$fingerprint" | tr '-' ' ')")"
 match_count=0
 while IFS= read -r existing_title; do
+  if [ -z "$keywords" ]; then
+    existing_exact="$(normalise_title "$existing_title")"
+    if [ "$existing_exact" = "$fingerprint_exact" ] || [ "$existing_exact" = "$fingerprint_title_exact" ]; then
+      match_count=$((match_count + 1))
+      break
+    fi
+    continue
+  fi
   existing_lower="$(printf '%s\n' "$existing_title" | tr '[:upper:]' '[:lower:]')"
   hits=0
   for kw in $keywords; do

--- a/scripts/goal-sprint/fingerprint.sh
+++ b/scripts/goal-sprint/fingerprint.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -uo pipefail
+trap 'status=$?; echo "WARN: fingerprint command failed near line $LINENO (status $status)" >&2; true' ERR
+
+json="/tmp/goal_sprint.json"
+sentinel="/tmp/goal-sprint-material-changed"
+state_file="company/goal-sprint-state.json"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+keywords_from_slug() {
+  printf '%s\n' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    tr '-' '\n' |
+    tr -cs 'a-z0-9' '\n' |
+    grep -v -E '^(the|a|an|in|on|for|to|of|and|or|is|set|add|configure|verify|check|update|review|approve|implement|basic|define|fix|enable|goal|sprint)$' |
+    head -5 || true
+}
+
+[ -f "$json" ] || fail "$json not found"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+fingerprint="$(jq -r '.top.fingerprint // .fingerprint // ""' "$json")" || fail "failed to read fingerprint"
+[ -n "$fingerprint" ] && [ "$fingerprint" != "null" ] || fail "fingerprint missing"
+
+last=""
+if [ -f "$state_file" ]; then
+  last="$(jq -r '.last_fingerprint // ""' "$state_file" 2>/dev/null || true)"
+fi
+
+if [ "$fingerprint" = "$last" ]; then
+  echo "false" > "$sentinel"
+  echo "Material changed: false (fingerprint unchanged: $fingerprint)"
+  exit 0
+fi
+
+seed_repo="${SEED_REPO:-}"
+[ -n "$seed_repo" ] || fail "SEED_REPO is required"
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+
+open_json="$(gh issue list --repo "$seed_repo" --label goal-sprint --state open --json title)" || fail "failed to list open goal-sprint issues"
+open_titles="/tmp/goal-sprint-open-titles.txt"
+printf '%s\n' "$open_json" | jq -r '.[].title // empty' > "$open_titles" || fail "failed to parse open issue titles"
+
+keywords="$(keywords_from_slug "$fingerprint")"
+match_count=0
+while IFS= read -r existing_title; do
+  existing_lower="$(printf '%s\n' "$existing_title" | tr '[:upper:]' '[:lower:]')"
+  hits=0
+  for kw in $keywords; do
+    if printf '%s\n' "$existing_lower" | grep -q "$kw"; then
+      hits=$((hits + 1))
+    fi
+  done
+  if [ "$hits" -ge 2 ]; then
+    match_count=$((match_count + 1))
+    break
+  fi
+done < "$open_titles"
+
+if [ "$match_count" = "0" ]; then
+  echo "true" > "$sentinel"
+  echo "Material changed: true (new fingerprint '$fingerprint', no matching open goal-sprint issue)"
+else
+  echo "false" > "$sentinel"
+  echo "Material changed: false (new fingerprint '$fingerprint' matches an open goal-sprint issue)"
+fi

--- a/scripts/goal-sprint/fingerprint.sh
+++ b/scripts/goal-sprint/fingerprint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-set -uo pipefail
-trap 'status=$?; echo "WARN: fingerprint command failed near line $LINENO (status $status)" >&2; true' ERR
+set -euo pipefail
+trap 'status=$?; echo "ERROR: fingerprint command failed near line $LINENO (status $status)" >&2; exit "$status"' ERR
 
 json="/tmp/goal_sprint.json"
 sentinel="/tmp/goal-sprint-material-changed"

--- a/scripts/goal-sprint/test-goal-sprint.sh
+++ b/scripts/goal-sprint/test-goal-sprint.sh
@@ -2,7 +2,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOTAL=7
+TOTAL=9
 PASSED=0
 
 pass() {
@@ -17,11 +17,16 @@ fail() {
 make_workspace() {
   local work
   work="$(mktemp -d)"
-  mkdir -p "$work/scripts/goal-sprint" "$work/company" "$work/docs/pulse-reports"
+  mkdir -p "$work/scripts/goal-sprint" "$work/company/scripts" "$work/docs/pulse-reports"
   cp "$SCRIPT_DIR/build-context.sh" "$work/scripts/goal-sprint/build-context.sh"
   cp "$SCRIPT_DIR/fingerprint.sh" "$work/scripts/goal-sprint/fingerprint.sh"
   cp "$SCRIPT_DIR/emit.sh" "$work/scripts/goal-sprint/emit.sh"
   chmod +x "$work/scripts/goal-sprint/"*.sh
+  cat > "$work/company/scripts/sanitise.sh" <<'EOF_SANITISE'
+#!/usr/bin/env bash
+cat
+EOF_SANITISE
+  chmod +x "$work/company/scripts/sanitise.sh"
   printf '%s\n' "$work"
 }
 
@@ -59,7 +64,11 @@ install_gh_mock() {
 #!/usr/bin/env bash
 echo "$*" >> /tmp/gh-mock-calls.log
 if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
-  printf '[]\n'
+  if [ -n "${GH_MOCK_ISSUES:-}" ]; then
+    printf '%s\n' "$GH_MOCK_ISSUES"
+  else
+    printf '[]\n'
+  fi
   exit 0
 fi
 if [ "${1:-}" = "issue" ] && [ "${2:-}" = "create" ]; then
@@ -135,7 +144,7 @@ scenario_3() {
   write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
   echo true > /tmp/goal-sprint-material-changed
   reset_mock_log
-  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario3.out 2>&1)
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario3.out 2>&1)
   rc=$?
   creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
   if [ "$rc" -eq 0 ] && [ "$creates" = "1" ] && grep -q -- '--label goal-sprint,needs-triage' /tmp/gh-mock-calls.log && ! grep -q 'needs-human' /tmp/gh-mock-calls.log; then
@@ -155,7 +164,7 @@ scenario_4() {
   write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
   echo true > /tmp/goal-sprint-material-changed
   reset_mock_log
-  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario4.out 2>&1)
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario4.out 2>&1)
   rc=$?
   creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
   if [ "$rc" -eq 0 ] && [ "$creates" = "0" ]; then
@@ -175,7 +184,7 @@ scenario_5() {
   write_goal_json /tmp/goal_sprint.json needs-human "Call Buyers This Week" "call-buyers-this-week"
   echo true > /tmp/goal-sprint-material-changed
   reset_mock_log
-  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario5.out 2>&1)
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario5.out 2>&1)
   rc=$?
   if [ "$rc" -eq 0 ] && grep -q -- '--label goal-sprint,needs-human' /tmp/gh-mock-calls.log && grep -q 'Autonomy ladder: attempt via pipeline -> Codex -> RAH bounty -> operator.' /tmp/gh-mock-calls.log; then
     pass "$desc"
@@ -214,6 +223,54 @@ scenario_7() {
   fi
 }
 
+scenario_8() {
+  local desc="emit.sh sanitise rejection blocks issue creation"
+  local work mock creates rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  cat > "$work/company/scripts/sanitise.sh" <<'EOF_SANITISE'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 1
+EOF_SANITISE
+  chmod +x "$work/company/scripts/sanitise.sh"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario8.out 2>&1)
+  rc=$?
+  creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+  if [ "$rc" -ne 0 ] && [ "$creates" = "0" ] && grep -q '::error:: sanitise.sh rejected issue content' /tmp/scenario8.out; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario8.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
+scenario_9() {
+  local desc="empty-keyword title falls back to exact-title dedup"
+  local work mock creates rc_emit rc_fingerprint
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "the and or" "the-and-or"
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo GH_MOCK_ISSUES='[{"title":"the and or"}]' scripts/goal-sprint/emit.sh >/tmp/scenario9-emit.out 2>&1)
+  rc_emit=$?
+  creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo GH_MOCK_ISSUES='[{"title":"the and or"}]' scripts/goal-sprint/fingerprint.sh >/tmp/scenario9-fingerprint.out 2>&1)
+  rc_fingerprint=$?
+  if [ "$rc_emit" -eq 0 ] && [ "$creates" = "0" ] && grep -q 'SKIP: duplicate detected' /tmp/scenario9-emit.out && [ "$rc_fingerprint" -eq 0 ] && [ "$(cat /tmp/goal-sprint-material-changed)" = "false" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario9-emit.out) $(cat /tmp/scenario9-fingerprint.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
 scenario_1
 scenario_2
 scenario_3
@@ -221,6 +278,8 @@ scenario_4
 scenario_5
 scenario_6
 scenario_7
+scenario_8
+scenario_9
 
 if [ "$PASSED" -eq "$TOTAL" ]; then
   echo "PASS $PASSED/$TOTAL"

--- a/scripts/goal-sprint/test-goal-sprint.sh
+++ b/scripts/goal-sprint/test-goal-sprint.sh
@@ -2,7 +2,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TOTAL=9
+TOTAL=11
 PASSED=0
 
 pass() {
@@ -35,6 +35,9 @@ write_goal_json() {
   local class="$2"
   local title="$3"
   local fingerprint="$4"
+  local labels_json="${5:-[\"goal-sprint\"]}"
+  local acceptance_criteria_json="${6:-[\"First criterion\", \"Second criterion\"]}"
+  local build_sequence_json="${7:-[\"First step\", \"Second step\"]}"
   cat > "$path" <<EOF_JSON
 {
   "ideas": [
@@ -47,10 +50,10 @@ write_goal_json() {
   "top": {
     "title": "$title",
     "problem": "A concrete test problem.",
-    "acceptance_criteria": ["First criterion", "Second criterion"],
-    "build_sequence": ["First step", "Second step"],
+    "acceptance_criteria": $acceptance_criteria_json,
+    "build_sequence": $build_sequence_json,
     "class": "$class",
-    "labels": ["goal-sprint"]
+    "labels": $labels_json
   },
   "fingerprint": "$fingerprint"
 }
@@ -87,6 +90,14 @@ if [ "${1:-}" = "issue" ] && [ "${2:-}" = "create" ]; then
     i=$((i + 1))
   done
   printf 'https://github.com/example/repo/issues/123\n'
+  exit 0
+fi
+if [ "${1:-}" = "label" ] && [ "${2:-}" = "list" ]; then
+  if [ -n "${GH_MOCK_LABELS:-}" ]; then
+    printf '%s\n' "$GH_MOCK_LABELS"
+  else
+    printf '%s\n' goal-sprint needs-triage needs-human
+  fi
   exit 0
 fi
 exit 0
@@ -271,6 +282,70 @@ scenario_9() {
   fi
 }
 
+scenario_10() {
+  local desc="emit.sh missing or empty top arrays fail without issue creation"
+  local variant work mock rc creates failures
+  failures=0
+  for variant in missing_acceptance empty_acceptance missing_build empty_build; do
+    work="$(make_workspace)"
+    mock="$work/mock-bin"
+    install_gh_mock "$mock"
+    printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+    case "$variant" in
+      missing_acceptance)
+        write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+        jq 'del(.top.acceptance_criteria)' /tmp/goal_sprint.json > /tmp/goal_sprint_variant.json
+        mv /tmp/goal_sprint_variant.json /tmp/goal_sprint.json
+        ;;
+      empty_acceptance)
+        write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric" '["goal-sprint"]' '[]'
+        ;;
+      missing_build)
+        write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+        jq 'del(.top.build_sequence)' /tmp/goal_sprint.json > /tmp/goal_sprint_variant.json
+        mv /tmp/goal_sprint_variant.json /tmp/goal_sprint.json
+        ;;
+      empty_build)
+        write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric" '["goal-sprint"]' '["First criterion"]' '[]'
+        ;;
+    esac
+    echo true > /tmp/goal-sprint-material-changed
+    reset_mock_log
+    (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >"/tmp/scenario10-$variant.out" 2>&1)
+    rc=$?
+    creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+    if [ "$rc" -eq 0 ] || [ "$creates" != "0" ] || ! grep -q '::error:: top\.' "/tmp/scenario10-$variant.out"; then
+      failures=$((failures + 1))
+    fi
+  done
+  if [ "$failures" -eq 0 ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$failures invalid variants did not fail as expected"
+  fi
+}
+
+scenario_11() {
+  local desc="emit.sh applies only existing top.labels plus base labels"
+  local work mock creates rc create_line
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric" '["priority-high", "missing-label"]'
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" GITHUB_WORKSPACE="$work" SEED_REPO=example/repo GH_MOCK_LABELS="$(printf '%s\n' goal-sprint needs-triage priority-high)" scripts/goal-sprint/emit.sh >/tmp/scenario11.out 2>&1)
+  rc=$?
+  creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+  create_line="$(grep '^issue create ' /tmp/gh-mock-calls.log || true)"
+  if [ "$rc" -eq 0 ] && [ "$creates" = "1" ] && printf '%s\n' "$create_line" | grep -q -- '--label goal-sprint,needs-triage,priority-high' && ! printf '%s\n' "$create_line" | grep -q 'missing-label'; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario11.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
 scenario_1
 scenario_2
 scenario_3
@@ -280,6 +355,8 @@ scenario_6
 scenario_7
 scenario_8
 scenario_9
+scenario_10
+scenario_11
 
 if [ "$PASSED" -eq "$TOTAL" ]; then
   echo "PASS $PASSED/$TOTAL"

--- a/scripts/goal-sprint/test-goal-sprint.sh
+++ b/scripts/goal-sprint/test-goal-sprint.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOTAL=7
+PASSED=0
+
+pass() {
+  PASSED=$((PASSED + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  echo "FAIL: $1 — $2"
+}
+
+make_workspace() {
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/scripts/goal-sprint" "$work/company" "$work/docs/pulse-reports"
+  cp "$SCRIPT_DIR/build-context.sh" "$work/scripts/goal-sprint/build-context.sh"
+  cp "$SCRIPT_DIR/fingerprint.sh" "$work/scripts/goal-sprint/fingerprint.sh"
+  cp "$SCRIPT_DIR/emit.sh" "$work/scripts/goal-sprint/emit.sh"
+  chmod +x "$work/scripts/goal-sprint/"*.sh
+  printf '%s\n' "$work"
+}
+
+write_goal_json() {
+  local path="$1"
+  local class="$2"
+  local title="$3"
+  local fingerprint="$4"
+  cat > "$path" <<EOF_JSON
+{
+  "ideas": [
+    {"title": "One", "rationale": "Moves a metric", "impact": "high", "effort": "low", "metric": "autonomous_ship_rate"},
+    {"title": "Two", "rationale": "Moves a metric", "impact": "medium", "effort": "low", "metric": "spec_coverage"},
+    {"title": "Three", "rationale": "Moves a metric", "impact": "medium", "effort": "medium", "metric": "active_stuck_issues"},
+    {"title": "Four", "rationale": "Moves a metric", "impact": "low", "effort": "low", "metric": "pr_processing_rate"},
+    {"title": "Five", "rationale": "Moves a metric", "impact": "high", "effort": "medium", "metric": "lead_time_hours"}
+  ],
+  "top": {
+    "title": "$title",
+    "problem": "A concrete test problem.",
+    "acceptance_criteria": ["First criterion", "Second criterion"],
+    "build_sequence": ["First step", "Second step"],
+    "class": "$class",
+    "labels": ["goal-sprint"]
+  },
+  "fingerprint": "$fingerprint"
+}
+EOF_JSON
+}
+
+install_gh_mock() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/gh" <<'EOF_GH'
+#!/usr/bin/env bash
+echo "$*" >> /tmp/gh-mock-calls.log
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "create" ]; then
+  i=1
+  while [ "$i" -le "$#" ]; do
+    eval "arg=\${$i}"
+    if [ "$arg" = "--body-file" ]; then
+      next=$((i + 1))
+      eval "body_file=\${$next}"
+      {
+        echo "BODY_BEGIN"
+        cat "$body_file"
+        echo "BODY_END"
+      } >> /tmp/gh-mock-calls.log
+    fi
+    i=$((i + 1))
+  done
+  printf 'https://github.com/example/repo/issues/123\n'
+  exit 0
+fi
+exit 0
+EOF_GH
+  chmod +x "$bin_dir/gh"
+}
+
+reset_mock_log() {
+  : > /tmp/gh-mock-calls.log
+}
+
+scenario_1() {
+  local desc="fingerprint.sh new idea writes true sentinel"
+  local work mock rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "old-idea", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/fingerprint.sh >/tmp/scenario1.out 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ "$(cat /tmp/goal-sprint-material-changed)" = "true" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario1.out)"
+  fi
+}
+
+scenario_2() {
+  local desc="fingerprint.sh same idea writes false sentinel"
+  local work mock rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "ship-real-metric", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/fingerprint.sh >/tmp/scenario2.out 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ "$(cat /tmp/goal-sprint-material-changed)" = "false" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario2.out)"
+  fi
+}
+
+scenario_3() {
+  local desc="emit.sh automatable creates one issue with goal-sprint and needs-triage labels"
+  local work mock creates rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario3.out 2>&1)
+  rc=$?
+  creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+  if [ "$rc" -eq 0 ] && [ "$creates" = "1" ] && grep -q -- '--label goal-sprint,needs-triage' /tmp/gh-mock-calls.log && ! grep -q 'needs-human' /tmp/gh-mock-calls.log; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario3.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
+scenario_4() {
+  local desc="emit.sh duplicate fingerprint creates zero issues"
+  local work mock creates rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "ship-real-metric", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json automatable "Ship Real Metric" "ship-real-metric"
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario4.out 2>&1)
+  rc=$?
+  creates="$(grep -c '^issue create ' /tmp/gh-mock-calls.log || true)"
+  if [ "$rc" -eq 0 ] && [ "$creates" = "0" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario4.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
+scenario_5() {
+  local desc="emit.sh needs-human labels and body escalation note"
+  local work mock rc
+  work="$(make_workspace)"
+  mock="$work/mock-bin"
+  install_gh_mock "$mock"
+  printf '{ "last_fingerprint": "", "last_week": "", "ledger": [], "last_issue": null }\n' > "$work/company/goal-sprint-state.json"
+  write_goal_json /tmp/goal_sprint.json needs-human "Call Buyers This Week" "call-buyers-this-week"
+  echo true > /tmp/goal-sprint-material-changed
+  reset_mock_log
+  (cd "$work" && PATH="$mock:$PATH" SEED_REPO=example/repo scripts/goal-sprint/emit.sh >/tmp/scenario5.out 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] && grep -q -- '--label goal-sprint,needs-human' /tmp/gh-mock-calls.log && grep -q 'Autonomy ladder: attempt via pipeline -> Codex -> RAH bounty -> operator.' /tmp/gh-mock-calls.log; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario5.out) $(cat /tmp/gh-mock-calls.log)"
+  fi
+}
+
+scenario_6() {
+  local desc="build-context.sh with all files present writes non-empty context containing STRATEGY.md content"
+  local work rc
+  work="$(make_workspace)"
+  echo "North Star Strategy Content" > "$work/STRATEGY.md"
+  echo "Pulse Report Content" > "$work/docs/pulse-reports/2026-06-05_20-30.md"
+  echo '{"status":"ok"}' > "$work/company/loop-state.json"
+  echo '{"last_fingerprint":"previous-bet"}' > "$work/company/goal-sprint-state.json"
+  (cd "$work" && scripts/goal-sprint/build-context.sh >/tmp/scenario6.out 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ -s /tmp/goal_sprint_user.txt ] && grep -q 'North Star Strategy Content' /tmp/goal_sprint_user.txt; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario6.out)"
+  fi
+}
+
+scenario_7() {
+  local desc="build-context.sh with optional files absent exits zero and writes non-empty context"
+  local work rc
+  work="$(make_workspace)"
+  (cd "$work" && scripts/goal-sprint/build-context.sh >/tmp/scenario7.out 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ -s /tmp/goal_sprint_user.txt ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$(cat /tmp/scenario7.out)"
+  fi
+}
+
+scenario_1
+scenario_2
+scenario_3
+scenario_4
+scenario_5
+scenario_6
+scenario_7
+
+if [ "$PASSED" -eq "$TOTAL" ]; then
+  echo "PASS $PASSED/$TOTAL"
+  exit 0
+fi
+
+echo "FAIL $((TOTAL - PASSED))/$TOTAL"
+exit 1


### PR DESCRIPTION
## What

Adds a recurring **goal-sprint** pipeline step: every Monday 07:00 UTC an LLM pass reads the STRATEGY.md goal + current metrics + latest pulse, **ideates** 5 grounded goal-advancing moves, **ranks** by impact/effort, **plans** the winner into a concrete spec, and **emits one issue** into the autonomous builder chain (`atvirokodosprendimai/wgmesh`). Implements the ce-ideate → ce-plan → lfg intent using the repo's proven OpenRouter-curl + system-prompt pattern (observation-loop), feeding the existing spec → copilot-impl → bot-merge builder rather than adding a new one.

## Why

Pulse diagnosis: pipeline is healthy but produces self-referential maintenance (heal/loop/audit) while the goal metric — first paid customer / seed-product convergence — sits at 0. This step forces one goal-advancing artifact per cycle. Constraint is acquisition, not build throughput, so ideas may be `automatable` (auto-shipped via the chain) or `needs-human` (acquisition/ops → escalated per the autonomy ladder).

## Files

- `.github/workflows/goal-sprint.yml` — cron + `workflow_dispatch(dry_run)`, App-token/PUSH_TOKEN, OpenRouter curl + stub & HTTP-error fallback
- `company/goal-sprint-system-prompt.md` — ideate→rank→plan→classify, strict JSON
- `scripts/goal-sprint/{build-context,fingerprint,emit}.sh` — context assembly, material-change sentinel, dedup-guarded single-issue emit
- `company/goal-sprint-state.json` — fingerprint/ledger state
- `scripts/goal-sprint/test-goal-sprint.sh` — 7-scenario offline harness
- `.compound-engineering/config.local.yaml` — goal_sprint_* keys + the new PR-processing pulse KPI

## Anti-flood

One artifact per run, max. Emit + state-commit gated on a material-change sentinel (supervisor-rank pattern). Dedup vs open+closed seed-repo titles (observation-loop keyword guard). Deliberately NOT the daily-PR audit-drift anti-pattern.

## Test plan

- [x] `scripts/goal-sprint/test-goal-sprint.sh` → **PASS 7/7** (new/repeat fingerprint, automatable/needs-human labels, dedup guard, build-context with/without optional files), run independently
- [x] YAML valid, shellcheck clean
- [ ] **Live `dry_run=true` dispatch** on this branch → confirm JSON contract + zero issues created
- [ ] Confirm App token / PUSH_TOKEN has `issues:write` on `atvirokodosprendimai/wgmesh` before first live (non-dry) run

## Rollback

Additive + cron-gated. Disable via `goal_sprint_enabled: false` or delete the workflow. No existing workflows modified.