### PR TITLE
fix: halt shadow pipeline before write stages

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -32,6 +32,10 @@ on:
       database_mode:
         description: 'DATABASE_MODE (local|turso)'
         default: 'turso'
+      reset_queue:
+        description: 'Clear durable pipeline queue/runs before polling'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -150,8 +154,11 @@ jobs:
           WGMESH_BOT_PAT: ${{ secrets.WGMESH_BOT_PAT }}
           MODE: ${{ github.event.inputs.pipeline_mode }}
           DBMODE: ${{ github.event.inputs.database_mode }}
+          RESET_QUEUE_INPUT: ${{ github.event.inputs.reset_queue }}
         run: |
           set -euo pipefail
+          RESET_QUEUE=0
+          if [ "${RESET_QUEUE_INPUT:-false}" = "true" ]; then RESET_QUEUE=1; fi
           # The pipeline reads ZAI_API_KEY; source it from the ANTHROPIC_API_KEY
           # secret (which holds the z.ai key).
           ssh -o StrictHostKeyChecking=no -i "$RUNNER_TEMP/box_key" root@"$BOX_IP" \
@@ -170,6 +177,7 @@ jobs:
           LANGFUSE_SECRET_KEY=$LANGFUSE_SECRET_KEY
           POLL_INTERVAL_SECONDS=300
           MAX_FILES=20
+          RESET_QUEUE=$RESET_QUEUE
           EOF
 
       - name: Deploy + start (shadow)
@@ -190,7 +198,10 @@ jobs:
              systemctl enable --now wgmesh-pipeline
              sleep 5
              systemctl --no-pager status wgmesh-pipeline | head -n 12
-             journalctl -u wgmesh-pipeline --no-pager | tail -n 20"
+             journalctl -u wgmesh-pipeline --no-pager | tail -n 20
+             if [ '${{ github.event.inputs.reset_queue }}' = 'true' ]; then
+               sed -i 's/^RESET_QUEUE=.*/RESET_QUEUE=0/' /etc/wgmesh-pipeline/env
+             fi"
 
       - name: Cleanup ephemeral hcloud ssh key
         if: always()

--- a/pipeline/tests/test_main.py
+++ b/pipeline/tests/test_main.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+
+from wgmesh_pipeline import main
+from wgmesh_pipeline.config import Config
+
+
+class Store:
+    def __init__(self) -> None:
+        self.reset_calls = 0
+
+    def reset_queue(self) -> dict[str, int]:
+        self.reset_calls += 1
+        return {"issues": 3, "runs": 4}
+
+
+class DummyPoller:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+    async def run_forever(self, stop) -> None:
+        stop.set()
+
+
+def test_async_main_honors_reset_queue_env_before_polling(monkeypatch, capsys) -> None:
+    store = Store()
+    cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local")
+
+    monkeypatch.setenv("RESET_QUEUE", "1")
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    monkeypatch.setattr(main, "init_tracing", lambda config: None)
+    monkeypatch.setattr(main, "init_scoring", lambda config: None)
+    monkeypatch.setattr(main, "open_state_store", lambda config: store)
+    monkeypatch.setattr(main, "GitHubClient", lambda config: object())
+    monkeypatch.setattr(main, "build_graph", lambda config: object())
+    monkeypatch.setattr(main, "Poller", DummyPoller)
+
+    asyncio.run(main.async_main())
+
+    assert store.reset_calls == 1
+    assert "[pipeline] reset_queue cleared issues=3 runs=4" in capsys.readouterr().err
+
+
+def test_main_reset_queue_flag_requests_reset(monkeypatch) -> None:
+    calls = []
+
+    async def fake_async_main(*, reset_queue: bool = False) -> None:
+        calls.append(reset_queue)
+
+    monkeypatch.setattr(main, "async_main", fake_async_main)
+
+    main.main(["--reset-queue"])
+
+    assert calls == [True]

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -175,10 +175,11 @@ def test_reviewed_issue_not_phantom_merged_when_side_effect_fails(tmp_path, cfg:
             self.merged_prs.append(pr_number)
             raise RuntimeError("merge side effect failed")
 
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(2, "Ready", stage="reviewed", impl_pr=321)
-    client = FailingMergeClient(cfg)
-    p = Poller(config=cfg, store=store, client=client, graph=Graph())
+    client = FailingMergeClient(live)
+    p = Poller(config=live, store=store, client=client, graph=Graph())
     p.scratch[2] = {
         "diff": "+docs\n",
         "changed_files": ["docs/readme.md"],
@@ -223,8 +224,22 @@ def test_specced_issue_opens_spec_pr_then_stops_in_spec_only(tmp_path, cfg: Conf
     assert p.graph.calls == ["spec_pr"]
 
 
-def test_spec_ready_issue_continues_to_implementation(tmp_path, cfg: Config) -> None:
+def test_specced_issue_in_shadow_does_not_open_spec_pr_or_advance(tmp_path, cfg: Config) -> None:
     p = poller(tmp_path, cfg)
+    p.store.upsert_issue(1, "Already specced", stage="specced")
+
+    result = asyncio.run(p.tick())
+
+    assert result is not None
+    assert result.stage == "specced"
+    assert p.store.get_issue(1).stage == "specced"
+    assert p.store.get_issue(1).spec_pr is None
+    assert p.graph.calls == []
+
+
+def test_spec_ready_issue_continues_to_implementation(tmp_path, cfg: Config) -> None:
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
+    p = poller(tmp_path, live)
     p.store.upsert_issue(1, "Spec PR opened", stage="spec_ready", spec_pr=99)
 
     result = asyncio.run(p.tick())
@@ -234,7 +249,7 @@ def test_spec_ready_issue_continues_to_implementation(tmp_path, cfg: Config) -> 
     assert p.graph.calls == ["implement"]
 
 
-def test_main_graph_shadow_fixture_can_complete_full_cycle_without_writes(tmp_path, cfg: Config, monkeypatch) -> None:
+def test_main_graph_shadow_fixture_halts_at_specced_without_writes(tmp_path, cfg: Config, monkeypatch) -> None:
     monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
     client = EmptyClient(cfg)
     store = StateStore(tmp_path / "state.db")
@@ -242,15 +257,8 @@ def test_main_graph_shadow_fixture_can_complete_full_cycle_without_writes(tmp_pa
     p = Poller(config=cfg, store=store, client=client, graph=build_graph(cfg))
     p.scratch[1] = {"verification": {"tests_passed": True}}
 
-    for _ in range(6):
+    for _ in range(3):
         asyncio.run(p.tick())
 
-    assert store.get_issue(1).stage == "merged"
-    assert [record.operation for record in client.dry_run_records] == [
-        "push_branch",
-        "create_pr",
-        "remove_label",
-        "add_label",
-        "create_pr",
-        "merge_pr",
-    ]
+    assert store.get_issue(1).stage == "specced"
+    assert client.dry_run_records == []

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -64,6 +64,24 @@ def test_injected_connection_adapter_roundtrip() -> None:
     assert versions == ["0001"]
 
 
+def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "queued")
+    db.upsert_issue(2, "specced", stage="specced")
+    db.record_run(issue=1, node="queued", outcome="ok")
+    db.record_run(issue=2, node="specced", outcome="ok")
+
+    cleared = db.reset_queue()
+    cleared_again = db.reset_queue()
+
+    assert cleared == {"issues": 2, "runs": 2}
+    assert cleared_again == {"issues": 0, "runs": 0}
+    assert db.list_issues() == []
+    assert db.list_runs() == []
+    versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
+    assert versions == ["0001"]
+
+
 def test_upsert_and_transition_persist(tmp_path) -> None:
     db = store(tmp_path)
     db.upsert_issue(1, "Fix relay")

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
+import os
 import signal
+import sys
 from pathlib import Path
 
 from wgmesh_pipeline.config import load_config
@@ -13,7 +16,11 @@ from wgmesh_pipeline.state.store import open_state_store
 from wgmesh_pipeline.tracing import init_tracing
 
 
-async def async_main() -> None:
+def _truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+async def async_main(*, reset_queue: bool = False) -> None:
     config = load_config()
     init_tracing(config)
     init_scoring(config)
@@ -21,6 +28,12 @@ async def async_main() -> None:
         db_path = Path(config.database_path)
         db_path.parent.mkdir(parents=True, exist_ok=True)
     store = open_state_store(config)
+    if reset_queue or _truthy(os.environ.get("RESET_QUEUE")):
+        cleared = store.reset_queue()
+        print(
+            f"[pipeline] reset_queue cleared issues={cleared['issues']} runs={cleared['runs']}",
+            file=sys.stderr,
+        )
     poller = Poller(config=config, store=store, client=GitHubClient(config), graph=build_graph(config))
 
     stop = asyncio.Event()
@@ -30,10 +43,12 @@ async def async_main() -> None:
     await poller.run_forever(stop)
 
 
-def main() -> None:
-    asyncio.run(async_main())
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reset-queue", action="store_true", help="clear durable issue queue and run history before polling")
+    args = parser.parse_args(argv)
+    asyncio.run(async_main(reset_queue=args.reset_queue))
 
 
 if __name__ == "__main__":
     main()
-

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -79,6 +79,9 @@ class Poller:
             self.scratch[issue.number] = dict(self.graph.spec(state))
             return self.store.transition(issue.number, "triaged", "specced")
 
+        if issue.stage in {"specced", "spec_ready", "implemented", "reviewed"} and self.config.mode == "shadow":
+            return issue
+
         if issue.stage == "specced":
             self.scratch[issue.number] = dict(self.graph.spec_pr(state))
             if self.scratch[issue.number].get("spec_pr") is not None:

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -238,6 +238,15 @@ class StateStore:
         rows = self._conn.execute("SELECT * FROM runs ORDER BY id").fetchall()
         return [dict(row) for row in rows]
 
+    def reset_queue(self) -> dict[str, int]:
+        """Clear durable pipeline work state while leaving migrations intact."""
+        issue_count = int(self._conn.execute("SELECT COUNT(*) AS count FROM issues").fetchone()["count"])
+        run_count = int(self._conn.execute("SELECT COUNT(*) AS count FROM runs").fetchone()["count"])
+        self._conn.execute("DELETE FROM runs")
+        self._conn.execute("DELETE FROM issues")
+        self._conn.commit()
+        return {"issues": issue_count, "runs": run_count}
+
     def bump_attempt(
         self,
         number: int,


### PR DESCRIPTION
## Summary
- stop shadow-mode poller advancement at specced and later write stages so durable state remains resumable
- add reset_queue support via CLI/env and provision workflow input
- add tests for shadow halt, spec-only resume, and reset clearing durable state

## Tests
- pipeline/.venv/bin/python -m pytest pipeline/ -q
- 97 passed in 0.57s