### PR TITLE
fix(ci): fix heartbeat fast-lane routing for 3 dwelling state/audit PRs

### DIFF
--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -18,6 +18,8 @@ jobs:
     if: >-
       startsWith(github.event.pull_request.title, 'loop: ') ||
       startsWith(github.event.pull_request.title, 'heal: ') ||
+      startsWith(github.event.pull_request.title, 'chore: supervisor-rank state ') ||
+      startsWith(github.event.pull_request.title, 'chore(pr-disposition): update state ') ||
       (startsWith(github.event.pull_request.title, 'audit: strategy baseline') &&
        !contains(github.event.pull_request.labels.*.name, 'needs-human'))
     runs-on: ubuntu-latest
@@ -78,6 +80,12 @@ jobs:
             heal:*)
               expected_branch='^pipeline-health/'
               ;;
+            'chore: supervisor-rank state'*)
+              expected_branch='^supervisor-rank/state-'
+              ;;
+            'chore(pr-disposition): update state'*)
+              expected_branch='^pr-disposition/'
+              ;;
             'audit: strategy baseline'*)
               expected_branch='^audit/strategy-baseline-'
               ;;
@@ -94,7 +102,7 @@ jobs:
 
           for path in "${changed_files[@]}"; do
             case "$path" in
-              company/loop-state.json|company/pipeline-health-state.json|company/audit-log.jsonl|company/strategy-audit-baseline.json)
+              company/loop-state.json|company/pipeline-health-state.json|company/audit-log.jsonl|company/strategy-audit-baseline.json|company/supervisor-rank-state.json|company/pr-disposition-state.json)
                 ;;
               company/loop-history/*.md)
                 ;;
@@ -126,7 +134,7 @@ jobs:
 
           for path in "${changed_files[@]}"; do
             case "$path" in
-              company/loop-state.json|company/pipeline-health-state.json|company/strategy-audit-baseline.json)
+              company/loop-state.json|company/pipeline-health-state.json|company/strategy-audit-baseline.json|company/supervisor-rank-state.json|company/pr-disposition-state.json)
                 jq empty "$path"
                 ;;
               company/audit-log.jsonl)

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -87,7 +87,11 @@ jobs:
               expected_branch='^pr-disposition/'
               ;;
             'audit: strategy baseline'*)
-              expected_branch='^audit/strategy-baseline-'
+              # strategy-audit.yml pushes the rolling telemetry PR to the fixed
+              # branch `audit/baseline-telemetry` (not `audit/strategy-baseline-*`).
+              # The old regex never matched, so the telemetry PR (e.g. #1468) always
+              # failed this scope gate. Match the actual branch name.
+              expected_branch='^audit/baseline-telemetry'
               ;;
             *)
               echo "::error::PR title does not match heartbeat prefixes: $PR_TITLE"

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -63,6 +63,22 @@ jobs:
               ;;
           esac
 
+          # Hard author gate for the supervisor-rank / pr-disposition state lanes:
+          # these are the only producers of those state files, so a non-bot
+          # same-repo PR matching the title+branch+file-scope must NOT ride the
+          # admin-bypass merge. (Copilot review on #1470.)
+          case "$PR_TITLE" in
+            'chore: supervisor-rank state'*|'chore(pr-disposition): update state'*)
+              case "$PR_AUTHOR" in
+                pupabobas[bot]|app/pupabobas) ;;
+                *)
+                  echo "::error::state-PR fast-lane requires pupabobas[bot] author; got '$PR_AUTHOR'"
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+
           changed_files=()
           while IFS= read -r path; do
             [ -n "$path" ] && changed_files+=("$path")


### PR DESCRIPTION
## What

Three fixes to `heartbeat-pr-automerge.yml` so machine-state PRs stop dwelling BLOCKED.

## Why (pulses 2026-06-06)

The heartbeat fast-lane (`--admin` merge, no Copilot review, gated by file-scope + sanitise + JSON-valid + size + branch-pattern) is the designed home for machine-written state PRs. Three classes leaked out of it and piled open:

1. **supervisor-rank** state PRs (`chore: supervisor-rank state …`, #1467) — not wired into the lane.
2. **pr-disposition** state PRs (`chore(pr-disposition): update state …`, #1463) — not wired in.
3. **audit baseline telemetry** PR (`audit: strategy baseline telemetry`, #1468) — triggered the lane but its branch `audit/baseline-telemetry` never matched the case's `^audit/strategy-baseline-` regex, so it always failed the scope gate.

## Change (1 file)

- Add #1 and #2 to the trigger `if:`, the `expected_branch` case, the file-scope allowlist, and the JSON-validation arm (paths `company/supervisor-rank-state.json`, `company/pr-disposition-state.json`).
- Fix #3: `expected_branch` for `audit: strategy baseline`* → `^audit/baseline-telemetry` (the actual branch strategy-audit.yml uses).

**All existing security gates unchanged** (file-scope allowlist, `sanitise.sh`, JSON-valid, size<1000, branch-pattern) — these justify the no-review admin merge for machine state.

## Test plan

- [x] YAML valid; actionlint clean
- [ ] Next supervisor-rank / pr-disposition / audit-telemetry run: state PR auto-merges via heartbeat
- [ ] Stale #1463 / #1467 / #1468 superseded by next auto-merging PR (one-time manual close)

## Out of scope (noted, not fixed here)

The drift/telemetry dedup in strategy-audit.yml (lines 330/403) still uses the eventually-consistent `gh pr list --search … in:title` pattern (same class as #1441). Not flooding now (1 drift PR open), so deferred.