### PR TITLE
fix(ci): supervisor-rank publishes via GITHUB_TOKEN, not app token

### DIFF
--- a/.github/workflows/supervisor-rank.yml
+++ b/.github/workflows/supervisor-rank.yml
@@ -80,7 +80,16 @@ jobs:
       - name: Publish supervisor rank
         if: steps.script-guard.outputs.present == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Use the default GITHUB_TOKEN (issues: write granted via the permissions
+          # block above), NOT the GitHub App token. The app installation has
+          # contents:write but lost issues:write (~2026-06-05 20:00Z), so
+          # `gh issue edit` of the anchor issue fails with "Resource not accessible
+          # by integration (updateIssue)". publish-rank.sh does only issue ops
+          # (list/create/edit/close/comment) on this repo, all covered by
+          # GITHUB_TOKEN. Keeps the supervisor self-publishing regardless of
+          # app-permission drift. Snapshot (cross-repo wgmesh read) and Commit
+          # (app identity for protected main) intentionally stay on the app token.
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

`Supervisor Rank` workflow's **Publish** step now uses the default `GITHUB_TOKEN` instead of the GitHub App token for issue operations.

## Why

Pulse 2026-06-06 flagged `Supervisor Rank` failing 4×/window:
```
failed to update .../issues/934: GraphQL: Resource not accessible by integration (updateIssue)
```

Root cause (not #1441):
- Last success **2026-06-05 17:54Z**, first failure **21:25Z**.
- `#1441` (publish-rank dedup) merged **22:14Z** — *after* failures began. `.yml` token block unchanged since day 1 (#930). #1441 exonerated.
- `pipeline-health` committed state via the app at 08:51Z today ✅ → the app still has **contents:write** but **lost issues:write** (~06-05 20:00Z). It created #934 on 05-15 when it still had the scope.

## Fix

`publish-rank.sh` does only issue ops (list/create/edit/close/comment) on this repo — all covered by `GITHUB_TOKEN`'s `issues: write` (already granted in the `permissions:` block). Route the Publish step through `github.token` so the supervisor self-publishes regardless of app-permission drift.

- **Snapshot** stays on app token (cross-repo wgmesh read).
- **Commit** stays on app token (app identity for protected-main PR).

## Test plan

- [x] `bash .github/scripts/test-publish.sh` → 10 scenarios PASS
- [x] YAML valid
- [ ] Next scheduled run (cron `0 */4 * * *`) publishes #934 green; `supervisor-rank-state.json` issue_number persists