### PR TITLE
fix(pipeline): observable poller (log ticks + surface swallowed errors)

### DIFF
--- a/pipeline/deploy/wgmesh-pipeline.service
+++ b/pipeline/deploy/wgmesh-pipeline.service
@@ -8,6 +8,9 @@ Type=simple
 User=wgmesh
 Group=wgmesh
 WorkingDirectory=/opt/wgmesh-pipeline
+# Unbuffered stdout so journald captures poller logs in real time (Python
+# block-buffers stdout when it is not a tty, hiding logs until exit).
+Environment=PYTHONUNBUFFERED=1
 # Secrets + config live here, root-owned chmod 600 (see .env.example).
 EnvironmentFile=/etc/wgmesh-pipeline/env
 ExecStart=/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import os
 import signal
 import sys
@@ -21,7 +22,17 @@ def _truthy(value: str | None) -> bool:
 
 
 async def async_main(*, reset_queue: bool = False) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
     config = load_config()
+    logging.getLogger("wgmesh_pipeline").info(
+        "starting: mode=%s database_mode=%s poll_interval=%ss",
+        config.mode, config.database_mode, config.poll_interval_seconds,
+    )
     init_tracing(config)
     init_scoring(config)
     if config.database_mode == "local":

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -10,6 +11,8 @@ from wgmesh_pipeline.github.reconcile import reconcile_issues
 from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
 from wgmesh_pipeline.scoring import score_run
 from wgmesh_pipeline.state.store import IssueRecord, StateStore
+
+log = logging.getLogger("wgmesh_pipeline.poller")
 
 
 @dataclass
@@ -32,11 +35,20 @@ class Poller:
 
     async def tick(self) -> IssueRecord | None:
         try:
-            reconcile_issues(self.client, self.store)
+            result = reconcile_issues(self.client, self.store)
             issue = self.store.claim_next(now=datetime.now(timezone.utc))
         except Exception as exc:
+            # Never silently swallow: a reconcile/claim failure here previously
+            # left the loop reconciling-but-never-advancing with the cause
+            # hidden in last_reconcile_error. Surface it loudly every tick.
             self.last_reconcile_error = str(exc)
+            log.exception("tick: reconcile/claim failed: %s", exc)
             return None
+        log.info(
+            "tick: reconcile seen=%s queued=%s; claimed=%s",
+            getattr(result, "seen", "?"), getattr(result, "queued", "?"),
+            f"#{issue.number}@{issue.stage}" if issue else "none",
+        )
         if issue is None:
             return None
 
@@ -48,9 +60,11 @@ class Poller:
             self.store.bump_attempt(issue.number, str(exc))
             self.store.record_run(issue=issue.number, node=node, started=started, ended=datetime.now(timezone.utc), outcome="error")
             score_run({**self.scratch.get(issue.number, {}), "issue": issue}, outcome="failed")
+            log.exception("tick: advance #%s@%s failed: %s", issue.number, node, exc)
             return None
 
         self.store.record_run(issue=issue.number, node=node, started=started, ended=datetime.now(timezone.utc), outcome="ok")
+        log.info("tick: advanced #%s %s -> %s", issue.number, node, getattr(advanced, "stage", "?"))
         return advanced
 
     def _advance_one_stage(self, issue: IssueRecord) -> IssueRecord:


### PR DESCRIPTION
Adds poller logging + unbuffered stdout + surfaces the reconcile/claim error that tick() was swallowing, so the spec-only box's reconcile-but-never-advance stall becomes visible in journalctl. 97 tests. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>