### PR TITLE
feat(pipeline): Phase 4 — Hetzner deploy + sensitive-env-var exclusion

### DIFF
--- a/pipeline/deploy/Dockerfile
+++ b/pipeline/deploy/Dockerfile
@@ -1,0 +1,22 @@
+# Containerized deploy option (alternative to the systemd unit).
+# The whole service runs in the container; mount secrets via --env-file.
+# (A per-Goose-run sandbox — running each goose invocation in its own throwaway
+# container — is a follow-up; this image runs the service itself.)
+FROM python:3.11-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash
+
+WORKDIR /app
+COPY pipeline/ /app/pipeline/
+RUN pip install --no-cache-dir -e /app/pipeline
+
+# Non-root: the container holds the bot PAT; shrink the blast radius.
+RUN useradd --system --uid 10001 wgmesh && chown -R wgmesh /app
+USER wgmesh
+
+# PIPELINE_MODE / secrets supplied at runtime via --env-file (see env.example).
+ENV PIPELINE_MODE=shadow
+CMD ["python", "-m", "wgmesh_pipeline.main"]

--- a/pipeline/deploy/deploy.sh
+++ b/pipeline/deploy/deploy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Deploy / update the wgmesh-pipeline on a Hetzner (or any systemd) host.
+# Idempotent: safe to re-run for updates (git pull + reinstall + restart).
+#
+# Usage (run as root on the host):
+#   ./deploy.sh                     # update from the checked-out repo
+#   REPO_URL=... ./deploy.sh        # first install: clone into /opt/wgmesh-pipeline
+#
+# Preconditions: Python 3.11+, git, and the Goose CLI installed on the host;
+# /etc/wgmesh-pipeline/env populated from env.example (chmod 600).
+set -euo pipefail
+
+APP_DIR=/opt/wgmesh-pipeline
+ENV_FILE=/etc/wgmesh-pipeline/env
+SERVICE=wgmesh-pipeline
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "::error:: $ENV_FILE missing — copy pipeline/deploy/env.example, fill secrets, chmod 600" >&2
+  exit 1
+fi
+
+# 1. Source: clone on first run, pull on updates.
+if [ ! -d "$APP_DIR/.git" ]; then
+  : "${REPO_URL:?set REPO_URL for first install}"
+  git clone "$REPO_URL" "$APP_DIR"
+fi
+git -C "$APP_DIR" fetch --depth 1 origin main
+git -C "$APP_DIR" reset --hard origin/main
+
+# 2. venv + package.
+if [ ! -d "$APP_DIR/.venv" ]; then
+  python3 -m venv "$APP_DIR/.venv"
+fi
+"$APP_DIR/.venv/bin/pip" install --upgrade pip
+"$APP_DIR/.venv/bin/pip" install -e "$APP_DIR/pipeline"
+
+# 3. Smoke test before swapping the running service — never deploy red.
+( cd "$APP_DIR" && "$APP_DIR/.venv/bin/python" -m pytest pipeline/tests/ -q )
+
+# 4. systemd unit + (re)start.
+install -m 0644 "$APP_DIR/pipeline/deploy/wgmesh-pipeline.service" \
+  /etc/systemd/system/${SERVICE}.service
+id wgmesh >/dev/null 2>&1 || useradd --system --home "$APP_DIR" --shell /usr/sbin/nologin wgmesh
+chown -R wgmesh:wgmesh "$APP_DIR"
+systemctl daemon-reload
+systemctl enable "$SERVICE"
+systemctl restart "$SERVICE"
+systemctl --no-pager status "$SERVICE" | head -n 15

--- a/pipeline/deploy/env.example
+++ b/pipeline/deploy/env.example
@@ -1,0 +1,24 @@
+# /etc/wgmesh-pipeline/env  —  root-owned, chmod 600.
+# The Goose subprocess does NOT inherit these secrets except the LLM key
+# (build_goose_env strips every secret-shaped var, then re-adds ANTHROPIC_*).
+
+# --- start in shadow; flip to spec-only, then live, per PHASE3-CUTOVER.md ---
+PIPELINE_MODE=shadow
+
+TARGET_REPO=atvirokodosprendimai/wgmesh
+
+# GitHub bot identity (replaces the dead PUSH_TOKEN). Fine-grained PAT with
+# issues:write + contents:write + pull_requests:write on the target repo.
+WGMESH_BOT_PAT=
+
+# Goose LLM (z.ai / GLM, OpenAI-anthropic-compat endpoint).
+ZAI_API_KEY=
+ANTHROPIC_HOST=https://api.z.ai/api/anthropic
+
+# Online run scoring (optional — degrades to no-op if unset).
+LANGSMITH_API_KEY=
+
+# Tuning.
+POLL_INTERVAL_SECONDS=300
+MAX_FILES=20
+DATABASE_PATH=/opt/wgmesh-pipeline/state.db

--- a/pipeline/deploy/hetzner-provision.sh
+++ b/pipeline/deploy/hetzner-provision.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Provision a Hetzner Cloud VM for the wgmesh-pipeline.
+# Requires the `hcloud` CLI authenticated (HCLOUD_TOKEN) and an SSH key already
+# uploaded to the project. Run from a workstation, NOT on the box.
+#
+#   HCLOUD_TOKEN=... SSH_KEY=my-key ./hetzner-provision.sh
+#
+# This only stands up the host + installs prerequisites. Secrets and the
+# service come from deploy.sh, run on the box afterwards (see PHASE4-DEPLOY.md).
+# Alternative (cheaper): co-locate on the existing chimney box and skip this —
+# just run deploy.sh there.
+set -euo pipefail
+
+: "${HCLOUD_TOKEN:?set HCLOUD_TOKEN}"
+: "${SSH_KEY:?set SSH_KEY (name of an uploaded hcloud SSH key)}"
+NAME=${NAME:-wgmesh-pipeline}
+TYPE=${TYPE:-cx22}          # 2 vCPU / 4 GB — ample for a single poll loop
+IMAGE=${IMAGE:-ubuntu-24.04}
+LOCATION=${LOCATION:-hel1}  # Helsinki
+
+cloud_init=$(cat <<'CLOUD'
+#cloud-config
+package_update: true
+packages: [git, python3, python3-venv, python3-pip, curl, jq]
+runcmd:
+  # Goose CLI (self-hosted, same install the Actions workflows used).
+  - curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash
+  - install -d -m 700 /etc/wgmesh-pipeline
+  # Operator then: scp env (chmod 600) + run pipeline/deploy/deploy.sh as root.
+CLOUD
+)
+
+hcloud server create \
+  --name "$NAME" \
+  --type "$TYPE" \
+  --image "$IMAGE" \
+  --location "$LOCATION" \
+  --ssh-key "$SSH_KEY" \
+  --user-data-from-file <(printf '%s' "$cloud_init")
+
+echo "Provisioned $NAME. Next:"
+echo "  1. scp pipeline/deploy/env.example root@<ip>:/etc/wgmesh-pipeline/env  (fill secrets, chmod 600)"
+echo "  2. ssh root@<ip>, REPO_URL=<this repo> bash /opt/.../deploy.sh"

--- a/pipeline/deploy/wgmesh-pipeline.service
+++ b/pipeline/deploy/wgmesh-pipeline.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=wgmesh autonomous LangGraph pipeline
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=wgmesh
+Group=wgmesh
+WorkingDirectory=/opt/wgmesh-pipeline
+# Secrets + config live here, root-owned chmod 600 (see .env.example).
+EnvironmentFile=/etc/wgmesh-pipeline/env
+ExecStart=/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main
+# main.py installs SIGTERM/SIGINT handlers and shuts down the poll loop
+# gracefully, so a normal stop drains the in-flight tick.
+KillSignal=SIGTERM
+TimeoutStopSec=120
+Restart=on-failure
+RestartSec=10
+# Hardening: the service holds the bot PAT — keep its blast radius small.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/opt/wgmesh-pipeline
+
+[Install]
+WantedBy=multi-user.target

--- a/pipeline/docs/PHASE4-DEPLOY.md
+++ b/pipeline/docs/PHASE4-DEPLOY.md
@@ -1,0 +1,66 @@
+# Phase 4 — Hetzner Deployment
+
+Stand up the wgmesh-pipeline as a long-running service. All artifacts are in
+`pipeline/deploy/`. Code is ready; this is the operational step (needs a host +
+secrets). Two host options — a dedicated Hetzner VM, or co-locate on chimney.
+
+## What ships in this phase
+
+- `deploy/wgmesh-pipeline.service` — systemd unit (graceful SIGTERM drain,
+  restart-on-failure, hardening: NoNewPrivileges/ProtectSystem/PrivateTmp).
+- `deploy/env.example` — the env contract (secrets live in
+  `/etc/wgmesh-pipeline/env`, chmod 600).
+- `deploy/deploy.sh` — idempotent install/update: pull → venv → `pip install -e`
+  → **run the test suite (never deploy red)** → install unit → restart.
+- `deploy/hetzner-provision.sh` — `hcloud` VM provisioning + cloud-init (installs
+  Python + Goose CLI).
+- `deploy/Dockerfile` — containerized alternative.
+- **Security hardening (Attractor borrow):** `build_goose_env` strips every
+  secret-shaped env var (PAT, LangSmith key, HCLOUD token, …) before launching
+  Goose, re-adding only the LLM credential. The agent never sees the box's
+  GitHub token. Verified by `tests/test_goose_env.py`.
+
+## Provision + deploy
+
+**Option A — dedicated Hetzner VM:**
+```
+HCLOUD_TOKEN=... SSH_KEY=<key> pipeline/deploy/hetzner-provision.sh
+# then on the box, as root:
+scp pipeline/deploy/env.example root@<ip>:/etc/wgmesh-pipeline/env   # fill, chmod 600
+REPO_URL=<this repo> bash deploy.sh
+```
+
+**Option B — co-locate on chimney (cheaper, no new VM):**
+```
+# on chimney, as root: ensure Python 3.11 + Goose CLI present, then
+install -d -m 700 /etc/wgmesh-pipeline   # fill env, chmod 600
+REPO_URL=<this repo> bash pipeline/deploy/deploy.sh
+```
+
+## Secrets to provision (the go-live gate)
+
+| Var | Purpose |
+|-----|---------|
+| `WGMESH_BOT_PAT` | fine-grained PAT, issues+contents+pull_requests on wgmesh (replaces dead PUSH_TOKEN) |
+| `ZAI_API_KEY` + `ANTHROPIC_HOST` | Goose LLM (z.ai/GLM) |
+| `LANGSMITH_API_KEY` | online scoring (optional) |
+
+## Bring-up sequence
+
+Start in **shadow** (`PIPELINE_MODE=shadow`, the env default) — the service runs
+the full loop against real wgmesh issues with zero GitHub writes. Watch the logs
+/ LangSmith. Then walk **spec-only → live** per `PHASE3-CUTOVER.md` (which also
+covers disabling the three wgmesh Actions workflows and rollback).
+
+## Observability
+
+- `journalctl -u wgmesh-pipeline -f` for service logs.
+- Existing coroot/signoz on the host for system metrics.
+- LangSmith for per-run traces + online scores (when `LANGSMITH_API_KEY` set).
+
+## Follow-ups (not in this phase)
+
+- Per-Goose-run sandbox: run each `goose` invocation in its own throwaway
+  container (the full Attractor ExecutionEnvironment abstraction) — currently
+  Goose runs as a subprocess on the host with a secret-stripped env.
+- Secret rotation cadence for `WGMESH_BOT_PAT`.

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wgmesh_pipeline.goose.runner import _is_secret_var, build_goose_env
+
+
+@dataclass(frozen=True)
+class _Cfg:
+    zai_api_key: str | None = "zai-secret"
+    anthropic_host: str = "https://api.z.ai/api/anthropic"
+
+
+def test_secret_vars_detected() -> None:
+    for name in (
+        "WGMESH_BOT_PAT",  # caught by explicit known-names set (no marker, PAT~PATH)
+        "LANGSMITH_API_KEY",
+        "GITHUB_TOKEN",
+        "APP_PRIVATE_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "DB_PASSWORD",
+        "SOME_CREDENTIAL",
+        "HCLOUD_TOKEN",
+    ):
+        assert _is_secret_var(name) is True
+    # plain non-secret vars are kept — PATH must NOT be mistaken for a PAT
+    for name in ("PATH", "HOME", "LANG", "TERM", "SHELL"):
+        assert _is_secret_var(name) is False
+
+
+def test_build_goose_env_strips_secrets_keeps_llm_cred() -> None:
+    base = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/bot",
+        "WGMESH_BOT_PAT": "ghp_secret",
+        "LANGSMITH_API_KEY": "ls-secret",
+        "GITHUB_TOKEN": "tok",
+        "APP_PRIVATE_KEY": "-----BEGIN-----",
+        "DB_PASSWORD": "hunter2",
+    }
+    env = build_goose_env(_Cfg(), base_env=base)
+
+    # safe vars retained
+    assert env["PATH"] == "/usr/bin"
+    assert env["HOME"] == "/home/bot"
+    # every secret-shaped var stripped — the agent never sees them
+    assert "WGMESH_BOT_PAT" not in env
+    assert "LANGSMITH_API_KEY" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "APP_PRIVATE_KEY" not in env
+    assert "DB_PASSWORD" not in env
+    # the single LLM credential Goose needs is added back explicitly
+    assert env["ANTHROPIC_API_KEY"] == "zai-secret"
+    assert env["ANTHROPIC_HOST"].endswith("/anthropic")
+
+
+def test_build_goose_env_without_zai_key_omits_anthropic_key() -> None:
+    env = build_goose_env(_Cfg(zai_api_key=None), base_env={"PATH": "/usr/bin"})
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["ANTHROPIC_HOST"]

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -28,30 +28,52 @@ def test_secret_vars_detected() -> None:
         assert _is_secret_var(name) is False
 
 
-def test_build_goose_env_strips_secrets_keeps_llm_cred() -> None:
+def test_build_goose_env_allowlist_drops_secrets_keeps_safe_and_llm_cred() -> None:
     base = {
         "PATH": "/usr/bin",
         "HOME": "/home/bot",
+        "LC_ALL": "C.UTF-8",
+        "SSL_CERT_FILE": "/etc/ssl/cert.pem",
+        "SSH_AUTH_SOCK": "/run/ssh",
         "WGMESH_BOT_PAT": "ghp_secret",
         "LANGSMITH_API_KEY": "ls-secret",
         "GITHUB_TOKEN": "tok",
         "APP_PRIVATE_KEY": "-----BEGIN-----",
         "DB_PASSWORD": "hunter2",
+        # fail-closed cases: real credentials whose NAME carries no secret marker
+        "NPM_AUTH": "npm-cred",
+        "SENTRY_DSN": "https://abc@sentry.io/1",
+        "PAT": "bare-pat",
     }
     env = build_goose_env(_Cfg(), base_env=base)
 
-    # safe vars retained
+    # allowlisted safe vars retained (PATH/HOME/locale/TLS/ssh-agent)
     assert env["PATH"] == "/usr/bin"
     assert env["HOME"] == "/home/bot"
-    # every secret-shaped var stripped — the agent never sees them
-    assert "WGMESH_BOT_PAT" not in env
-    assert "LANGSMITH_API_KEY" not in env
-    assert "GITHUB_TOKEN" not in env
-    assert "APP_PRIVATE_KEY" not in env
-    assert "DB_PASSWORD" not in env
+    assert env["LC_ALL"] == "C.UTF-8"
+    assert env["SSL_CERT_FILE"] == "/etc/ssl/cert.pem"
+    assert env["SSH_AUTH_SOCK"] == "/run/ssh"
+    # EVERYTHING not allowlisted is dropped — incl. marker-less credentials
+    for leaked in (
+        "WGMESH_BOT_PAT", "LANGSMITH_API_KEY", "GITHUB_TOKEN", "APP_PRIVATE_KEY",
+        "DB_PASSWORD", "NPM_AUTH", "SENTRY_DSN", "PAT",
+    ):
+        assert leaked not in env
     # the single LLM credential Goose needs is added back explicitly
     assert env["ANTHROPIC_API_KEY"] == "zai-secret"
     assert env["ANTHROPIC_HOST"].endswith("/anthropic")
+
+
+def test_build_goose_env_only_anthropic_key_is_secret_shaped() -> None:
+    # Property: nothing secret-shaped leaks. The only secret in the output is the
+    # explicitly re-added LLM credential.
+    base = {
+        "PATH": "/usr/bin", "HOME": "/h", "FOO_TOKEN": "x", "BAR_SECRET": "y",
+        "RANDOM_THING": "z", "AWS_SECRET_ACCESS_KEY": "k",
+    }
+    env = build_goose_env(_Cfg(), base_env=base)
+    for key in env:
+        assert key == "ANTHROPIC_API_KEY" or not _is_secret_var(key)
 
 
 def test_build_goose_env_without_zai_key_omits_anthropic_key() -> None:

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -13,6 +13,48 @@ from wgmesh_pipeline.config import Config
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
 GOOSE_TIMEOUT_SECONDS = 1800
 
+# Substrings that mark an env var as secret. Goose is an LLM agent — it must NOT
+# inherit the box's PAT, LangSmith key, or any other credential (it could echo
+# them into output or logs). We strip every secret-shaped var and then add back
+# ONLY the LLM credential Goose legitimately needs. (Borrowed from the Attractor
+# coding-agent spec: exclude sensitive env vars from the agent by default.)
+_SECRET_MARKERS = (
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "CREDENTIAL",
+    "PRIVATE_KEY",
+    "API_KEY",
+    "ACCESS_KEY",
+    "APP_KEY",
+)
+
+# Known sensitive var names that the substring markers miss — notably
+# WGMESH_BOT_PAT (the box's GitHub token; "PAT" can't be a marker because it
+# would also strip PATH).
+_KNOWN_SECRET_NAMES = frozenset(
+    {"WGMESH_BOT_PAT", "BOT_PAT", "GH_PAT", "HCLOUD_TOKEN", "OPENROUTER_API_KEY"}
+)
+
+
+def _is_secret_var(name: str) -> bool:
+    upper = name.upper()
+    if upper in _KNOWN_SECRET_NAMES:
+        return True
+    return any(marker in upper for marker in _SECRET_MARKERS)
+
+
+def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Subprocess env for Goose with all secret-shaped vars stripped, then the
+    single LLM credential Goose needs added back explicitly."""
+    source = os.environ if base_env is None else base_env
+    env = {key: value for key, value in source.items() if not _is_secret_var(key)}
+    if config.zai_api_key:
+        env["ANTHROPIC_API_KEY"] = config.zai_api_key
+    env["ANTHROPIC_HOST"] = config.anthropic_host
+    return env
+
 
 @dataclass(frozen=True)
 class GooseResult:
@@ -45,10 +87,7 @@ class GooseRunner:
         for key, value in params.items():
             command.extend(["--params", f"{key}={value}"])
 
-        env = os.environ.copy()
-        if self.config.zai_api_key:
-            env["ANTHROPIC_API_KEY"] = self.config.zai_api_key
-        env["ANTHROPIC_HOST"] = self.config.anthropic_host
+        env = build_goose_env(self.config)
 
         started = time.monotonic()
         try:

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -45,11 +45,53 @@ def _is_secret_var(name: str) -> bool:
     return any(marker in upper for marker in _SECRET_MARKERS)
 
 
+# ALLOWLIST (fail-closed): Goose's subprocess env is built from {} by copying
+# ONLY these known-safe vars, then adding the LLM credential. A denylist over an
+# unbounded env namespace is fail-open — a future/ambient credential with no
+# secret-marker in its name would leak to the LLM agent. The allowlist drops
+# anything not explicitly named. Goose needs to find its binary + tools (PATH),
+# its config/keyring (HOME), reach z.ai over TLS (SSL_CERT_*), and basic locale.
+# It does NOT push git — our GitHubClient does that with the PAT — so no GIT_/
+# auth vars are passed.
+_SAFE_ENV_NAMES = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "LANG",
+        "TERM",
+        "SHELL",
+        "TZ",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "PWD",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "SSH_AUTH_SOCK",
+        "NO_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "no_proxy",
+        "http_proxy",
+        "https_proxy",
+    }
+)
+_SAFE_ENV_PREFIXES = ("LC_",)
+
+
+def _is_safe_var(name: str) -> bool:
+    return name in _SAFE_ENV_NAMES or name.startswith(_SAFE_ENV_PREFIXES)
+
+
 def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -> dict[str, str]:
-    """Subprocess env for Goose with all secret-shaped vars stripped, then the
-    single LLM credential Goose needs added back explicitly."""
+    """Subprocess env for Goose: fail-closed allowlist of known-safe vars, then
+    the single LLM credential Goose legitimately needs added back explicitly.
+    Anything not on the allowlist (incl. the box's PAT and any unknown secret)
+    is dropped — the LLM agent never sees it."""
     source = os.environ if base_env is None else base_env
-    env = {key: value for key, value in source.items() if not _is_secret_var(key)}
+    env = {key: value for key, value in source.items() if _is_safe_var(key)}
     if config.zai_api_key:
         env["ANTHROPIC_API_KEY"] = config.zai_api_key
     env["ANTHROPIC_HOST"] = config.anthropic_host


### PR DESCRIPTION
## What (Phase 4 of the LangGraph pipeline)
Makes the box deployable as a long-running service, and closes a real secret-exposure hole. Builds on Phases 1–3 (#1501/#1502/#1503).

## Security: Goose no longer inherits the box's secrets
Previously the Goose subprocess got `os.environ.copy()` — the **whole box env, including `WGMESH_BOT_PAT`**, handed to an LLM agent that can echo vars into output/logs. `build_goose_env` now uses a **fail-closed allowlist**: copy only known-safe vars (PATH/HOME/locale/SSL_CERT_*/SSH_AUTH_SOCK/proxy) + the single LLM credential; everything else dropped. (Attractor coding-agent-spec borrow; hardened from denylist→allowlist after security review SEC-1.)

## Deploy artifacts (`pipeline/deploy/`)
- `wgmesh-pipeline.service` — systemd unit, graceful SIGTERM drain, hardened (NoNewPrivileges/ProtectSystem/PrivateTmp, dedicated user).
- `env.example` — secrets contract (`/etc/wgmesh-pipeline/env`, chmod 600; no committed secrets).
- `deploy.sh` — idempotent install/update; **runs the test suite before restart** (never deploy red).
- `hetzner-provision.sh` — hcloud VM + cloud-init (no secrets in user-data).
- `Dockerfile` — containerized alt (no secrets baked in layers).
- `docs/PHASE4-DEPLOY.md` — provision (Hetzner VM or co-locate on chimney), secrets table, shadow→spec-only→live bring-up, observability.

## Tests
85 passing (+4): marker-less secret dropped, safe vars survive, only-LLM-key-is-secret property test. Security review confirmed deploy artifacts clean and the re-added LLM key has no path back into public PR/spec content (sanitise gate + file-sourced content).

## Go-live (operational, not in this PR)
Provision a host + secrets (token + ZAI_API_KEY + LANGSMITH_API_KEY), run deploy.sh, start in shadow, walk to live per the runbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)