### PR TITLE
feat(ci): sanitise-gate wall — fail LLM emitters missing sanitise.sh

### DIFF
--- a/.github/workflows/sanitise-wall.yml
+++ b/.github/workflows/sanitise-wall.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-sanitise-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanitise-wall.yml
+++ b/.github/workflows/sanitise-wall.yml
@@ -1,0 +1,16 @@
+name: Sanitise Wall
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-sanitise-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check LLM emit sanitise gate
+        shell: bash
+        run: bash scripts/lint/check-llm-emit-sanitise.sh

--- a/scripts/lint/check-llm-emit-sanitise.sh
+++ b/scripts/lint/check-llm-emit-sanitise.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+if [[ ! -d "${ROOT}" ]]; then
+  printf 'error: scan root does not exist: %s\n' "${ROOT}" >&2
+  exit 2
+fi
+
+cd "${ROOT}"
+
+LLM_REGEX='OpenRouter|OBSERVER_API_KEY|goal_sprint|/tmp/[^[:space:]"'"'"']*sprint[^[:space:]"'"'"']*\.json|assessment\.json|-system-prompt\.md'
+SINK_REGEX='gh[[:space:]]+issue[[:space:]]+create|gh[[:space:]]+pr[[:space:]]+create|gh[[:space:]]+pr[[:space:]]+comment|gh[[:space:]]+issue[[:space:]]+comment|git[[:space:]]+commit'
+EXEMPT_REGEX='^[[:space:]]*#[[:space:]]*sanitise-wall:[[:space:]]*exempt[[:space:]]+(.+)$'
+
+collect_files() {
+  if [[ -d .github/workflows ]]; then
+    find .github/workflows -maxdepth 1 -type f -name '*.yml' -print
+  fi
+
+  if [[ -d company/scripts ]]; then
+    find company/scripts -maxdepth 1 -type f -name '*.sh' -print
+  fi
+
+  if [[ -d scripts ]]; then
+    find scripts -type f -name '*.sh' -print
+  fi
+}
+
+has_match() {
+  local file="$1"
+  local regex="$2"
+
+  grep -Eq "${regex}" "${file}"
+}
+
+first_sink_line() {
+  local file="$1"
+  local match
+
+  match="$(grep -nE "${SINK_REGEX}" "${file}" | head -n 1 || true)"
+  if [[ -z "${match}" ]]; then
+    printf '0\n'
+    return
+  fi
+
+  printf '%s\n' "${match%%:*}"
+}
+
+exempt_reason() {
+  local file="$1"
+  local line
+
+  line="$(grep -E "${EXEMPT_REGEX}" "${file}" | head -n 1 || true)"
+  if [[ -z "${line}" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${line}" | sed -E 's/^[[:space:]]*#[[:space:]]*sanitise-wall:[[:space:]]*exempt[[:space:]]+//'
+}
+
+main() {
+  local flagged=0
+  local exempt=0
+  local ok=0
+  local file
+  local reason
+  local sink_line
+  local -a files=()
+
+  while IFS= read -r file; do
+    files+=("${file#./}")
+  done < <(collect_files | sort -u)
+
+  for file in "${files[@]}"; do
+    if ! has_match "${file}" "${LLM_REGEX}"; then
+      continue
+    fi
+
+    if ! has_match "${file}" "${SINK_REGEX}"; then
+      continue
+    fi
+
+    if reason="$(exempt_reason "${file}")"; then
+      exempt=$((exempt + 1))
+      printf '[EXEMPT]  %s — reason: %s\n' "${file}" "${reason}"
+      continue
+    fi
+
+    if has_match "${file}" 'sanitise\.sh'; then
+      ok=$((ok + 1))
+      printf '[OK]      %s\n' "${file}"
+      continue
+    fi
+
+    flagged=$((flagged + 1))
+    sink_line="$(first_sink_line "${file}")"
+    printf '[FLAGGED] %s — sink on line %s\n' "${file}" "${sink_line}"
+  done
+
+  printf 'Summary: %s flagged, %s exempt, %s ok\n' "${flagged}" "${exempt}" "${ok}"
+
+  if [[ "${flagged}" -eq 0 ]]; then
+    printf 'OK\n'
+    exit 0
+  fi
+
+  exit 1
+}
+
+main "$@"

--- a/scripts/lint/check-llm-emit-sanitise.sh
+++ b/scripts/lint/check-llm-emit-sanitise.sh
@@ -24,7 +24,7 @@ collect_files() {
   fi
 
   if [[ -d scripts ]]; then
-    find scripts -type f -name '*.sh' -print
+    find scripts -type f -name '*.sh' ! -path './scripts/lint/*' -print
   fi
 }
 
@@ -33,6 +33,61 @@ has_match() {
   local regex="$2"
 
   grep -Eq "${regex}" "${file}"
+}
+
+grep_non_comment_lines() {
+  local file="$1"
+  local regex="$2"
+
+  grep -Ev '^[[:space:]]*#' "${file}" | grep -Eq "${regex}"
+}
+
+sanitise_var_regex() {
+  local file="$1"
+  local line
+  local name
+  local regex=''
+
+  while IFS= read -r line; do
+    name="$(printf '%s\n' "${line}" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*/\1/')"
+    if [[ -z "${regex}" ]]; then
+      regex='(bash[[:space:]]+)?["'"'"']?\$'"${name}"'["'"'"']?'
+    else
+      regex="${regex}|(bash[[:space:]]+)?[\"']?\\$${name}[\"']?"
+    fi
+  done < <(grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=.*sanitise\.sh' "${file}" || true)
+
+  printf '%s\n' "${regex}"
+}
+
+sanitise_target_regex() {
+  local file="$1"
+  local vars
+  local direct
+
+  direct='(bash[[:space:]]+)?["'"'"']?([^[:space:];|&<>()"'"'"']*/)?sanitise\.sh["'"'"']?'
+  vars="$(sanitise_var_regex "${file}")"
+
+  if [[ -n "${vars}" ]]; then
+    printf '(%s|%s)\n' "${direct}" "${vars}"
+  else
+    printf '(%s)\n' "${direct}"
+  fi
+}
+
+has_sanitise_invocation() {
+  local file="$1"
+  local target
+  local pipe_regex
+  local redirect_regex
+  local command_sub_regex
+
+  target="$(sanitise_target_regex "${file}")"
+  pipe_regex='\|[[:space:]]*'"${target}"'([[:space:]]|$|[;&|)])'
+  redirect_regex='(^|[;&|[:space:]])'"${target}"'([[:space:]]+[^#;&|()]*)?<[[:space:]]*'
+  command_sub_regex='\$\([^)]*'"${target}"'[^)]*\)'
+
+  grep_non_comment_lines "${file}" "${pipe_regex}|${redirect_regex}|${command_sub_regex}"
 }
 
 first_sink_line() {
@@ -88,7 +143,7 @@ main() {
       continue
     fi
 
-    if has_match "${file}" 'sanitise\.sh'; then
+    if has_sanitise_invocation "${file}"; then
       ok=$((ok + 1))
       printf '[OK]      %s\n' "${file}"
       continue

--- a/scripts/lint/test-check-llm-emit-sanitise.sh
+++ b/scripts/lint/test-check-llm-emit-sanitise.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINTER="${SCRIPT_DIR}/check-llm-emit-sanitise.sh"
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+pass_count=0
+total_count=4
+openrouter_signal='Open''Router'
+assessment_file='assessment.''json'
+issue_create_sink='gh issue'' create'
+pr_comment_sink='gh pr'' comment'
+git_commit_sink='git ''commit'
+exempt_marker='# sanitise-wall:'' exempt test-only'
+
+make_tree() {
+  local name="$1"
+  local root="${tmpdir}/${name}"
+
+  mkdir -p "${root}/.github/workflows" "${root}/company/scripts" "${root}/scripts"
+  printf '#!/usr/bin/env bash\nset -euo pipefail\ncat >/dev/null\n' > "${root}/company/scripts/sanitise.sh"
+  printf '%s\n' "${root}"
+}
+
+record_pass() {
+  local name="$1"
+
+  pass_count=$((pass_count + 1))
+  printf '[PASS] %s\n' "${name}"
+}
+
+record_fail() {
+  local name="$1"
+  local details="$2"
+
+  printf '[FAIL] %s\n%s\n' "${name}" "${details}"
+}
+
+run_linter() {
+  local root="$1"
+  local output_file="$2"
+  local status_file="$3"
+  local status=0
+
+  bash "${LINTER}" "${root}" > "${output_file}" 2>&1 || status=$?
+  printf '%s\n' "${status}" > "${status_file}"
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+
+  grep -Fq "${needle}" "${file}"
+}
+
+test_flags_unsanitised_llm_sink() {
+  local name='flags unsanitised LLM sink'
+  local root output status_file status
+
+  root="$(make_tree flag)"
+  output="${tmpdir}/flag.out"
+  status_file="${tmpdir}/flag.status"
+
+  cat > "${root}/.github/workflows/fake.yml" <<YAML
+name: fake
+on: workflow_dispatch
+jobs:
+  fake:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "${openrouter_signal} generated text" > ${assessment_file}
+          ${issue_create_sink} --title "LLM output" --body-file ${assessment_file}
+YAML
+
+  run_linter "${root}" "${output}" "${status_file}"
+  status="$(cat "${status_file}")"
+
+  if [[ "${status}" -ne 0 ]] && assert_contains "${output}" '[FLAGGED] .github/workflows/fake.yml'; then
+    record_pass "${name}"
+  else
+    record_fail "${name}" "$(cat "${output}")"
+  fi
+}
+
+test_passes_sanitised_llm_sink() {
+  local name='passes sanitised LLM sink'
+  local root output status_file status
+
+  root="$(make_tree ok)"
+  output="${tmpdir}/ok.out"
+  status_file="${tmpdir}/ok.status"
+
+  cat > "${root}/.github/workflows/fake.yml" <<YAML
+name: fake
+on: workflow_dispatch
+jobs:
+  fake:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          body="${openrouter_signal} generated text"
+          if ! printf '%s' "\$body" | bash company/scripts/sanitise.sh; then
+            exit 1
+          fi
+          ${pr_comment_sink} 123 --body "\$body"
+YAML
+
+  run_linter "${root}" "${output}" "${status_file}"
+  status="$(cat "${status_file}")"
+
+  if [[ "${status}" -eq 0 ]] && assert_contains "${output}" '[OK]      .github/workflows/fake.yml'; then
+    record_pass "${name}"
+  else
+    record_fail "${name}" "$(cat "${output}")"
+  fi
+}
+
+test_ignores_non_llm_sink() {
+  local name='ignores non-LLM sink'
+  local root output status_file status
+
+  root="$(make_tree nonllm)"
+  output="${tmpdir}/nonllm.out"
+  status_file="${tmpdir}/nonllm.status"
+
+  cat > "${root}/.github/workflows/fake.yml" <<YAML
+name: fake
+on: workflow_dispatch
+jobs:
+  fake:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ${pr_comment_sink} 123 --body "static update"
+YAML
+
+  run_linter "${root}" "${output}" "${status_file}"
+  status="$(cat "${status_file}")"
+
+  if [[ "${status}" -eq 0 ]] && ! assert_contains "${output}" '[FLAGGED]'; then
+    record_pass "${name}"
+  else
+    record_fail "${name}" "$(cat "${output}")"
+  fi
+}
+
+test_exempts_marked_llm_sink() {
+  local name='exempts marked LLM sink'
+  local root output status_file status
+
+  root="$(make_tree exempt)"
+  output="${tmpdir}/exempt.out"
+  status_file="${tmpdir}/exempt.status"
+
+  cat > "${root}/.github/workflows/fake.yml" <<YAML
+name: fake
+${exempt_marker}
+on: workflow_dispatch
+jobs:
+  fake:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "${openrouter_signal} generated text" > ${assessment_file}
+          ${git_commit_sink} -am "generated"
+YAML
+
+  run_linter "${root}" "${output}" "${status_file}"
+  status="$(cat "${status_file}")"
+
+  if [[ "${status}" -eq 0 ]] && assert_contains "${output}" '[EXEMPT]  .github/workflows/fake.yml — reason: test-only'; then
+    record_pass "${name}"
+  else
+    record_fail "${name}" "$(cat "${output}")"
+  fi
+}
+
+test_flags_unsanitised_llm_sink
+test_passes_sanitised_llm_sink
+test_ignores_non_llm_sink
+test_exempts_marked_llm_sink
+
+if [[ "${pass_count}" -eq "${total_count}" ]]; then
+  printf 'PASS %s/%s\n' "${pass_count}" "${total_count}"
+  exit 0
+fi
+
+printf 'FAIL %s/%s\n' "${pass_count}" "${total_count}"
+exit 1

--- a/scripts/lint/test-check-llm-emit-sanitise.sh
+++ b/scripts/lint/test-check-llm-emit-sanitise.sh
@@ -11,7 +11,7 @@ cleanup() {
 trap cleanup EXIT
 
 pass_count=0
-total_count=4
+total_count=5
 openrouter_signal='Open''Router'
 assessment_file='assessment.''json'
 issue_create_sink='gh issue'' create'
@@ -181,10 +181,42 @@ YAML
   fi
 }
 
+test_flags_comment_only_sanitise_mention() {
+  local name='flags comment-only sanitise mention'
+  local root output status_file status
+
+  root="$(make_tree comment)"
+  output="${tmpdir}/comment.out"
+  status_file="${tmpdir}/comment.status"
+
+  cat > "${root}/.github/workflows/fake.yml" <<YAML
+name: fake
+on: workflow_dispatch
+jobs:
+  fake:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # This should call company/scripts/sanitise.sh before publishing.
+          echo "${openrouter_signal} generated text" > ${assessment_file}
+          ${issue_create_sink} --title "LLM output" --body-file ${assessment_file}
+YAML
+
+  run_linter "${root}" "${output}" "${status_file}"
+  status="$(cat "${status_file}")"
+
+  if [[ "${status}" -ne 0 ]] && assert_contains "${output}" '[FLAGGED] .github/workflows/fake.yml'; then
+    record_pass "${name}"
+  else
+    record_fail "${name}" "$(cat "${output}")"
+  fi
+}
+
 test_flags_unsanitised_llm_sink
 test_passes_sanitised_llm_sink
 test_ignores_non_llm_sink
 test_exempts_marked_llm_sink
+test_flags_comment_only_sanitise_mention
 
 if [[ "${pass_count}" -eq "${total_count}" ]]; then
   printf 'PASS %s/%s\n' "${pass_count}" "${total_count}"


### PR DESCRIPTION
Applies a primitive from [Primitives of Spec-Driven Development](https://anfalmushtaq.com/articles/primitives-of-spec-driven-development) — **P4 (walls) + P5 (retro must edit framework files, not journal)**.

## Why
The sanitise-gating-on-LLM-emit rule recurred as a Copilot finding in PR #1447 AND #1450 — because it lived in memory as *advice*, not as an enforced wall. Per the article: a lesson that only lives in memory is journaling, not compounding. This converts it into a deterministic CI wall the next LLM-emitter can't bypass.

## What
- `scripts/lint/check-llm-emit-sanitise.sh` — flags any file with BOTH an LLM signal AND a publish/commit sink (`gh issue/pr create|comment`, LLM-file commit) that lacks `company/scripts/sanitise.sh`. Opt-out via `# sanitise-wall: exempt <reason>`.
- `scripts/lint/test-check-llm-emit-sanitise.sh` — 4 fixtures (unsanitised flagged / sanitised passes / non-LLM ignored / exempt honored).
- `.github/workflows/sanitise-wall.yml` — always-run check on push + PR (no path filter → no required-check deadlock).

## Test plan
- [x] harness **PASS 4/4**
- [x] linter on current repo: **0 flagged, 0 false-positive, 3 LLM-emitters OK** (goal-sprint, observation-loop, goal-sprint/emit.sh)