### PR TITLE
fix(pipeline): libsql adapter — Turso state store verified live

### DIFF
--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -44,6 +44,26 @@ def test_open_state_store_unknown_mode_raises() -> None:
         open_state_store(_DbCfg(database_mode="bogus"))
 
 
+def test_injected_connection_adapter_roundtrip() -> None:
+    # libsql returns plain tuples and rejects row_factory; the _LibsqlConn
+    # adapter must present sqlite3-Row-style mapping rows. A tuple-returning
+    # sqlite3 connection (no row_factory) stands in for a libsql connection and
+    # exercises the same adapter path verified live against Turso.
+    import sqlite3
+
+    raw = sqlite3.connect(":memory:")  # returns tuples, has .description + executescript
+    db = StateStore(connection=raw)  # wrapped in _LibsqlConn
+    db.upsert_issue(7, "via adapter")
+    got = db.get_issue(7)
+    assert got.number == 7 and got.stage == "queued" and got.title == "via adapter"
+    assert db.transition(7, "queued", "triaged").stage == "triaged"
+    db.record_run(issue=7, node="queued", outcome="ok")
+    assert len(db.list_runs()) == 1
+    # migrations tracked through the adapter
+    versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
+    assert versions == ["0001"]
+
+
 def test_upsert_and_transition_persist(tmp_path) -> None:
     db = store(tmp_path)
     db.upsert_issue(1, "Fix relay")

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -49,7 +49,9 @@ class StateStore:
         # OpenTurso, where both paths call migrate().
         if connection is not None:
             self.path = None
-            self._conn = connection
+            # libsql returns plain tuples and rejects row_factory; adapt it to
+            # the sqlite3-Row mapping interface the rest of the store expects.
+            self._conn = _LibsqlConn(connection)
         else:
             self.path = str(path)
             self._conn = sqlite3.connect(self.path)
@@ -57,7 +59,7 @@ class StateStore:
             # server manages its own journaling.
             self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.execute("PRAGMA busy_timeout=5000")
-        self._conn.row_factory = sqlite3.Row
+            self._conn.row_factory = sqlite3.Row
         self.migrate()
 
     def close(self) -> None:
@@ -257,6 +259,58 @@ class StateStore:
         )
         self._conn.commit()
         return self.get_issue(number)
+
+
+class _MappingCursor:
+    """Wraps a libsql cursor so fetchone/fetchall return name-accessible dict
+    rows (libsql yields plain tuples); column names come from .description."""
+
+    def __init__(self, cursor: Any):
+        self._cur = cursor
+        self._cols = [d[0] for d in (cursor.description or [])]
+
+    def fetchone(self) -> dict[str, Any] | None:
+        row = self._cur.fetchone()
+        return None if row is None else dict(zip(self._cols, row))
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return [dict(zip(self._cols, row)) for row in self._cur.fetchall()]
+
+    @property
+    def rowcount(self) -> int:
+        return self._cur.rowcount
+
+    @property
+    def lastrowid(self) -> int | None:
+        return self._cur.lastrowid
+
+
+class _LibsqlConn:
+    """Adapts a libsql connection to the sqlite3-with-Row interface StateStore
+    expects: execute() returns mapping rows; executescript() splits statements
+    (libsql has no executescript)."""
+
+    def __init__(self, conn: Any):
+        self._conn = conn
+
+    def execute(self, sql: str, params: Iterable[Any] = ()) -> _MappingCursor:
+        return _MappingCursor(self._conn.execute(sql, tuple(params)))
+
+    def executescript(self, script: str) -> None:
+        native = getattr(self._conn, "executescript", None)
+        if callable(native):
+            native(script)
+            return
+        for statement in script.split(";"):
+            stmt = statement.strip()
+            if stmt:
+                self._conn.execute(stmt)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
 
 
 def _load_migrations() -> list[tuple[str, str]]:


### PR DESCRIPTION
## What
The mailservice-sqlite adoption (#1507) wired Turso, but smoke-testing against the **real** Turso DB exposed two libsql-vs-sqlite3 gaps:
- libsql returns **plain tuples** (no `row["name"]` access)
- libsql's Connection **rejects `row_factory`** (native object)

The store reads rows by name throughout, so Turso connected then crashed.

## Fix
`_LibsqlConn` adapter presents the sqlite3-Row interface the store expects:
- `execute()` → `_MappingCursor` (tuple → dict via `cursor.description`)
- `executescript()` → splits statements (libsql has no executescript)
- `commit`/`close`/`rowcount`/`lastrowid` passthrough

Applied only to injected (libsql) connections; the local sqlite3 path is unchanged (keeps `sqlite3.Row` + WAL).

## Verified live
Against `libsql://ai-pipeline-nycterent...turso.io`: connect + migrate (`schema_migrations=['0001']`) + upsert/get/transition/record_run roundtrip + cleanup — full state store works over Turso cloud. CI test uses a tuple-returning sqlite3 connection as a libsql stand-in (no real Turso in CI). **90 tests.**

Turso is now go-live ready: set `DATABASE_MODE=turso` + the two vars on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)