### PR TITLE
fix(ci): self-heal skips completed issues — stop false 'stuck at triage' escalations

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -131,6 +131,23 @@ jobs:
               continue
             fi
 
+            # Skip completed issues: a merged spec/impl PR for this issue already
+            # exists. Reopened or stale-labelled done work must NOT be re-triaged
+            # or escalated as "stuck" (false positives like #540, whose impl PR
+            # #544 merged with "Closes #540" yet was reopened). The issue number
+            # is encoded in spec/impl PR titles ("... Issue #N ..."). Uses the
+            # List API (--state merged) + jq title match, NOT the Search API —
+            # deterministic, no eventual-consistency flakiness (cf. PR #1441).
+            # closedByPullRequestsReferences was tried first but returns empty
+            # once an issue is reopened, so it cannot be used.
+            merged_pr=$(gh pr list --repo "$TARGET_REPO" --state merged --limit 300 \
+              --json title \
+              --jq "[.[] | select(.title | test(\"Issue #${number}\\\\b\"))] | length" 2>/dev/null || echo 0)
+            if [ "${merged_pr:-0}" -gt 0 ]; then
+              echo "Skipping #${number} — completed (merged spec/impl PR exists), not stuck"
+              continue
+            fi
+
             local_stale=$((local_stale + 1))
 
             # Read retry tracker


### PR DESCRIPTION
## What

Add a guard to the pipeline-health stale-needs-triage sweep: skip any issue that already has a **merged spec/impl PR**.

## Why (diagnosis 2026-06-06)

Self-heal escalated 5 wgmesh issues as `[needs-human] Stuck at triage: #N` (#653–657). Investigation: **the triage trigger is not broken** — `copilot-triage.yml` fires and produced merged specs. The real defect is the sweep keyed only on `createdAt` age and never checked completion. Issues whose spec/impl PR merged, then got **reopened** or kept a stale `needs-triage` label, were re-triaged and escalated.

Confirmed: #540's impl PR #544 merged with `Closes #540` (2026-04-29), issue reopened 05-05, escalated as #656. Same false pattern for #539 (#653) and #573 (#655).

## Change (1 file, +14 lines)

Guard in the sweep loop, before an issue is counted stale: query merged PRs whose title encodes `Issue #N` (List API `--state merged` + jq title match — **not** the Search API, so no eventual-consistency flakiness, cf. #1441). `closedByPullRequestsReferences` was tried first but returns empty once an issue is reopened.

## Verified live against the 5 escalated issues

| Issue | merged spec/impl PR? | Result |
|---|---|---|
| #539 / #540 / #573 | yes (#576 / #544 / #574) | **skip** — false 'stuck', now suppressed |
| #584 | no spec | still swept (genuine) |
| #651 (`fn:gtm` pilot-eval) | no, never triaged | still swept (genuine) |

So 3 false escalations stop; the 2 real gaps still surface.

## Out of scope (follow-ups)

- Terminal transition: close issue + strip pipeline labels on impl-merge (so reopened-done issues don't linger).
- Find/stop whatever reopens completed issues (relates to in-flight #750 reopen-handler).
- #651 actually needs triage fired.

## Test plan

- [x] YAML valid; actionlint clean
- [x] Guard discrimination verified live (3 skip / 2 keep)
- [ ] Next self-heal run: no new escalation for #539/#540/#573; existing #653/#655/#656 can be closed as false-positive