### PR TITLE
fix(ci): heartbeat author gate — quote [bot] glob so state PRs merge

### DIFF
--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
           case "$PR_AUTHOR" in
-            github-actions[bot]|copilot-swe-agent[bot]|goose[bot])
+            'github-actions[bot]'|'copilot-swe-agent[bot]'|'goose[bot]')
               echo "Heartbeat PR author allowed explicitly: $PR_AUTHOR"
               ;;
             *)
@@ -70,7 +70,7 @@ jobs:
           case "$PR_TITLE" in
             'chore: supervisor-rank state'*|'chore(pr-disposition): update state'*)
               case "$PR_AUTHOR" in
-                pupabobas[bot]|app/pupabobas) ;;
+                'pupabobas[bot]'|app/pupabobas) ;;
                 *)
                   echo "::error::state-PR fast-lane requires pupabobas[bot] author; got '$PR_AUTHOR'"
                   exit 1


### PR DESCRIPTION
## Problem
Pulse 2026-06-07 flagged **action-success KPI = FAIL**: 5 `Heartbeat PR Auto-Merge` failures in 24h, error:
```
state-PR fast-lane requires pupabobas[bot] author; got 'pupabobas[bot]'
```
Author **equals** the expected value yet the gate rejects it → every supervisor-rank / pr-disposition state PR dwells (8 piled open: #1491 #1489 #1485 #1483 #1481 #1474 #1473 #1469).

## Root cause
`heartbeat-pr-automerge.yml:73` — bash `case` pattern `pupabobas[bot]`. `[bot]` is a **glob character class** (matches one of `b`/`o`/`t`), so it matches `pupabobasb`/`pupabobaso`/`pupabobast` but **not** the literal login `pupabobas[bot]`. Falls through to `*) exit 1`. #1470 fixed routing but not this glob.

## Fix
Quote the bracket patterns to disable globbing (`'pupabobas[bot]'`). Also quoted the explicit-allowlist case (line 58) which had the same latent bug (was silently hitting the `*)` warning path).

## Verification
```
PR_AUTHOR='pupabobas[bot]'
case $PR_AUTHOR in pupabobas[bot]) ...   # NO MATCH (bug)
case $PR_AUTHOR in 'pupabobas[bot]') ... # MATCH (fixed)
```

Drains the dwelling state-PR pile and clears the action-success KPI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)