### PR TITLE
fix(ci): pr-disposition commits state via PR (was failing GH013 on protected main)

### DIFF
--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-  HAS_APP_CREDS: ${{ secrets.GITHUB_APP_ID != '' && secrets.GITHUB_APP_PRIVATE_KEY != '' }}
+  HAS_APP_CREDS: ${{ vars.APP_ID != '' && secrets.APP_PRIVATE_KEY != '' }}
 
 jobs:
   disposition:
@@ -37,8 +37,8 @@ jobs:
         if: env.HAS_APP_CREDS == 'true'
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GITHUB_APP_ID }}
-          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Select GitHub token
         run: |
@@ -208,5 +208,16 @@ jobs:
           git config user.email "pupabobas[bot]@users.noreply.github.com"
           git add company/pr-disposition-state.json
           git diff --cached --quiet && echo "No state changes to commit" && exit 0
-          git commit -m "chore(pr-disposition): update state"
-          git push
+
+          today=$(date -u '+%Y-%m-%d')
+          branch="pr-disposition/${today}-${GITHUB_RUN_ID}"
+          git checkout -b "$branch" origin/main
+          git commit -m "chore(pr-disposition): update state $today"
+          git push -u origin "$branch"
+
+          pr_url=$(gh pr create \
+            --title "chore(pr-disposition): update state $today" \
+            --body "Automated PR-disposition state update." \
+            --base main \
+            --head "$branch")
+          echo "Opened state PR: $pr_url"


### PR DESCRIPTION
## Why

The self-repo PR closer/router (`pr-disposition.yml`, 6h cron) failed **every live run**:
```
remote: error: GH013: Repository rule violations found for refs/heads/main
error: failed to push some refs
```
Its "Commit state" step pushed `company/pr-disposition-state.json` directly to protected `main`. The labeling/commenting (gh API) worked, but state never persisted — so the loop had no memory of `acted_fingerprints` and re-processed the same PRs on every run while exiting red. `HAS_APP_CREDS` also checked `secrets.GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`, but the repo uses `vars.APP_ID`/`secrets.APP_PRIVATE_KEY` — so it never acquired an app token.

## What

- Commit state via a `pr-disposition/<date>-<run>` branch + PR, mirroring the working `pipeline-health.yml` pattern. A feature-branch push isn't blocked by the main ruleset.
- Fix the app-token cred refs to `vars.APP_ID` / `secrets.APP_PRIVATE_KEY`.

Found while diagnosing why 15 open PRs / 8 issues weren't draining: the loop *was* correctly routing operator/Copilot PRs to `needs-human` and auto-closed #870, but couldn't persist its decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)