### PR TITLE
fix(tracing): langfuse v4 start_observation — 0 traces bug

### DIFF
--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -2,7 +2,85 @@ from __future__ import annotations
 
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubIssue
-from wgmesh_pipeline.tracing import init_tracing, trace_node
+from wgmesh_pipeline.tracing import _LangfuseSpan, init_tracing, trace_node
+
+
+class _FakeSdkSpan:
+    def __init__(self, record):
+        self.record = record
+        self.ended = False
+
+    def update(self, **kwargs):
+        self.record.setdefault("updates", []).append(kwargs)
+
+    def end(self):
+        self.ended = True
+        self.record["ended"] = True
+
+
+class _FakeLangfuseV4:
+    """Mirrors langfuse>=4: client exposes start_observation, NOT start_span."""
+
+    def __init__(self):
+        self.record = {}
+        self.flushed = False
+
+    def start_observation(self, *, name, as_type, input, metadata):
+        self.record.update({"name": name, "as_type": as_type, "input": input, "metadata": metadata})
+        return _FakeSdkSpan(self.record)
+
+    def flush(self):
+        self.flushed = True
+
+
+class _FakeLangfuseV3:
+    """Mirrors langfuse 3.x: client exposes start_span only."""
+
+    def __init__(self):
+        self.record = {}
+        self.flushed = False
+
+    def start_span(self, *, name, input, metadata):
+        self.record.update({"name": name, "input": input, "metadata": metadata})
+        return _FakeSdkSpan(self.record)
+
+    def flush(self):
+        self.flushed = True
+
+
+def test_langfuse_span_uses_v4_start_observation() -> None:
+    lf = _FakeLangfuseV4()
+    span = _LangfuseSpan(lf, "triage", {"x": 1}, {"stage": "triage"})
+    span.end(outputs={"classification": "fix"})
+
+    assert lf.record["name"] == "triage"
+    assert lf.record["as_type"] == "span"  # proves v4 path taken, not silent no-op
+    assert lf.record["ended"] is True
+    assert lf.flushed is True
+    assert {"output": {"classification": "fix"}} in lf.record["updates"]
+
+
+def test_langfuse_span_falls_back_to_v3_start_span() -> None:
+    lf = _FakeLangfuseV3()
+    span = _LangfuseSpan(lf, "triage", {"x": 1}, {"stage": "triage"})
+    span.end(outputs={"ok": True})
+
+    assert lf.record["name"] == "triage"
+    assert lf.record["ended"] is True
+    assert lf.flushed is True
+
+
+def test_langfuse_span_swallows_sdk_break_but_warns(capsys) -> None:
+    _LangfuseSpan._warned = False
+
+    class _Broken:
+        def start_observation(self, **kwargs):
+            raise AttributeError("api drift")
+
+    span = _LangfuseSpan(_Broken(), "triage", {}, {})  # must NOT raise into loop
+    span.end(outputs={})
+    err = capsys.readouterr().err
+    assert "tracing degraded" in err
 
 
 class FakeSpan:

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import time
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -47,13 +48,31 @@ class _LangfuseSpan:
     """Defensive wrapper — tracing must NEVER raise into the loop, so every
     Langfuse SDK call is guarded. Falls back to a silent no-op on any error."""
 
+    # Only the first swallowed SDK error is announced, so a version/API break
+    # (e.g. langfuse v3 `start_span` → v4 `start_observation`) surfaces instead
+    # of silently degrading to a no-op tracer for the life of the process.
+    _warned = False
+
     def __init__(self, lf: Any, name: str, inputs: Any, tags: dict[str, str]):
         self._lf = lf
         self._span = None
         try:
-            self._span = lf.start_span(name=name, input=inputs, metadata=tags)
-        except Exception:
+            # langfuse v4 dropped the client-level `start_span`; the equivalent
+            # is `start_observation(..., as_type="span")`. Fall back to the v3
+            # name so a downgraded SDK keeps working.
+            if hasattr(lf, "start_observation"):
+                self._span = lf.start_observation(name=name, as_type="span", input=inputs, metadata=tags)
+            else:
+                self._span = lf.start_span(name=name, input=inputs, metadata=tags)
+        except Exception as exc:  # never raise into the loop
             self._span = None
+            self._announce(exc)
+
+    @classmethod
+    def _announce(cls, exc: BaseException) -> None:
+        if not cls._warned:
+            cls._warned = True
+            print(f"[tracing] langfuse span creation failed, tracing degraded: {exc!r}", file=sys.stderr)
 
     def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
         try:
@@ -64,8 +83,8 @@ class _LangfuseSpan:
                     self._span.update(output=outputs)
                 self._span.end()
             self._lf.flush()
-        except Exception:
-            pass
+        except Exception as exc:
+            self._announce(exc)
 
 
 class LangfuseTracer:


### PR DESCRIPTION
## Problem
Self-hosted Langfuse UI showed **0 traces / $0 / 0 scores** despite the full tracing chain being wired (box live, secrets set, env passed to pipeline box, `[trace]` extra installed, nodes wrapped with `trace_node`).

## Root cause
`pyproject` pins `langfuse>=3` → installs **v4.7.1**. Langfuse v4 **removed the client-level `start_span`**. `LangfuseTracer` called `lf.start_span(...)` → `AttributeError` → caught by the defensive `except Exception` → silent no-op span for the whole process. Hollow-green: the existing tests only mocked the high-level `Tracer` protocol, never the real SDK boundary, so nothing failed.

## Fix
- `_LangfuseSpan` calls v4 `start_observation(name=, as_type='span', input=, metadata=)`, with a v3 `start_span` fallback (version-tolerant).
- First swallowed SDK error now prints to stderr — an API/version break surfaces instead of silently disabling tracing forever.
- New tests exercise `_LangfuseSpan` against fake v4, v3, and broken clients (the missing SDK-boundary coverage).

## Verify
93 tests pass (was 90). After merge, **re-provision the pipeline box** so it picks up the fix, then traces should appear in the `pipeline` project.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>