### PR TITLE
chore(pulse): extend action-success KPI scope to seed repo (wgmesh)

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -69,8 +69,17 @@ pulse_pr_processing_sla_days: 7
 # or TRANSIENT (succeeded on retry, root cause confirmed non-recurring). A window
 # is only KPI-clean when every failed action is FIXED or TRANSIENT with proof;
 # any OPEN failed action fails the KPI.
+#
+# SCOPE = BOTH repos. The KPI covers workflow runs in the meta-repo AND in the
+# seed repo (pulse_seed_product_repo / TARGET_REPO = atvirokodosprendimai/wgmesh).
+# Querying only the meta-repo hid a 2-week wgmesh outage: `Copilot Issue Triage`
+# failed `Bad credentials` on every run from ~2026-05-21, stalling the entire
+# seed pipeline at triage while the meta-repo read "healthy". A pulse MUST run
+# `gh run list --repo <seed>` and disposition seed-repo failures too. See
+# docs/pulse-reports + memory project_wgmesh_triage_bad_credentials.
 pulse_action_success_kpi: enabled
 pulse_action_success_target: 1.0
+pulse_action_success_scope: meta-repo,seed-repo
 
 goal_sprint_enabled: true
 goal_sprint_cadence: weekly

--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -71,12 +71,12 @@ pulse_pr_processing_sla_days: 7
 # any OPEN failed action fails the KPI.
 #
 # SCOPE = BOTH repos. The KPI covers workflow runs in the meta-repo AND in the
-# seed repo (pulse_seed_product_repo / TARGET_REPO = atvirokodosprendimai/wgmesh).
-# Querying only the meta-repo hid a 2-week wgmesh outage: `Copilot Issue Triage`
-# failed `Bad credentials` on every run from ~2026-05-21, stalling the entire
-# seed pipeline at triage while the meta-repo read "healthy". A pulse MUST run
-# `gh run list --repo <seed>` and disposition seed-repo failures too. See
-# docs/pulse-reports + memory project_wgmesh_triage_bad_credentials.
+# seed repo configured via `pulse_seed_product_repo` (resolved to TARGET_REPO at
+# pulse time). Querying only the meta-repo once hid a 2-week seed-repo outage:
+# `Copilot Issue Triage` failed `Bad credentials` on every run from ~2026-05-21,
+# stalling the entire seed pipeline at triage while the meta-repo read "healthy".
+# A pulse MUST run `gh run list --repo <seed>` and disposition seed-repo failures
+# too. See docs/pulse-reports/ for the incident write-up.
 pulse_action_success_kpi: enabled
 pulse_action_success_target: 1.0
 pulse_action_success_scope: meta-repo,seed-repo


### PR DESCRIPTION
## What

Add `pulse_action_success_scope: meta-repo,seed-repo` and document that the action-success KPI covers seed-repo (`TARGET_REPO` = wgmesh) workflow runs, not just meta-repo CI.

## Why

The KPI as merged (#1472) counted only meta-repo runs. That hid a **~2-week wgmesh outage**: `Copilot Issue Triage` failed `Bad credentials` on the Copilot-agent assignment on **every run since ~2026-05-21**, stalling the entire seed pipeline at the triage stage — while the meta-repo CI read healthy and pulses reported KPI-clean. The self-heal 'stuck at triage' escalations (#653–657) were the downstream symptom.

A KPI whose whole point is 'all actions must succeed' is worthless if it can't see the repo where the product actually converges.

## Change

- `pulse_action_success_scope: meta-repo,seed-repo`
- Comment: a pulse MUST `gh run list --repo <seed>` and disposition seed-repo failures too.

## Follow-up (separate, operator)

The underlying wgmesh outage needs the credential fix: rotate `PUSH_TOKEN` to a PAT with Copilot access, or re-enable Copilot coding agent for the repo/org. Tracked in memory `project_wgmesh_triage_bad_credentials`.

## Test plan

- [x] YAML valid; scope key parses
- [ ] Next pulse queries wgmesh runs and surfaces the triage `Bad credentials` failures as OPEN until the credential fix lands