### PR TITLE
chore(pulse): add action-success KPI — all actions must succeed

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -57,6 +57,21 @@ pulse_pending_metrics: cycle_time_to_revenue,spec_coverage
 pulse_pr_processing_kpi: enabled
 pulse_pr_processing_sla_days: 7
 
+# --- Action-success KPI (added 2026-06-06) ---
+# Andon/jidoka: EVERY autonomous action the pipeline attempts must succeed.
+# A failed action = a tracked breach to drive to zero, never normalised as noise.
+# "Action" = a workflow run that attempts a mutation/decision: heal, escalate,
+# merge (heartbeat/bot-review), pr-disposition, supervisor-rank publish,
+# observation-loop, goal-sprint emit, strategy-audit. NOT actions: `skipped`
+# (conditional no-op) and `action_required` (awaiting input) — exclude from the rate.
+# Each pulse asserts: failed_actions == 0. If >0, list every failed action with a
+# disposition tag — FIXED (root cause + merged fix PR), OPEN (defect still live),
+# or TRANSIENT (succeeded on retry, root cause confirmed non-recurring). A window
+# is only KPI-clean when every failed action is FIXED or TRANSIENT with proof;
+# any OPEN failed action fails the KPI.
+pulse_action_success_kpi: enabled
+pulse_action_success_target: 1.0
+
 goal_sprint_enabled: true
 goal_sprint_cadence: weekly
 goal_sprint_seed_repo_source: pulse_seed_product_repo


### PR DESCRIPTION
## What

Add `pulse_action_success_kpi` to the pulse config: every autonomous action the pipeline attempts must succeed (Andon/jidoka).

## Why

Operator directive 2026-06-06: *"pulse kpi: all actions must succeed."* Failed pipeline actions were being read as background noise in pulses. This makes zero-failed-actions an explicit, tracked target.

## Definition

- **Action** = a workflow run attempting a mutation/decision: heal, escalate, merge (heartbeat / bot-review), pr-disposition, supervisor-rank publish, observation-loop, goal-sprint emit, strategy-audit.
- **Not actions** (excluded): `skipped` (conditional no-op), `action_required` (awaiting input).
- Each pulse asserts `failed_actions == 0`. Any failure is dispositioned **FIXED** (root cause + merged fix PR), **OPEN** (live defect), or **TRANSIENT** (succeeded on retry, root cause confirmed). Window is KPI-clean only when every failure is FIXED/TRANSIENT-with-proof; any OPEN fails the KPI.

## First application (pulse 2026-06-06_14-43)

6 failed actions, all dispositioned, 0 OPEN: Supervisor Rank ×4 → FIXED #1466; Heartbeat ×1 → FIXED #1470; PR Disposition ×1 → TRANSIENT. Verdict: breached-then-remediated, forward target 0.

## Test plan

- [x] YAML valid; KPI keys parse
- [ ] Next pulse renders the action-success table with dispositions