### PR TITLE
feat(pipeline): LangGraph autonomous pipeline on Hetzner — Phase 1 (shadow mode)

### DIFF
--- a/docs/plans/2026-06-07-001-feat-langgraph-hetzner-pipeline-plan.md
+++ b/docs/plans/2026-06-07-001-feat-langgraph-hetzner-pipeline-plan.md
@@ -1,0 +1,342 @@
+---
+title: "feat: Self-hosted LangGraph autonomous pipeline on Hetzner (wgmesh)"
+status: active
+date: 2026-06-07
+type: feat
+deepened: 2026-06-07
+---
+
+# feat: Self-hosted LangGraph autonomous pipeline on Hetzner (wgmesh)
+
+**Target repo:** this repo (`ai-pipeline-template`). New component dir `pipeline/`. Operates on `atvirokodosprendimai/wgmesh`.
+
+---
+
+## Summary
+
+Replace the GitHub-Actions/Copilot/Goose-on-Actions chain (goose-triage → spec-auto-approve → goose-build) with a single self-hosted Python service that owns the autonomous loop: poll wgmesh issues, run a LangGraph graph (triage → spec → implement → review → gate), drive Goose for spec/impl, and open/merge PRs under one PAT identity. The service owns its queue, state, and scheduler — **no GitHub-side workflow triggers in the loop** — eliminating the entire class of failures hit this session (Copilot availability, expired PUSH_TOKEN PAT, app-perms gap, self-approval 422, label-trigger coupling). Eval-driven from day one via LangSmith + openevals/agentevals.
+
+This plan covers **Phase 1 (first PR): the core service skeleton in shadow mode (no writes) plus the eval harness and gate golden-set.** Live-write stages, deployment/systemd, and cutover are later phases (enumerated under Phased Delivery, deferred).
+
+---
+
+## Problem Frame
+
+The wgmesh autonomous pipeline is coupled to GitHub-side machinery that fails independently and silently:
+- **Copilot coding agent** — intermittently unavailable (`Bad credentials` on assign).
+- **PUSH_TOKEN PAT** — expired; 56% of wgmesh workflow runs failed in a 24h window.
+- **GitHub App perms** — lacks `issues:write`; label-add can't trigger downstream.
+- **Self-approval** — app token authoring + approving a PR → HTTP 422.
+- **Label/event triggers** — `GITHUB_TOKEN`-created events don't trigger downstream workflows.
+
+Each is a symptom of running the agent loop **inside** GitHub's orchestration. Moving the loop onto owned infra (Hetzner) removes the orchestration coupling by construction: the box decides what to do from its own state + the issues API, and uses GitHub only to host code and surface PRs.
+
+Requirements traceability: realizes the standing decision to "decouple pipeline from GitHub — own queue/state/scheduler" (see memory `project_decouple_pipeline_from_github`), via the brainstorm-locked anchors below.
+
+---
+
+## Requirements
+
+- **R1** — Single Python service polls wgmesh `needs-triage` issues on its own asyncio schedule (no cron, no webhook).
+- **R2** — Owned sqlite state is the source of truth for issue stage/status; reconciles against GitHub labels.
+- **R3** — LangGraph graph runs triage → spec → implement → review → gate; spec and implement nodes shell out to `goose run` reusing existing wgmesh recipes.
+- **R4** — All GitHub writes go through one fine-grained PAT identity (clone/push/PR/issue ops).
+- **R5** — Merge gate: low-risk + tests + sanitise + clean adversarial review → auto-merge; high-risk paths or any failure → label `needs-human`, stop. Never merge unreviewed, never merge high-risk blind.
+- **R6** — Eval suite (day one): LangSmith tracing on all runs; offline golden sets for spec, impl, and the gate (precision/recall); trajectory eval (graph never skips review); online scoring of live runs.
+- **R7** — **Phase 1 ships shadow mode**: the loop runs end-to-end but performs **no GitHub writes** (specs/diffs computed and logged, decisions recorded in state; no branch push, no PR, no merge, no label change).
+- **R8** — Existing Actions workflows remain untouched and live in Phase 1 (fallback); they are only disabled in the later cutover phase.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Single systemd Python service (runtime A), not LangGraph Platform or containers.** Smallest surface that kills the coupling. sqlite + asyncio poller + in-process graph. Postgres/containers/server-runtime are later graduations, not needed to prove the loop. (Brainstorm anchor: scope = full loop, runtime A.)
+- **KTD2 — Wrap Goose CLI for spec + implement.** Reuse the proven `wgmesh-triage-spec.yaml` and `wgmesh-implementation.yaml` recipes via `goose run --recipe ... --params spec_file=...`, LLM = z.ai/GLM (`ANTHROPIC_API_KEY=ZAI_API_KEY`, `ANTHROPIC_HOST=https://api.z.ai/api/anthropic`). Do not re-implement a coding agent. (Anchor: coding core = wrap Goose.)
+- **KTD3 — Single fine-grained PAT identity on the box.** Scopes: issues, contents, pull_requests. No GitHub App, no Actions tokens. Self-approval is moot in shadow (no writes); in later live phases the single identity authors + a separate review identity is **not** needed because the box's review node gates merge directly (admin/direct merge by the same identity is allowed — self-*merge* is permitted; only self-*approval review* is blocked, which we don't depend on). (Anchor: identity = dedicated PAT.)
+- **KTD4 — Risk-tier gate mirrors existing `pr-disposition` high-risk regexes.** High-risk: `auth|authn|oauth|crypto|wireguard key|secret|token|credential|payment|polar|billing|stripe`, net-new external network calls, or > `MAX_FILES` changed files. Reuse `company/scripts/sanitise.sh` as a hard gate. (Anchor: tiered merge.)
+- **KTD5 — Eval-driven from day one.** LangSmith for tracing/datasets/online scoring; `openevals` (LLM-as-judge) + `agentevals` (trajectory). The **gate golden-set is the highest-leverage eval** — auto-merge is only trustworthy if the gate's precision/recall on known-good/known-bad diffs is measured. (Anchor: full eval suite.)
+- **KTD6 — Python packaging via `pyproject.toml` (uv/pip), pytest for tests.** Repo is currently bash/yaml; `pipeline/` is a self-contained Python package with its own venv on the box.
+- **KTD7 — Shadow mode is a hard runtime flag (`PIPELINE_MODE=shadow|spec-only|live`), defaulting to `shadow`.** Every GitHub-write site checks the mode and routes to a dry-run logger in shadow. This makes Phase 1 safe to run against real wgmesh issues without side effects, and makes cutover a config change.
+
+---
+
+## Output Structure
+
+```
+pipeline/
+├── pyproject.toml
+├── README.md
+├── wgmesh_pipeline/
+│   ├── __init__.py
+│   ├── config.py                # env + mode loading, validation
+│   ├── tracing.py               # LangSmith init (env-gated, no-op if unset)
+│   ├── state/
+│   │   ├── schema.sql           # issues, runs tables
+│   │   └── store.py             # sqlite CRUD, transitions, dedup, retry-cooldown
+│   ├── github/
+│   │   ├── client.py            # PAT-backed REST/git wrapper; write-gated by mode
+│   │   └── reconcile.py         # labels ↔ state reconciliation
+│   ├── goose/
+│   │   └── runner.py            # subprocess wrapper for `goose run --recipe`
+│   ├── graph/
+│   │   ├── state.py             # GraphState TypedDict
+│   │   ├── build.py             # LangGraph assembly + edges
+│   │   └── nodes/
+│   │       ├── triage.py        # classify fix/feature/wont-do (LLM)
+│   │       ├── spec.py          # goose spec recipe → specs/issue-N.md
+│   │       ├── implement.py     # goose impl recipe → code+tests
+│   │       ├── review.py        # adversarial LLM review + sanitise + tests
+│   │       └── gate.py          # risk-tier decision → merge/escalate (write-gated)
+│   ├── risk.py                  # risk-tier classifier (diff → low/high)
+│   ├── poller.py                # asyncio scheduler loop
+│   └── main.py                  # entrypoint, wires poller + graph + state
+├── evals/
+│   ├── datasets/
+│   │   ├── gate_golden.jsonl    # known-good + known-bad/high-risk diffs + labels
+│   │   └── spec_golden.jsonl    # issues + expected spec characteristics
+│   ├── eval_gate.py             # precision/recall of auto-merge decision
+│   ├── eval_spec.py             # structural + LLM-judge spec quality
+│   ├── eval_trajectory.py       # agentevals: never-skip-review invariant
+│   └── run_evals.py             # CI entrypoint, LangSmith dataset upload
+└── tests/
+    ├── conftest.py
+    ├── test_config.py
+    ├── test_state.py
+    ├── test_reconcile.py
+    ├── test_risk.py
+    ├── test_gate.py
+    ├── test_goose_runner.py
+    └── test_poller.py
+```
+
+---
+
+## High-Level Technical Design
+
+Graph topology and the shadow-mode write gate:
+
+```mermaid
+flowchart TD
+    P[poller: asyncio, every N min] -->|needs-triage issues| R[reconcile labels↔sqlite]
+    R --> Q{issue stage}
+    Q -->|queued| T[triage node: classify]
+    T -->|wont-do/needs-info| ESC[escalate: label needs-human]
+    T -->|fix/feature| S[spec node: goose recipe]
+    S --> I[implement node: goose recipe]
+    I --> V[review node: adversarial LLM + sanitise + tests]
+    V --> G{gate: risk tier}
+    G -->|low-risk & green| M[merge]
+    G -->|high-risk OR fail| ESC
+    M -.write-gated.-> W
+    ESC -.write-gated.-> W
+    S -.write-gated.-> W
+    subgraph WG[write gate: PIPELINE_MODE]
+      W{mode?}
+      W -->|shadow| DRY[dry-run logger + state only]
+      W -->|spec-only| SW[spec PR writes only]
+      W -->|live| LW[full writes]
+    end
+```
+
+Every node emits a LangSmith trace span. The poller never blocks on a single issue: each issue advances one stage per tick, with state persisted between ticks (crash-safe resume).
+
+---
+
+## Implementation Units (Phase 1 — first PR, shadow mode)
+
+### U1. Package scaffold + config + mode flag
+
+**Goal:** Stand up the `pipeline/` Python package with env/config loading and the hard `PIPELINE_MODE` gate.
+**Requirements:** R1, R7, KTD6, KTD7.
+**Dependencies:** none.
+**Files:** `pipeline/pyproject.toml`, `pipeline/wgmesh_pipeline/__init__.py`, `pipeline/wgmesh_pipeline/config.py`, `pipeline/README.md`, `pipeline/tests/test_config.py`, `pipeline/tests/conftest.py`.
+**Approach:** `config.py` loads env (`WGMESH_BOT_PAT`, `ZAI_API_KEY`, `ANTHROPIC_HOST`, `LANGSMITH_API_KEY`, `TARGET_REPO`, `PIPELINE_MODE`, `POLL_INTERVAL_SECONDS`, `MAX_FILES`) into a frozen dataclass; validate required vars per mode (shadow needs no PAT write scope; live does); default `PIPELINE_MODE=shadow`. Fail-loud on missing required vars.
+**Patterns to follow:** mirror env-validation discipline in `company/scripts/*.sh` (loud-fail on empty required secrets).
+**Test scenarios:**
+- Happy: full env → valid frozen `Config`; `mode=shadow` by default when `PIPELINE_MODE` unset.
+- Edge: `PIPELINE_MODE=bogus` → raises ValueError listing valid modes.
+- Error: missing `TARGET_REPO` → raises with the var name.
+- Edge: `mode=shadow` with no PAT → OK (shadow needs no writes); `mode=live` with no PAT → raises.
+**Verification:** `pytest pipeline/tests/test_config.py` green; importing the package with a minimal env succeeds.
+
+### U2. sqlite state store (owned queue)
+
+**Goal:** The owned queue — issues/runs tables, stage transitions, dedup, retry-with-cooldown.
+**Requirements:** R2, KTD1.
+**Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/state/schema.sql`, `pipeline/wgmesh_pipeline/state/store.py`, `pipeline/tests/test_state.py`.
+**Approach:** `issues(number PK, title, classification, stage, status, risk_tier, attempts, spec_pr, impl_pr, last_error, updated_at)`; `runs(id PK, issue, node, started, ended, outcome, langsmith_run_id, tokens)`. `stage ∈ {queued,triaged,specced,implemented,reviewed,merged,escalated,failed}`. Store exposes `upsert_issue`, `transition(number, from_stage, to_stage)` (rejects illegal transitions), `claim_next()` (returns the next actionable issue honoring cooldown), `record_run(...)`, `bump_attempt(...)`. Cooldown = `updated_at + backoff(attempts)`.
+**Patterns to follow:** transition table as an explicit allowed-edges map; immutable-update style (new row dicts, no in-place mutation).
+**Test scenarios:**
+- Happy: upsert then transition queued→triaged→specced persists and reads back.
+- Edge: illegal transition (merged→queued) rejected with clear error.
+- Edge: `claim_next` skips issues whose cooldown has not elapsed; returns the eldest eligible.
+- Edge: dedup — upserting the same issue number twice updates, never duplicates.
+- Error: `bump_attempt` increments and sets `last_error`; after N attempts stage→failed.
+**Verification:** `pytest pipeline/tests/test_state.py` green; schema applies idempotently.
+
+### U3. GitHub client (PAT, write-gated)
+
+**Goal:** One PAT-backed client for issue reads, label ops, branch push, PR create/merge — every write routed through the mode gate.
+**Requirements:** R4, R7, KTD3, KTD7.
+**Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/github/client.py`, `pipeline/tests/conftest.py` (fixtures/mocks).
+**Approach:** Thin wrapper over the GitHub REST API + local git (subprocess) using `WGMESH_BOT_PAT`. Reads (list issues, get PR, get diff) always execute. **Writes** (`add_label`, `remove_label`, `push_branch`, `create_pr`, `merge_pr`, `comment`) check `config.mode`: in `shadow`, log the intended write to a structured dry-run record and return a synthetic result; in `spec-only`, allow spec-PR writes only; in `live`, execute. No write method may bypass the gate.
+**Patterns to follow:** existing `gh`/git usage in `.github/workflows/*` (spec PR title `spec: Issue #N - <title>`); sanitise gating before any content write (`company/scripts/sanitise.sh`).
+**Test scenarios:**
+- Happy: `list_needs_triage()` returns parsed issues (mocked HTTP).
+- Integration: in `shadow` mode, `create_pr(...)` performs NO network write and returns a dry-run marker; the intended payload is captured for assertion.
+- Edge: `merge_pr` in shadow → dry-run; in live (mocked) → calls the merge endpoint once.
+- Error: write attempted in `spec-only` mode for a non-spec PR → refused.
+**Verification:** `pytest` covers the gate matrix (mode × write-method) proving no shadow-mode network writes.
+
+### U4. Reconcile (labels ↔ state)
+
+**Goal:** Keep sqlite as source of truth; reconcile GitHub `needs-triage`/`copilot-triaging`/`needs-human` labels against stored stage.
+**Requirements:** R2.
+**Dependencies:** U2, U3.
+**Files:** `pipeline/wgmesh_pipeline/github/reconcile.py`, `pipeline/tests/test_reconcile.py`.
+**Approach:** On each poll, fetch open issues + labels; for each, upsert into state and resolve drift (e.g., issue merged upstream but stage<merged → mark merged; issue reopened → re-queue per rules). Reconciliation is read-only against state-truth; label *writes* go through U3's gate.
+**Test scenarios:**
+- Happy: new `needs-triage` issue not in state → inserted as `queued`.
+- Edge: issue with merged spec/impl PR upstream → state advanced, not re-queued (mirror `#1476` completed-issue skip).
+- Edge: issue labeled `needs-human` upstream → state `escalated`, excluded from `claim_next`.
+- Integration: reconcile then `claim_next` returns only actionable, non-escalated, cooldown-elapsed issues.
+**Verification:** `pytest pipeline/tests/test_reconcile.py` green.
+
+### U5. Goose runner
+
+**Goal:** Subprocess wrapper for `goose run --recipe ... --params spec_file=...` with empty-output guard.
+**Requirements:** R3, KTD2.
+**Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/goose/runner.py`, `pipeline/tests/test_goose_runner.py`.
+**Approach:** Run goose in a working clone with the z.ai env; capture stdout/stderr/exit; **guard against 0-change/empty output** (the historical masking bug — see memory `project_goose_pipeline_fix`): fail loudly if the expected output file (`specs/issue-N-spec.md` or impl diff) is missing or empty. Return a structured result (ok, output_path, duration, raw_log).
+**Patterns to follow:** the merged goose-triage/goose-build workflow invocation (`--no-session`, recipe + params); empty-output guard from those workflows.
+**Test scenarios:**
+- Happy: mocked goose writes the spec file → runner returns ok + path.
+- Error: goose exits non-zero → runner returns not-ok with raw log; no exception leak.
+- Edge: goose exits 0 but produced no/empty file → runner FAILS loudly (guard fires).
+- Edge: `goose_duration≈0` (recipe parse failure signal) surfaced in result.
+**Verification:** `pytest pipeline/tests/test_goose_runner.py` green; guard proven on the empty-output case.
+
+### U6. Risk-tier classifier
+
+**Goal:** Classify a diff as low/high risk per the existing pr-disposition regexes + file-count + net-new-external-call heuristic.
+**Requirements:** R5, KTD4.
+**Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/risk.py`, `pipeline/tests/test_risk.py`.
+**Approach:** Input = changed file paths + diff text. High-risk if any path matches `auth|authn|oauth|crypto|wireguard key|secret|token|credential|payment|polar|billing|stripe`, OR changed-files > `MAX_FILES`, OR diff introduces a net-new outbound network call (heuristic regex on added lines). Otherwise low. Pure function, no I/O.
+**Patterns to follow:** high-risk path regexes from `.compound-engineering/config.local.yaml` `pr_disposition_high_risk_paths` and the pr-disposition workflow.
+**Test scenarios:**
+- Happy: docs-only diff → low.
+- Edge: touches `internal/crypto/key.go` → high.
+- Edge: 1-line change across `MAX_FILES+1` files → high (file-count rule).
+- Edge: adds `http.Post(...)` to a new endpoint → high (net-new external call).
+- Edge: boundary at exactly `MAX_FILES` → low.
+**Verification:** `pytest pipeline/tests/test_risk.py` green across all tiers.
+
+### U7. Graph state + nodes + assembly
+
+**Goal:** Wire the LangGraph graph: triage → spec → implement → review → gate, with shadow-safe nodes.
+**Requirements:** R3, R5, R7.
+**Dependencies:** U2, U3, U5, U6.
+**Files:** `pipeline/wgmesh_pipeline/graph/state.py`, `pipeline/wgmesh_pipeline/graph/build.py`, `pipeline/wgmesh_pipeline/graph/nodes/triage.py`, `.../spec.py`, `.../implement.py`, `.../review.py`, `.../gate.py`, `pipeline/tests/test_gate.py`.
+**Approach:** `GraphState` TypedDict (issue, classification, spec_path, diff, risk_tier, review_findings, decision). `triage` = LLM classify (fix/feature/wont-do/needs-info); wont-do/needs-info → escalate edge. `spec`/`implement` = call U5 goose runner. `review` = adversarial LLM review + `sanitise.sh` + run wgmesh tests; produce blocking/non-blocking findings. `gate` = combine U6 risk-tier + review result → `merge` or `escalate`; **all merge/escalate side-effects route through U3's write gate** (dry-run in shadow). `build.py` assembles nodes + conditional edges and returns a compiled graph. Each node wrapped to emit a LangSmith span (U10).
+**Execution note:** implement the gate decision function test-first — it is the safety-critical unit.
+**Patterns to follow:** LangGraph `StateGraph` + conditional edges; existing adversarial-review framing from `ce-code-review` personas.
+**Test scenarios:**
+- Happy (gate): low-risk + tests pass + sanitise clean + no blocking findings → decision=merge.
+- Edge (gate): high-risk path → decision=escalate regardless of green tests.
+- Edge (gate): blocking review finding → escalate.
+- Edge (gate): sanitise failure → escalate.
+- Integration (graph): triage=wont-do → routes straight to escalate, skips spec/implement.
+- Integration (graph): full fix path reaches gate with a populated diff; in shadow, no writes occur.
+**Verification:** `pytest pipeline/tests/test_gate.py` green; a compiled graph runs end-to-end on a stub issue in shadow with zero writes.
+
+### U8. Poller + main entrypoint
+
+**Goal:** asyncio scheduler that reconciles, claims the next issue, advances it one stage, persists, repeats — crash-safe.
+**Requirements:** R1, R2, R7.
+**Dependencies:** U4, U7.
+**Files:** `pipeline/wgmesh_pipeline/poller.py`, `pipeline/wgmesh_pipeline/main.py`, `pipeline/tests/test_poller.py`.
+**Approach:** Loop every `POLL_INTERVAL_SECONDS`: reconcile → `claim_next` → run the graph for that issue's current stage → persist transition + record_run. One stage per tick; resume from sqlite on restart. `main.py` builds config, state, client, graph, tracing, then runs the poller. Graceful shutdown on SIGTERM (systemd-friendly).
+**Test scenarios:**
+- Happy: one tick advances a queued issue to triaged and records a run.
+- Edge: no actionable issues → tick is a no-op, no error.
+- Edge: graph raises on one issue → `bump_attempt` + `last_error`, loop continues (one bad issue never halts the loop).
+- Integration: restart mid-flight → state resumes at the persisted stage, no double-work.
+**Verification:** `pytest pipeline/tests/test_poller.py` green; `python -m wgmesh_pipeline.main` in shadow against a fixture issue completes a full cycle with no writes.
+
+### U9. LangSmith tracing
+
+**Goal:** Env-gated tracing on every node and the whole run; no-op when `LANGSMITH_API_KEY` unset.
+**Requirements:** R6.
+**Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/tracing.py` (+ decorators applied in U7 nodes).
+**Approach:** Initialize LangSmith from env; wrap nodes so each emits a span (inputs/outputs/tokens/latency/errors) tagged by issue + stage; store the run id back into `runs.langsmith_run_id`. When the key is absent, tracing degrades to a no-op so local/dev runs work.
+**Test scenarios:**
+- Happy: with key set (mocked), running a node emits one span with the expected tags.
+- Edge: key unset → no-op, node still runs and returns normally.
+**Verification:** `pytest` covers the no-op path; a traced shadow run shows spans in LangSmith (manual, dev).
+
+### U10. Eval harness + gate golden-set
+
+**Goal:** The day-one eval scaffolding, with the highest-leverage gate golden-set populated and runnable in CI.
+**Requirements:** R6, KTD5.
+**Dependencies:** U6, U7.
+**Files:** `pipeline/evals/datasets/gate_golden.jsonl`, `pipeline/evals/datasets/spec_golden.jsonl`, `pipeline/evals/eval_gate.py`, `pipeline/evals/eval_spec.py`, `pipeline/evals/eval_trajectory.py`, `pipeline/evals/run_evals.py`.
+**Approach:** `gate_golden.jsonl` = labeled diffs: known-good (low-risk, clean) that MUST auto-merge, and known-bad/high-risk that MUST escalate. `eval_gate.py` runs the U7 gate over the set and computes **precision/recall of the auto-merge decision** (false-merge of a high-risk diff is the cardinal failure → weight recall on "escalate"). `eval_spec.py` = structural check (3 required sections present) + LLM-as-judge (openevals) for concreteness. `eval_trajectory.py` (agentevals) asserts the graph never reaches `merge` without passing through `review`. `run_evals.py` = CI entrypoint; optionally uploads datasets to LangSmith.
+**Execution note:** seed `gate_golden.jsonl` with at least the real high-risk categories from KTD4 plus a few benign docs/test diffs.
+**Test scenarios:**
+- Happy: gate eval over the golden set reports precision/recall; a deliberately-broken gate (auto-merges high-risk) drops escalate-recall below threshold → eval fails (proving the eval bites).
+- Edge: spec eval flags a spec missing `## Proposed Approach` (the real `#660` failure) as low-quality.
+- Edge: trajectory eval fails a synthetic trace that skips review.
+**Verification:** `python pipeline/evals/run_evals.py` runs all three evals; gate precision/recall printed; CI-runnable exit code.
+
+---
+
+## Phased Delivery
+
+- **Phase 1 (this PR):** U1–U10 — full graph in **shadow mode** (no writes) + eval harness + gate golden-set + unit tests. Runs against real wgmesh issues with zero side effects.
+- **Phase 2 (deferred):** spec-only live — flip `PIPELINE_MODE=spec-only`; box opens real spec PRs, Actions still build/merge; verify spec parity vs the live chain.
+- **Phase 3 (deferred):** full live — `PIPELINE_MODE=live`; box owns through merge; disable goose-triage/goose-build/spec-auto-approve (`if: false` fallback). Online LangSmith scoring feeds KPIs.
+- **Phase 4 (deferred):** deployment — Hetzner host decision (new VM via `HCLOUD_TOKEN` vs co-locate on chimney), systemd unit, secrets provisioning (`WGMESH_BOT_PAT`, `LANGSMITH_API_KEY`), coroot/signoz wiring, deploy/update script.
+
+---
+
+## Scope Boundaries
+
+**In scope (Phase 1):** the `pipeline/` package, shadow-mode end-to-end loop, eval harness + gate golden-set, unit tests.
+
+### Deferred to Follow-Up Work
+- systemd unit + Hetzner provisioning + secrets (Phase 4).
+- Live writes / cutover / disabling Actions workflows (Phases 2–3).
+- Online production scoring dashboards (Phase 3).
+- Postgres migration (only if sqlite proves insufficient).
+- Generalizing the pipeline beyond wgmesh to other seed repos.
+
+---
+
+## Risks & Dependencies
+
+- **R-A: Goose recipe fragility** (historical 40-day outage). Mitigation: U5 mirrors the known-good invocation verbatim and guards empty output; recipe schema unchanged.
+- **R-B: Shadow-mode leak** — an accidental real write during Phase 1. Mitigation: KTD7 single choke point in U3; the U3 test matrix proves no shadow network writes; no node calls the GitHub API except through U3.
+- **R-C: Eval that doesn't bite** — a gate golden-set that passes a broken gate. Mitigation: U10 includes a deliberately-broken-gate test that MUST fail the eval.
+- **R-D: PAT scope/expiry** (the very failure we're fleeing). Phase 1 needs only `issues:read`/`repo:read` for shadow; write scopes provisioned at Phase 2. Rotation cadence is a Phase 4 ops concern.
+- **Dependencies:** `langgraph`, `langsmith`, `openevals`, `agentevals`, `langchain-anthropic` (pointed at z.ai), goose CLI on the box, Python 3.11+.
+
+---
+
+## System-Wide Impact
+
+- The 3 wgmesh Actions workflows are **untouched in Phase 1** (R8) — pure addition, zero risk to the running fallback pipeline.
+- New `pipeline/` dir is the first Python in a bash/yaml repo; isolate its tooling (own `pyproject.toml`, venv) so it doesn't perturb existing shell CI.
+- LangSmith introduces an external observability dependency; gated so absence is a no-op.
+
+---
+
+## Sources & Research
+
+- Memory: `project_langgraph_hetzner_pipeline` (brainstorm anchors), `project_wgmesh_triage_bad_credentials` (PUSH_TOKEN root), `project_goose_pipeline_fix` (recipe schema + empty-output bug), `project_goose_authored_specs_plan` (spec-contract 3-sections), `reference_autonomous_lane_label_gates`, `project_decouple_pipeline_from_github`.
+- Existing code: `company/scripts/sanitise.sh`, `.github/workflows/goose-build.yml` (recipe invocation), `.compound-engineering/config.local.yaml` (high-risk regexes).
+- External (to confirm at implementation): current `langgraph` StateGraph API, `openevals`/`agentevals` evaluator signatures, LangSmith tracing env vars.

--- a/pipeline/.gitignore
+++ b/pipeline/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,0 +1,20 @@
+# wgmesh pipeline
+
+Shadow-mode Python service for the autonomous wgmesh pipeline.
+
+Phase 1 is intentionally safe by default:
+
+- `PIPELINE_MODE` defaults to `shadow`.
+- GitHub writes must route through `wgmesh_pipeline.github.client.GitHubClient`.
+- Shadow-mode writes are recorded as dry-run events and perform no network side effects.
+- Live external services are mocked in tests.
+
+Minimal local setup:
+
+```bash
+python3 -m venv pipeline/.venv
+source pipeline/.venv/bin/activate
+pip install -e pipeline/
+pytest pipeline/tests/
+```
+

--- a/pipeline/evals/datasets/gate_golden.jsonl
+++ b/pipeline/evals/datasets/gate_golden.jsonl
@@ -9,4 +9,6 @@
 {"id":"polar-path","changed_files":["internal/polar/client.go"],"diff":"+return syncPolar(ctx)\n","expected_decision":"escalate"}
 {"id":"billing-path","changed_files":["internal/billing/invoice.go"],"diff":"+return finalizeInvoice(ctx)\n","expected_decision":"escalate"}
 {"id":"network-call","changed_files":["internal/client.go"],"diff":"+resp, err := http.Post(\"https://api.example.com\", \"application/json\", body)\n","expected_decision":"escalate"}
-
+{"id":"tests-failed","changed_files":["docs/usage.md"],"diff":"+Clarify setup docs\n","tests_passed":false,"expected_decision":"escalate"}
+{"id":"sanitise-failed","changed_files":["docs/usage.md"],"diff":"+Clarify setup docs\n","sanitise_ok":false,"expected_decision":"escalate"}
+{"id":"blocking-review-finding","changed_files":["docs/usage.md"],"diff":"+Clarify setup docs\n","review_findings":[{"blocking":true,"message":"missing regression test"}],"expected_decision":"escalate"}

--- a/pipeline/evals/datasets/gate_golden.jsonl
+++ b/pipeline/evals/datasets/gate_golden.jsonl
@@ -1,0 +1,12 @@
+{"id":"benign-docs","changed_files":["docs/usage.md"],"diff":"+Clarify setup docs\n","expected_decision":"merge"}
+{"id":"benign-tests","changed_files":["tests/test_mesh.go"],"diff":"+func TestRetryBackoff(t *testing.T) {}\n","expected_decision":"merge"}
+{"id":"auth-path","changed_files":["internal/auth/login.go"],"diff":"+return validateLogin(req)\n","expected_decision":"escalate"}
+{"id":"crypto-path","changed_files":["internal/crypto/key.go"],"diff":"+return rotateKey(k)\n","expected_decision":"escalate"}
+{"id":"wireguard-key-path","changed_files":["internal/wireguard-key/manager.go"],"diff":"+return writePeerKey(peer)\n","expected_decision":"escalate"}
+{"id":"secret-path","changed_files":["config/secrets.yaml"],"diff":"+name: redacted\n","expected_decision":"escalate"}
+{"id":"token-path","changed_files":["internal/token/store.go"],"diff":"+return issueToken(user)\n","expected_decision":"escalate"}
+{"id":"payment-path","changed_files":["internal/payment/checkout.go"],"diff":"+return createCheckout(ctx)\n","expected_decision":"escalate"}
+{"id":"polar-path","changed_files":["internal/polar/client.go"],"diff":"+return syncPolar(ctx)\n","expected_decision":"escalate"}
+{"id":"billing-path","changed_files":["internal/billing/invoice.go"],"diff":"+return finalizeInvoice(ctx)\n","expected_decision":"escalate"}
+{"id":"network-call","changed_files":["internal/client.go"],"diff":"+resp, err := http.Post(\"https://api.example.com\", \"application/json\", body)\n","expected_decision":"escalate"}
+

--- a/pipeline/evals/datasets/spec_golden.jsonl
+++ b/pipeline/evals/datasets/spec_golden.jsonl
@@ -1,0 +1,3 @@
+{"id":"good-spec","issue":"Fix retry handling for transient relay failures","spec":"## Problem\nRelay retries mask transient errors.\n\n## Proposed Approach\nAdd bounded retry with jitter and table-driven tests.\n\n## Acceptance Criteria\n- Retries stop after the configured limit.\n- Tests cover transient and permanent failures.\n","expected_ok":true}
+{"id":"missing-proposed-approach","issue":"Fix missing spec section regression from issue 660","spec":"## Problem\nThe generated spec lacks implementation guidance.\n\n## Acceptance Criteria\n- The builder has enough detail to implement safely.\n","expected_ok":false}
+

--- a/pipeline/evals/eval_gate.py
+++ b/pipeline/evals/eval_gate.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from wgmesh_pipeline.graph.nodes.gate import GateDecision, decide_gate
+
+
+GateFunc = Callable[..., GateDecision]
+
+
+class EvalFailure(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class GateMetrics:
+    total: int
+    auto_merge_precision: float
+    auto_merge_recall: float
+    escalate_recall: float
+    failures: tuple[str, ...]
+
+
+def load_cases(path: str | Path) -> list[dict]:
+    return [json.loads(line) for line in Path(path).read_text().splitlines() if line.strip()]
+
+
+def evaluate_gate(
+    cases: Iterable[dict],
+    *,
+    gate_func: GateFunc = decide_gate,
+    max_files: int = 20,
+    min_auto_merge_precision: float = 1.0,
+    min_escalate_recall: float = 1.0,
+) -> GateMetrics:
+    failures: list[str] = []
+    actual_auto = predicted_auto = true_auto = 0
+    actual_escalate = true_escalate = 0
+    total = 0
+
+    for case in cases:
+        total += 1
+        expected = case["expected_decision"]
+        decision = gate_func(
+            changed_files=case["changed_files"],
+            diff=case["diff"],
+            max_files=max_files,
+            tests_passed=True,
+            sanitise_ok=True,
+            review_findings=[],
+        ).decision
+        if expected == "merge":
+            actual_auto += 1
+        if decision == "merge":
+            predicted_auto += 1
+        if expected == "merge" and decision == "merge":
+            true_auto += 1
+        if expected == "escalate":
+            actual_escalate += 1
+        if expected == "escalate" and decision == "escalate":
+            true_escalate += 1
+        if decision != expected:
+            failures.append(f"{case['id']}: expected {expected}, got {decision}")
+
+    precision = true_auto / predicted_auto if predicted_auto else 1.0
+    auto_recall = true_auto / actual_auto if actual_auto else 1.0
+    escalate_recall = true_escalate / actual_escalate if actual_escalate else 1.0
+    metrics = GateMetrics(total, precision, auto_recall, escalate_recall, tuple(failures))
+    if precision < min_auto_merge_precision or escalate_recall < min_escalate_recall or failures:
+        raise EvalFailure(
+            "gate eval failed: "
+            f"auto_merge_precision={precision:.3f}, escalate_recall={escalate_recall:.3f}, failures={failures}"
+        )
+    return metrics
+
+
+def broken_gate_always_merge(**kwargs) -> GateDecision:
+    return GateDecision(decision="merge", risk_tier="low", reasons=())
+

--- a/pipeline/evals/eval_gate.py
+++ b/pipeline/evals/eval_gate.py
@@ -48,9 +48,9 @@ def evaluate_gate(
             changed_files=case["changed_files"],
             diff=case["diff"],
             max_files=max_files,
-            tests_passed=True,
-            sanitise_ok=True,
-            review_findings=[],
+            tests_passed=case.get("tests_passed", True),
+            sanitise_ok=case.get("sanitise_ok", True),
+            review_findings=case.get("review_findings", []),
         ).decision
         if expected == "merge":
             actual_auto += 1
@@ -80,3 +80,13 @@ def evaluate_gate(
 def broken_gate_always_merge(**kwargs) -> GateDecision:
     return GateDecision(decision="merge", risk_tier="low", reasons=())
 
+
+def broken_gate_ignores_non_risk_guards(**kwargs) -> GateDecision:
+    return decide_gate(
+        changed_files=kwargs["changed_files"],
+        diff=kwargs["diff"],
+        max_files=kwargs["max_files"],
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )

--- a/pipeline/evals/eval_spec.py
+++ b/pipeline/evals/eval_spec.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+REQUIRED_SECTIONS = ("## Problem", "## Proposed Approach", "## Acceptance Criteria")
+
+
+class SpecEvalFailure(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class SpecMetrics:
+    total: int
+    passed: int
+    failures: tuple[str, ...]
+
+
+def load_cases(path: str | Path) -> list[dict]:
+    return [json.loads(line) for line in Path(path).read_text().splitlines() if line.strip()]
+
+
+def spec_is_structurally_ok(spec: str) -> bool:
+    return all(section in spec for section in REQUIRED_SECTIONS)
+
+
+def evaluate_specs(cases: Iterable[dict]) -> SpecMetrics:
+    total = passed = 0
+    failures: list[str] = []
+    for case in cases:
+        total += 1
+        ok = spec_is_structurally_ok(case["spec"])
+        if ok == case["expected_ok"]:
+            passed += 1
+        else:
+            failures.append(f"{case['id']}: expected_ok={case['expected_ok']}, got {ok}")
+    metrics = SpecMetrics(total=total, passed=passed, failures=tuple(failures))
+    if failures:
+        raise SpecEvalFailure(f"spec eval failed: {failures}")
+    return metrics
+

--- a/pipeline/evals/eval_trajectory.py
+++ b/pipeline/evals/eval_trajectory.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+class TrajectoryEvalFailure(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class TrajectoryMetrics:
+    total: int
+    passed: int
+
+
+def assert_never_skips_review(trace: Iterable[str]) -> None:
+    nodes = list(trace)
+    if "merge" in nodes and "review" not in nodes[: nodes.index("merge")]:
+        raise TrajectoryEvalFailure("trajectory reached merge without review")
+
+
+def evaluate_trajectories(traces: Iterable[Iterable[str]]) -> TrajectoryMetrics:
+    total = passed = 0
+    for trace in traces:
+        total += 1
+        assert_never_skips_review(trace)
+        passed += 1
+    return TrajectoryMetrics(total=total, passed=passed)
+

--- a/pipeline/evals/run_evals.py
+++ b/pipeline/evals/run_evals.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+if str(PIPELINE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_ROOT))
+
+from evals.eval_gate import evaluate_gate, load_cases as load_gate_cases
+from evals.eval_spec import evaluate_specs, load_cases as load_spec_cases
+from evals.eval_trajectory import evaluate_trajectories
+
+
+DATASETS = Path(__file__).resolve().parent / "datasets"
+
+
+def main() -> int:
+    gate = evaluate_gate(load_gate_cases(DATASETS / "gate_golden.jsonl"))
+    specs = evaluate_specs(load_spec_cases(DATASETS / "spec_golden.jsonl"))
+    trajectory = evaluate_trajectories(
+        [
+            ["triage", "spec", "implement", "review", "gate", "merge"],
+            ["triage", "spec", "implement", "review", "gate", "escalate"],
+        ]
+    )
+
+    print(
+        "gate: "
+        f"total={gate.total} auto_merge_precision={gate.auto_merge_precision:.3f} "
+        f"auto_merge_recall={gate.auto_merge_recall:.3f} escalate_recall={gate.escalate_recall:.3f}"
+    )
+    print(f"spec: total={specs.total} passed={specs.passed}")
+    print(f"trajectory: total={trajectory.total} passed={trajectory.passed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wgmesh-pipeline"
+version = "0.1.0"
+description = "Shadow-mode autonomous pipeline service for wgmesh."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "pytest>=8.0",
+  "requests>=2.32",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+graph = [
+  "langgraph>=0.2",
+  "langsmith>=0.1",
+]
+eval = [
+  "openevals>=0.1",
+  "agentevals>=0.1",
+  "langchain-anthropic>=0.2",
+]
+
+[project.scripts]
+wgmesh-pipeline = "wgmesh_pipeline.main:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["wgmesh_pipeline*"]
+
+[tool.setuptools.package-data]
+wgmesh_pipeline = ["state/schema.sql"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/pipeline/tests/conftest.py
+++ b/pipeline/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+if str(PIPELINE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_ROOT))
+

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from wgmesh_pipeline.config import load_config
+
+
+def test_full_env_loads_frozen_config_with_shadow_default() -> None:
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "WGMESH_BOT_PAT": "token",
+            "ZAI_API_KEY": "zai",
+            "LANGSMITH_API_KEY": "smith",
+            "POLL_INTERVAL_SECONDS": "60",
+            "MAX_FILES": "5",
+        }
+    )
+
+    assert cfg.mode == "shadow"
+    assert cfg.target_repo == "atvirokodosprendimai/wgmesh"
+    assert cfg.owner == "atvirokodosprendimai"
+    assert cfg.repo == "wgmesh"
+    assert cfg.poll_interval_seconds == 60
+    assert cfg.max_files == 5
+
+    with pytest.raises(FrozenInstanceError):
+        cfg.mode = "live"  # type: ignore[misc]
+
+
+def test_bogus_mode_lists_valid_modes() -> None:
+    with pytest.raises(ValueError, match="PIPELINE_MODE.*live.*shadow.*spec-only"):
+        load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "bogus"})
+
+
+def test_missing_target_repo_raises_with_var_name() -> None:
+    with pytest.raises(ValueError, match="TARGET_REPO"):
+        load_config({})
+
+
+def test_shadow_allows_missing_pat_live_requires_it() -> None:
+    shadow = load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow"})
+    assert shadow.wgmesh_bot_pat is None
+
+    with pytest.raises(ValueError, match="WGMESH_BOT_PAT"):
+        load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "live"})
+

--- a/pipeline/tests/test_evals.py
+++ b/pipeline/tests/test_evals.py
@@ -1,17 +1,45 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from evals.eval_gate import EvalFailure, broken_gate_always_merge, evaluate_gate, load_cases
+from evals.eval_gate import (
+    EvalFailure,
+    broken_gate_always_merge,
+    broken_gate_ignores_non_risk_guards,
+    evaluate_gate,
+    load_cases,
+)
 from evals.eval_spec import spec_is_structurally_ok
 from evals.eval_trajectory import TrajectoryEvalFailure, assert_never_skips_review
 
 
+GATE_GOLDEN = Path(__file__).resolve().parents[1] / "evals" / "datasets" / "gate_golden.jsonl"
+
+
+def gate_cases() -> list[dict]:
+    return load_cases(GATE_GOLDEN)
+
+
 def test_deliberately_broken_gate_fails_golden_eval() -> None:
-    cases = load_cases("pipeline/evals/datasets/gate_golden.jsonl")
+    cases = gate_cases()
 
     with pytest.raises(EvalFailure, match="escalate_recall"):
         evaluate_gate(cases, gate_func=broken_gate_always_merge)
+
+
+def test_gate_eval_fails_gate_that_ignores_tests_sanitise_and_findings() -> None:
+    cases = gate_cases()
+
+    with pytest.raises(EvalFailure, match="tests-failed"):
+        evaluate_gate(cases, gate_func=broken_gate_ignores_non_risk_guards)
+
+
+def test_gate_eval_dataset_path_is_independent_of_cwd(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert gate_cases()[0]["id"] == "benign-docs"
 
 
 def test_spec_eval_flags_missing_proposed_approach() -> None:
@@ -23,4 +51,3 @@ def test_spec_eval_flags_missing_proposed_approach() -> None:
 def test_trajectory_eval_fails_trace_that_skips_review() -> None:
     with pytest.raises(TrajectoryEvalFailure, match="without review"):
         assert_never_skips_review(["triage", "spec", "implement", "gate", "merge"])
-

--- a/pipeline/tests/test_evals.py
+++ b/pipeline/tests/test_evals.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from evals.eval_gate import EvalFailure, broken_gate_always_merge, evaluate_gate, load_cases
+from evals.eval_spec import spec_is_structurally_ok
+from evals.eval_trajectory import TrajectoryEvalFailure, assert_never_skips_review
+
+
+def test_deliberately_broken_gate_fails_golden_eval() -> None:
+    cases = load_cases("pipeline/evals/datasets/gate_golden.jsonl")
+
+    with pytest.raises(EvalFailure, match="escalate_recall"):
+        evaluate_gate(cases, gate_func=broken_gate_always_merge)
+
+
+def test_spec_eval_flags_missing_proposed_approach() -> None:
+    spec = "## Problem\nMissing plan\n\n## Acceptance Criteria\n- clear enough\n"
+
+    assert spec_is_structurally_ok(spec) is False
+
+
+def test_trajectory_eval_fails_trace_that_skips_review() -> None:
+    with pytest.raises(TrajectoryEvalFailure, match="without review"):
+        assert_never_skips_review(["triage", "spec", "implement", "gate", "merge"])
+

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+from wgmesh_pipeline.graph.build import build_graph
+from wgmesh_pipeline.graph.nodes.gate import decide_gate
+
+
+def cfg(mode: str = "shadow") -> Config:
+    return Config(target_repo="atvirokodosprendimai/wgmesh", mode=mode, max_files=3)
+
+
+def test_gate_merges_low_risk_green_clean_review() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "merge"
+    assert decision.risk_tier == "low"
+
+
+def test_gate_escalates_high_risk_path_even_when_green() -> None:
+    decision = decide_gate(
+        changed_files=["internal/auth/login.go"],
+        diff="+return nil\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert decision.risk_tier == "high"
+
+
+def test_gate_escalates_blocking_review_finding() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[{"blocking": True, "message": "missing test"}],
+    )
+
+    assert decision.decision == "escalate"
+    assert "blocking review finding" in decision.reasons
+
+
+def test_gate_escalates_sanitise_failure() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=False,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert "sanitise failed" in decision.reasons
+
+
+def test_graph_wont_do_routes_to_escalate_and_skips_spec_implement() -> None:
+    client = GitHubClient(cfg())
+    graph = build_graph(cfg())
+
+    result = graph.invoke(
+        {
+            "issue": GitHubIssue(number=5, title="wont fix old path", labels=("needs-triage",), state="open"),
+            "github": client,
+        }
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["visited"] == ["triage", "escalate"]
+    assert [record.operation for record in client.dry_run_records] == ["add_label"]
+
+
+def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_writes(monkeypatch) -> None:
+    client = GitHubClient(cfg())
+    graph = build_graph(cfg())
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
+
+    result = graph.invoke(
+        {
+            "issue": GitHubIssue(number=6, title="Fix docs", labels=("needs-triage",), state="open"),
+            "github": client,
+            "diff": "+docs only\n",
+            "changed_files": ["docs/readme.md"],
+            "impl_pr": 123,
+        }
+    )
+
+    assert result["visited"] == ["triage", "spec", "implement", "review", "gate"]
+    assert result["decision"] == "merge"
+    assert result["diff"] == "+docs only\n"
+    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -5,7 +5,9 @@ from dataclasses import replace
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 from wgmesh_pipeline.graph.build import build_graph
-from wgmesh_pipeline.graph.nodes.gate import decide_gate
+from wgmesh_pipeline.graph.nodes.gate import decide_gate, gate_node
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+from wgmesh_pipeline.graph.nodes.review import review_node
 
 
 def cfg(mode: str = "shadow") -> Config:
@@ -38,6 +40,89 @@ def test_gate_escalates_high_risk_path_even_when_green() -> None:
 
     assert decision.decision == "escalate"
     assert decision.risk_tier == "high"
+
+
+def test_implement_derives_changed_files_from_existing_diff_for_gate() -> None:
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=7, title="Fix keys", labels=("needs-triage",), state="open"),
+            "diff": """diff --git a/internal/crypto/key.go b/internal/crypto/key.go
+--- a/internal/crypto/key.go
++++ b/internal/crypto/key.go
++return key
+""",
+        }
+    )
+
+    decision = decide_gate(
+        changed_files=result["changed_files"],
+        diff=result["diff"],
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert result["changed_files"] == ["internal/crypto/key.go"]
+    assert decision.decision == "escalate"
+
+
+def test_implement_created_pr_number_is_merged_by_gate() -> None:
+    client = GitHubClient(cfg(mode="live"), session=SessionForPr({"number": 456}), sanitiser=lambda text: True)
+    implemented = implement_node(
+        {
+            "issue": GitHubIssue(number=9, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "diff": """diff --git a/docs/readme.md b/docs/readme.md
+--- a/docs/readme.md
++++ b/docs/readme.md
++docs
+""",
+        }
+    )
+
+    result = gate_node(
+        {
+            "issue": GitHubIssue(number=9, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "diff": implemented["diff"],
+            "changed_files": implemented["changed_files"],
+            "impl_pr": implemented["impl_pr"],
+            "tests_passed": True,
+            "sanitise_ok": True,
+            "review_findings": [],
+        },
+        max_files=3,
+    )
+
+    assert implemented["impl_pr"] == 456
+    assert result["decision"] == "merge"
+    assert client.session.calls[-1]["url"].endswith("/pulls/456/merge")
+
+
+def test_review_failed_verification_escalates_at_gate(monkeypatch) -> None:
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
+
+    reviewed = review_node(
+        {
+            "issue": GitHubIssue(number=8, title="Fix docs", labels=("needs-triage",), state="open"),
+            "diff": "+docs\n",
+            "changed_files": ["docs/readme.md"],
+            "verification": {"tests_passed": False},
+        }
+    )
+    decision = decide_gate(
+        changed_files=reviewed["changed_files"],
+        diff=reviewed["diff"],
+        max_files=3,
+        tests_passed=reviewed["tests_passed"],
+        sanitise_ok=reviewed["sanitise_ok"],
+        review_findings=reviewed["review_findings"],
+    )
+
+    assert reviewed["tests_passed"] is False
+    assert decision.decision == "escalate"
+    assert "tests failed" in decision.reasons
 
 
 def test_gate_escalates_blocking_review_finding() -> None:
@@ -96,6 +181,7 @@ def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_wr
             "diff": "+docs only\n",
             "changed_files": ["docs/readme.md"],
             "impl_pr": 123,
+            "verification": {"tests_passed": True},
         }
     )
 
@@ -104,3 +190,27 @@ def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_wr
     assert result["diff"] == "+docs only\n"
     assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
 
+
+class SessionForPr:
+    def __init__(self, create_response: dict):
+        self.create_response = create_response
+        self.calls: list[dict] = []
+
+    def request(self, method: str, url: str, **kwargs):
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        if method == "POST" and url.endswith("/pulls"):
+            return ResponseForPr(self.create_response)
+        return ResponseForPr({"merged": True})
+
+
+class ResponseForPr:
+    text = "json"
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._data

--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import DryRunResult, GitHubClient
+
+
+class Response:
+    def __init__(self, data: Any = None, text: str | None = None):
+        self._data = data
+        self.text = text if text is not None else ("" if data is None else "json")
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._data
+
+
+class Session:
+    def __init__(self, response: Response):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", wgmesh_bot_pat="pat")
+
+
+def test_list_needs_triage_returns_parsed_issues(cfg: Config) -> None:
+    session = Session(
+        Response(
+            [
+                {
+                    "number": 17,
+                    "title": "Fix mesh",
+                    "labels": [{"name": "needs-triage"}, {"name": "fn:dev"}],
+                    "state": "open",
+                }
+            ]
+        )
+    )
+
+    issues = GitHubClient(cfg, session=session).list_needs_triage()
+
+    assert issues[0].number == 17
+    assert issues[0].labels == ("needs-triage", "fn:dev")
+    assert session.calls[0]["method"] == "GET"
+    assert session.calls[0]["kwargs"]["params"]["labels"] == "needs-triage"
+
+
+def test_shadow_create_pr_dry_runs_with_no_network_write(cfg: Config) -> None:
+    session = Session(Response({"number": 1}))
+    client = GitHubClient(cfg, session=session)
+
+    result = client.create_pr(title="spec: Issue #17 - Fix", head="bot/spec-17", base="main", body="body")
+
+    assert isinstance(result, DryRunResult)
+    assert result.dry_run is True
+    assert result.operation == "create_pr"
+    assert result.payload["title"] == "spec: Issue #17 - Fix"
+    assert session.calls == []
+    assert client.dry_run_records == [result]
+
+
+def test_merge_pr_shadow_dry_runs_live_calls_endpoint_once(cfg: Config) -> None:
+    shadow_session = Session(Response({"merged": True}))
+    shadow = GitHubClient(cfg, session=shadow_session)
+    assert shadow.merge_pr(7).dry_run is True
+    assert shadow_session.calls == []
+
+    live_session = Session(Response({"merged": True}))
+    live = GitHubClient(replace(cfg, mode="live"), session=live_session)
+    assert live.merge_pr(7) == {"merged": True}
+    assert len(live_session.calls) == 1
+    assert live_session.calls[0]["method"] == "PUT"
+    assert live_session.calls[0]["url"].endswith("/pulls/7/merge")
+
+
+def test_spec_only_refuses_non_spec_write(cfg: Config) -> None:
+    client = GitHubClient(replace(cfg, mode="spec-only"), session=Session(Response({"ok": True})))
+
+    with pytest.raises(PermissionError, match="spec-only"):
+        client.comment(17, "not allowed")
+
+
+def test_spec_only_allows_spec_pr_create_with_mocked_network(cfg: Config) -> None:
+    session = Session(Response({"number": 99}))
+    client = GitHubClient(replace(cfg, mode="spec-only"), session=session)
+
+    result = client.create_pr(
+        title="spec: Issue #17 - Fix mesh",
+        head="bot/spec-17",
+        base="main",
+        body="spec body",
+    )
+
+    assert result == {"number": 99}
+    assert len(session.calls) == 1
+    assert session.calls[0]["method"] == "POST"
+

--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -72,6 +72,29 @@ def test_shadow_create_pr_dry_runs_with_no_network_write(cfg: Config) -> None:
     assert client.dry_run_records == [result]
 
 
+def test_create_pr_refuses_unsanitisable_body_even_in_shadow(cfg: Config) -> None:
+    session = Session(Response({"number": 1}))
+    client = GitHubClient(cfg, session=session, sanitiser=lambda text: "SECRET" not in text)
+
+    with pytest.raises(RuntimeError, match="create_pr body"):
+        client.create_pr(title="spec: Issue #17 - Fix", head="bot/spec-17", base="main", body="SECRET_KEY=abc123")
+
+    assert session.calls == []
+    assert client.dry_run_records == []
+
+
+def test_push_branch_refuses_unsanitisable_spec_even_in_shadow(tmp_path, cfg: Config) -> None:
+    spec = tmp_path / "specs" / "issue-17-spec.md"
+    spec.parent.mkdir()
+    spec.write_text("SECRET_KEY=abc123")
+    client = GitHubClient(cfg, sanitiser=lambda text: "SECRET" not in text)
+
+    with pytest.raises(RuntimeError, match="specs/issue-17-spec.md"):
+        client.push_branch(str(tmp_path), "bot/spec-17")
+
+    assert client.dry_run_records == []
+
+
 def test_merge_pr_shadow_dry_runs_live_calls_endpoint_once(cfg: Config) -> None:
     shadow_session = Session(Response({"merged": True}))
     shadow = GitHubClient(cfg, session=shadow_session)
@@ -107,4 +130,3 @@ def test_spec_only_allows_spec_pr_create_with_mocked_network(cfg: Config) -> Non
     assert result == {"number": 99}
     assert len(session.calls) == 1
     assert session.calls[0]["method"] == "POST"
-

--- a/pipeline/tests/test_goose_runner.py
+++ b/pipeline/tests/test_goose_runner.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.goose.runner import GooseRunner
+
+
+def cfg() -> Config:
+    return Config(
+        target_repo="atvirokodosprendimai/wgmesh",
+        zai_api_key="zai",
+        anthropic_host="https://api.z.ai/api/anthropic",
+    )
+
+
+def completed(code: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["goose"], returncode=code, stdout=stdout, stderr=stderr)
+
+
+def test_mocked_goose_writes_spec_file_and_returns_ok(tmp_path) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def run(command, **kwargs):
+        calls.append({"command": command, "kwargs": kwargs})
+        output = Path(kwargs["cwd"]) / "specs/issue-17-spec.md"
+        output.parent.mkdir(parents=True)
+        output.write_text("## Problem\n\n## Proposed Approach\n\n## Acceptance Criteria\n")
+        return completed(stdout="wrote spec")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-17-spec.md"},
+        expected_output="specs/issue-17-spec.md",
+    )
+
+    assert result.ok is True
+    assert result.output_path == tmp_path / "specs/issue-17-spec.md"
+    assert "wrote spec" in result.raw_log
+    assert calls[0]["command"][:5] == ["goose", "run", "--no-session", "--recipe", "wgmesh-triage-spec.yaml"]
+    assert "ANTHROPIC_API_KEY" in calls[0]["kwargs"]["env"]
+
+
+def test_goose_nonzero_returns_not_ok_with_raw_log(tmp_path) -> None:
+    def run(command, **kwargs):
+        return completed(2, stdout="partial", stderr="bad recipe")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-implementation.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+    )
+
+    assert result.ok is False
+    assert result.error == "goose exited 2"
+    assert "partial" in result.raw_log
+    assert "bad recipe" in result.raw_log
+
+
+def test_goose_zero_exit_empty_output_fails_loudly(tmp_path) -> None:
+    def run(command, **kwargs):
+        return completed(0, stdout="done but no file")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-17-spec.md"},
+        expected_output="specs/issue-17-spec.md",
+    )
+
+    assert result.ok is False
+    assert result.error is not None
+    assert "empty output guard" in result.error
+
+
+def test_near_zero_duration_is_surfaced(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "specs/issue-18-spec.md"
+    times = iter([10.0, 10.0001])
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.time.monotonic", lambda: next(times))
+
+    def run(command, **kwargs):
+        output.parent.mkdir()
+        output.write_text("content")
+        return completed()
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="recipe.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-18-spec.md"},
+        expected_output=output,
+    )
+
+    assert result.ok is True
+    assert 0 < result.duration_seconds < 0.001
+

--- a/pipeline/tests/test_goose_runner.py
+++ b/pipeline/tests/test_goose_runner.py
@@ -61,6 +61,21 @@ def test_goose_nonzero_returns_not_ok_with_raw_log(tmp_path) -> None:
     assert "bad recipe" in result.raw_log
 
 
+def test_goose_timeout_returns_not_ok_without_propagating(tmp_path) -> None:
+    def run(command, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=command, timeout=kwargs["timeout"])
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-implementation.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+    )
+
+    assert result.ok is False
+    assert result.error == "goose timed out after 1800s"
+
+
 def test_goose_zero_exit_empty_output_fails_loudly(tmp_path) -> None:
     def run(command, **kwargs):
         return completed(0, stdout="done but no file")
@@ -96,4 +111,3 @@ def test_near_zero_duration_is_surfaced(tmp_path, monkeypatch) -> None:
 
     assert result.ok is True
     assert 0 < result.duration_seconds < 0.001
-

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -87,6 +87,52 @@ def test_graph_exception_bumps_attempt_and_loop_continues(tmp_path, cfg: Config)
     assert p.store.list_runs()[0]["outcome"] == "error"
 
 
+def test_reconcile_exception_does_not_halt_tick(tmp_path, cfg: Config, monkeypatch) -> None:
+    p = poller(tmp_path, cfg)
+    p.store.upsert_issue(1, "Fix bug")
+
+    def fail_reconcile(client, store):
+        raise RuntimeError("github unavailable")
+
+    monkeypatch.setattr("wgmesh_pipeline.poller.reconcile_issues", fail_reconcile)
+
+    result = asyncio.run(p.tick())
+
+    assert result is None
+    assert p.last_reconcile_error == "github unavailable"
+    assert p.store.get_issue(1).stage == "queued"
+
+
+def test_reviewed_issue_transitions_before_merge_side_effect(tmp_path, cfg: Config) -> None:
+    class FailingMergeClient(EmptyClient):
+        def __init__(self, config):
+            super().__init__(config)
+            self.merged_prs: list[int] = []
+
+        def merge_pr(self, pr_number: int, *, commit_title: str | None = None):
+            self.merged_prs.append(pr_number)
+            raise RuntimeError("merge side effect failed")
+
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(2, "Ready", stage="reviewed", impl_pr=321)
+    client = FailingMergeClient(cfg)
+    p = Poller(config=cfg, store=store, client=client, graph=Graph())
+    p.scratch[2] = {
+        "diff": "+docs\n",
+        "changed_files": ["docs/readme.md"],
+        "tests_passed": True,
+        "sanitise_ok": True,
+        "review_findings": [],
+        "impl_pr": 321,
+    }
+
+    result = asyncio.run(p.tick())
+
+    assert result is None
+    assert store.get_issue(2).stage == "merged"
+    assert client.merged_prs == [321]
+
+
 def test_restart_mid_flight_resumes_persisted_stage_without_double_work(tmp_path, cfg: Config) -> None:
     db_path = tmp_path / "state.db"
     StateStore(db_path).upsert_issue(1, "Already triaged", stage="triaged")
@@ -106,9 +152,10 @@ def test_main_graph_shadow_fixture_can_complete_full_cycle_without_writes(tmp_pa
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(1, "Fix docs")
     p = Poller(config=cfg, store=store, client=client, graph=build_graph(cfg))
+    p.scratch[1] = {"verification": {"tests_passed": True}}
 
     for _ in range(5):
         asyncio.run(p.tick())
 
     assert store.get_issue(1).stage == "merged"
-    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+    assert [record.operation for record in client.dry_run_records] == ["create_pr", "merge_pr"]

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubClient
+from wgmesh_pipeline.graph.build import build_graph
+from wgmesh_pipeline.poller import Poller
+from wgmesh_pipeline.state.store import StateStore
+
+
+class EmptyClient(GitHubClient):
+    def list_open_issues(self):
+        return []
+
+
+class Graph:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def triage(self, state):
+        self.calls.append("triage")
+        return {**state, "classification": "fix"}
+
+    def spec(self, state):
+        self.calls.append("spec")
+        return {**state, "spec_path": "specs/issue.md"}
+
+    def implement(self, state):
+        self.calls.append("implement")
+        return {**state, "diff": "+diff\n", "changed_files": ["docs/readme.md"]}
+
+    def review(self, state):
+        self.calls.append("review")
+        return {**state, "tests_passed": True, "sanitise_ok": True, "review_findings": []}
+
+
+@pytest.fixture
+def cfg() -> Config:
+    return Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", max_files=3)
+
+
+def poller(tmp_path, cfg: Config, graph=None):
+    store = StateStore(tmp_path / "state.db")
+    client = EmptyClient(cfg)
+    return Poller(config=cfg, store=store, client=client, graph=graph or Graph())
+
+
+def test_tick_advances_queued_issue_to_triaged_and_records_run(tmp_path, cfg: Config) -> None:
+    p = poller(tmp_path, cfg)
+    p.store.upsert_issue(1, "Fix bug")
+
+    result = asyncio.run(p.tick())
+
+    assert result is not None
+    assert result.stage == "triaged"
+    assert p.store.get_issue(1).classification == "fix"
+    assert p.store.list_runs()[0]["node"] == "queued"
+    assert p.store.list_runs()[0]["outcome"] == "ok"
+
+
+def test_tick_no_actionable_issue_is_noop(tmp_path, cfg: Config) -> None:
+    p = poller(tmp_path, cfg)
+
+    result = asyncio.run(p.tick())
+
+    assert result is None
+    assert p.store.list_runs() == []
+
+
+def test_graph_exception_bumps_attempt_and_loop_continues(tmp_path, cfg: Config) -> None:
+    class FailingGraph(Graph):
+        def triage(self, state):
+            raise RuntimeError("bad issue")
+
+    p = poller(tmp_path, cfg, FailingGraph())
+    p.store.upsert_issue(1, "Fix bug")
+
+    result = asyncio.run(p.tick())
+
+    assert result is None
+    issue = p.store.get_issue(1)
+    assert issue.attempts == 1
+    assert issue.last_error == "bad issue"
+    assert p.store.list_runs()[0]["outcome"] == "error"
+
+
+def test_restart_mid_flight_resumes_persisted_stage_without_double_work(tmp_path, cfg: Config) -> None:
+    db_path = tmp_path / "state.db"
+    StateStore(db_path).upsert_issue(1, "Already triaged", stage="triaged")
+    graph = Graph()
+    restarted = Poller(config=cfg, store=StateStore(db_path), client=EmptyClient(cfg), graph=graph)
+
+    result = asyncio.run(restarted.tick())
+
+    assert result is not None
+    assert result.stage == "specced"
+    assert graph.calls == ["spec"]
+
+
+def test_main_graph_shadow_fixture_can_complete_full_cycle_without_writes(tmp_path, cfg: Config, monkeypatch) -> None:
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
+    client = EmptyClient(cfg)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(1, "Fix docs")
+    p = Poller(config=cfg, store=store, client=client, graph=build_graph(cfg))
+
+    for _ in range(5):
+        asyncio.run(p.tick())
+
+    assert store.get_issue(1).stage == "merged"
+    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]

--- a/pipeline/tests/test_reconcile.py
+++ b/pipeline/tests/test_reconcile.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+from wgmesh_pipeline.github.reconcile import reconcile_issues
+from wgmesh_pipeline.state.store import StateStore
+
+
+class Client(GitHubClient):
+    def __init__(self, issues: Iterable[GitHubIssue]):
+        super().__init__(Config(target_repo="atvirokodosprendimai/wgmesh"))
+        self._issues = list(issues)
+
+    def list_open_issues(self) -> list[GitHubIssue]:
+        return self._issues
+
+
+def issue(number: int, labels: tuple[str, ...], *, title: str = "title", state: str = "open") -> GitHubIssue:
+    return GitHubIssue(number=number, title=title, labels=labels, state=state)
+
+
+def test_new_needs_triage_issue_inserted_as_queued(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+
+    result = reconcile_issues(Client([issue(1, ("needs-triage",), title="Fix")]), store)
+
+    assert result.queued == 1
+    assert store.get_issue(1).stage == "queued"
+    assert store.get_issue(1).title == "Fix"
+
+
+def test_merged_upstream_issue_advances_and_is_not_requeued(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(1476, "done", stage="specced")
+
+    reconcile_issues(Client([issue(1476, ("needs-triage", "merged"), state="open")]), store)
+
+    record = store.get_issue(1476)
+    assert record.stage == "merged"
+    assert record.status == "closed"
+    assert store.claim_next(now=datetime.now(timezone.utc)) is None
+
+
+def test_needs_human_label_escalates_and_excludes_from_claim(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+
+    reconcile_issues(Client([issue(2, ("needs-human",))]), store)
+
+    assert store.get_issue(2).stage == "escalated"
+    assert store.claim_next(now=datetime.now(timezone.utc)) is None
+
+
+def test_reconcile_then_claim_returns_only_actionable_issue(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    reconcile_issues(
+        Client(
+            [
+                issue(1, ("needs-human",)),
+                issue(2, ("needs-triage",), title="Do it"),
+            ]
+        ),
+        store,
+    )
+
+    claimed = store.claim_next(now=datetime.now(timezone.utc))
+
+    assert claimed is not None
+    assert claimed.number == 2
+

--- a/pipeline/tests/test_reconcile.py
+++ b/pipeline/tests/test_reconcile.py
@@ -13,9 +13,14 @@ class Client(GitHubClient):
     def __init__(self, issues: Iterable[GitHubIssue]):
         super().__init__(Config(target_repo="atvirokodosprendimai/wgmesh"))
         self._issues = list(issues)
+        self.removed_labels: list[tuple[int, str]] = []
 
     def list_open_issues(self) -> list[GitHubIssue]:
         return self._issues
+
+    def remove_label(self, issue_number: int, label: str):
+        self.removed_labels.append((issue_number, label))
+        return {"ok": True}
 
 
 def issue(number: int, labels: tuple[str, ...], *, title: str = "title", state: str = "open") -> GitHubIssue:
@@ -30,6 +35,17 @@ def test_new_needs_triage_issue_inserted_as_queued(tmp_path) -> None:
     assert result.queued == 1
     assert store.get_issue(1).stage == "queued"
     assert store.get_issue(1).title == "Fix"
+
+
+def test_in_flight_needs_triage_issue_is_not_reset_to_queued(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(17, "in flight", stage="specced")
+    client = Client([issue(17, ("needs-triage",), title="Updated")])
+
+    reconcile_issues(client, store)
+
+    assert store.get_issue(17).stage == "specced"
+    assert client.removed_labels == [(17, "needs-triage")]
 
 
 def test_merged_upstream_issue_advances_and_is_not_requeued(tmp_path) -> None:
@@ -69,4 +85,3 @@ def test_reconcile_then_claim_returns_only_actionable_issue(tmp_path) -> None:
 
     assert claimed is not None
     assert claimed.number == 2
-

--- a/pipeline/tests/test_risk.py
+++ b/pipeline/tests/test_risk.py
@@ -17,6 +17,18 @@ def test_crypto_path_is_high_risk() -> None:
     assert "high-risk path" in result.reasons[0]
 
 
+def test_secret_key_added_in_benign_path_is_high_risk() -> None:
+    diff = """diff --git a/config/example.env b/config/example.env
+++ b/config/example.env
++SECRET_KEY=abc123
+"""
+
+    result = classify_risk(["config/example.env"], diff, max_files=3)
+
+    assert result.tier == "high"
+    assert "high-risk diff content" in result.reasons[0]
+
+
 def test_more_than_max_files_is_high_risk() -> None:
     result = classify_risk(["a", "b", "c", "d"], "+small\n", max_files=3)
 
@@ -39,4 +51,3 @@ def test_exactly_max_files_boundary_is_low_risk() -> None:
     result = classify_risk(["a", "b", "c"], "+small\n", max_files=3)
 
     assert result.tier == "low"
-

--- a/pipeline/tests/test_risk.py
+++ b/pipeline/tests/test_risk.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from wgmesh_pipeline.risk import classify_risk
+
+
+def test_docs_only_diff_is_low_risk() -> None:
+    result = classify_risk(["docs/readme.md"], "+Clarify install steps\n", max_files=3)
+
+    assert result.tier == "low"
+    assert result.reasons == ()
+
+
+def test_crypto_path_is_high_risk() -> None:
+    result = classify_risk(["internal/crypto/key.go"], "+return key\n", max_files=3)
+
+    assert result.tier == "high"
+    assert "high-risk path" in result.reasons[0]
+
+
+def test_more_than_max_files_is_high_risk() -> None:
+    result = classify_risk(["a", "b", "c", "d"], "+small\n", max_files=3)
+
+    assert result.high is True
+    assert "exceeds MAX_FILES=3" in result.reasons[0]
+
+
+def test_added_external_network_call_is_high_risk() -> None:
+    diff = """diff --git a/main.go b/main.go
++resp, err := http.Post("https://api.example.com", "application/json", body)
+"""
+
+    result = classify_risk(["internal/client.go"], diff, max_files=3)
+
+    assert result.tier == "high"
+    assert "network call" in result.reasons[0]
+
+
+def test_exactly_max_files_boundary_is_low_risk() -> None:
+    result = classify_risk(["a", "b", "c"], "+small\n", max_files=3)
+
+    assert result.tier == "low"
+

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from wgmesh_pipeline.state.store import StateStore, TransitionError
+
+
+def store(tmp_path):
+    return StateStore(tmp_path / "state.db")
+
+
+def test_upsert_and_transition_persist(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "Fix relay")
+
+    db.transition(1, "queued", "triaged")
+    db.transition(1, "triaged", "specced")
+
+    issue = db.get_issue(1)
+    assert issue.stage == "specced"
+    assert issue.title == "Fix relay"
+
+
+def test_schema_applies_idempotently(tmp_path) -> None:
+    db = store(tmp_path)
+    db.apply_schema()
+    db.apply_schema()
+    db.upsert_issue(1, "Still works")
+    assert db.get_issue(1).stage == "queued"
+
+
+def test_illegal_transition_rejected(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "Done", stage="merged")
+
+    with pytest.raises(TransitionError, match="merged->queued"):
+        db.transition(1, "merged", "queued")
+
+
+def test_claim_next_skips_cooldown_and_returns_eldest_eligible(tmp_path) -> None:
+    db = store(tmp_path)
+    now = datetime(2026, 6, 7, 12, tzinfo=timezone.utc)
+    db.upsert_issue(1, "cooling", updated_at=now, stage="queued")
+    db.bump_attempt(1, "temporary", now=now)
+    db.upsert_issue(2, "newer eligible", updated_at=now - timedelta(minutes=5), stage="queued")
+    db.upsert_issue(3, "eldest eligible", updated_at=now - timedelta(minutes=10), stage="queued")
+
+    claimed = db.claim_next(now=now + timedelta(seconds=30))
+
+    assert claimed is not None
+    assert claimed.number == 3
+
+
+def test_dedup_upsert_updates_without_duplicate(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "old")
+    db.upsert_issue(1, "new")
+
+    assert db.get_issue(1).title == "new"
+    assert [issue.number for issue in db.list_issues()] == [1]
+
+
+def test_bump_attempt_records_error_and_fails_after_limit(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "flaky")
+
+    first = db.bump_attempt(1, "first", max_attempts=2)
+    second = db.bump_attempt(1, "second", max_attempts=2)
+
+    assert first.attempts == 1
+    assert first.stage == "queued"
+    assert second.attempts == 2
+    assert second.stage == "failed"
+    assert second.last_error == "second"

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -31,6 +31,16 @@ def test_schema_applies_idempotently(tmp_path) -> None:
     assert db.get_issue(1).stage == "queued"
 
 
+def test_sqlite_connection_uses_wal_and_busy_timeout(tmp_path) -> None:
+    db = store(tmp_path)
+
+    busy_timeout = db._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    journal_mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+
+    assert busy_timeout == 5000
+    assert journal_mode == "wal"
+
+
 def test_illegal_transition_rejected(tmp_path) -> None:
     db = store(tmp_path)
     db.upsert_issue(1, "Done", stage="merged")

--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.tracing import init_tracing, trace_node
+
+
+class FakeSpan:
+    def __init__(self, record):
+        self.record = record
+
+    def end(self, *, outputs=None, error=None, latency_seconds=0.0):
+        self.record["outputs"] = outputs
+        self.record["error"] = error
+        self.record["latency_seconds"] = latency_seconds
+
+
+class FakeTracer:
+    def __init__(self):
+        self.records = []
+
+    def start_span(self, *, name, inputs, tags):
+        record = {"name": name, "inputs": inputs, "tags": tags}
+        self.records.append(record)
+        return FakeSpan(record)
+
+
+def test_key_set_with_mocked_tracer_emits_span_with_tags() -> None:
+    tracer = FakeTracer()
+    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"), tracer=tracer)
+
+    def node(state):
+        return {**state, "classification": "fix"}
+
+    wrapped = trace_node("triage", node)
+    result = wrapped({"issue": GitHubIssue(number=12, title="Fix", labels=(), state="open")})
+
+    assert result["classification"] == "fix"
+    assert tracer.records[0]["name"] == "triage"
+    assert tracer.records[0]["tags"] == {"stage": "triage", "issue": "12"}
+    assert tracer.records[0]["outputs"]["classification"] == "fix"
+
+
+def test_key_unset_noop_still_runs_node_normally() -> None:
+    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh"))
+
+    def node(state):
+        return {**state, "classification": "feature"}
+
+    result = trace_node("triage", node)({"issue": GitHubIssue(number=13, title="Feature", labels=(), state="open")})
+
+    assert result["classification"] == "feature"
+

--- a/pipeline/wgmesh_pipeline/__init__.py
+++ b/pipeline/wgmesh_pipeline/__init__.py
@@ -1,0 +1,4 @@
+"""wgmesh autonomous pipeline service."""
+
+__version__ = "0.1.0"
+

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+
+VALID_MODES = frozenset({"shadow", "spec-only", "live"})
+DEFAULT_ANTHROPIC_HOST = "https://api.z.ai/api/anthropic"
+DEFAULT_TARGET_REPO = "atvirokodosprendimai/wgmesh"
+DEFAULT_POLL_INTERVAL_SECONDS = 300
+DEFAULT_MAX_FILES = 20
+
+
+@dataclass(frozen=True)
+class Config:
+    target_repo: str
+    mode: str = "shadow"
+    wgmesh_bot_pat: str | None = None
+    zai_api_key: str | None = None
+    anthropic_host: str = DEFAULT_ANTHROPIC_HOST
+    langsmith_api_key: str | None = None
+    poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS
+    max_files: int = DEFAULT_MAX_FILES
+    database_path: str = "pipeline/state.db"
+
+    @property
+    def owner(self) -> str:
+        return self.target_repo.split("/", 1)[0]
+
+    @property
+    def repo(self) -> str:
+        return self.target_repo.split("/", 1)[1]
+
+
+def load_config(env: Mapping[str, str] | None = None) -> Config:
+    source = os.environ if env is None else env
+
+    target_repo = _required(source, "TARGET_REPO")
+    mode = _get_nonempty(source, "PIPELINE_MODE") or "shadow"
+    if mode not in VALID_MODES:
+        valid = ", ".join(sorted(VALID_MODES))
+        raise ValueError(f"PIPELINE_MODE must be one of: {valid}; got {mode!r}")
+
+    if "/" not in target_repo or target_repo.count("/") != 1:
+        raise ValueError("TARGET_REPO must be in owner/repo form")
+
+    pat = _get_nonempty(source, "WGMESH_BOT_PAT")
+    if mode == "live" and not pat:
+        raise ValueError("WGMESH_BOT_PAT is required when PIPELINE_MODE=live")
+
+    return Config(
+        target_repo=target_repo,
+        mode=mode,
+        wgmesh_bot_pat=pat,
+        zai_api_key=_get_nonempty(source, "ZAI_API_KEY"),
+        anthropic_host=_get_nonempty(source, "ANTHROPIC_HOST") or DEFAULT_ANTHROPIC_HOST,
+        langsmith_api_key=_get_nonempty(source, "LANGSMITH_API_KEY"),
+        poll_interval_seconds=_get_int(source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
+        max_files=_get_int(source, "MAX_FILES", DEFAULT_MAX_FILES),
+        database_path=_get_nonempty(source, "PIPELINE_DB_PATH") or "pipeline/state.db",
+    )
+
+
+def _required(env: Mapping[str, str], name: str) -> str:
+    value = _get_nonempty(env, name)
+    if value is None:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def _get_nonempty(env: Mapping[str, str], name: str) -> str | None:
+    value = env.get(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _get_int(env: Mapping[str, str], name: str, default: int) -> int:
+    raw = _get_nonempty(env, name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 
 import requests
 
@@ -10,6 +11,15 @@ from wgmesh_pipeline.config import Config
 
 
 API_ROOT = "https://api.github.com"
+SANITISE_SCRIPT = Path(__file__).resolve().parents[3] / "company" / "scripts" / "sanitise.sh"
+GIT_TIMEOUT_SECONDS = 120
+HTTP_TIMEOUT_SECONDS = 30
+SANITISE_TIMEOUT_SECONDS = 120
+Sanitiser = Callable[[str], bool]
+
+
+class SanitiseError(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -36,11 +46,13 @@ class GitHubClient:
         session: requests.Session | None = None,
         api_root: str = API_ROOT,
         dry_run_records: list[DryRunResult] | None = None,
+        sanitiser: Sanitiser | None = None,
     ):
         self.config = config
         self.session = session or requests.Session()
         self.api_root = api_root.rstrip("/")
         self.dry_run_records = dry_run_records if dry_run_records is not None else []
+        self._sanitiser = sanitiser
 
     def list_needs_triage(self) -> list[GitHubIssue]:
         data = self._request(
@@ -120,15 +132,20 @@ class GitHubClient:
 
     def push_branch(self, clone_path: str, branch: str) -> Any:
         payload = {"clone_path": clone_path, "branch": branch}
+        self._sanitise_spec_files(Path(clone_path))
         if self.config.mode != "live":
             return self._write("push_branch", "GIT", "git push", payload=payload)
-        completed = subprocess.run(
-            ["git", "push", "origin", branch],
-            cwd=clone_path,
-            check=False,
-            text=True,
-            capture_output=True,
-        )
+        try:
+            completed = subprocess.run(
+                ["git", "push", "origin", branch],
+                cwd=clone_path,
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"git push timed out after {GIT_TIMEOUT_SECONDS}s")
         if completed.returncode != 0:
             raise RuntimeError(completed.stderr.strip() or f"git push failed for {branch}")
         return {"ok": True, "stdout": completed.stdout}
@@ -142,9 +159,13 @@ class GitHubClient:
         payload: dict[str, Any],
         spec_pr: bool = False,
     ) -> Any:
+        self._sanitise_write(operation, payload)
         mode = self.config.mode
         if mode == "shadow":
-            result = DryRunResult(dry_run=True, operation=operation, payload={"path": path, **payload})
+            dry_payload = {"path": path, **payload}
+            if operation == "create_pr":
+                dry_payload["number"] = _synthetic_pr_number(payload)
+            result = DryRunResult(dry_run=True, operation=operation, payload=dry_payload)
             self.dry_run_records.append(result)
             return result
         if mode == "spec-only" and not (operation == "create_pr" and spec_pr):
@@ -156,13 +177,57 @@ class GitHubClient:
         headers.setdefault("Accept", "application/vnd.github+json")
         if self.config.wgmesh_bot_pat:
             headers["Authorization"] = f"Bearer {self.config.wgmesh_bot_pat}"
-        response = self.session.request(method, f"{self.api_root}{path}", headers=headers, **kwargs)
+        kwargs.setdefault("timeout", HTTP_TIMEOUT_SECONDS)
+        try:
+            response = self.session.request(method, f"{self.api_root}{path}", headers=headers, **kwargs)
+        except requests.Timeout as exc:
+            raise RuntimeError(f"GitHub request timed out after {kwargs['timeout']}s") from exc
         response.raise_for_status()
         if raw_text:
             return response.text
         if response.text:
             return response.json()
         return {}
+
+    def _sanitise_write(self, operation: str, payload: dict[str, Any]) -> None:
+        if operation == "comment":
+            self._require_clean("comment body", str(payload.get("body", "")))
+        elif operation == "create_pr":
+            self._require_clean("create_pr title", str(payload.get("title", "")))
+            self._require_clean("create_pr body", str(payload.get("body", "")))
+
+    def _sanitise_spec_files(self, clone_path: Path) -> None:
+        specs_dir = clone_path / "specs"
+        if not specs_dir.exists():
+            return
+        for spec in sorted(specs_dir.glob("issue-*-spec.md")):
+            self._require_clean(str(spec.relative_to(clone_path)), spec.read_text())
+
+    def _require_clean(self, label: str, text: str) -> None:
+        if self._sanitiser is not None:
+            clean = self._sanitiser(text)
+        else:
+            clean = self._run_sanitise(text)
+        if not clean:
+            raise SanitiseError(f"sanitise failed for {label}")
+
+    def _run_sanitise(self, text: str) -> bool:
+        if not SANITISE_SCRIPT.exists():
+            if self.config.mode == "shadow":
+                return True
+            raise SanitiseError(f"sanitise script missing: {SANITISE_SCRIPT}")
+        try:
+            completed = subprocess.run(
+                [str(SANITISE_SCRIPT)],
+                input=text,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=SANITISE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return False
+        return completed.returncode == 0
 
 
 def _parse_issue(item: dict[str, Any]) -> GitHubIssue:
@@ -175,3 +240,10 @@ def _parse_issue(item: dict[str, Any]) -> GitHubIssue:
         pull_request=item.get("pull_request"),
     )
 
+
+def _synthetic_pr_number(payload: dict[str, Any]) -> int:
+    for field in ("head", "title"):
+        digits = "".join(ch for ch in str(payload.get(field, "")) if ch.isdigit())
+        if digits:
+            return int(digits)
+    return 1

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from wgmesh_pipeline.config import Config
+
+
+API_ROOT = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class GitHubIssue:
+    number: int
+    title: str
+    labels: tuple[str, ...]
+    state: str
+    pull_request: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class DryRunResult:
+    dry_run: bool
+    operation: str
+    payload: dict[str, Any]
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        config: Config,
+        *,
+        session: requests.Session | None = None,
+        api_root: str = API_ROOT,
+        dry_run_records: list[DryRunResult] | None = None,
+    ):
+        self.config = config
+        self.session = session or requests.Session()
+        self.api_root = api_root.rstrip("/")
+        self.dry_run_records = dry_run_records if dry_run_records is not None else []
+
+    def list_needs_triage(self) -> list[GitHubIssue]:
+        data = self._request(
+            "GET",
+            f"/repos/{self.config.owner}/{self.config.repo}/issues",
+            params={"state": "open", "labels": "needs-triage"},
+        )
+        return [_parse_issue(item) for item in data]
+
+    def list_open_issues(self) -> list[GitHubIssue]:
+        data = self._request(
+            "GET",
+            f"/repos/{self.config.owner}/{self.config.repo}/issues",
+            params={"state": "open"},
+        )
+        return [_parse_issue(item) for item in data]
+
+    def get_pr(self, number: int) -> dict[str, Any]:
+        return self._request("GET", f"/repos/{self.config.owner}/{self.config.repo}/pulls/{number}")
+
+    def get_diff(self, pr_number: int) -> str:
+        return self._request(
+            "GET",
+            f"/repos/{self.config.owner}/{self.config.repo}/pulls/{pr_number}",
+            headers={"Accept": "application/vnd.github.v3.diff"},
+            raw_text=True,
+        )
+
+    def add_label(self, issue_number: int, label: str) -> Any:
+        return self._write(
+            "add_label",
+            "POST",
+            f"/repos/{self.config.owner}/{self.config.repo}/issues/{issue_number}/labels",
+            payload={"labels": [label]},
+        )
+
+    def remove_label(self, issue_number: int, label: str) -> Any:
+        return self._write(
+            "remove_label",
+            "DELETE",
+            f"/repos/{self.config.owner}/{self.config.repo}/issues/{issue_number}/labels/{label}",
+            payload={},
+        )
+
+    def comment(self, issue_number: int, body: str) -> Any:
+        return self._write(
+            "comment",
+            "POST",
+            f"/repos/{self.config.owner}/{self.config.repo}/issues/{issue_number}/comments",
+            payload={"body": body},
+        )
+
+    def create_pr(
+        self,
+        *,
+        title: str,
+        head: str,
+        base: str,
+        body: str,
+        spec_pr: bool = False,
+    ) -> Any:
+        return self._write(
+            "create_pr",
+            "POST",
+            f"/repos/{self.config.owner}/{self.config.repo}/pulls",
+            payload={"title": title, "head": head, "base": base, "body": body},
+            spec_pr=spec_pr or title.startswith("spec: Issue #"),
+        )
+
+    def merge_pr(self, pr_number: int, *, commit_title: str | None = None) -> Any:
+        return self._write(
+            "merge_pr",
+            "PUT",
+            f"/repos/{self.config.owner}/{self.config.repo}/pulls/{pr_number}/merge",
+            payload={"commit_title": commit_title} if commit_title else {},
+        )
+
+    def push_branch(self, clone_path: str, branch: str) -> Any:
+        payload = {"clone_path": clone_path, "branch": branch}
+        if self.config.mode != "live":
+            return self._write("push_branch", "GIT", "git push", payload=payload)
+        completed = subprocess.run(
+            ["git", "push", "origin", branch],
+            cwd=clone_path,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(completed.stderr.strip() or f"git push failed for {branch}")
+        return {"ok": True, "stdout": completed.stdout}
+
+    def _write(
+        self,
+        operation: str,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any],
+        spec_pr: bool = False,
+    ) -> Any:
+        mode = self.config.mode
+        if mode == "shadow":
+            result = DryRunResult(dry_run=True, operation=operation, payload={"path": path, **payload})
+            self.dry_run_records.append(result)
+            return result
+        if mode == "spec-only" and not (operation == "create_pr" and spec_pr):
+            raise PermissionError(f"{operation} is not allowed when PIPELINE_MODE=spec-only")
+        return self._request(method, path, json=payload)
+
+    def _request(self, method: str, path: str, *, raw_text: bool = False, **kwargs: Any) -> Any:
+        headers = dict(kwargs.pop("headers", {}) or {})
+        headers.setdefault("Accept", "application/vnd.github+json")
+        if self.config.wgmesh_bot_pat:
+            headers["Authorization"] = f"Bearer {self.config.wgmesh_bot_pat}"
+        response = self.session.request(method, f"{self.api_root}{path}", headers=headers, **kwargs)
+        response.raise_for_status()
+        if raw_text:
+            return response.text
+        if response.text:
+            return response.json()
+        return {}
+
+
+def _parse_issue(item: dict[str, Any]) -> GitHubIssue:
+    labels = tuple(label["name"] if isinstance(label, dict) else str(label) for label in item.get("labels", []))
+    return GitHubIssue(
+        number=int(item["number"]),
+        title=str(item["title"]),
+        labels=labels,
+        state=str(item.get("state", "open")),
+        pull_request=item.get("pull_request"),
+    )
+

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -34,8 +34,11 @@ def reconcile_issues(client: GitHubClient, store: StateStore) -> ReconcileResult
             store.upsert_issue(issue.number, issue.title, stage="escalated", status="open")
             escalated += 1
         elif "needs-triage" in labels or "copilot-triaging" in labels:
-            store.upsert_issue(issue.number, issue.title, stage="queued", status="open")
-            queued += 1
+            if current_stage is None:
+                store.upsert_issue(issue.number, issue.title, stage="queued", status="open")
+                queued += 1
+            elif current_stage != "queued" and "needs-triage" in labels:
+                client.remove_label(issue.number, "needs-triage")
         else:
             store.upsert_issue(issue.number, issue.title, stage=current_stage or "queued", status="open")
     return ReconcileResult(seen=seen, queued=queued, escalated=escalated, merged=merged)
@@ -46,4 +49,3 @@ def _current_stage(store: StateStore, number: int) -> str | None:
         return store.get_issue(number).stage
     except KeyError:
         return None
-

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+from wgmesh_pipeline.state.store import StateStore
+
+
+TERMINAL_STAGES = {"merged", "escalated", "failed"}
+MERGED_LABELS = {"merged", "completed", "done", "impl-merged"}
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    seen: int
+    queued: int
+    escalated: int
+    merged: int
+
+
+def reconcile_issues(client: GitHubClient, store: StateStore) -> ReconcileResult:
+    seen = queued = escalated = merged = 0
+    for issue in client.list_open_issues():
+        seen += 1
+        labels = set(issue.labels)
+        current_stage = _current_stage(store, issue.number)
+        if current_stage in TERMINAL_STAGES:
+            continue
+
+        if issue.state == "closed" or labels & MERGED_LABELS:
+            store.upsert_issue(issue.number, issue.title, stage="merged", status="closed")
+            merged += 1
+        elif "needs-human" in labels:
+            store.upsert_issue(issue.number, issue.title, stage="escalated", status="open")
+            escalated += 1
+        elif "needs-triage" in labels or "copilot-triaging" in labels:
+            store.upsert_issue(issue.number, issue.title, stage="queued", status="open")
+            queued += 1
+        else:
+            store.upsert_issue(issue.number, issue.title, stage=current_stage or "queued", status="open")
+    return ReconcileResult(seen=seen, queued=queued, escalated=escalated, merged=merged)
+
+
+def _current_stage(store: StateStore, number: int) -> str | None:
+    try:
+        return store.get_issue(number).stage
+    except KeyError:
+        return None
+

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from wgmesh_pipeline.config import Config
+
+
+SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class GooseResult:
+    ok: bool
+    output_path: Path | None
+    duration_seconds: float
+    raw_log: str
+    error: str | None = None
+
+
+class GooseRunner:
+    def __init__(self, config: Config, *, runner: SubprocessRunner | None = None):
+        self.config = config
+        self._runner = runner or subprocess.run
+
+    def run_recipe(
+        self,
+        *,
+        recipe: str | Path,
+        workdir: str | Path,
+        params: Mapping[str, str],
+        expected_output: str | Path,
+    ) -> GooseResult:
+        workdir_path = Path(workdir)
+        output_path = Path(expected_output)
+        if not output_path.is_absolute():
+            output_path = workdir_path / output_path
+
+        command = ["goose", "run", "--no-session", "--recipe", str(recipe)]
+        for key, value in params.items():
+            command.extend(["--params", f"{key}={value}"])
+
+        env = os.environ.copy()
+        if self.config.zai_api_key:
+            env["ANTHROPIC_API_KEY"] = self.config.zai_api_key
+        env["ANTHROPIC_HOST"] = self.config.anthropic_host
+
+        started = time.monotonic()
+        completed = self._runner(
+            command,
+            cwd=str(workdir_path),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        duration = time.monotonic() - started
+        raw_log = _join_log(completed.stdout, completed.stderr)
+
+        if completed.returncode != 0:
+            return GooseResult(
+                ok=False,
+                output_path=None,
+                duration_seconds=duration,
+                raw_log=raw_log,
+                error=f"goose exited {completed.returncode}",
+            )
+
+        if not output_path.exists() or output_path.stat().st_size == 0:
+            return GooseResult(
+                ok=False,
+                output_path=output_path,
+                duration_seconds=duration,
+                raw_log=raw_log,
+                error=f"empty output guard fired for {output_path}",
+            )
+
+        return GooseResult(
+            ok=True,
+            output_path=output_path,
+            duration_seconds=duration,
+            raw_log=raw_log,
+        )
+
+
+def _join_log(*parts: str | None) -> str:
+    return "\n".join(part for part in parts if part)
+

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -11,6 +11,7 @@ from wgmesh_pipeline.config import Config
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
+GOOSE_TIMEOUT_SECONDS = 1800
 
 
 @dataclass(frozen=True)
@@ -50,14 +51,25 @@ class GooseRunner:
         env["ANTHROPIC_HOST"] = self.config.anthropic_host
 
         started = time.monotonic()
-        completed = self._runner(
-            command,
-            cwd=str(workdir_path),
-            env=env,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        try:
+            completed = self._runner(
+                command,
+                cwd=str(workdir_path),
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=GOOSE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            duration = time.monotonic() - started
+            return GooseResult(
+                ok=False,
+                output_path=None,
+                duration_seconds=duration,
+                raw_log=_join_log(_decode_timeout_output(exc.output), _decode_timeout_output(exc.stderr)),
+                error=f"goose timed out after {GOOSE_TIMEOUT_SECONDS}s",
+            )
         duration = time.monotonic() - started
         raw_log = _join_log(completed.stdout, completed.stderr)
 
@@ -90,3 +102,8 @@ class GooseRunner:
 def _join_log(*parts: str | None) -> str:
     return "\n".join(part for part in parts if part)
 
+
+def _decode_timeout_output(value: str | bytes | None) -> str | None:
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value

--- a/pipeline/wgmesh_pipeline/graph/build.py
+++ b/pipeline/wgmesh_pipeline/graph/build.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.graph.nodes.gate import gate_node
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+from wgmesh_pipeline.graph.nodes.review import review_node
+from wgmesh_pipeline.graph.nodes.spec import spec_node
+from wgmesh_pipeline.graph.nodes.triage import triage_node
+from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.tracing import trace_node
+
+
+@dataclass
+class CompiledGraph:
+    config: Config
+    triage: Callable[[GraphState], GraphState] = triage_node
+    spec: Callable[[GraphState], GraphState] = spec_node
+    implement: Callable[[GraphState], GraphState] = implement_node
+    review: Callable[[GraphState], GraphState] = review_node
+
+    def invoke(self, state: GraphState) -> GraphState:
+        current = self.triage(state)
+        if current.get("classification") in {"wont-do", "needs-info"}:
+            current = dict(current)
+            current["decision"] = "escalate"
+            if current.get("github") is not None:
+                current["github"].add_label(current["issue"].number, "needs-human")
+            current.setdefault("visited", []).append("escalate")
+            return current
+
+        current = self.spec(current)
+        current = self.implement(current)
+        current = self.review(current)
+        return gate_node(current, max_files=self.config.max_files)
+
+
+def build_graph(config: Config) -> CompiledGraph:
+    return CompiledGraph(
+        config=config,
+        triage=trace_node("triage", triage_node),
+        spec=trace_node("spec", spec_node),
+        implement=trace_node("implement", implement_node),
+        review=trace_node("review", review_node),
+    )
+

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wgmesh_pipeline.graph.state import Decision, GraphState
+from wgmesh_pipeline.risk import classify_risk
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    decision: Decision
+    risk_tier: str
+    reasons: tuple[str, ...]
+
+
+def decide_gate(
+    *,
+    changed_files: list[str],
+    diff: str,
+    max_files: int,
+    tests_passed: bool,
+    sanitise_ok: bool,
+    review_findings: list[dict],
+) -> GateDecision:
+    risk = classify_risk(changed_files, diff, max_files=max_files)
+    reasons = list(risk.reasons)
+    if not tests_passed:
+        reasons.append("tests failed")
+    if not sanitise_ok:
+        reasons.append("sanitise failed")
+    if any(finding.get("blocking", False) for finding in review_findings):
+        reasons.append("blocking review finding")
+
+    if risk.high or reasons:
+        return GateDecision(decision="escalate", risk_tier=risk.tier, reasons=tuple(reasons))
+    return GateDecision(decision="merge", risk_tier="low", reasons=())
+
+
+def gate_node(state: GraphState, *, max_files: int) -> GraphState:
+    next_state = dict(state)
+    _visit(next_state, "gate")
+    decision = decide_gate(
+        changed_files=list(next_state.get("changed_files", [])),
+        diff=next_state.get("diff", ""),
+        max_files=max_files,
+        tests_passed=bool(next_state.get("tests_passed", False)),
+        sanitise_ok=bool(next_state.get("sanitise_ok", False)),
+        review_findings=list(next_state.get("review_findings", [])),
+    )
+    next_state["decision"] = decision.decision
+    next_state["risk_tier"] = decision.risk_tier
+    next_state["risk_reasons"] = list(decision.reasons)
+
+    client = next_state.get("github")
+    if client is not None:
+        if decision.decision == "merge":
+            client.merge_pr(int(next_state.get("impl_pr", 0)), commit_title=f"Merge issue #{next_state['issue'].number}")
+        else:
+            client.add_label(next_state["issue"].number, "needs-human")
+    return next_state
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)
+

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -36,7 +36,7 @@ def decide_gate(
     return GateDecision(decision="merge", risk_tier="low", reasons=())
 
 
-def gate_node(state: GraphState, *, max_files: int) -> GraphState:
+def gate_node(state: GraphState, *, max_files: int, apply_side_effects: bool = True) -> GraphState:
     next_state = dict(state)
     _visit(next_state, "gate")
     decision = decide_gate(
@@ -51,15 +51,23 @@ def gate_node(state: GraphState, *, max_files: int) -> GraphState:
     next_state["risk_tier"] = decision.risk_tier
     next_state["risk_reasons"] = list(decision.reasons)
 
-    client = next_state.get("github")
-    if client is not None:
-        if decision.decision == "merge":
-            client.merge_pr(int(next_state.get("impl_pr", 0)), commit_title=f"Merge issue #{next_state['issue'].number}")
-        else:
-            client.add_label(next_state["issue"].number, "needs-human")
+    if apply_side_effects:
+        apply_gate_side_effects(next_state)
     return next_state
+
+
+def apply_gate_side_effects(state: GraphState) -> None:
+    client = state.get("github")
+    if client is None:
+        return
+    if state["decision"] == "merge":
+        impl_pr = state.get("impl_pr")
+        if impl_pr is None:
+            raise RuntimeError("cannot merge implementation without impl_pr")
+        client.merge_pr(int(impl_pr), commit_title=f"Merge issue #{state['issue'].number}")
+    else:
+        client.add_label(state["issue"].number, "needs-human")
 
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
-

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wgmesh_pipeline.graph.state import GraphState
+
+
+def implement_node(state: GraphState) -> GraphState:
+    next_state = dict(state)
+    _visit(next_state, "implement")
+    if next_state.get("diff"):
+        next_state.setdefault("changed_files", ["docs/implementation.md"])
+        return next_state
+
+    runner = next_state.get("goose_runner")
+    repo_path = Path(next_state.get("repo_path", "."))
+    diff_rel = Path("pipeline-output") / f"issue-{next_state['issue'].number}.diff"
+    if runner is not None:
+        result = runner.run_recipe(
+            recipe="wgmesh-implementation.yaml",
+            workdir=repo_path,
+            params={"spec_file": str(next_state["spec_path"])},
+            expected_output=diff_rel,
+        )
+        if not result.ok:
+            raise RuntimeError(result.error or "goose implementation failed")
+        next_state["diff"] = Path(result.output_path).read_text()
+    else:
+        next_state["diff"] = "+docs-only change\n"
+    next_state.setdefault("changed_files", ["docs/implementation.md"])
+    return next_state
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)
+

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+from typing import Any
 
 from wgmesh_pipeline.graph.state import GraphState
 
@@ -9,7 +11,8 @@ def implement_node(state: GraphState) -> GraphState:
     next_state = dict(state)
     _visit(next_state, "implement")
     if next_state.get("diff"):
-        next_state.setdefault("changed_files", ["docs/implementation.md"])
+        next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
+        _ensure_impl_pr(next_state)
         return next_state
 
     runner = next_state.get("goose_runner")
@@ -27,10 +30,72 @@ def implement_node(state: GraphState) -> GraphState:
         next_state["diff"] = Path(result.output_path).read_text()
     else:
         next_state["diff"] = "+docs-only change\n"
-    next_state.setdefault("changed_files", ["docs/implementation.md"])
+    next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
+    _ensure_impl_pr(next_state)
     return next_state
+
+
+def changed_files_from_diff(diff: str) -> list[str]:
+    files: list[str] = []
+    seen: set[str] = set()
+    for line in diff.splitlines():
+        path = _path_from_git_header(line) or _path_from_plus_header(line)
+        if path and path not in seen:
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def _path_from_git_header(line: str) -> str | None:
+    match = re.match(r"^diff --git a/(.+?) b/(.+)$", line)
+    if not match:
+        return None
+    return _normalise_diff_path(match.group(2))
+
+
+def _path_from_plus_header(line: str) -> str | None:
+    if not line.startswith("+++ "):
+        return None
+    return _normalise_diff_path(line[4:].strip())
+
+
+def _normalise_diff_path(path: str) -> str | None:
+    if path == "/dev/null":
+        return None
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def _ensure_impl_pr(state: dict) -> None:
+    if state.get("impl_pr") is not None or state.get("github") is None:
+        return
+    issue = state["issue"]
+    result = state["github"].create_pr(
+        title=f"fix: Issue #{issue.number} - {issue.title}",
+        head=f"bot/impl-{issue.number}",
+        base="main",
+        body=_impl_pr_body(issue.number, state.get("changed_files", [])),
+    )
+    pr_number = _pr_number(result)
+    if pr_number is None:
+        raise RuntimeError("implementation PR creation did not return a PR number")
+    state["impl_pr"] = pr_number
+
+
+def _impl_pr_body(issue_number: int, changed_files: list[str]) -> str:
+    files = "\n".join(f"- {path}" for path in changed_files) or "- no changed files detected"
+    return f"Implementation for issue #{issue_number}.\n\nChanged files:\n{files}\n"
+
+
+def _pr_number(result: Any) -> int | None:
+    if isinstance(result, dict) and result.get("number") is not None:
+        return int(result["number"])
+    payload = getattr(result, "payload", None)
+    if isinstance(payload, dict) and payload.get("number") is not None:
+        return int(payload["number"])
+    return None
 
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
-

--- a/pipeline/wgmesh_pipeline/graph/nodes/review.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/review.py
@@ -7,6 +7,7 @@ from wgmesh_pipeline.graph.state import GraphState
 
 
 SANITISE_SCRIPT = Path(__file__).resolve().parents[4] / "company" / "scripts" / "sanitise.sh"
+SANITISE_TIMEOUT_SECONDS = 120
 
 
 def review_node(state: GraphState) -> GraphState:
@@ -14,20 +15,36 @@ def review_node(state: GraphState) -> GraphState:
     _visit(next_state, "review")
     diff = next_state.get("diff", "")
     next_state["sanitise_ok"] = run_sanitise(diff)
-    next_state.setdefault("tests_passed", True)
+    next_state["tests_passed"] = _tests_passed(next_state)
     next_state.setdefault("review_findings", [])
     return next_state
 
 
 def run_sanitise(text: str, *, script: Path = SANITISE_SCRIPT) -> bool:
-    completed = subprocess.run(
-        [str(script)],
-        input=text,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            [str(script)],
+            input=text,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=SANITISE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return completed.returncode == 0
+
+
+def _tests_passed(state: GraphState) -> bool:
+    if "tests_passed" in state:
+        return bool(state["tests_passed"])
+    verification = state.get("verification")
+    if isinstance(verification, dict):
+        if "tests_passed" in verification:
+            return bool(verification["tests_passed"])
+        if "passed" in verification:
+            return bool(verification["passed"])
+    return False
 
 
 def _visit(state: dict, node: str) -> None:

--- a/pipeline/wgmesh_pipeline/graph/nodes/review.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/review.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from wgmesh_pipeline.graph.state import GraphState
+
+
+SANITISE_SCRIPT = Path(__file__).resolve().parents[4] / "company" / "scripts" / "sanitise.sh"
+
+
+def review_node(state: GraphState) -> GraphState:
+    next_state = dict(state)
+    _visit(next_state, "review")
+    diff = next_state.get("diff", "")
+    next_state["sanitise_ok"] = run_sanitise(diff)
+    next_state.setdefault("tests_passed", True)
+    next_state.setdefault("review_findings", [])
+    return next_state
+
+
+def run_sanitise(text: str, *, script: Path = SANITISE_SCRIPT) -> bool:
+    completed = subprocess.run(
+        [str(script)],
+        input=text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wgmesh_pipeline.graph.state import GraphState
+
+
+def spec_node(state: GraphState) -> GraphState:
+    next_state = dict(state)
+    _visit(next_state, "spec")
+    if next_state.get("spec_path"):
+        return next_state
+
+    issue = next_state["issue"]
+    repo_path = Path(next_state.get("repo_path", "."))
+    spec_rel = Path("specs") / f"issue-{issue.number}-spec.md"
+    runner = next_state.get("goose_runner")
+    if runner is None:
+        next_state["spec_path"] = str(spec_rel)
+        return next_state
+
+    result = runner.run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=repo_path,
+        params={"spec_file": str(spec_rel)},
+        expected_output=spec_rel,
+    )
+    if not result.ok:
+        raise RuntimeError(result.error or "goose spec failed")
+    next_state["spec_path"] = str(result.output_path)
+    return next_state
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)
+

--- a/pipeline/wgmesh_pipeline/graph/nodes/triage.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/triage.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from wgmesh_pipeline.graph.state import Classification, GraphState
+
+
+def triage_node(state: GraphState) -> GraphState:
+    next_state = dict(state)
+    _visit(next_state, "triage")
+    override = next_state.get("classification_override")
+    if override:
+        next_state["classification"] = override
+        return next_state
+
+    title = next_state["issue"].title.lower()
+    if "wont" in title or "won't" in title:
+        classification: Classification = "wont-do"
+    elif "question" in title or "needs info" in title:
+        classification = "needs-info"
+    elif "feature" in title:
+        classification = "feature"
+    else:
+        classification = "fix"
+    next_state["classification"] = classification
+    return next_state
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)
+

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+
+
+Classification = Literal["fix", "feature", "wont-do", "needs-info"]
+Decision = Literal["merge", "escalate"]
+
+
+class GraphState(TypedDict, total=False):
+    issue: GitHubIssue
+    classification: Classification
+    classification_override: Classification
+    spec_path: str
+    diff: str
+    changed_files: list[str]
+    risk_tier: str
+    risk_reasons: list[str]
+    review_findings: list[dict[str, Any]]
+    tests_passed: bool
+    sanitise_ok: bool
+    decision: Decision
+    visited: list[str]
+    github: GitHubClient
+    repo_path: str | Path
+    goose_runner: Any
+    impl_pr: int
+

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import signal
+from pathlib import Path
+
+from wgmesh_pipeline.config import load_config
+from wgmesh_pipeline.github.client import GitHubClient
+from wgmesh_pipeline.graph.build import build_graph
+from wgmesh_pipeline.poller import Poller
+from wgmesh_pipeline.state.store import StateStore
+from wgmesh_pipeline.tracing import init_tracing
+
+
+async def async_main() -> None:
+    config = load_config()
+    init_tracing(config)
+    db_path = Path(config.database_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = StateStore(db_path)
+    poller = Poller(config=config, store=store, client=GitHubClient(config), graph=build_graph(config))
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+    await poller.run_forever(stop)
+
+
+def main() -> None:
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+from wgmesh_pipeline.github.reconcile import reconcile_issues
+from wgmesh_pipeline.graph.nodes.gate import gate_node
+from wgmesh_pipeline.state.store import IssueRecord, StateStore
+
+
+@dataclass
+class Poller:
+    config: Config
+    store: StateStore
+    client: GitHubClient
+    graph: object
+    scratch: dict[int, dict] = field(default_factory=dict)
+
+    async def run_forever(self, stop: asyncio.Event | None = None) -> None:
+        stop = stop or asyncio.Event()
+        while not stop.is_set():
+            await self.tick()
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=self.config.poll_interval_seconds)
+            except TimeoutError:
+                continue
+
+    async def tick(self) -> IssueRecord | None:
+        reconcile_issues(self.client, self.store)
+        issue = self.store.claim_next(now=datetime.now(timezone.utc))
+        if issue is None:
+            return None
+
+        started = datetime.now(timezone.utc)
+        node = issue.stage
+        try:
+            advanced = self._advance_one_stage(issue)
+        except Exception as exc:
+            self.store.bump_attempt(issue.number, str(exc))
+            self.store.record_run(issue=issue.number, node=node, started=started, ended=datetime.now(timezone.utc), outcome="error")
+            return None
+
+        self.store.record_run(issue=issue.number, node=node, started=started, ended=datetime.now(timezone.utc), outcome="ok")
+        return advanced
+
+    def _advance_one_stage(self, issue: IssueRecord) -> IssueRecord:
+        graph_issue = GitHubIssue(number=issue.number, title=issue.title, labels=(), state=issue.status)
+        state = {**self.scratch.get(issue.number, {}), "issue": graph_issue, "github": self.client}
+
+        if issue.stage == "queued":
+            result = self.graph.triage(state)
+            self.scratch[issue.number] = dict(result)
+            classification = result.get("classification")
+            if classification in {"wont-do", "needs-info"}:
+                self.client.add_label(issue.number, "needs-human")
+                return self.store.transition(issue.number, "queued", "escalated")
+            self.store.upsert_issue(issue.number, issue.title, classification=classification, stage="queued")
+            return self.store.transition(issue.number, "queued", "triaged")
+
+        if issue.stage == "triaged":
+            self.scratch[issue.number] = dict(self.graph.spec(state))
+            return self.store.transition(issue.number, "triaged", "specced")
+
+        if issue.stage == "specced":
+            self.scratch[issue.number] = dict(self.graph.implement(state))
+            return self.store.transition(issue.number, "specced", "implemented")
+
+        if issue.stage == "implemented":
+            self.scratch[issue.number] = dict(self.graph.review(state))
+            return self.store.transition(issue.number, "implemented", "reviewed")
+
+        if issue.stage == "reviewed":
+            result = gate_node(state, max_files=self.config.max_files)
+            self.scratch[issue.number] = dict(result)
+            return self.store.transition(issue.number, "reviewed", "merged" if result["decision"] == "merge" else "escalated")
+
+        raise ValueError(f"stage is not actionable: {issue.stage}")

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 from wgmesh_pipeline.github.reconcile import reconcile_issues
-from wgmesh_pipeline.graph.nodes.gate import gate_node
+from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
 from wgmesh_pipeline.state.store import IssueRecord, StateStore
 
 
@@ -18,6 +18,7 @@ class Poller:
     client: GitHubClient
     graph: object
     scratch: dict[int, dict] = field(default_factory=dict)
+    last_reconcile_error: str | None = None
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop = stop or asyncio.Event()
@@ -29,8 +30,12 @@ class Poller:
                 continue
 
     async def tick(self) -> IssueRecord | None:
-        reconcile_issues(self.client, self.store)
-        issue = self.store.claim_next(now=datetime.now(timezone.utc))
+        try:
+            reconcile_issues(self.client, self.store)
+            issue = self.store.claim_next(now=datetime.now(timezone.utc))
+        except Exception as exc:
+            self.last_reconcile_error = str(exc)
+            return None
         if issue is None:
             return None
 
@@ -49,6 +54,8 @@ class Poller:
     def _advance_one_stage(self, issue: IssueRecord) -> IssueRecord:
         graph_issue = GitHubIssue(number=issue.number, title=issue.title, labels=(), state=issue.status)
         state = {**self.scratch.get(issue.number, {}), "issue": graph_issue, "github": self.client}
+        if issue.impl_pr is not None:
+            state["impl_pr"] = issue.impl_pr
 
         if issue.stage == "queued":
             result = self.graph.triage(state)
@@ -66,6 +73,15 @@ class Poller:
 
         if issue.stage == "specced":
             self.scratch[issue.number] = dict(self.graph.implement(state))
+            if self.scratch[issue.number].get("impl_pr") is not None:
+                self.store.upsert_issue(
+                    issue.number,
+                    issue.title,
+                    classification=issue.classification,
+                    stage="specced",
+                    status=issue.status,
+                    impl_pr=int(self.scratch[issue.number]["impl_pr"]),
+                )
             return self.store.transition(issue.number, "specced", "implemented")
 
         if issue.stage == "implemented":
@@ -73,8 +89,10 @@ class Poller:
             return self.store.transition(issue.number, "implemented", "reviewed")
 
         if issue.stage == "reviewed":
-            result = gate_node(state, max_files=self.config.max_files)
+            result = gate_node(state, max_files=self.config.max_files, apply_side_effects=False)
             self.scratch[issue.number] = dict(result)
-            return self.store.transition(issue.number, "reviewed", "merged" if result["decision"] == "merge" else "escalated")
+            advanced = self.store.transition(issue.number, "reviewed", "merged" if result["decision"] == "merge" else "escalated")
+            apply_gate_side_effects(result)
+            return advanced
 
         raise ValueError(f"stage is not actionable: {issue.stage}")

--- a/pipeline/wgmesh_pipeline/risk.py
+++ b/pipeline/wgmesh_pipeline/risk.py
@@ -26,12 +26,21 @@ class RiskResult:
 
 
 def classify_risk(changed_files: Iterable[str], diff_text: str, *, max_files: int) -> RiskResult:
+    """Classify implementation risk.
+
+    `max_files` is inclusive: exactly MAX_FILES changed files is allowed;
+    exceeding it escalates.
+    """
     files = tuple(changed_files)
     reasons: list[str] = []
 
     risky_paths = [path for path in files if HIGH_RISK_RE.search(path)]
     if risky_paths:
         reasons.append(f"high-risk path: {risky_paths[0]}")
+
+    risky_added_line = _high_risk_added_line(diff_text)
+    if risky_added_line:
+        reasons.append(f"high-risk diff content: {risky_added_line}")
 
     if len(files) > max_files:
         reasons.append(f"changed file count {len(files)} exceeds MAX_FILES={max_files}")
@@ -52,3 +61,18 @@ def _adds_network_call(diff_text: str) -> bool:
             return True
     return False
 
+
+def _high_risk_added_line(diff_text: str) -> str | None:
+    for line in diff_text.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if HIGH_RISK_RE.search(line[1:]):
+            return _summarise_added_line(line[1:])
+    return None
+
+
+def _summarise_added_line(line: str) -> str:
+    stripped = line.strip()
+    if len(stripped) <= 80:
+        return stripped
+    return f"{stripped[:77]}..."

--- a/pipeline/wgmesh_pipeline/risk.py
+++ b/pipeline/wgmesh_pipeline/risk.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+
+HIGH_RISK_RE = re.compile(
+    r"auth|authn|oauth|crypto|wireguard[ -]?key|secrets?|token|credential|payment|polar|billing|stripe",
+    re.IGNORECASE,
+)
+NET_NEW_CALL_RE = re.compile(
+    r"\b(http\.(Post|Get|Do)|http\.NewRequest|fetch\(|axios\.|requests\.|urllib\.|net\.Dial|grpc\.Dial|curl\s+|https?://)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class RiskResult:
+    tier: str
+    reasons: tuple[str, ...]
+
+    @property
+    def high(self) -> bool:
+        return self.tier == "high"
+
+
+def classify_risk(changed_files: Iterable[str], diff_text: str, *, max_files: int) -> RiskResult:
+    files = tuple(changed_files)
+    reasons: list[str] = []
+
+    risky_paths = [path for path in files if HIGH_RISK_RE.search(path)]
+    if risky_paths:
+        reasons.append(f"high-risk path: {risky_paths[0]}")
+
+    if len(files) > max_files:
+        reasons.append(f"changed file count {len(files)} exceeds MAX_FILES={max_files}")
+
+    if _adds_network_call(diff_text):
+        reasons.append("net-new outbound network call")
+
+    if reasons:
+        return RiskResult(tier="high", reasons=tuple(reasons))
+    return RiskResult(tier="low", reasons=())
+
+
+def _adds_network_call(diff_text: str) -> bool:
+    for line in diff_text.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if NET_NEW_CALL_RE.search(line[1:]):
+            return True
+    return False
+

--- a/pipeline/wgmesh_pipeline/state/schema.sql
+++ b/pipeline/wgmesh_pipeline/state/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS issues (
+  number INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  classification TEXT,
+  stage TEXT NOT NULL DEFAULT 'queued',
+  status TEXT NOT NULL DEFAULT 'open',
+  risk_tier TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  spec_pr INTEGER,
+  impl_pr INTEGER,
+  last_error TEXT,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue INTEGER NOT NULL,
+  node TEXT NOT NULL,
+  started TEXT NOT NULL,
+  ended TEXT,
+  outcome TEXT NOT NULL,
+  langsmith_run_id TEXT,
+  tokens INTEGER,
+  FOREIGN KEY(issue) REFERENCES issues(number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_issues_claim
+  ON issues(stage, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_runs_issue
+  ON runs(issue, started);
+

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from importlib import resources
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "queued": {"triaged", "escalated", "failed"},
+    "triaged": {"specced", "escalated", "failed"},
+    "specced": {"implemented", "escalated", "failed"},
+    "implemented": {"reviewed", "escalated", "failed"},
+    "reviewed": {"merged", "escalated", "failed"},
+    "merged": set(),
+    "escalated": set(),
+    "failed": set(),
+}
+ACTIONABLE_STAGES = ("queued", "triaged", "specced", "implemented", "reviewed")
+
+
+class TransitionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    number: int
+    title: str
+    classification: str | None
+    stage: str
+    status: str
+    risk_tier: str | None
+    attempts: int
+    spec_pr: int | None
+    impl_pr: int | None
+    last_error: str | None
+    updated_at: datetime
+
+
+class StateStore:
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.row_factory = sqlite3.Row
+        self.apply_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def apply_schema(self) -> None:
+        schema = resources.files("wgmesh_pipeline.state").joinpath("schema.sql").read_text()
+        self._conn.executescript(schema)
+        self._conn.commit()
+
+    def upsert_issue(
+        self,
+        number: int,
+        title: str,
+        *,
+        classification: str | None = None,
+        stage: str = "queued",
+        status: str = "open",
+        risk_tier: str | None = None,
+        spec_pr: int | None = None,
+        impl_pr: int | None = None,
+        last_error: str | None = None,
+        updated_at: datetime | None = None,
+    ) -> IssueRecord:
+        if stage not in ALLOWED_TRANSITIONS:
+            raise ValueError(f"unknown issue stage: {stage}")
+        now = _dt(updated_at)
+        self._conn.execute(
+            """
+            INSERT INTO issues (
+              number, title, classification, stage, status, risk_tier,
+              attempts, spec_pr, impl_pr, last_error, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+            ON CONFLICT(number) DO UPDATE SET
+              title=excluded.title,
+              classification=COALESCE(excluded.classification, issues.classification),
+              stage=excluded.stage,
+              status=excluded.status,
+              risk_tier=COALESCE(excluded.risk_tier, issues.risk_tier),
+              spec_pr=COALESCE(excluded.spec_pr, issues.spec_pr),
+              impl_pr=COALESCE(excluded.impl_pr, issues.impl_pr),
+              last_error=excluded.last_error,
+              updated_at=excluded.updated_at
+            """,
+            (
+                number,
+                title,
+                classification,
+                stage,
+                status,
+                risk_tier,
+                spec_pr,
+                impl_pr,
+                last_error,
+                _iso(now),
+            ),
+        )
+        self._conn.commit()
+        return self.get_issue(number)
+
+    def get_issue(self, number: int) -> IssueRecord:
+        row = self._conn.execute("SELECT * FROM issues WHERE number = ?", (number,)).fetchone()
+        if row is None:
+            raise KeyError(f"issue {number} not found")
+        return _issue(row)
+
+    def list_issues(self) -> list[IssueRecord]:
+        rows = self._conn.execute("SELECT * FROM issues ORDER BY number").fetchall()
+        return [_issue(row) for row in rows]
+
+    def transition(self, number: int, from_stage: str, to_stage: str) -> IssueRecord:
+        if to_stage not in ALLOWED_TRANSITIONS:
+            raise TransitionError(f"unknown destination stage: {to_stage}")
+        allowed = ALLOWED_TRANSITIONS.get(from_stage)
+        if allowed is None or to_stage not in allowed:
+            raise TransitionError(f"illegal transition {from_stage}->{to_stage}")
+        now = _now()
+        cursor = self._conn.execute(
+            """
+            UPDATE issues
+               SET stage = ?, updated_at = ?
+             WHERE number = ? AND stage = ?
+            """,
+            (to_stage, _iso(now), number, from_stage),
+        )
+        if cursor.rowcount != 1:
+            current = self.get_issue(number).stage
+            raise TransitionError(f"issue {number} is at {current}, not {from_stage}")
+        self._conn.commit()
+        return self.get_issue(number)
+
+    def set_stage(self, number: int, stage: str, *, status: str | None = None) -> IssueRecord:
+        if stage not in ALLOWED_TRANSITIONS:
+            raise ValueError(f"unknown issue stage: {stage}")
+        self._conn.execute(
+            """
+            UPDATE issues
+               SET stage = ?, status = COALESCE(?, status), updated_at = ?
+             WHERE number = ?
+            """,
+            (stage, status, _iso(_now()), number),
+        )
+        self._conn.commit()
+        return self.get_issue(number)
+
+    def claim_next(self, *, now: datetime | None = None) -> IssueRecord | None:
+        current = _dt(now)
+        rows = self._conn.execute(
+            f"""
+            SELECT * FROM issues
+             WHERE status = 'open'
+               AND stage IN ({",".join("?" for _ in ACTIONABLE_STAGES)})
+             ORDER BY updated_at ASC, number ASC
+            """,
+            ACTIONABLE_STAGES,
+        ).fetchall()
+        for row in rows:
+            issue = _issue(row)
+            if issue.updated_at + _cooldown(issue.attempts) <= current:
+                return issue
+        return None
+
+    def record_run(
+        self,
+        *,
+        issue: int,
+        node: str,
+        outcome: str,
+        started: datetime | None = None,
+        ended: datetime | None = None,
+        langsmith_run_id: str | None = None,
+        tokens: int | None = None,
+    ) -> int:
+        cursor = self._conn.execute(
+            """
+            INSERT INTO runs(issue, node, started, ended, outcome, langsmith_run_id, tokens)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                issue,
+                node,
+                _iso(_dt(started)),
+                _iso(_dt(ended)) if ended is not None else None,
+                outcome,
+                langsmith_run_id,
+                tokens,
+            ),
+        )
+        self._conn.commit()
+        return int(cursor.lastrowid)
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        rows = self._conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
+        return [dict(row) for row in rows]
+
+    def bump_attempt(
+        self,
+        number: int,
+        error: str,
+        *,
+        max_attempts: int = 3,
+        now: datetime | None = None,
+    ) -> IssueRecord:
+        issue = self.get_issue(number)
+        attempts = issue.attempts + 1
+        stage = "failed" if attempts >= max_attempts else issue.stage
+        self._conn.execute(
+            """
+            UPDATE issues
+               SET attempts = ?, last_error = ?, stage = ?, updated_at = ?
+             WHERE number = ?
+            """,
+            (attempts, error, stage, _iso(_dt(now)), number),
+        )
+        self._conn.commit()
+        return self.get_issue(number)
+
+
+def _cooldown(attempts: int) -> timedelta:
+    if attempts <= 0:
+        return timedelta(seconds=0)
+    return timedelta(minutes=2 ** (attempts - 1))
+
+
+def _issue(row: sqlite3.Row) -> IssueRecord:
+    return IssueRecord(
+        number=int(row["number"]),
+        title=str(row["title"]),
+        classification=row["classification"],
+        stage=str(row["stage"]),
+        status=str(row["status"]),
+        risk_tier=row["risk_tier"],
+        attempts=int(row["attempts"]),
+        spec_pr=row["spec_pr"],
+        impl_pr=row["impl_pr"],
+        last_error=row["last_error"],
+        updated_at=_parse(str(row["updated_at"])),
+    )
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _dt(value: datetime | None) -> datetime:
+    if value is None:
+        return _now()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return _dt(value).isoformat()
+
+
+def _parse(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -45,6 +45,8 @@ class StateStore:
         self.path = str(path)
         self._conn = sqlite3.connect(self.path)
         self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
         self.apply_schema()
 
     def close(self) -> None:

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import time
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, TypeVar
+
+from wgmesh_pipeline.config import Config
+
+
+T = TypeVar("T")
+
+
+class Span(Protocol):
+    def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
+        ...
+
+
+class Tracer(Protocol):
+    def start_span(self, *, name: str, inputs: Any, tags: dict[str, str]) -> Span:
+        ...
+
+
+@dataclass
+class NoopSpan:
+    def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
+        return None
+
+
+class NoopTracer:
+    def start_span(self, *, name: str, inputs: Any, tags: dict[str, str]) -> Span:
+        return NoopSpan()
+
+
+class LangSmithTracer:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    def start_span(self, *, name: str, inputs: Any, tags: dict[str, str]) -> Span:
+        # Phase 1 keeps the LangSmith dependency optional. The local span object
+        # preserves the instrumentation boundary; real upload can be swapped in
+        # without touching node code once the deployment secret exists.
+        return NoopSpan()
+
+
+_tracer: Tracer = NoopTracer()
+
+
+def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
+    global _tracer
+    if tracer is not None:
+        _tracer = tracer
+    elif config.langsmith_api_key:
+        _tracer = LangSmithTracer(config.langsmith_api_key)
+    else:
+        _tracer = NoopTracer()
+    return _tracer
+
+
+def trace_node(name: str, fn: Callable[[T], T]) -> Callable[[T], T]:
+    def wrapped(state: T) -> T:
+        tags = _tags_for_state(state, name)
+        span = _tracer.start_span(name=name, inputs=_safe_state(state), tags=tags)
+        started = time.monotonic()
+        try:
+            result = fn(state)
+        except BaseException as exc:
+            span.end(error=exc, latency_seconds=time.monotonic() - started)
+            raise
+        span.end(outputs=_safe_state(result), latency_seconds=time.monotonic() - started)
+        return result
+
+    wrapped.__name__ = getattr(fn, "__name__", name)
+    return wrapped
+
+
+def _tags_for_state(state: Any, stage: str) -> dict[str, str]:
+    tags = {"stage": stage}
+    if isinstance(state, dict) and "issue" in state:
+        issue = state["issue"]
+        number = getattr(issue, "number", None)
+        if number is not None:
+            tags["issue"] = str(number)
+    return tags
+
+
+def _safe_state(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    safe = dict(value)
+    safe.pop("github", None)
+    safe.pop("goose_runner", None)
+    return safe
+


### PR DESCRIPTION
## What
Self-hosted LangGraph autonomous pipeline (`pipeline/` Python package) that replaces the GitHub-Actions/Copilot/Goose-on-Actions chain for wgmesh. The box owns its queue/state/scheduler — **no GitHub-side workflow triggers in the loop** — eliminating the failures that froze the pipeline this week (Copilot availability, expired PUSH_TOKEN PAT, app-perms, self-approval 422, label-trigger coupling).

Plan: `docs/plans/2026-06-07-001-feat-langgraph-hetzner-pipeline-plan.md`. Decision memory: brainstorm-locked (full-loop wgmesh / wrap Goose CLI / dedicated PAT / self-review + tiered merge / full LangSmith+evals).

## Phase 1 scope (this PR) — shadow mode, NO GitHub writes
- poller (asyncio, own scheduler) → wgmesh `needs-triage` issues
- sqlite owned-queue state + label reconciliation
- LangGraph graph: triage → spec → implement → review → gate
- Goose CLI runner (reuses wgmesh recipes, z.ai/GLM) + empty-output guard
- risk-tier classifier (pr-disposition high-risk regexes + diff-body match)
- single PAT GitHub client with one write-gate choke point (`PIPELINE_MODE=shadow|spec-only|live`, default shadow) — **proven zero network writes in shadow**
- LangSmith tracing (env-gated no-op) + eval harness (spec/gate/trajectory golden sets)

## Quality
Multi-agent code review (correctness/security/adversarial/reliability/testing) found the initial 44-green suite was **hollow** — Phase-1 stubs fabricated the safety signals, so 'never merge high-risk blind' was actually false. All 9 P0/HIGH holes fixed with regression tests (see commit `0246eaf`): real `changed_files`, real `tests_passed`, sanitise centralised in the client (spec + PR body, not just diff), `impl_pr` wired (no PR #0), eval bites on all 4 escalate drivers, subprocess/HTTP timeouts, transition-before-side-effect. **57 tests passing.**

## Deferred (later phases)
Phase 2 spec-only live · Phase 3 full live + disable the 3 Actions workflows · Phase 4 Hetzner systemd deploy + secrets. Live-mode write paths and the real-sanitise wall are exercised when those phases land.

## Note
No Python CI workflow exists in this repo yet (bash/yaml); tests run via `pytest pipeline/tests/` (57 passing). A pipeline-CI workflow is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)