### PR TITLE
feat(pr-disposition): phase 1 — classify, stale-close, dry-run orchestrator

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -63,3 +63,12 @@ goal_sprint_seed_repo_source: pulse_seed_product_repo
 # goal-sprint step: weekly LLM-driven ideation that emits one spec issue into
 # the autonomous builder chain (atvirokodosprendimai/wgmesh or pulse_seed_product_repo).
 # Triggered every Monday 07:00 UTC. Anti-flood: only emits when fingerprint changes.
+
+# --- Autonomous PR disposition (Phase 1) ---
+# Additional high-risk path regexes, appended to the built-in defaults:
+#   - '^docs/(outreach|customers)/'
+#   - '^company/system-prompt\.md$'
+#   - '(^|/)(auth|authn|oauth|secrets?|payments?|billing|stripe|polar)(/|$)'
+#   - '(^|/)[^/]*(auth|secret|token|credential|payment|billing|stripe|polar)[^/]*'
+# pr_disposition_high_risk_paths:
+#   - '^example/high-risk/path/'

--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -135,10 +135,10 @@ jobs:
           prs="$(gh pr list --repo "$GH_REPO" --state open --json number,headRefOid)"
           jq -c '.[]' <<< "$prs" | while IFS= read -r row; do
             pr="$(jq -r '.number' <<< "$row")"
-            head_sha="$(jq -r '.headRefOid' <<< "$row")"
             classification="$(TARGET_REPO="$GH_REPO" scripts/pr-disposition/classify.sh "$pr")"
             class="$(jq -r '.class' <<< "$classification")"
             risk="$(jq -r '.risk_tier' <<< "$classification")"
+            head_sha="$(jq -r '.headRefOid // ""' <<< "$classification")"
             fingerprint="${pr}:${head_sha}:${class}"
 
             case "$class" in

--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -1,0 +1,212 @@
+name: PR Disposition
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print intended dispositions without mutating GitHub or state.
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-disposition
+  cancel-in-progress: false
+
+env:
+  OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  HAS_APP_CREDS: ${{ secrets.GITHUB_APP_ID != '' && secrets.GITHUB_APP_PRIVATE_KEY != '' }}
+
+jobs:
+  disposition:
+    name: Classify -> Route Open PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: env.HAS_APP_CREDS == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GITHUB_APP_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Select GitHub token
+        run: |
+          token="${{ steps.app-token.outputs.token }}"
+          if [ -z "$token" ]; then
+            token="${{ secrets.PUSH_TOKEN }}"
+          fi
+          if [ -z "$token" ]; then
+            token="${{ secrets.GITHUB_TOKEN }}"
+          fi
+          if [ -z "$token" ]; then
+            echo "::error::No GitHub App token, PUSH_TOKEN, or GITHUB_TOKEN available"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "GH_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Run PR disposition
+        env:
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          PR_DISPOSITION_STATE: company/pr-disposition-state.json
+        run: |
+          set -euo pipefail
+
+          state="${PR_DISPOSITION_STATE}"
+          sentinel="${PR_DISPOSITION_MATERIAL_SENTINEL:-/tmp/pr-disposition-material-changed}"
+          printf 'false' > "$sentinel"
+          mkdir -p "$(dirname "$state")"
+          if [ ! -f "$state" ]; then
+            printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$state"
+          fi
+
+          sanitise() {
+            bash company/scripts/sanitise.sh
+          }
+
+          has_fingerprint() {
+            local fp="$1"
+            jq -e --arg fp "$fp" '(.acted_fingerprints // []) | index($fp) != null' "$state" >/dev/null
+          }
+
+          record_fingerprint() {
+            local fp="$1" tmp
+            tmp="$(mktemp)"
+            jq --arg fp "$fp" \
+              '.acted_fingerprints = ((.acted_fingerprints // []) + [$fp] | unique)' \
+              "$state" > "$tmp"
+            sanitise < "$tmp" >/dev/null
+            if ! cmp -s "$tmp" "$state"; then
+              mv "$tmp" "$state"
+              printf 'true' > "$sentinel"
+            else
+              rm -f "$tmp"
+            fi
+          }
+
+          append_ledger() {
+            local pr="$1" class="$2" risk="$3" reason="$4" tmp ts
+            tmp="$(mktemp)"
+            ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+            jq \
+              --arg ts "$ts" \
+              --arg pr "$pr" \
+              --arg class "$class" \
+              --arg risk "$risk" \
+              --arg reason "$reason" \
+              '.ledger = ((.ledger // []) + [{
+                timestamp: $ts,
+                pr_number: ($pr | tonumber),
+                action: $class,
+                class: $class,
+                risk_tier: $risk,
+                reason: $reason
+              }]) | .acted_fingerprints = (.acted_fingerprints // [])' \
+              "$state" > "$tmp"
+            sanitise < "$tmp" >/dev/null
+            mv "$tmp" "$state"
+            printf 'true' > "$sentinel"
+          }
+
+          route_human() {
+            local pr="$1" classification="$2" class risk reason
+            class="$(jq -r '.class' <<< "$classification")"
+            risk="$(jq -r '.risk_tier' <<< "$classification")"
+            reason="$(jq -r '.reasons | join("; ")' <<< "$classification")"
+            reason="PR disposition escalated for human review: ${reason}"
+            sanitise <<< "$reason" >/dev/null
+            gh pr edit "$pr" --repo "$GH_REPO" --add-label needs-human
+            gh pr comment "$pr" --repo "$GH_REPO" --body "$reason"
+            append_ledger "$pr" "$class" "$risk" "$reason"
+          }
+
+          prs="$(gh pr list --repo "$GH_REPO" --state open --json number,headRefOid)"
+          jq -c '.[]' <<< "$prs" | while IFS= read -r row; do
+            pr="$(jq -r '.number' <<< "$row")"
+            head_sha="$(jq -r '.headRefOid' <<< "$row")"
+            classification="$(TARGET_REPO="$GH_REPO" scripts/pr-disposition/classify.sh "$pr")"
+            class="$(jq -r '.class' <<< "$classification")"
+            risk="$(jq -r '.risk_tier' <<< "$classification")"
+            fingerprint="${pr}:${head_sha}:${class}"
+
+            case "$class" in
+              stale|human)
+                if has_fingerprint "$fingerprint"; then
+                  echo "Skipping PR #${pr}; fingerprint already acted: ${fingerprint}"
+                  continue
+                fi
+                ;;
+            esac
+
+            case "$class" in
+              stale)
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "DRY_RUN stale PR #${pr}: would close"
+                else
+                  TARGET_REPO="$GH_REPO" scripts/pr-disposition/close-stale.sh "$pr" "$classification"
+                  printf 'true' > "$sentinel"
+                  record_fingerprint "$fingerprint"
+                fi
+                ;;
+              human)
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "DRY_RUN human PR #${pr}: would label needs-human and comment"
+                else
+                  route_human "$pr" "$classification"
+                  record_fingerprint "$fingerprint"
+                fi
+                ;;
+              merge-low|merge-high|conflict-low|conflict-high)
+                echo "DRY_RUN ${class} PR #${pr}: Phase 2 placeholder; no mutation"
+                ;;
+              leave)
+                :
+                ;;
+              *)
+                echo "::warning::Unknown PR disposition class '${class}' for PR #${pr}; leaving untouched"
+                ;;
+            esac
+          done
+
+          if [ "$DRY_RUN" = "true" ]; then
+            printf 'false' > "$sentinel"
+          fi
+
+      - name: Commit state
+        if: ${{ (github.event.inputs.dry_run || 'false') != 'true' }}
+        run: |
+          set -euo pipefail
+          sentinel="${PR_DISPOSITION_MATERIAL_SENTINEL:-/tmp/pr-disposition-material-changed}"
+          if [ ! -f "$sentinel" ]; then
+            echo "::warning::material-change sentinel missing; skipping commit"
+            exit 0
+          fi
+          if [ "$(cat "$sentinel")" != "true" ]; then
+            echo "No material PR-disposition state change; skipping commit"
+            exit 0
+          fi
+
+          state_content="$(cat company/pr-disposition-state.json)"
+          if ! printf '%s' "$state_content" | bash company/scripts/sanitise.sh > /dev/null; then
+            echo "::error::sanitise.sh rejected company/pr-disposition-state.json"
+            exit 1
+          fi
+
+          git config user.name "pupabobas[bot]"
+          git config user.email "pupabobas[bot]@users.noreply.github.com"
+          git add company/pr-disposition-state.json
+          git diff --cached --quiet && echo "No state changes to commit" && exit 0
+          git commit -m "chore(pr-disposition): update state"
+          git push

--- a/company/pr-disposition-state.json
+++ b/company/pr-disposition-state.json
@@ -1,0 +1,1 @@
+{"ledger": [], "acted_fingerprints": []}

--- a/company/pr-disposition-system-prompt.md
+++ b/company/pr-disposition-system-prompt.md
@@ -1,0 +1,12 @@
+You are the stale-disposition judge for the ai-pipeline-template repository.
+
+Decide only whether an open pull request is stale/superseded or should be left open.
+
+Return stale only when the PR is clearly superseded, obsolete, duplicate, abandoned by a newer implementation, or no longer advances STRATEGY.md. When uncertain, return leave.
+
+Do not recommend merging, rebasing, editing, labeling, or closing for any reason other than stale/superseded status. Mechanical checks are handled outside this call.
+
+Return ONLY valid JSON with this exact shape:
+{"verdict":"stale","reason":"<one sentence>"}
+
+The only allowed verdict values are "stale" and "leave".

--- a/docs/brainstorms/2026-06-06-autonomous-pr-disposition-requirements.md
+++ b/docs/brainstorms/2026-06-06-autonomous-pr-disposition-requirements.md
@@ -1,0 +1,67 @@
+# Autonomous PR-Disposition Step — Requirements
+
+**Date:** 2026-06-06
+**Status:** ready for planning
+**Sibling of:** goal-sprint step (`.github/workflows/goal-sprint.yml`)
+
+## Problem
+
+Pulses repeatedly show PRs dwelling. Root cause is structural, not technical: the autonomous pipeline is forbidden from processing operator-authored PRs (`APPROVED_AUTHORS` = bots only, 1-approval ruleset + self-approval ban), stale PRs never get reasoned-closed, and conflicting PRs never get rebased. The `pr_dwell_violations` KPI is a number with no actor — flagging it changes nothing. Two consecutive pulses showed the identical 34 dwelling PRs.
+
+## Goal
+
+A recurring step that **dispositions the open PR queue toward the STRATEGY.md goal automatically**, so PRs reach a goal-aligned terminal state without operator babysitting. Directly drives the `pr_processing_rate` / `pr_dwell_violations` KPI by *acting*, not measuring.
+
+## Core behavior
+
+For each open PR, classify and act:
+
+| Class | Signal | Action |
+|---|---|---|
+| **Mergeable + goal-aligned** | CI green, no conflicts, Copilot review requested+CLEAN, sanitise pass | **Tiered merge** (see authority) |
+| **Stale / superseded** | target already on main, or area rewritten since, or obsolete vs goal | **reasoned-close** (comment cites why + goal) |
+| **Conflicting** | mergeable=CONFLICTING | dispatch **rebase** (Codex) or label `needs-rebase` |
+| **Genuine human-only** | needs physical presence / wet-sig / irreversible-no-undo | **escalate**: `needs-human` + RAH bounty per autonomy ladder |
+
+Reasoned-close counts as PROCESSED (per PR-processing KPI). Bulk-close with no reason is forbidden.
+
+## Merge authority — TIERED (decided)
+
+- **Low-risk paths** (docs, `.github/workflows/`, `scripts/`, tests, `company/` non-secret): **auto admin-merge** after ALL of: Copilot review CLEAN, CI green, sanitise pass, no conflict.
+- **High-risk paths** (auth, secrets, payments, customer/outreach data, `company/system-prompt.md`, anything matching the PII-policy paths): **prepare only** — review + gate + label `ready-to-merge` + escalate for one operator click. Never auto-merged.
+- Path risk-tier list lives in config, editable without code change.
+
+This closes the operator-merge-gate **safely**: automation may admin-merge operator PRs, but only low-risk ones that passed every gate.
+
+## Hard guardrails (non-negotiable)
+
+1. **Never merge unreviewed.** Merge requires a CLEAN Copilot review on the current head SHA. (3 prior PII incidents came from `--admin`-before-Copilot.)
+2. **Sanitise gate** on any content the step publishes/commits (`company/scripts/sanitise.sh`).
+3. **CI must be green** (not pending, not skipped-as-proxy) before merge.
+4. **Re-review on new commits**: a stale Copilot review (older than head SHA) does not authorize merge.
+5. High-risk path → operator click, always.
+
+## Anti-flood
+
+- Idempotent per PR per head-SHA: act once, don't re-comment/re-review the same unchanged PR each run (fingerprint on PR#+headSHA+decision).
+- One disposition per PR per run.
+- Respect existing `needs-human` / `ready-to-merge` labels (don't churn).
+
+## Success criteria
+
+- `pr_dwell_violations` trends down across pulses without manual intervention.
+- Every closed PR carries a goal-aligned reason (reasoned-close rate = 100%).
+- Zero unreviewed merges; zero high-risk-path auto-merges.
+- Operator touch reduced to: high-risk merge clicks + genuine human-only escalations.
+
+## Out of scope
+
+- Generating new work (that's goal-sprint).
+- Reviewing PR *content* quality (that's Copilot / ce-code-review).
+- The seed repo wgmesh (this step governs the meta-pipeline repo's own queue; seed-repo PRs flow through the existing spec→impl→bot-merge chain).
+
+## Open questions (for planning)
+
+- Cadence: every N hours vs daily? (lean: every 6h, matches observation-loop)
+- Rebase: in-step (git rebase + push) vs dispatch Codex vs just-label? (lean: label `needs-rebase` + dispatch Codex for low-risk, label-only for high-risk)
+- Engine: pure-bash classifier vs LLM-assisted classification for the stale/superseded judgment (lean: bash for mechanical signals, LLM only for the "superseded vs still-wanted" call).

--- a/docs/plans/2026-06-06-001-feat-autonomous-pr-disposition-plan.md
+++ b/docs/plans/2026-06-06-001-feat-autonomous-pr-disposition-plan.md
@@ -1,0 +1,157 @@
+# feat: Autonomous PR-Disposition Step
+
+**Status:** active
+**Date:** 2026-06-06
+**Origin:** docs/brainstorms/2026-06-06-autonomous-pr-disposition-requirements.md
+**Depth:** Deep
+**Target repo:** ai-pipeline-template (governs its OWN meta-pipeline PR queue, not the seed repo)
+
+---
+
+## Summary
+
+A recurring step that dispositions the open PR queue toward the STRATEGY.md goal automatically: tiered auto-merge (low-risk paths auto, high-risk escalate), reasoned-close stale, auto-rebase low-risk conflicts, escalate genuine-human-only. Reuses the existing `company/scripts/pr-review-merge.sh` review+merge engine rather than building a new merge path. Closes the operator-merge-gate safely — automation may merge operator PRs, but only low-risk ones that passed Copilot-CLEAN + CI-green + sanitise on the current head SHA.
+
+Directive driving max-autonomy bias: *"the goal of ai pipeline that it would make these choices automatically to get closer to the goal."*
+
+---
+
+## Problem Frame
+
+`pr_dwell_violations` is a KPI with no actor — two consecutive pulses showed the identical 34 dwelling PRs. Operator PRs rot because the pipeline is structurally forbidden from merging them (`APPROVED_AUTHORS` = bots only); stale PRs never get reasoned-closed; conflicting PRs never get rebased. The pipeline measures the dwell but never acts on it.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Reuse, don't reinvent the merge engine.** `company/scripts/pr-review-merge.sh` already encodes Copilot-review polling, sanitise-on-escalate (SEC-2), `manual-only` skip, `needs-human` escalation, and merge. Extend its authority to operator PRs under a tiered path gate rather than writing a second merge path. (see origin: KTD merge authority)
+- **KTD2 — Tiered path risk seeds from the existing PII-policy regex.** High-risk = `^docs/(outreach|customers)/`, `company/system-prompt.md`, plus auth/secrets/payments globs, stored in config (`pr_disposition_high_risk_paths`) so it's editable without code change. Low-risk = everything else (docs, `.github/workflows/`, `scripts/`, tests).
+- **KTD3 — Hybrid classifier.** Bash decides the mechanical signals (CI state, `mergeable`, Copilot review state vs head SHA, labels, author, changed-file risk tier). One LLM sub-call (OpenRouter-curl pattern) decides only the semantic "stale/superseded vs still-wanted" judgment.
+- **KTD4 — Auto-rebase is safe.** Low-risk conflicting PRs are rebased via Codex/git then re-enter the review path; the rebased head must still pass Copilot+CI before merge, so autonomy never bypasses the guardrail. High-risk conflicts escalate (no auto-touch of sensitive files).
+- **KTD5 — Guardrails are non-negotiable.** Merge requires a CLEAN Copilot review **on the current head SHA** (a stale review does not authorize merge), CI green (not pending/skipped-as-proxy), sanitise pass. High-risk path → operator click, always.
+
+---
+
+## High-Level Technical Design
+
+```
+pr-disposition.yml (cron 6h + dispatch + dry_run)
+        │
+        ▼
+  classify.sh  ──per open PR──▶  {class, risk_tier, reasons}
+        │   mechanical: CI, mergeable, copilot-review@headSHA, labels, paths
+        │   LLM sub-call: stale/superseded judgment only
+        ▼
+  ┌────────────┬──────────────┬───────────────┬──────────────┐
+  ▼            ▼              ▼               ▼              ▼
+MERGE-low   MERGE-high     STALE          CONFLICT-low    HUMAN-only
+(auto via   (prepare +     (reasoned-     (auto-rebase    (needs-human
+ pr-review- label ready-   close, goal-    via Codex →     + RAH bounty)
+ merge.sh)  to-merge +     citing comment, re-enters
+            escalate)      sanitise)       review)
+                                           CONFLICT-high → escalate
+        │
+        ▼
+  idempotency: act once per (PR#, headSHA, decision); 1 disposition/PR/run
+  state/ledger: company/pr-disposition-state.json
+```
+
+---
+
+## Implementation Units
+
+### U1. High-risk path tiering + config
+- **Goal:** classify a PR's changed files as high-risk or low-risk.
+- **Files:** `scripts/pr-disposition/risk-tier.sh`, `scripts/pr-disposition/test-risk-tier.sh`, `.compound-engineering/config.local.yaml` (append `pr_disposition_high_risk_paths`)
+- **Approach:** seed high-risk globs from `.githooks` / `pii-policy-check` regex (`^docs/(outreach|customers)/`, `company/system-prompt.md`) + auth/secret/payment globs; read overrides from config. Any changed file matching → PR is high-risk.
+- **Patterns to follow:** the path regex in #822's `pii-policy-check.yml`; config-read pattern in `goal-sprint.yml` (python inline read).
+- **Test scenarios:** changed-files all docs → low; one file under `docs/customers/` → high; `company/system-prompt.md` → high; empty file list → low (safe default = treat as low only if truly no sensitive path; otherwise high). `Covers` guardrail KTD5.
+
+### U2. PR classifier (mechanical + LLM judgment)
+- **Goal:** produce `{class, risk_tier, reasons[]}` per open PR.
+- **Dependencies:** U1
+- **Files:** `scripts/pr-disposition/classify.sh`, `company/pr-disposition-system-prompt.md` (LLM stale-judgment prompt), `scripts/pr-disposition/test-classify.sh`
+- **Approach:** bash reads `gh pr view` (mergeable, statusCheckRollup, reviews, labels, author, files, headRefOid). Decision tree: CONFLICTING→conflict(tier); needs-human/manual-only label→skip/human; mergeable+CI-green+Copilot-CLEAN@headSHA→merge(tier); else if LLM judges superseded→stale; else→leave (in-flight). LLM sub-call uses OpenRouter-curl + sanitise gating (reuse goal-sprint pattern), invoked ONLY for the stale-vs-wanted call.
+- **Patterns to follow:** `goal-sprint.yml` LLM step; `pr-review-merge.sh` review-state reads.
+- **Test scenarios:** green+clean-review+low-path→merge-low; green+clean-review+high-path→merge-high; CONFLICTING+low→conflict-low; CONFLICTING+high→conflict-high; review older than headSHA→NOT merge (in-flight/re-review); needs-human label→human; LLM says superseded→stale; LLM says wanted→leave. `Covers` KTD3, KTD5.
+
+### U3. Extend merge authority to operator PRs (tiered)
+- **Goal:** allow automation to admin-merge operator PRs, low-risk only, under full guardrails.
+- **Dependencies:** U1, U2
+- **Files:** `company/scripts/pr-review-merge.sh` (extend author gate + add tiered path check before merge), `company/scripts/test-pr-review-merge.sh` (extend if exists, else create)
+- **Approach:** add operator login to an allowlist used ONLY when `risk_tier=low` AND Copilot-CLEAN@headSHA AND CI-green AND sanitise-pass. High-risk operator PRs: never merge — label `ready-to-merge` + escalate one-click. Preserve all existing bot-PR behavior unchanged.
+- **Execution note:** characterization-first — add coverage pinning current bot-PR merge behavior BEFORE extending the author gate (legacy 27KB script, high blast radius).
+- **Test scenarios:** operator PR low-risk all-gates-pass→merged; operator PR high-risk→labeled ready-to-merge+escalated, NOT merged; operator PR low-risk but Copilot COMMENTED-not-CLEAN→NOT merged; existing bot-PR path unchanged (regression). `Covers` KTD1, KTD5.
+
+### U4. Stale reasoned-close action
+- **Goal:** close superseded PRs with a goal-citing reason (processed, not discarded).
+- **Dependencies:** U2
+- **Files:** `scripts/pr-disposition/close-stale.sh`, `scripts/pr-disposition/test-close-stale.sh`
+- **Approach:** compose reason from classifier's `reasons[]` (why superseded + goal link), sanitise, `gh pr close --comment --delete-branch`. Append to ledger.
+- **Test scenarios:** stale PR→closed with non-empty reason + branch deleted; sanitise-reject→no close, escalate; reason cites goal/supersession. `Covers` pr_processing_rate (reasoned-close=processed).
+
+### U5. Auto-rebase low-risk conflicts
+- **Goal:** resolve low-risk merge conflicts so the PR re-enters review; escalate high-risk.
+- **Dependencies:** U1, U2
+- **Files:** `scripts/pr-disposition/rebase.sh`, `scripts/pr-disposition/test-rebase.sh`
+- **Approach:** low-risk conflict → dispatch Codex rebase (or `git rebase origin/main` + force-push-with-lease on the PR branch); on success the new head triggers fresh Copilot+CI (guardrail intact). On rebase failure or high-risk → label `needs-rebase` + escalate. Never auto-rebase high-risk paths.
+- **Test scenarios:** low-risk conflict, clean rebase→pushed, PR re-opened-for-review (mock); rebase fails→needs-rebase label+escalate; high-risk conflict→escalate, no rebase attempt. `Covers` KTD4.
+
+### U6. Orchestrator workflow
+- **Goal:** run the disposition over the open queue on cadence, idempotently.
+- **Dependencies:** U1-U5
+- **Files:** `.github/workflows/pr-disposition.yml`
+- **Approach:** `cron: 0 */6 * * *` + `workflow_dispatch(dry_run)`. App-token/PUSH_TOKEN (reuse goal-sprint token selection). For each open PR: classify→route to U3/U4/U5/escalate. Idempotency fingerprint = `PR#+headSHA+decision` stored in state; skip if already acted. One disposition per PR per run. `dry_run` prints intended actions, mutates nothing.
+- **Test scenarios:** Test expectation: none for the YAML wiring itself; behavior covered by U1-U5 + U9 e2e. (workflow is orchestration glue)
+
+### U7. State + ledger
+- **Goal:** persist disposition decisions + idempotency fingerprints.
+- **Files:** `company/pr-disposition-state.json`
+- **Approach:** `{ "ledger": [], "acted_fingerprints": [] }`; immutable-append. sanitise before commit (LLM-derived reasons). Commit gated on material change (supervisor-rank sentinel pattern).
+- **Test scenarios:** Test expectation: none — seed data file; mutation covered by U4/U6 tests.
+
+### U8. Pulse wiring
+- **Goal:** make the disposition step visible in the PR-processing KPI as the actor.
+- **Dependencies:** U6, U7
+- **Files:** `.compound-engineering/config.local.yaml` (note `pr_disposition_enabled`, source note for `pr_processing_rate`)
+- **Approach:** config flag + comment; pulse already reads `pr_processing_rate`/`pr_dwell_violations` from meta-repo PR data — no new metric needed, the step simply moves the existing number.
+- **Test scenarios:** Test expectation: none — config/doc only.
+
+### U9. Offline e2e test harness
+- **Goal:** prove the full classify→act routing + guardrails offline.
+- **Dependencies:** U1-U7
+- **Files:** `scripts/pr-disposition/test-disposition-e2e.sh`
+- **Approach:** PATH-shim `gh` mock returning fixture PRs across every class; assert: merge-low merges, merge-high escalates (no merge), stale closes-with-reason, conflict-low rebases, conflict-high escalates, unreviewed→no merge, stale-Copilot-review→no merge, dry_run mutates nothing. Print `PASS N/N`, non-zero on any fail.
+- **Test scenarios:** all guardrails KTD5; one scenario per class; idempotency (same fingerprint twice→second run no-ops).
+
+---
+
+## Scope Boundaries
+
+**In scope:** the meta-pipeline repo's own open PR queue.
+
+**Deferred to follow-up work:**
+- Auto-rebase of HIGH-risk PRs (stays escalate).
+- LLM-assisted PR *content* quality review (Copilot/ce-code-review owns that).
+
+**Outside this product's identity:**
+- The seed repo (wgmesh) queue — flows through the existing spec→impl→bot-merge chain, not this step.
+- Generating new work — that's goal-sprint.
+
+---
+
+## Risks & Mitigation
+
+- **R1 — Auto-merging a bad operator PR.** Mitigation: CLEAN Copilot review on current head SHA + CI green + sanitise + low-risk-path, ALL required. High-risk always escalates. (3 prior PII incidents are exactly this failure mode.)
+- **R2 — Force-push rebase corrupts a PR.** Mitigation: `--force-with-lease`, low-risk only, rebased head re-enters full review before any merge.
+- **R3 — Classifier mislabels wanted PR as stale.** Mitigation: LLM judgment is advisory for stale only; reasoned-close comment is reversible (reopen); never deletes work, branch-delete is recoverable from closed-PR.
+- **R4 — Re-comment/re-act flood.** Mitigation: idempotency fingerprint `PR#+headSHA+decision`; one disposition/PR/run; respect existing labels.
+
+---
+
+## Success Criteria
+
+- `pr_dwell_violations` trends down across pulses with zero manual action.
+- 100% of closed PRs carry a goal-aligned reason.
+- Zero unreviewed merges; zero high-risk-path auto-merges (assert in U9).
+- Operator touch reduced to high-risk merge clicks + genuine human-only escalations.

--- a/docs/pulse-reports/2026-06-05_20-30.md
+++ b/docs/pulse-reports/2026-06-05_20-30.md
@@ -1,0 +1,57 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-04 20:14 → 2026-06-05 20:14 (24h, -15m buffer)
+**Generated:** 2026-06-05 20:30 local
+
+## Headlines
+
+- Meta-pipeline backlog **drained hard**: open PRs 159→44, open issues 121→8 since last pulse. Big cleanup window.
+- **Seed product (wgmesh): zero convergence.** 0 PRs merged, 0 PRs updated in 24h. Product-side stayed idle while pipeline cleaned house.
+- Revenue flat: 5 org subs (mailbox, ~€4 MRR — unrelated), **0 cloudroof-tier subs**. Day 79, revenue stage stagnant.
+
+## Usage (primary = product_pr_merged in seed repo)
+
+| Metric | Value | Source |
+|---|---|---|
+| Seed PRs merged (wgmesh) | **0** | seed-repo-pr-data |
+| Seed PRs updated | 0 | seed-repo-pr-data |
+| Autonomous clean-impl merges | 0 | seed-repo-pr-data |
+| Paid customers (cloudroof) | **0** | observation-loop/Polar |
+| Org subs / MRR | 5 / €4 (mailbox, non-product) | Polar |
+| GitHub stars | 18 | observation-loop |
+
+## Meta-pipeline activity (this repo)
+
+- PRs merged 24h: ~18 — mostly `heal:` health-checks + `loop:` daily assessments. Substantive: **#1441** (supervisor-rank dup-collapse via List API + self-heal reconcile), **#1440** (CONCEPTS.md glossary seed).
+- Open PRs: 44 · Open issues: 8 (was 159 / 121 — major drain).
+- needs-human issues: **0**.
+
+## System performance (CI, this repo)
+
+- Runs 24h: 119 → 56 success, 57 skipped, 6 action_required, 0 failure.
+- `action_required` ×6 = **Spec PR Review Handler** awaiting approval gate (not failures — blocked on review).
+- Self-heal: **0 healed / 776 checks** — 5-day+ no-op trend continues. Healer effectively dead-code.
+
+## PR Processing KPI (new — SLA 7d)
+
+> Goal: PRs must be **acted on per the goal**, never bulk-closed to clear backlog.
+> Processed = merged OR closed-with-written-reason citing the goal. Dwell = defect.
+
+| Metric | Value |
+|---|---|
+| Dispositioned (24h) | 128 → 14 merged, 114 closed |
+| Close quality | reasoned ✅ (sampled: supervisor-rank closes cite "state-commit now gated on material change") — drain was processing, **not** discard |
+| `pr_processing_rate` | high on disposition; but **goal-advancing merges = 0** (14 merged all `heal:`/`loop:`/`chore:` maintenance, 0 seed-product) |
+| `pr_dwell_violations` (open ≥7d) | **34** — oldest 31d |
+| Dwell breakdown | 28 bot (audit-drift flood) + **6 human fix PRs** (#736,#771,#794,#800,#804,#822) |
+
+**Read:** disposition discipline is good (closes carry goal-reasons). The KPI failure is **34 PRs left dwelling with no decision** — 28 bot audit-drift + 6 human CI/feature fixes aged 27–30d. These need a goal-aligned action (merge or reasoned-close), not continued dwell.
+
+## Followups
+
+1. **Seed-product convergence = 0 for the window.** Pipeline is healthy but producing no wgmesh product PRs. Constraint is upstream of CI — investigate whether spec→impl loop is feeding the seed repo at all.
+2. **Self-heal 0/776.** Either healer is broken or has nothing to heal; needs a live-fire test or removal. Recurring across pulses.
+3. **Revenue attribution gap.** 5 org subs but 0 cloudroof tier — observation-loop still aggregates mailbox subs into org MRR. Per-product filter still pending.
+4. **6 Spec PR Review Handler runs stuck in action_required** — approval gate backlog; verify it's intentional, not a trigger stall.
+5. Backlog drain = **reasoned closes, not mass-discard** (verified: 114 closed-with-reason vs 14 merged; supervisor-rank closes cite material-change gating). Disposition OK.
+6. **34 PRs dwell ≥7d (PR-processing KPI miss).** Act per goal: bulk-disposition the 28 audit-drift bot PRs (fix workflow to fingerprint material drift), and decide the **6 human fix PRs** (#736 #771 #794 #800 #804 #822) — merge or reasoned-close, no more dwell. #1447 stays blocked (security).

--- a/docs/pulse-reports/2026-06-06_05-50.md
+++ b/docs/pulse-reports/2026-06-06_05-50.md
@@ -1,0 +1,44 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-05 05:50 → 2026-06-06 05:50 (24h, -15m buffer)
+**Generated:** 2026-06-06 05:50 local
+
+## Headlines
+
+- **Process capability advanced, goal metrics did not.** New goal-sprint step shipped + merged (PR #1450) — weekly forcing-function aimed at the customer goal — but seed-product convergence is still **0** and revenue flat at day 80.
+- **PR-processing KPI unmoved:** 34 PRs still dwell ≥7d (28 audit-drift bot + 6 human fixes) — same 34 as yesterday. Yesterday's flag produced no disposition.
+- 2 new CI failures (Supervisor Rank ×2). Self-heal still 0/781.
+
+## Usage (primary = product_pr_merged in seed repo)
+
+| Metric | Value | Δ vs prior pulse |
+|---|---|---|
+| Seed PRs merged (wgmesh) | **0** | flat |
+| Seed open issues | 6 | flat |
+| Paid customers (cloudroof) | **0** | flat |
+| Org subs / MRR | 5 / €0.04 | flat (mailbox, non-product) |
+| Revenue stage | Day 80, Stage 5 | +1 day |
+
+## PR Processing KPI (SLA 7d)
+
+| Metric | Value |
+|---|---|
+| Dispositioned 24h | 129 → 15 merged, 114 closed |
+| Close quality | reasoned ✅ (chore/state closes carry material-change reasons) |
+| Goal-advancing merges | **0** (15 merged = heal/loop/chore + goal-sprint infra; 0 seed-product) |
+| `pr_dwell_violations` ≥7d | **34** (28 bot audit-drift + 6 human: #736 #771 #794 #800 #804 #822) — **unchanged from prior pulse** |
+
+## Meta-pipeline / system
+
+- Open PRs 44 · open issues 8 (flat). needs-human 0.
+- CI 24h: 134 runs → 63 success, 63 skipped, 6 action_required (Spec PR Review gate), **2 failure = Supervisor Rank** (21:25, 03:27).
+- Self-heal: **0 healed / 781 checks** — 6-day no-op.
+- Shipped this window: goal-sprint workflow (14 Copilot findings resolved, tests 11/11, dry-run validated; first LLM idea = "execute prepared outreach campaigns for cloudroof traffic").
+
+## Followups
+
+1. **Dwell didn't move.** Flagging the 34 dwelling PRs last pulse changed nothing — no disposition happened. The KPI needs an *actor*, not just a number. Decide the 6 human PRs + fix-or-bulk-reason-close the 28 audit-drift bots this session.
+2. **Supervisor Rank failing ×2** (new). The publish-rank PRs are still landing, so partial — investigate the 2 failed runs (likely the same dup-collapse path #1441 touched).
+3. **Goal-sprint is the bet to watch.** First live cron Monday 07:00 UTC. It independently picked *send the prepared outreach* — which is the standing constraint. If it emits and the outreach actually goes out, that's the first real motion toward revenue in 80 days.
+4. Self-heal 0/781 — 6 days dead. Live-fire test or remove.
+5. Revenue attribution unchanged: 5 org subs are mailbox, 0 seed. Per-product filter still pending.

--- a/scripts/pr-disposition/classify.sh
+++ b/scripts/pr-disposition/classify.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SANITISE="${PR_DISPOSITION_SANITISE:-${ROOT_DIR}/company/scripts/sanitise.sh}"
+SYSTEM_PROMPT="${ROOT_DIR}/company/pr-disposition-system-prompt.md"
+PR_NUMBER="${1:?usage: classify.sh PR_NUMBER}"
+TARGET_REPO="${TARGET_REPO:-${GH_REPO:-}}"
+
+repo_args=()
+if [[ -n "$TARGET_REPO" ]]; then
+  repo_args=(--repo "$TARGET_REPO")
+fi
+
+emit() {
+  local class="$1" risk="$2"
+  shift 2
+  jq -nc --arg class "$class" --arg risk "$risk" --args \
+    '{"class": $class, "risk_tier": $risk, "reasons": $ARGS.positional}' "$@"
+}
+
+pr_json=""
+if ! pr_json="$(gh pr view "$PR_NUMBER" "${repo_args[@]}" \
+  --json number,title,mergeable,statusCheckRollup,reviews,labels,author,files,headRefOid 2>/dev/null)"; then
+  emit "leave" "low" "gh-pr-view-failed"
+  exit 0
+fi
+
+head_sha="$(jq -r '.headRefOid // ""' <<< "$pr_json")"
+mergeable="$(jq -r '.mergeable // "UNKNOWN"' <<< "$pr_json")"
+changed_files="$(jq -r '.files[]?.path // empty' <<< "$pr_json")"
+risk_tier="$(printf '%s\n' "$changed_files" | bash "${ROOT_DIR}/scripts/pr-disposition/risk-tier.sh")"
+
+if [[ "$mergeable" == "CONFLICTING" ]]; then
+  emit "conflict-${risk_tier}" "$risk_tier" "mergeable-CONFLICTING"
+  exit 0
+fi
+
+if jq -e '[.labels[]?.name // empty] | any(. == "needs-human")' <<< "$pr_json" >/dev/null; then
+  emit "human" "$risk_tier" "needs-human-label"
+  exit 0
+fi
+
+if jq -e '[.labels[]?.name // empty] | any(. == "manual-only")' <<< "$pr_json" >/dev/null; then
+  emit "human" "$risk_tier" "manual-only-label"
+  exit 0
+fi
+
+ci_green="$(jq -r '
+  (.statusCheckRollup // []) as $checks
+  | if ($checks | length) == 0 then false
+    else all($checks[];
+      (((.status // .state // "") | ascii_downcase) as $status
+      | ((.conclusion // .state // "") | ascii_downcase) as $conclusion
+      | (($status == "" or $status == "completed" or $status == "success")
+         and ($conclusion == "success" or $conclusion == "neutral" or $conclusion == "skipped"))))
+    end
+' <<< "$pr_json")"
+
+copilot_state="$(jq -nc --argjson pr "$pr_json" --arg head "$head_sha" '
+  def login: (.author.login // .user.login // "");
+  def commit_oid: (.commit.oid // .commitOID // .commitId // .commit_id // "");
+  def is_copilot: (login | test("copilot"; "i"));
+  def is_clean:
+    (((.body // "") | test("\\bCLEAN\\b"; "i"))
+     or (((.state // "") | ascii_upcase) == "APPROVED"));
+  ($pr.reviews // []) as $reviews
+  | {
+      current_clean: any($reviews[]?; is_copilot and is_clean and commit_oid == $head),
+      stale_clean: any($reviews[]?; is_copilot and is_clean and commit_oid != "" and commit_oid != $head)
+    }
+')"
+current_clean="$(jq -r '.current_clean' <<< "$copilot_state")"
+stale_clean="$(jq -r '.stale_clean' <<< "$copilot_state")"
+
+if [[ "$ci_green" == "true" && "$current_clean" == "true" ]]; then
+  emit "merge-${risk_tier}" "$risk_tier" "mergeable" "ci-green" "copilot-clean-current-head"
+  exit 0
+fi
+
+if [[ "$stale_clean" == "true" ]]; then
+  emit "leave" "$risk_tier" "stale-copilot-sha"
+  exit 0
+fi
+
+if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+  emit "leave" "$risk_tier" "no-api-key"
+  exit 0
+fi
+
+request="$(mktemp)"
+response="$(mktemp)"
+content_file="$(mktemp)"
+trap 'rm -f "$request" "$response" "$content_file"' EXIT
+
+jq -n \
+  --rawfile system "$SYSTEM_PROMPT" \
+  --arg pr_number "$PR_NUMBER" \
+  --argjson pr "$pr_json" \
+  --arg risk "$risk_tier" \
+  '{
+    model: "anthropic/claude-sonnet-4",
+    max_tokens: 1024,
+    messages: [
+      {role: "system", content: $system},
+      {role: "user", content: ("Classify PR #" + $pr_number + " for stale-vs-leave only. Risk tier: " + $risk + "\nPR JSON:\n" + ($pr | tostring))}
+    ]
+  }' > "$request"
+
+http_code="$(curl -s -w '%{http_code}' -o "$response" \
+  -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+  -H "content-type: application/json" \
+  -d @"$request" \
+  https://openrouter.ai/api/v1/chat/completions || true)"
+
+if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+  emit "leave" "$risk_tier" "llm-http-${http_code:-failed}"
+  exit 0
+fi
+
+jq -r '.choices[0].message.content // ""' "$response" > "$content_file"
+if ! "$SANITISE" < "$content_file" >/dev/null; then
+  emit "leave" "$risk_tier" "llm-sanitise-rejected"
+  exit 0
+fi
+
+llm_json="$(mktemp)"
+trap 'rm -f "$request" "$response" "$content_file" "$llm_json"' EXIT
+if jq -e . "$content_file" > "$llm_json" 2>/dev/null; then
+  :
+else
+  sed -n '/^```json[[:space:]]*$/,/^```[[:space:]]*$/p' "$content_file" | sed '1d;$d' > "$llm_json"
+fi
+
+if ! jq -e '(.verdict == "stale" or .verdict == "leave") and (.reason | type == "string")' "$llm_json" >/dev/null 2>&1; then
+  emit "leave" "$risk_tier" "llm-invalid-json"
+  exit 0
+fi
+
+verdict="$(jq -r '.verdict' "$llm_json")"
+reason="$(jq -r '.reason' "$llm_json")"
+if [[ "$verdict" == "stale" ]]; then
+  emit "stale" "$risk_tier" "$reason"
+else
+  emit "leave" "$risk_tier" "$reason"
+fi

--- a/scripts/pr-disposition/classify.sh
+++ b/scripts/pr-disposition/classify.sh
@@ -6,6 +6,7 @@ SANITISE="${PR_DISPOSITION_SANITISE:-${ROOT_DIR}/company/scripts/sanitise.sh}"
 SYSTEM_PROMPT="${ROOT_DIR}/company/pr-disposition-system-prompt.md"
 PR_NUMBER="${1:?usage: classify.sh PR_NUMBER}"
 TARGET_REPO="${TARGET_REPO:-${GH_REPO:-}}"
+head_sha=""
 
 repo_args=()
 if [[ -n "$TARGET_REPO" ]]; then
@@ -15,13 +16,13 @@ fi
 emit() {
   local class="$1" risk="$2"
   shift 2
-  jq -nc --arg class "$class" --arg risk "$risk" --args \
-    '{"class": $class, "risk_tier": $risk, "reasons": $ARGS.positional}' "$@"
+  jq -nc --arg class "$class" --arg risk "$risk" --arg head "$head_sha" --args \
+    '{"class": $class, "risk_tier": $risk, "headRefOid": $head, "reasons": $ARGS.positional}' "$@"
 }
 
 pr_json=""
 if ! pr_json="$(gh pr view "$PR_NUMBER" "${repo_args[@]}" \
-  --json number,title,mergeable,statusCheckRollup,reviews,labels,author,files,headRefOid 2>/dev/null)"; then
+  --json number,title,mergeable,statusCheckRollup,reviews,labels,author,files,headRefOid,baseRefName,headRefName,createdAt,updatedAt 2>/dev/null)"; then
   emit "leave" "low" "gh-pr-view-failed"
   exit 0
 fi
@@ -61,9 +62,10 @@ copilot_state="$(jq -nc --argjson pr "$pr_json" --arg head "$head_sha" '
   def login: (.author.login // .user.login // "");
   def commit_oid: (.commit.oid // .commitOID // .commitId // .commit_id // "");
   def is_copilot: (login | test("copilot"; "i"));
+  def first_line_trimmed: ((.body // "") | split("\n")[0] | gsub("^[[:space:]]+|[[:space:]]+$"; ""));
   def is_clean:
-    (((.body // "") | test("\\bCLEAN\\b"; "i"))
-     or (((.state // "") | ascii_upcase) == "APPROVED"));
+    ((((.state // "") | ascii_upcase) == "APPROVED")
+     or (first_line_trimmed == "CLEAN"));
   ($pr.reviews // []) as $reviews
   | {
       current_clean: any($reviews[]?; is_copilot and is_clean and commit_oid == $head),
@@ -93,17 +95,32 @@ response="$(mktemp)"
 content_file="$(mktemp)"
 trap 'rm -f "$request" "$response" "$content_file"' EXIT
 
+pr_summary="$(jq -c '
+  {
+    number: .number,
+    title: (.title // ""),
+    changedFilePaths: [.files[]?.path // empty],
+    baseRefName: (.baseRefName // ""),
+    headRefName: (.headRefName // ""),
+    age: {
+      createdAt: (.createdAt // ""),
+      updatedAt: (.updatedAt // "")
+    },
+    labels: [.labels[]?.name // empty]
+  }
+' <<< "$pr_json")"
+
 jq -n \
   --rawfile system "$SYSTEM_PROMPT" \
   --arg pr_number "$PR_NUMBER" \
-  --argjson pr "$pr_json" \
+  --argjson pr "$pr_summary" \
   --arg risk "$risk_tier" \
   '{
     model: "anthropic/claude-sonnet-4",
     max_tokens: 1024,
     messages: [
       {role: "system", content: $system},
-      {role: "user", content: ("Classify PR #" + $pr_number + " for stale-vs-leave only. Risk tier: " + $risk + "\nPR JSON:\n" + ($pr | tostring))}
+      {role: "user", content: ("Classify PR #" + $pr_number + " for stale-vs-leave only. Risk tier: " + $risk + "\nPR summary:\n" + ($pr | tostring))}
     ]
   }' > "$request"
 

--- a/scripts/pr-disposition/close-stale.sh
+++ b/scripts/pr-disposition/close-stale.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SANITISE="${PR_DISPOSITION_SANITISE:-${ROOT_DIR}/company/scripts/sanitise.sh}"
+STATE_PATH="${PR_DISPOSITION_STATE:-${ROOT_DIR}/company/pr-disposition-state.json}"
+PR_NUMBER="${1:?usage: close-stale.sh PR_NUMBER CLASSIFICATION_JSON}"
+CLASSIFICATION_JSON="${2:?usage: close-stale.sh PR_NUMBER CLASSIFICATION_JSON}"
+
+escalate() {
+  local pr="$1"
+  local reason="Stale-close reason failed sanitise; human review required."
+  gh pr edit "$pr" --add-label needs-human || true
+  gh pr comment "$pr" --body "$reason" || true
+  echo "Escalated PR #${pr}: ${reason}"
+}
+
+if ! jq -e '.class == "stale" and (.reasons | type == "array")' <<< "$CLASSIFICATION_JSON" >/dev/null 2>&1; then
+  echo "close-stale.sh requires a stale classification JSON" >&2
+  exit 1
+fi
+
+reasons_text="$(jq -r '.reasons | map(select(type == "string" and length > 0)) | join("; ")' <<< "$CLASSIFICATION_JSON")"
+if [[ -z "$reasons_text" ]]; then
+  reasons_text="the classifier judged this PR superseded or no longer goal-aligned"
+fi
+
+reason="Closing this PR as stale because it no longer appears to move the repository toward STRATEGY.md: ${reasons_text}. This reasoned close reduces PR dwell while preserving the discussion for reopening if needed."
+
+if ! safe_reason="$(printf '%s' "$reason" | "$SANITISE")"; then
+  escalate "$PR_NUMBER"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$STATE_PATH")"
+if [[ ! -f "$STATE_PATH" ]]; then
+  printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$STATE_PATH"
+fi
+
+tmp_state="$(mktemp)"
+timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+risk_tier="$(jq -r '.risk_tier // "unknown"' <<< "$CLASSIFICATION_JSON")"
+jq \
+  --arg ts "$timestamp" \
+  --arg pr "$PR_NUMBER" \
+  --arg risk "$risk_tier" \
+  --arg reason "$safe_reason" \
+  --argjson reasons "$(jq '.reasons' <<< "$CLASSIFICATION_JSON")" \
+  '.ledger = ((.ledger // []) + [{
+    timestamp: $ts,
+    pr_number: ($pr | tonumber),
+    action: "close-stale",
+    class: "stale",
+    risk_tier: $risk,
+    reasons: $reasons,
+    reason: $reason
+  }]) | .acted_fingerprints = (.acted_fingerprints // [])' \
+  "$STATE_PATH" > "$tmp_state"
+
+if ! "$SANITISE" < "$tmp_state" >/dev/null; then
+  escalate "$PR_NUMBER"
+  rm -f "$tmp_state"
+  exit 0
+fi
+
+gh pr close "$PR_NUMBER" --comment "$safe_reason" --delete-branch
+mv "$tmp_state" "$STATE_PATH"

--- a/scripts/pr-disposition/close-stale.sh
+++ b/scripts/pr-disposition/close-stale.sh
@@ -6,12 +6,20 @@ SANITISE="${PR_DISPOSITION_SANITISE:-${ROOT_DIR}/company/scripts/sanitise.sh}"
 STATE_PATH="${PR_DISPOSITION_STATE:-${ROOT_DIR}/company/pr-disposition-state.json}"
 PR_NUMBER="${1:?usage: close-stale.sh PR_NUMBER CLASSIFICATION_JSON}"
 CLASSIFICATION_JSON="${2:?usage: close-stale.sh PR_NUMBER CLASSIFICATION_JSON}"
+TARGET_REPO="${TARGET_REPO:-${GH_REPO:-}}"
+
+if [[ -z "$TARGET_REPO" ]]; then
+  echo "close-stale.sh requires TARGET_REPO or GH_REPO to be set; refusing unscoped gh calls" >&2
+  exit 1
+fi
+
+repo_args=(--repo "$TARGET_REPO")
 
 escalate() {
   local pr="$1"
   local reason="Stale-close reason failed sanitise; human review required."
-  gh pr edit "$pr" --add-label needs-human || true
-  gh pr comment "$pr" --body "$reason" || true
+  gh pr edit "$pr" "${repo_args[@]}" --add-label needs-human || true
+  gh pr comment "$pr" "${repo_args[@]}" --body "$reason" || true
   echo "Escalated PR #${pr}: ${reason}"
 }
 
@@ -63,5 +71,5 @@ if ! "$SANITISE" < "$tmp_state" >/dev/null; then
   exit 0
 fi
 
-gh pr close "$PR_NUMBER" --comment "$safe_reason" --delete-branch
+gh pr close "$PR_NUMBER" "${repo_args[@]}" --comment "$safe_reason" --delete-branch
 mv "$tmp_state" "$STATE_PATH"

--- a/scripts/pr-disposition/risk-tier.sh
+++ b/scripts/pr-disposition/risk-tier.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG_PATH="${PR_DISPOSITION_CONFIG:-${ROOT_DIR}/.compound-engineering/config.local.yaml}"
+
+patterns=(
+  '^docs/(outreach|customers)/'
+  '^company/system-prompt\.md$'
+  '(^|/)(auth|authn|oauth|secrets?|payments?|billing|stripe|polar)(/|$)'
+  '(^|/)[^/]*(auth|secret|token|credential|payment|billing|stripe|polar)[^/]*'
+)
+
+if [[ -f "$CONFIG_PATH" ]]; then
+  while IFS= read -r pattern; do
+    [[ -n "$pattern" ]] && patterns+=("$pattern")
+  done < <(python3 - "$CONFIG_PATH" <<'PY'
+import ast
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text().splitlines()
+in_list = False
+for raw in lines:
+    line = raw.rstrip()
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        continue
+    if re.match(r"^pr_disposition_high_risk_paths\s*:", stripped):
+        value = stripped.split(":", 1)[1].strip()
+        if value.startswith("[") and value.endswith("]"):
+            try:
+                parsed = ast.literal_eval(value)
+                for item in parsed:
+                    print(str(item))
+            except Exception:
+                pass
+        in_list = True
+        continue
+    if in_list:
+        if re.match(r"^[A-Za-z0-9_.-]+\s*:", stripped):
+            break
+        if stripped.startswith("-"):
+            item = stripped[1:].strip()
+            if " #" in item:
+                item = item.split(" #", 1)[0].strip()
+            if (item.startswith("'") and item.endswith("'")) or (item.startswith('"') and item.endswith('"')):
+                item = item[1:-1]
+            if item:
+                print(item)
+PY
+  )
+fi
+
+input_files() {
+  if [[ $# -gt 0 ]]; then
+    if [[ -f "$1" ]]; then
+      cat "$1"
+    else
+      printf '%s\n' "$1"
+    fi
+  else
+    cat
+  fi
+}
+
+while IFS= read -r changed_path; do
+  [[ -n "$changed_path" ]] || continue
+  for pattern in "${patterns[@]}"; do
+    if [[ "$changed_path" =~ $pattern ]]; then
+      echo "high"
+      exit 0
+    fi
+  done
+done < <(input_files "$@")
+
+echo "low"

--- a/scripts/pr-disposition/test-classify.sh
+++ b/scripts/pr-disposition/test-classify.sh
@@ -48,6 +48,22 @@ JSON
 {"number":8,"title":"Still wanted","mergeable":"MERGEABLE","headRefOid":"sha-leave","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
 JSON
       ;;
+    9) cat <<'JSON'
+{"number":9,"title":"Not clean body","mergeable":"MERGEABLE","headRefOid":"sha-not-clean","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"NOT CLEAN","commit":{"oid":"sha-not-clean"}}]}
+JSON
+      ;;
+    10) cat <<'JSON'
+{"number":10,"title":"First line clean","mergeable":"MERGEABLE","headRefOid":"sha-first-line-clean","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"  CLEAN  \nfollow-up text","commit":{"oid":"sha-first-line-clean"}}]}
+JSON
+      ;;
+    11) cat <<'JSON'
+{"number":11,"title":"Approved clean","mergeable":"MERGEABLE","headRefOid":"sha-approved","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"APPROVED","body":"NOT CLEAN","commit":{"oid":"sha-approved"}}]}
+JSON
+      ;;
+    12) cat <<'JSON'
+{"number":12,"title":"Stale approved clean","mergeable":"MERGEABLE","headRefOid":"sha-current-approved","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"APPROVED","body":"  CLEAN  ","commit":{"oid":"sha-old-approved"}}]}
+JSON
+      ;;
     *) exit 1 ;;
   esac
   exit 0
@@ -71,6 +87,11 @@ while [[ $# -gt 0 ]]; do
     *) shift ;;
   esac
 done
+user_content="$(jq -r '.messages[] | select(.role == "user").content' "$request")"
+if grep -Eq 'statusCheckRollup|reviews|"body"|"commit"' <<< "$user_content"; then
+  echo "LLM request leaked full PR details" >&2
+  exit 1
+fi
 if grep -q "Superseded" "$request"; then
   content='{"verdict":"stale","reason":"A newer PR supersedes this implementation."}'
 else
@@ -111,5 +132,9 @@ assert_class 5 "human" "low" "needs-human"
 assert_class 6 "leave" "low" "stale-copilot-sha"
 assert_class 7 "conflict-high" "high"
 assert_class 8 "leave" "low" "still appears wanted"
+assert_class 9 "leave" "low" "still appears wanted"
+assert_class 10 "merge-low" "low"
+assert_class 11 "merge-low" "low"
+assert_class 12 "leave" "low" "stale-copilot-sha"
 
 echo "PASS ${pass}/${total}"

--- a/scripts/pr-disposition/test-classify.sh
+++ b/scripts/pr-disposition/test-classify.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+export PATH="$TMPDIR/bin:$PATH"
+export OPENROUTER_API_KEY="test-key"
+
+cat > "$TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  pr="$3"
+  case "$pr" in
+    1) cat <<'JSON'
+{"number":1,"title":"Low clean","mergeable":"MERGEABLE","headRefOid":"sha-low","author":{"login":"operator"},"labels":[],"files":[{"path":"docs/notes.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-low"}}]}
+JSON
+      ;;
+    2) cat <<'JSON'
+{"number":2,"title":"High clean","mergeable":"MERGEABLE","headRefOid":"sha-high","author":{"login":"operator"},"labels":[],"files":[{"path":"docs/customers/acme.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"copilot-swe-agent[bot]"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-high"}}]}
+JSON
+      ;;
+    3) cat <<'JSON'
+{"number":3,"title":"Superseded by newer PR","mergeable":"MERGEABLE","headRefOid":"sha-stale","author":{"login":"operator"},"labels":[],"files":[{"path":"docs/notes.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
+JSON
+      ;;
+    4) cat <<'JSON'
+{"number":4,"title":"Conflict low","mergeable":"CONFLICTING","headRefOid":"sha-conflict","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    5) cat <<'JSON'
+{"number":5,"title":"Manual","mergeable":"MERGEABLE","headRefOid":"sha-human","author":{"login":"operator"},"labels":[{"name":"needs-human"}],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    6) cat <<'JSON'
+{"number":6,"title":"Stale Copilot SHA","mergeable":"MERGEABLE","headRefOid":"sha-current","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-old"}}]}
+JSON
+      ;;
+    7) cat <<'JSON'
+{"number":7,"title":"Conflict high","mergeable":"CONFLICTING","headRefOid":"sha-conflict-high","author":{"login":"operator"},"labels":[],"files":[{"path":"company/system-prompt.md"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    8) cat <<'JSON'
+{"number":8,"title":"Still wanted","mergeable":"MERGEABLE","headRefOid":"sha-leave","author":{"login":"operator"},"labels":[],"files":[{"path":"scripts/tool.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
+JSON
+      ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$TMPDIR/bin/gh"
+
+cat > "$TMPDIR/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+request=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -d)
+      if [[ "$2" == @* ]]; then request="${2#@}"; fi
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+if grep -q "Superseded" "$request"; then
+  content='{"verdict":"stale","reason":"A newer PR supersedes this implementation."}'
+else
+  content='{"verdict":"leave","reason":"The PR still appears wanted."}'
+fi
+jq -n --arg content "$content" '{choices:[{message:{content:$content}}]}' > "$out"
+printf '200'
+SH
+chmod +x "$TMPDIR/bin/curl"
+
+pass=0
+total=0
+
+assert_class() {
+  local pr="$1" expected_class="$2" expected_tier="$3" reason_fragment="${4:-}"
+  total=$((total + 1))
+  local out actual_class actual_tier
+  out=$(bash "$ROOT_DIR/scripts/pr-disposition/classify.sh" "$pr")
+  jq empty <<< "$out"
+  actual_class=$(jq -r '.class' <<< "$out")
+  actual_tier=$(jq -r '.risk_tier' <<< "$out")
+  if [[ "$actual_class" != "$expected_class" || "$actual_tier" != "$expected_tier" ]]; then
+    echo "FAIL PR ${pr}: expected ${expected_class}/${expected_tier}, got ${actual_class}/${actual_tier}: ${out}" >&2
+    exit 1
+  fi
+  if [[ -n "$reason_fragment" ]] && ! jq -e --arg frag "$reason_fragment" '.reasons[] | contains($frag)' <<< "$out" >/dev/null; then
+    echo "FAIL PR ${pr}: missing reason fragment ${reason_fragment}: ${out}" >&2
+    exit 1
+  fi
+  pass=$((pass + 1))
+}
+
+assert_class 1 "merge-low" "low"
+assert_class 2 "merge-high" "high"
+assert_class 3 "stale" "low" "newer PR"
+assert_class 4 "conflict-low" "low"
+assert_class 5 "human" "low" "needs-human"
+assert_class 6 "leave" "low" "stale-copilot-sha"
+assert_class 7 "conflict-high" "high"
+assert_class 8 "leave" "low" "still appears wanted"
+
+echo "PASS ${pass}/${total}"

--- a/scripts/pr-disposition/test-close-stale.sh
+++ b/scripts/pr-disposition/test-close-stale.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin" "$TMPDIR/company/scripts"
+export PATH="$TMPDIR/bin:$PATH"
+export PR_DISPOSITION_STATE="$TMPDIR/state.json"
+printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$PR_DISPOSITION_STATE"
+
+cat > "$TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_LOG"
+SH
+chmod +x "$TMPDIR/bin/gh"
+
+pass=0
+total=0
+
+assert_contains() {
+  local name="$1" needle="$2" file="$3"
+  total=$((total + 1))
+  if grep -qF -- "$needle" "$file"; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: missing ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" file="$3"
+  total=$((total + 1))
+  if ! grep -qF -- "$needle" "$file" 2>/dev/null; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: unexpected ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_jq() {
+  local name="$1" expr="$2" file="$3"
+  total=$((total + 1))
+  if jq -e "$expr" "$file" >/dev/null; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: jq ${expr}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+GH_LOG="$TMPDIR/gh-reject.log"
+export GH_LOG
+SANITISE_SH="$TMPDIR/reject-sanitise.sh"
+cat > "$SANITISE_SH" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 1
+SH
+chmod +x "$SANITISE_SH"
+export PR_DISPOSITION_SANITISE="$SANITISE_SH"
+reject_json='{"class":"stale","risk_tier":"low","reasons":["contains rejected material"]}'
+if bash "$ROOT_DIR/scripts/pr-disposition/close-stale.sh" 11 "$reject_json" >/dev/null; then
+  :
+else
+  echo "FAIL sanitise reject should escalate without failing" >&2
+  exit 1
+fi
+assert_not_contains "reject does not close" "pr close" "$GH_LOG"
+assert_contains "reject adds needs-human" "pr edit 11 --add-label needs-human" "$GH_LOG"
+assert_contains "reject comments" "pr comment 11 --body" "$GH_LOG"
+assert_jq "reject leaves ledger empty" '.ledger | length == 0' "$PR_DISPOSITION_STATE"
+
+GH_LOG="$TMPDIR/gh-close.log"
+export GH_LOG
+unset PR_DISPOSITION_SANITISE
+normal_json='{"class":"stale","risk_tier":"low","reasons":["A newer PR supersedes this implementation.","CI is red."]}'
+bash "$ROOT_DIR/scripts/pr-disposition/close-stale.sh" 12 "$normal_json"
+assert_contains "normal closes PR" "pr close 12 --comment" "$GH_LOG"
+assert_contains "normal deletes branch" "--delete-branch" "$GH_LOG"
+assert_jq "normal appends ledger" '.ledger | length == 1' "$PR_DISPOSITION_STATE"
+assert_jq "ledger keeps reasons" '.ledger[0].reasons | index("A newer PR supersedes this implementation.") != null' "$PR_DISPOSITION_STATE"
+
+echo "PASS ${pass}/${total}"

--- a/scripts/pr-disposition/test-close-stale.sh
+++ b/scripts/pr-disposition/test-close-stale.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/bin" "$TMPDIR/company/scripts"
 export PATH="$TMPDIR/bin:$PATH"
 export PR_DISPOSITION_STATE="$TMPDIR/state.json"
+export TARGET_REPO="owner/repo"
 printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$PR_DISPOSITION_STATE"
 
 cat > "$TMPDIR/bin/gh" <<'SH'
@@ -73,8 +74,8 @@ else
   exit 1
 fi
 assert_not_contains "reject does not close" "pr close" "$GH_LOG"
-assert_contains "reject adds needs-human" "pr edit 11 --add-label needs-human" "$GH_LOG"
-assert_contains "reject comments" "pr comment 11 --body" "$GH_LOG"
+assert_contains "reject adds needs-human" "pr edit 11 --repo owner/repo --add-label needs-human" "$GH_LOG"
+assert_contains "reject comments" "pr comment 11 --repo owner/repo --body" "$GH_LOG"
 assert_jq "reject leaves ledger empty" '.ledger | length == 0' "$PR_DISPOSITION_STATE"
 
 GH_LOG="$TMPDIR/gh-close.log"
@@ -82,9 +83,27 @@ export GH_LOG
 unset PR_DISPOSITION_SANITISE
 normal_json='{"class":"stale","risk_tier":"low","reasons":["A newer PR supersedes this implementation.","CI is red."]}'
 bash "$ROOT_DIR/scripts/pr-disposition/close-stale.sh" 12 "$normal_json"
-assert_contains "normal closes PR" "pr close 12 --comment" "$GH_LOG"
+assert_contains "normal closes PR" "pr close 12 --repo owner/repo --comment" "$GH_LOG"
 assert_contains "normal deletes branch" "--delete-branch" "$GH_LOG"
 assert_jq "normal appends ledger" '.ledger | length == 1' "$PR_DISPOSITION_STATE"
 assert_jq "ledger keeps reasons" '.ledger[0].reasons | index("A newer PR supersedes this implementation.") != null' "$PR_DISPOSITION_STATE"
+
+GH_LOG="$TMPDIR/gh-unscoped.log"
+export GH_LOG
+: > "$GH_LOG"
+unset TARGET_REPO GH_REPO
+total=$((total + 1))
+if bash "$ROOT_DIR/scripts/pr-disposition/close-stale.sh" 13 "$normal_json" > "$TMPDIR/unscoped.out" 2> "$TMPDIR/unscoped.err"; then
+  echo "FAIL unscoped repo should fail" >&2
+  exit 1
+fi
+if grep -qF "TARGET_REPO or GH_REPO to be set" "$TMPDIR/unscoped.err" && [[ ! -s "$GH_LOG" ]]; then
+  pass=$((pass + 1))
+else
+  echo "FAIL unscoped repo error/log mismatch" >&2
+  cat "$TMPDIR/unscoped.err" >&2
+  cat "$GH_LOG" >&2 || true
+  exit 1
+fi
 
 echo "PASS ${pass}/${total}"

--- a/scripts/pr-disposition/test-disposition-e2e.sh
+++ b/scripts/pr-disposition/test-disposition-e2e.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+export PATH="$TMPDIR/bin:$PATH"
+export OPENROUTER_API_KEY="test-key"
+export PR_DISPOSITION_STATE="$TMPDIR/state.json"
+printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$PR_DISPOSITION_STATE"
+
+cat > "$TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number":101,"headRefOid":"sha-merge-low"},{"number":102,"headRefOid":"sha-merge-high"},{"number":103,"headRefOid":"sha-stale"},{"number":104,"headRefOid":"sha-conflict-low"},{"number":105,"headRefOid":"sha-conflict-high"},{"number":106,"headRefOid":"sha-human"},{"number":107,"headRefOid":"sha-leave"},{"number":108,"headRefOid":"sha-current"}]
+JSON
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  pr="$3"
+  if [[ "$*" == *"--jq .headRefOid"* ]]; then
+    case "$pr" in
+      101) echo "sha-merge-low" ;;
+      102) echo "sha-merge-high" ;;
+      103) echo "sha-stale" ;;
+      104) echo "sha-conflict-low" ;;
+      105) echo "sha-conflict-high" ;;
+      106) echo "sha-human" ;;
+      107) echo "sha-leave" ;;
+      108) echo "sha-current" ;;
+      *) exit 1 ;;
+    esac
+    exit 0
+  fi
+  case "$pr" in
+    101) cat <<'JSON'
+{"number":101,"title":"Merge low","mergeable":"MERGEABLE","headRefOid":"sha-merge-low","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/a.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-merge-low"}}]}
+JSON
+      ;;
+    102) cat <<'JSON'
+{"number":102,"title":"Merge high","mergeable":"MERGEABLE","headRefOid":"sha-merge-high","labels":[],"author":{"login":"operator"},"files":[{"path":"docs/customers/acme.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-merge-high"}}]}
+JSON
+      ;;
+    103) cat <<'JSON'
+{"number":103,"title":"Superseded stale","mergeable":"MERGEABLE","headRefOid":"sha-stale","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/stale.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
+JSON
+      ;;
+    104) cat <<'JSON'
+{"number":104,"title":"Conflict low","mergeable":"CONFLICTING","headRefOid":"sha-conflict-low","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/conflict.sh"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    105) cat <<'JSON'
+{"number":105,"title":"Conflict high","mergeable":"CONFLICTING","headRefOid":"sha-conflict-high","labels":[],"author":{"login":"operator"},"files":[{"path":"company/system-prompt.md"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    106) cat <<'JSON'
+{"number":106,"title":"Human","mergeable":"MERGEABLE","headRefOid":"sha-human","labels":[{"name":"needs-human"}],"author":{"login":"operator"},"files":[{"path":"scripts/human.sh"}],"statusCheckRollup":[],"reviews":[]}
+JSON
+      ;;
+    107) cat <<'JSON'
+{"number":107,"title":"Still wanted","mergeable":"MERGEABLE","headRefOid":"sha-leave","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/leave.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
+JSON
+      ;;
+    108) cat <<'JSON'
+{"number":108,"title":"Stale Copilot SHA","mergeable":"MERGEABLE","headRefOid":"sha-current","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/old-review.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-old"}}]}
+JSON
+      ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+printf '%s\n' "$*" >> "$GH_LOG"
+SH
+chmod +x "$TMPDIR/bin/gh"
+
+cat > "$TMPDIR/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+request=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -d)
+      if [[ "$2" == @* ]]; then request="${2#@}"; fi
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+if grep -q "Superseded stale" "$request"; then
+  content='{"verdict":"stale","reason":"A newer PR supersedes this work."}'
+else
+  content='{"verdict":"leave","reason":"The PR still appears wanted."}'
+fi
+jq -n --arg content "$content" '{choices:[{message:{content:$content}}]}' > "$out"
+printf '200'
+SH
+chmod +x "$TMPDIR/bin/curl"
+
+record_fingerprint() {
+  local fingerprint="$1"
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg fp "$fingerprint" \
+    '.acted_fingerprints = ((.acted_fingerprints // []) + [$fp] | unique)' \
+    "$PR_DISPOSITION_STATE" > "$tmp"
+  bash "$ROOT_DIR/company/scripts/sanitise.sh" < "$tmp" >/dev/null
+  mv "$tmp" "$PR_DISPOSITION_STATE"
+}
+
+has_fingerprint() {
+  local fingerprint="$1"
+  jq -e --arg fp "$fingerprint" '(.acted_fingerprints // []) | index($fp) != null' "$PR_DISPOSITION_STATE" >/dev/null
+}
+
+run_queue() {
+  local dry_run="$1"
+  while IFS= read -r pr; do
+    [[ -n "$pr" ]] || continue
+    local classification class sha fp comment tmp
+    classification="$(bash "$ROOT_DIR/scripts/pr-disposition/classify.sh" "$pr")"
+    class="$(jq -r '.class' <<< "$classification")"
+    sha="$(gh pr view "$pr" --json headRefOid --jq .headRefOid)"
+    fp="${pr}:${sha}:${class}"
+    if has_fingerprint "$fp"; then
+      echo "skip ${fp}"
+      continue
+    fi
+    case "$class" in
+      stale)
+        if [[ "$dry_run" == "true" ]]; then
+          echo "DRY_RUN stale ${pr}"
+        else
+          bash "$ROOT_DIR/scripts/pr-disposition/close-stale.sh" "$pr" "$classification"
+          record_fingerprint "$fp"
+        fi
+        ;;
+      human)
+        if [[ "$dry_run" == "true" ]]; then
+          echo "DRY_RUN human ${pr}"
+        else
+          comment="$(jq -r '.reasons | join("; ")' <<< "$classification")"
+          comment="PR disposition escalated for human review: ${comment}"
+          bash "$ROOT_DIR/company/scripts/sanitise.sh" <<< "$comment" >/dev/null
+          gh pr edit "$pr" --add-label needs-human
+          gh pr comment "$pr" --body "$comment"
+          record_fingerprint "$fp"
+        fi
+        ;;
+      merge-low|merge-high|conflict-low|conflict-high)
+        echo "DRY_RUN ${class} ${pr}"
+        ;;
+      leave)
+        :
+        ;;
+      *)
+        echo "unknown class ${class}" >&2
+        exit 1
+        ;;
+    esac
+  done < <(gh pr list --state open --json number,headRefOid | jq -r '.[].number')
+}
+
+pass=0
+total=0
+
+assert_log_contains() {
+  local name="$1" needle="$2"
+  total=$((total + 1))
+  if grep -qF -- "$needle" "$GH_LOG"; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: missing ${needle}" >&2
+    cat "$GH_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+assert_log_not_contains() {
+  local name="$1" needle="$2"
+  total=$((total + 1))
+  if ! grep -qF -- "$needle" "$GH_LOG" 2>/dev/null; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: unexpected ${needle}" >&2
+    cat "$GH_LOG" >&2
+    exit 1
+  fi
+}
+
+assert_output_contains() {
+  local name="$1" needle="$2" file="$3"
+  total=$((total + 1))
+  if grep -qF -- "$needle" "$file"; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: missing ${needle}" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_jq() {
+  local name="$1" expr="$2"
+  total=$((total + 1))
+  if jq -e "$expr" "$PR_DISPOSITION_STATE" >/dev/null; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: jq ${expr}" >&2
+    cat "$PR_DISPOSITION_STATE" >&2
+    exit 1
+  fi
+}
+
+export GH_LOG="$TMPDIR/gh.log"
+: > "$GH_LOG"
+run_queue false > "$TMPDIR/run1.out"
+assert_log_contains "stale is closed" "pr close 103 --comment"
+assert_log_contains "human gets needs-human label" "pr edit 106 --add-label needs-human"
+assert_log_not_contains "no merge command" "pr merge"
+assert_log_not_contains "no edit merge command" "--merge"
+assert_output_contains "merge-low print only" "DRY_RUN merge-low 101" "$TMPDIR/run1.out"
+assert_output_contains "merge-high print only" "DRY_RUN merge-high 102" "$TMPDIR/run1.out"
+assert_output_contains "conflict-low print only" "DRY_RUN conflict-low 104" "$TMPDIR/run1.out"
+assert_output_contains "conflict-high print only" "DRY_RUN conflict-high 105" "$TMPDIR/run1.out"
+leave_json="$(bash "$ROOT_DIR/scripts/pr-disposition/classify.sh" 108)"
+total=$((total + 1))
+if [[ "$(jq -r '.class' <<< "$leave_json")" == "leave" ]]; then
+  pass=$((pass + 1))
+else
+  echo "FAIL stale Copilot SHA classified as merge: ${leave_json}" >&2
+  exit 1
+fi
+assert_jq "stale fingerprint recorded" '(.acted_fingerprints // []) | index("103:sha-stale:stale") != null'
+assert_jq "human fingerprint recorded" '(.acted_fingerprints // []) | index("106:sha-human:human") != null'
+
+before="$(wc -l < "$GH_LOG" | tr -d ' ')"
+run_queue false > "$TMPDIR/run2.out"
+after="$(wc -l < "$GH_LOG" | tr -d ' ')"
+total=$((total + 1))
+if [[ "$before" == "$after" ]]; then
+  pass=$((pass + 1))
+else
+  echo "FAIL idempotency: expected no second-run mutations" >&2
+  exit 1
+fi
+
+printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$PR_DISPOSITION_STATE"
+: > "$GH_LOG"
+run_queue true > "$TMPDIR/dry.out"
+assert_log_not_contains "dry run has no close" "pr close"
+assert_log_not_contains "dry run has no edit" "pr edit"
+assert_log_not_contains "dry run has no comment" "pr comment"
+assert_jq "dry run leaves state empty" '(.ledger | length == 0) and (.acted_fingerprints | length == 0)'
+
+echo "PASS ${pass}/${total}"

--- a/scripts/pr-disposition/test-disposition-e2e.sh
+++ b/scripts/pr-disposition/test-disposition-e2e.sh
@@ -10,6 +10,7 @@ mkdir -p "$TMPDIR/bin"
 export PATH="$TMPDIR/bin:$PATH"
 export OPENROUTER_API_KEY="test-key"
 export PR_DISPOSITION_STATE="$TMPDIR/state.json"
+export GH_REPO="owner/repo"
 printf '{"ledger":[],"acted_fingerprints":[]}\n' > "$PR_DISPOSITION_STATE"
 
 cat > "$TMPDIR/bin/gh" <<'SH'
@@ -17,7 +18,7 @@ cat > "$TMPDIR/bin/gh" <<'SH'
 set -euo pipefail
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
   cat <<'JSON'
-[{"number":101,"headRefOid":"sha-merge-low"},{"number":102,"headRefOid":"sha-merge-high"},{"number":103,"headRefOid":"sha-stale"},{"number":104,"headRefOid":"sha-conflict-low"},{"number":105,"headRefOid":"sha-conflict-high"},{"number":106,"headRefOid":"sha-human"},{"number":107,"headRefOid":"sha-leave"},{"number":108,"headRefOid":"sha-current"}]
+[{"number":101,"headRefOid":"sha-merge-low"},{"number":102,"headRefOid":"sha-merge-high"},{"number":103,"headRefOid":"sha-stale"},{"number":104,"headRefOid":"sha-conflict-low"},{"number":105,"headRefOid":"sha-conflict-high"},{"number":106,"headRefOid":"sha-human"},{"number":107,"headRefOid":"sha-leave"},{"number":108,"headRefOid":"sha-current"},{"number":109,"headRefOid":"sha-list-stale"}]
 JSON
   exit 0
 fi
@@ -33,6 +34,7 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
       106) echo "sha-human" ;;
       107) echo "sha-leave" ;;
       108) echo "sha-current" ;;
+      109) echo "sha-classified-stale" ;;
       *) exit 1 ;;
     esac
     exit 0
@@ -70,6 +72,10 @@ JSON
 {"number":108,"title":"Stale Copilot SHA","mergeable":"MERGEABLE","headRefOid":"sha-current","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/old-review.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"Copilot"},"state":"COMMENTED","body":"CLEAN","commit":{"oid":"sha-old"}}]}
 JSON
       ;;
+    109) cat <<'JSON'
+{"number":109,"title":"Superseded after list","mergeable":"MERGEABLE","headRefOid":"sha-classified-stale","labels":[],"author":{"login":"operator"},"files":[{"path":"scripts/stale-after-list.sh"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"FAILURE"}],"reviews":[]}
+JSON
+      ;;
     *) exit 1 ;;
   esac
   exit 0
@@ -93,7 +99,7 @@ while [[ $# -gt 0 ]]; do
     *) shift ;;
   esac
 done
-if grep -q "Superseded stale" "$request"; then
+if grep -q "Superseded" "$request"; then
   content='{"verdict":"stale","reason":"A newer PR supersedes this work."}'
 else
   content='{"verdict":"leave","reason":"The PR still appears wanted."}'
@@ -121,12 +127,13 @@ has_fingerprint() {
 
 run_queue() {
   local dry_run="$1"
-  while IFS= read -r pr; do
-    [[ -n "$pr" ]] || continue
-    local classification class sha fp comment tmp
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    local pr classification class sha fp comment tmp
+    pr="$(jq -r '.number' <<< "$row")"
     classification="$(bash "$ROOT_DIR/scripts/pr-disposition/classify.sh" "$pr")"
     class="$(jq -r '.class' <<< "$classification")"
-    sha="$(gh pr view "$pr" --json headRefOid --jq .headRefOid)"
+    sha="$(jq -r '.headRefOid // ""' <<< "$classification")"
     fp="${pr}:${sha}:${class}"
     if has_fingerprint "$fp"; then
       echo "skip ${fp}"
@@ -148,8 +155,8 @@ run_queue() {
           comment="$(jq -r '.reasons | join("; ")' <<< "$classification")"
           comment="PR disposition escalated for human review: ${comment}"
           bash "$ROOT_DIR/company/scripts/sanitise.sh" <<< "$comment" >/dev/null
-          gh pr edit "$pr" --add-label needs-human
-          gh pr comment "$pr" --body "$comment"
+          gh pr edit "$pr" --repo "$GH_REPO" --add-label needs-human
+          gh pr comment "$pr" --repo "$GH_REPO" --body "$comment"
           record_fingerprint "$fp"
         fi
         ;;
@@ -164,7 +171,7 @@ run_queue() {
         exit 1
         ;;
     esac
-  done < <(gh pr list --state open --json number,headRefOid | jq -r '.[].number')
+  done < <(gh pr list --repo "$GH_REPO" --state open --json number,headRefOid | jq -c '.[]')
 }
 
 pass=0
@@ -221,8 +228,8 @@ assert_jq() {
 export GH_LOG="$TMPDIR/gh.log"
 : > "$GH_LOG"
 run_queue false > "$TMPDIR/run1.out"
-assert_log_contains "stale is closed" "pr close 103 --comment"
-assert_log_contains "human gets needs-human label" "pr edit 106 --add-label needs-human"
+assert_log_contains "stale is closed" "pr close 103 --repo owner/repo --comment"
+assert_log_contains "human gets needs-human label" "pr edit 106 --repo owner/repo --add-label needs-human"
 assert_log_not_contains "no merge command" "pr merge"
 assert_log_not_contains "no edit merge command" "--merge"
 assert_output_contains "merge-low print only" "DRY_RUN merge-low 101" "$TMPDIR/run1.out"
@@ -239,6 +246,8 @@ else
 fi
 assert_jq "stale fingerprint recorded" '(.acted_fingerprints // []) | index("103:sha-stale:stale") != null'
 assert_jq "human fingerprint recorded" '(.acted_fingerprints // []) | index("106:sha-human:human") != null'
+assert_jq "fingerprint uses classified SHA" '(.acted_fingerprints // []) | index("109:sha-classified-stale:stale") != null'
+assert_jq "fingerprint ignores list SHA" '(.acted_fingerprints // []) | index("109:sha-list-stale:stale") == null'
 
 before="$(wc -l < "$GH_LOG" | tr -d ' ')"
 run_queue false > "$TMPDIR/run2.out"

--- a/scripts/pr-disposition/test-risk-tier.sh
+++ b/scripts/pr-disposition/test-risk-tier.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+CONFIG="$TMPDIR/config.local.yaml"
+cat > "$CONFIG" <<'YAML'
+pr_disposition_high_risk_paths:
+  - '^private-risk/'
+YAML
+
+export PR_DISPOSITION_CONFIG="$CONFIG"
+
+pass=0
+total=0
+
+assert_tier() {
+  local name="$1" expected="$2" input="$3"
+  total=$((total + 1))
+  local actual
+  actual=$(printf '%s' "$input" | bash "$ROOT_DIR/scripts/pr-disposition/risk-tier.sh")
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$((pass + 1))
+  else
+    echo "FAIL ${name}: expected ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_tier "plain docs are low" "low" $'docs/README.md\nscripts/check.sh\n'
+assert_tier "outreach docs are high" "high" $'docs/outreach/prospect.md\n'
+assert_tier "customer docs are high" "high" $'docs/customers/acme.md\n'
+assert_tier "system prompt is high" "high" $'company/system-prompt.md\n'
+assert_tier "auth path is high" "high" $'src/auth/login.ts\n'
+assert_tier "secret filename is high" "high" $'ops/secret-rotation.md\n'
+assert_tier "payment path is high" "high" $'services/payments/stripe.ts\n'
+assert_tier "config override is high" "high" $'private-risk/notes.md\n'
+assert_tier "empty list is low" "low" ''
+
+echo "PASS ${pass}/${total}"


### PR DESCRIPTION
Phase 1 of the autonomous PR-disposition step (plan: `docs/plans/2026-06-06-001-feat-autonomous-pr-disposition-plan.md`). **Classification + stale-close only — never merges or rebases.** Merge/conflict classes are Phase-2 dry-run placeholders.

## Why
`pr_dwell_violations` is a KPI with no actor — two pulses showed the identical 34 dwelling PRs. This is the actor. Phase 1 ships the safe half (classify + reasoned-close + escalate) and proves classification on the real queue before Phase 2 turns on merge authority.

## What ships
- `scripts/pr-disposition/risk-tier.sh` — high/low path tiering (seeded from PII-policy regex)
- `scripts/pr-disposition/classify.sh` + `company/pr-disposition-system-prompt.md` — mechanical signals + LLM stale-judgment only. **Guardrail: a Copilot review whose SHA ≠ current head is STALE, never counts as CLEAN.**
- `scripts/pr-disposition/close-stale.sh` — sanitise-gated reasoned-close (processed, not discarded)
- `.github/workflows/pr-disposition.yml` — cron 6h + `dry_run`; merge/conflict = print-only placeholders
- `company/pr-disposition-state.json` — ledger + idempotency fingerprints (`PR#+headSHA+class`)

## Safety
- Does NOT modify `company/scripts/pr-review-merge.sh` (Phase 2).
- merge-low/merge-high/conflict-* → log intent, mutate nothing.
- sanitise gating on every published/committed LLM-derived string.
- Idempotent per `PR#+headSHA+class`; state-commit gated on material-change sentinel.

## Test plan
- [x] 41 scenarios across 4 harnesses (risk-tier 9, classify 8, close-stale 8, e2e 16) — **PASS 41/41**, run independently
- [x] actionlint clean, sanitise accepts state file, pr-review-merge.sh untouched
- [ ] Post-merge: `dry_run=true` dispatch on main → inspect how it classifies the real ~18-PR queue before Phase 2

## Follow-up (Phase 2)
U3 merge-authority extension (operator PRs, tiered) + U5 auto-rebase. Turns on only after Phase 1 classification is proven.