### PR TITLE
feat(pipeline): adopt mailservice sqlite solution (migrations + explicit DB mode + Turso)

### DIFF
--- a/pipeline/deploy/env.example
+++ b/pipeline/deploy/env.example
@@ -18,7 +18,15 @@ ANTHROPIC_HOST=https://api.z.ai/api/anthropic
 # Online run scoring (optional — degrades to no-op if unset).
 LANGSMITH_API_KEY=
 
+# Database — EXPLICIT mode, no silent fallback (mailservice pattern).
+#   local : file SQLite at PIPELINE_DB_PATH
+#   turso : remote libsql (durable; survives box rebuild) — needs the two vars
+DATABASE_MODE=local
+PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db
+# For DATABASE_MODE=turso (leave blank for local):
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
+
 # Tuning.
 POLL_INTERVAL_SECONDS=300
 MAX_FILES=20
-DATABASE_PATH=/opt/wgmesh-pipeline/state.db

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -27,7 +27,7 @@ eval = [
   "langchain-anthropic>=0.2",
 ]
 turso = [
-  "libsql-experimental>=0.0.30",
+  "libsql>=0.1",
 ]
 
 [project.scripts]

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -26,6 +26,9 @@ eval = [
   "agentevals>=0.1",
   "langchain-anthropic>=0.2",
 ]
+turso = [
+  "libsql-experimental>=0.0.30",
+]
 
 [project.scripts]
 wgmesh-pipeline = "wgmesh_pipeline.main:main"
@@ -35,7 +38,7 @@ where = ["."]
 include = ["wgmesh_pipeline*"]
 
 [tool.setuptools.package-data]
-wgmesh_pipeline = ["state/schema.sql"]
+wgmesh_pipeline = ["state/migrations/*.sql"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -11,6 +11,7 @@ def test_full_env_loads_frozen_config_with_shadow_default() -> None:
     cfg = load_config(
         {
             "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
             "WGMESH_BOT_PAT": "token",
             "ZAI_API_KEY": "zai",
             "LANGSMITH_API_KEY": "smith",
@@ -25,6 +26,7 @@ def test_full_env_loads_frozen_config_with_shadow_default() -> None:
     assert cfg.repo == "wgmesh"
     assert cfg.poll_interval_seconds == 60
     assert cfg.max_files == 5
+    assert cfg.database_mode == "local"
 
     with pytest.raises(FrozenInstanceError):
         cfg.mode = "live"  # type: ignore[misc]
@@ -41,9 +43,43 @@ def test_missing_target_repo_raises_with_var_name() -> None:
 
 
 def test_shadow_allows_missing_pat_live_requires_it() -> None:
-    shadow = load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow"})
+    shadow = load_config(
+        {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow", "DATABASE_MODE": "local"}
+    )
     assert shadow.wgmesh_bot_pat is None
 
     with pytest.raises(ValueError, match="WGMESH_BOT_PAT"):
-        load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "live"})
+        load_config(
+            {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "live", "DATABASE_MODE": "local"}
+        )
+
+
+def test_database_mode_explicit_no_silent_fallback() -> None:
+    # The mailservice lesson: a misconfigured deploy must fail, not silently
+    # write local. DATABASE_MODE is required and validated.
+    with pytest.raises(ValueError, match="DATABASE_MODE"):
+        load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow"})
+
+    with pytest.raises(ValueError, match="DATABASE_MODE"):
+        load_config(
+            {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow", "DATABASE_MODE": "bogus"}
+        )
+
+    # turso requires the URL — fail-loud, never fall back to local
+    with pytest.raises(ValueError, match="TURSO_DATABASE_URL"):
+        load_config(
+            {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "PIPELINE_MODE": "shadow", "DATABASE_MODE": "turso"}
+        )
+
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "PIPELINE_MODE": "shadow",
+            "DATABASE_MODE": "turso",
+            "TURSO_DATABASE_URL": "libsql://db.turso.io",
+            "TURSO_AUTH_TOKEN": "tok",
+        }
+    )
+    assert cfg.database_mode == "turso"
+    assert cfg.turso_url == "libsql://db.turso.io"
 

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -4,11 +4,44 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from wgmesh_pipeline.state.store import StateStore, TransitionError
+from dataclasses import dataclass
+
+from wgmesh_pipeline.state.store import StateStore, TransitionError, open_state_store
 
 
 def store(tmp_path):
     return StateStore(tmp_path / "state.db")
+
+
+@dataclass
+class _DbCfg:
+    database_mode: str
+    database_path: str = "x.db"
+    turso_url: str | None = None
+    turso_auth_token: str | None = None
+
+
+def test_open_state_store_local(tmp_path) -> None:
+    db = open_state_store(_DbCfg(database_mode="local", database_path=str(tmp_path / "s.db")))
+    db.upsert_issue(1, "ok")
+    assert db.get_issue(1).stage == "queued"
+
+
+def test_open_state_store_turso_fails_loud_never_falls_back_local() -> None:
+    # No silent fallback: turso selected but unreachable/unavailable must raise,
+    # never silently return a local store. (RuntimeError if libsql absent; a
+    # conn/libsql error if present + bogus url — either way, it raises.)
+    import pytest as _pytest
+
+    with _pytest.raises(Exception):
+        open_state_store(_DbCfg(database_mode="turso", turso_url="libsql://nonexistent.invalid"))
+
+
+def test_open_state_store_unknown_mode_raises() -> None:
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError, match="database_mode"):
+        open_state_store(_DbCfg(database_mode="bogus"))
 
 
 def test_upsert_and_transition_persist(tmp_path) -> None:
@@ -23,12 +56,15 @@ def test_upsert_and_transition_persist(tmp_path) -> None:
     assert issue.title == "Fix relay"
 
 
-def test_schema_applies_idempotently(tmp_path) -> None:
+def test_migrations_apply_idempotently(tmp_path) -> None:
     db = store(tmp_path)
-    db.apply_schema()
-    db.apply_schema()
+    # already migrated on open; re-running applies nothing new
+    assert db.migrate() == []
     db.upsert_issue(1, "Still works")
     assert db.get_issue(1).stage == "queued"
+    # schema_migrations records the initial migration exactly once
+    versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
+    assert versions == ["0001"]
 
 
 def test_sqlite_connection_uses_wal_and_busy_timeout(tmp_path) -> None:

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -6,6 +6,7 @@ from typing import Mapping
 
 
 VALID_MODES = frozenset({"shadow", "spec-only", "live"})
+VALID_DB_MODES = frozenset({"local", "turso"})
 DEFAULT_ANTHROPIC_HOST = "https://api.z.ai/api/anthropic"
 DEFAULT_TARGET_REPO = "atvirokodosprendimai/wgmesh"
 DEFAULT_POLL_INTERVAL_SECONDS = 300
@@ -22,7 +23,10 @@ class Config:
     langsmith_api_key: str | None = None
     poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS
     max_files: int = DEFAULT_MAX_FILES
+    database_mode: str = "local"
     database_path: str = "pipeline/state.db"
+    turso_url: str | None = None
+    turso_auth_token: str | None = None
 
     @property
     def owner(self) -> str:
@@ -49,6 +53,17 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
     if mode == "live" and not pat:
         raise ValueError("WGMESH_BOT_PAT is required when PIPELINE_MODE=live")
 
+    # Explicit database selection — no silent fallback (mailservice lesson: a
+    # misconfigured deploy must fail, not silently write to a local file).
+    db_mode = _required(source, "DATABASE_MODE").lower()
+    if db_mode not in VALID_DB_MODES:
+        valid = ", ".join(sorted(VALID_DB_MODES))
+        raise ValueError(f"DATABASE_MODE must be one of: {valid}; got {db_mode!r}")
+    turso_url = _get_nonempty(source, "TURSO_DATABASE_URL")
+    turso_token = _get_nonempty(source, "TURSO_AUTH_TOKEN")
+    if db_mode == "turso" and not turso_url:
+        raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
+
     return Config(
         target_repo=target_repo,
         mode=mode,
@@ -58,7 +73,10 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         langsmith_api_key=_get_nonempty(source, "LANGSMITH_API_KEY"),
         poll_interval_seconds=_get_int(source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
         max_files=_get_int(source, "MAX_FILES", DEFAULT_MAX_FILES),
+        database_mode=db_mode,
         database_path=_get_nonempty(source, "PIPELINE_DB_PATH") or "pipeline/state.db",
+        turso_url=turso_url,
+        turso_auth_token=turso_token,
     )
 
 

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -9,7 +9,7 @@ from wgmesh_pipeline.github.client import GitHubClient
 from wgmesh_pipeline.graph.build import build_graph
 from wgmesh_pipeline.poller import Poller
 from wgmesh_pipeline.scoring import init_scoring
-from wgmesh_pipeline.state.store import StateStore
+from wgmesh_pipeline.state.store import open_state_store
 from wgmesh_pipeline.tracing import init_tracing
 
 
@@ -17,9 +17,10 @@ async def async_main() -> None:
     config = load_config()
     init_tracing(config)
     init_scoring(config)
-    db_path = Path(config.database_path)
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    store = StateStore(db_path)
+    if config.database_mode == "local":
+        db_path = Path(config.database_path)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = open_state_store(config)
     poller = Poller(config=config, store=store, client=GitHubClient(config), graph=build_graph(config))
 
     stop = asyncio.Event()

--- a/pipeline/wgmesh_pipeline/state/migrations/0001_initial.sql
+++ b/pipeline/wgmesh_pipeline/state/migrations/0001_initial.sql
@@ -1,3 +1,5 @@
+-- +migrate Up
+-- Initial schema: owned-queue issues + run log.
 CREATE TABLE IF NOT EXISTS issues (
   number INTEGER PRIMARY KEY,
   title TEXT NOT NULL,
@@ -29,4 +31,3 @@ CREATE INDEX IF NOT EXISTS idx_issues_claim
 
 CREATE INDEX IF NOT EXISTS idx_runs_issue
   ON runs(issue, started);
-

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -299,12 +299,15 @@ def _open_turso(config: Any) -> Any:
     if not url:
         raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
     try:
-        import libsql_experimental as libsql  # type: ignore
+        import libsql  # type: ignore
     except ImportError as exc:  # fail-loud, never silently fall back to local
         raise RuntimeError(
             "DATABASE_MODE=turso but the libsql client is not installed "
-            "(pip install libsql-experimental)"
+            "(pip install 'wgmesh-pipeline[turso]'  # installs libsql)"
         ) from exc
+    # Pure remote over-the-wire: database is the libsql:// URL, every query hits
+    # the cloud primary — durable state that survives a box rebuild (no local
+    # file to lose). auth_token is the Turso database/group token.
     return libsql.connect(database=url, auth_token=token or "")
 
 

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -43,21 +43,52 @@ class IssueRecord:
 
 
 class StateStore:
-    def __init__(self, path: str | Path):
-        self.path = str(path)
-        self._conn = sqlite3.connect(self.path)
+    def __init__(self, path: str | Path | None = None, *, connection: Any = None):
+        # Local SQLite (path) or an injected libsql/Turso connection. Both run
+        # the same versioned migrations — mirrors mailservice's OpenAndMigrate /
+        # OpenTurso, where both paths call migrate().
+        if connection is not None:
+            self.path = None
+            self._conn = connection
+        else:
+            self.path = str(path)
+            self._conn = sqlite3.connect(self.path)
+            # WAL + busy_timeout only apply to a local file db; a Turso/libsql
+            # server manages its own journaling.
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA busy_timeout=5000")
-        self.apply_schema()
+        self.migrate()
 
     def close(self) -> None:
         self._conn.close()
 
-    def apply_schema(self) -> None:
-        schema = resources.files("wgmesh_pipeline.state").joinpath("schema.sql").read_text()
-        self._conn.executescript(schema)
+    def migrate(self) -> list[str]:
+        """Apply pending versioned migrations in order; return versions applied
+        this call. Tracked in schema_migrations so each runs exactly once."""
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations ("
+            "  version TEXT PRIMARY KEY,"
+            "  applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"
+            ")"
+        )
         self._conn.commit()
+        applied = {
+            str(row["version"])
+            for row in self._conn.execute("SELECT version FROM schema_migrations").fetchall()
+        }
+        newly: list[str] = []
+        for version, sql in _load_migrations():
+            if version in applied:
+                continue
+            self._conn.executescript(sql)
+            self._conn.execute(
+                "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+                (version, _iso(_now())),
+            )
+            self._conn.commit()
+            newly.append(version)
+        return newly
 
     def upsert_issue(
         self,
@@ -226,6 +257,55 @@ class StateStore:
         )
         self._conn.commit()
         return self.get_issue(number)
+
+
+def _load_migrations() -> list[tuple[str, str]]:
+    """Return (version, sql) for every migration, sorted by filename. version is
+    the leading numeric prefix; sql is the `-- +migrate Up` body (or whole file
+    if no marker)."""
+    out: list[tuple[str, str]] = []
+    mig_dir = resources.files("wgmesh_pipeline.state").joinpath("migrations")
+    names = sorted(p.name for p in mig_dir.iterdir() if p.name.endswith(".sql"))
+    for name in names:
+        version = name.split("_", 1)[0]
+        text = mig_dir.joinpath(name).read_text()
+        out.append((version, _up_section(text)))
+    return out
+
+
+def _up_section(text: str) -> str:
+    if "-- +migrate Up" not in text:
+        return text
+    body = text.split("-- +migrate Up", 1)[1]
+    # Stop at a Down marker if present (forward-only runner ignores Down).
+    return body.split("-- +migrate Down", 1)[0]
+
+
+def open_state_store(config: Any) -> "StateStore":
+    """Factory honoring an EXPLICIT database mode — no silent fallback (the
+    mailservice lesson). local -> file SQLite; turso -> remote libsql. Both run
+    the same migrations."""
+    mode = getattr(config, "database_mode", "local")
+    if mode == "turso":
+        return StateStore(connection=_open_turso(config))
+    if mode == "local":
+        return StateStore(config.database_path)
+    raise ValueError(f"unknown database_mode: {mode!r} (expected 'local' or 'turso')")
+
+
+def _open_turso(config: Any) -> Any:
+    url = getattr(config, "turso_url", None)
+    token = getattr(config, "turso_auth_token", None)
+    if not url:
+        raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
+    try:
+        import libsql_experimental as libsql  # type: ignore
+    except ImportError as exc:  # fail-loud, never silently fall back to local
+        raise RuntimeError(
+            "DATABASE_MODE=turso but the libsql client is not installed "
+            "(pip install libsql-experimental)"
+        ) from exc
+    return libsql.connect(database=url, auth_token=token or "")
 
 
 def _cooldown(attempts: int) -> timedelta:


### PR DESCRIPTION
## What
Adopts `atvirokodosprendimai/mailservice`'s sqlite approach for the pipeline state store.

- **Versioned migrations** — replaces the single idempotent `schema.sql` with `state/migrations/*.sql` applied in order and tracked in a `schema_migrations` table (each runs once). `StateStore.migrate()`. 0001 = the existing schema.
- **Explicit `DATABASE_MODE` (local|turso) — no silent fallback** — the mailservice lesson 'explicit database mode prevents silent fallback'. `load_config` requires it; `turso` requires `TURSO_DATABASE_URL`; fail-loud, never silently write local.
- **Local-or-Turso factory** `open_state_store(config)` — file SQLite or remote libsql, **both run the same migrations** (mirrors mailservice `OpenAndMigrate`/`OpenTurso`). Turso = durable state surviving box rebuild; `libsql` is an optional `[turso]` extra.
- env.example gains `DATABASE_MODE`; pyproject `[turso]` extra.

WAL + busy_timeout were already present (Phase 3).

## Tests
89 passing (+migrations-idempotent, explicit-mode-no-fallback, factory local/turso/unknown-mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)