### PR TITLE
fix: wire goose spec authoring path

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -36,9 +36,6 @@ on:
         description: 'Clear durable pipeline queue/runs before polling'
         type: boolean
         default: false
-      poll_interval:
-        description: 'POLL_INTERVAL_SECONDS (seconds between ticks)'
-        default: '300'
 
 permissions:
   contents: read
@@ -158,7 +155,6 @@ jobs:
           MODE: ${{ github.event.inputs.pipeline_mode }}
           DBMODE: ${{ github.event.inputs.database_mode }}
           RESET_QUEUE_INPUT: ${{ github.event.inputs.reset_queue }}
-          PINT: ${{ github.event.inputs.poll_interval }}
         run: |
           set -euo pipefail
           RESET_QUEUE=0
@@ -172,6 +168,9 @@ jobs:
           WGMESH_BOT_PAT=$WGMESH_BOT_PAT
           ZAI_API_KEY=$ANTHROPIC_API_KEY
           ANTHROPIC_HOST=https://api.z.ai/api/anthropic
+          GOOSE_PROVIDER=anthropic
+          GOOSE_MODEL=GLM-4.7
+          WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
           DATABASE_MODE=$DBMODE
           PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db
           TURSO_DATABASE_URL=$TURSO_DATABASE_URL
@@ -179,7 +178,7 @@ jobs:
           LANGFUSE_HOST=$LANGFUSE_HOST
           LANGFUSE_PUBLIC_KEY=$LANGFUSE_PUBLIC_KEY
           LANGFUSE_SECRET_KEY=$LANGFUSE_SECRET_KEY
-          POLL_INTERVAL_SECONDS=${PINT:-300}
+          POLL_INTERVAL_SECONDS=300
           MAX_FILES=20
           RESET_QUEUE=$RESET_QUEUE
           EOF
@@ -190,6 +189,9 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}.git"
           ssh -o StrictHostKeyChecking=no -i "$RUNNER_TEMP/box_key" root@"$BOX_IP" \
             "set -euo pipefail
+             set -a
+             . /etc/wgmesh-pipeline/env
+             set +a
              git clone --depth 1 '$REPO_URL' /opt/wgmesh-pipeline || (cd /opt/wgmesh-pipeline && git pull)
              if [ '${{ github.event.inputs.database_mode }}' = 'turso' ]; then EXTRA='[turso,trace]'; else EXTRA='[trace]'; fi
              python3 -m venv /opt/wgmesh-pipeline/.venv
@@ -197,7 +199,14 @@ jobs:
              /opt/wgmesh-pipeline/.venv/bin/pip install -q -e \"/opt/wgmesh-pipeline/pipeline\${EXTRA}\"
              install -m 0644 /opt/wgmesh-pipeline/pipeline/deploy/wgmesh-pipeline.service /etc/systemd/system/
              id wgmesh >/dev/null 2>&1 || useradd --system --home /opt/wgmesh-pipeline --shell /usr/sbin/nologin wgmesh
+             rm -rf /opt/wgmesh-checkout
+             if [ -n \"\$WGMESH_BOT_PAT\" ]; then
+               git clone \"https://x-access-token:\$WGMESH_BOT_PAT@github.com/atvirokodosprendimai/wgmesh.git\" /opt/wgmesh-checkout
+             else
+               git clone https://github.com/atvirokodosprendimai/wgmesh.git /opt/wgmesh-checkout
+             fi
              chown -R wgmesh:wgmesh /opt/wgmesh-pipeline
+             chown -R wgmesh:wgmesh /opt/wgmesh-checkout
              systemctl daemon-reload
              systemctl enable --now wgmesh-pipeline
              sleep 5

--- a/pipeline/deploy/env.example
+++ b/pipeline/deploy/env.example
@@ -14,6 +14,9 @@ WGMESH_BOT_PAT=
 # Goose LLM (z.ai / GLM, OpenAI-anthropic-compat endpoint).
 ZAI_API_KEY=
 ANTHROPIC_HOST=https://api.z.ai/api/anthropic
+GOOSE_PROVIDER=anthropic
+GOOSE_MODEL=GLM-4.7
+WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
 
 # Online run scoring (optional — degrades to no-op if unset).
 LANGSMITH_API_KEY=

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -1,0 +1,37 @@
+version: "1.0.0"
+title: "wgmesh Triage Spec"
+description: "Write a structured implementation spec for a wgmesh GitHub issue."
+parameters:
+  - key: issue_number
+    input_type: string
+    requirement: required
+    description: "GitHub issue number."
+  - key: issue_title
+    input_type: string
+    requirement: required
+    description: "GitHub issue title."
+  - key: spec_file
+    input_type: string
+    requirement: required
+    description: "Repository-relative markdown path where the spec must be written."
+prompt: |
+  You are writing an implementation specification for wgmesh, a decentralized
+  WireGuard mesh networking product with managed ingress.
+
+  Issue: #{{ issue_number }} - {{ issue_title }}
+
+  Write a markdown implementation spec to this exact repository-relative path:
+  {{ spec_file }}
+
+  Requirements:
+  - Create parent directories if needed.
+  - Write the file; do not only print the spec.
+  - Keep the content public-repo safe: no secrets, no customer PII, no exact revenue figures.
+  - Use this exact section structure:
+    - Summary
+    - Context
+    - Requirements
+    - Acceptance Criteria
+    - Out of scope
+  - Keep the spec concrete enough for an implementation agent to build from it.
+  - Do not modify unrelated files.

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,9 @@ def test_full_env_loads_frozen_config_with_shadow_default() -> None:
     assert cfg.poll_interval_seconds == 60
     assert cfg.max_files == 5
     assert cfg.database_mode == "local"
+    assert cfg.repo_path == "/opt/wgmesh-checkout"
+    assert Path(cfg.recipes_dir).name == "recipes"
+    assert Path(cfg.recipes_dir).parent.name == "pipeline"
 
     with pytest.raises(FrozenInstanceError):
         cfg.mode = "live"  # type: ignore[misc]
@@ -83,3 +87,18 @@ def test_database_mode_explicit_no_silent_fallback() -> None:
     assert cfg.database_mode == "turso"
     assert cfg.turso_url == "libsql://db.turso.io"
 
+
+def test_wgmesh_checkout_path_env_and_recipes_dir_override() -> None:
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "PIPELINE_MODE": "spec-only",
+            "DATABASE_MODE": "local",
+            "WGMESH_BOT_PAT": "token",
+            "WGMESH_CHECKOUT_PATH": "/tmp/wgmesh",
+            "RECIPES_DIR": "/tmp/recipes",
+        }
+    )
+
+    assert cfg.repo_path == "/tmp/wgmesh"
+    assert cfg.recipes_dir == "/tmp/recipes"

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -62,6 +62,8 @@ def test_build_goose_env_allowlist_drops_secrets_keeps_safe_and_llm_cred() -> No
     # the single LLM credential Goose needs is added back explicitly
     assert env["ANTHROPIC_API_KEY"] == "zai-secret"
     assert env["ANTHROPIC_HOST"].endswith("/anthropic")
+    assert env["GOOSE_PROVIDER"] == "anthropic"
+    assert env["GOOSE_MODEL"]
 
 
 def test_build_goose_env_only_anthropic_key_is_secret_shaped() -> None:
@@ -80,3 +82,17 @@ def test_build_goose_env_without_zai_key_omits_anthropic_key() -> None:
     env = build_goose_env(_Cfg(zai_api_key=None), base_env={"PATH": "/usr/bin"})
     assert "ANTHROPIC_API_KEY" not in env
     assert env["ANTHROPIC_HOST"]
+
+
+def test_build_goose_env_prefers_explicit_goose_provider_model_from_base_env() -> None:
+    env = build_goose_env(
+        _Cfg(),
+        base_env={
+            "PATH": "/usr/bin",
+            "GOOSE_PROVIDER": "anthropic",
+            "GOOSE_MODEL": "custom-zai-model",
+        },
+    )
+
+    assert env["GOOSE_PROVIDER"] == "anthropic"
+    assert env["GOOSE_MODEL"] == "custom-zai-model"

--- a/pipeline/tests/test_main.py
+++ b/pipeline/tests/test_main.py
@@ -16,16 +16,21 @@ class Store:
 
 
 class DummyPoller:
+    instances = []
+
     def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
+        self.instances.append(self)
 
     async def run_forever(self, stop) -> None:
         stop.set()
 
 
 def test_async_main_honors_reset_queue_env_before_polling(monkeypatch, capsys) -> None:
+    DummyPoller.instances = []
     store = Store()
     cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local")
+    goose_runner = object()
 
     monkeypatch.setenv("RESET_QUEUE", "1")
     monkeypatch.setattr(main, "load_config", lambda: cfg)
@@ -34,11 +39,13 @@ def test_async_main_honors_reset_queue_env_before_polling(monkeypatch, capsys) -
     monkeypatch.setattr(main, "open_state_store", lambda config: store)
     monkeypatch.setattr(main, "GitHubClient", lambda config: object())
     monkeypatch.setattr(main, "build_graph", lambda config: object())
+    monkeypatch.setattr(main, "GooseRunner", lambda config: goose_runner, raising=False)
     monkeypatch.setattr(main, "Poller", DummyPoller)
 
     asyncio.run(main.async_main())
 
     assert store.reset_calls == 1
+    assert DummyPoller.instances[0].kwargs["goose_runner"] is goose_runner
     assert "[pipeline] reset_queue cleared issues=3 runs=4" in capsys.readouterr().err
 
 

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -209,6 +209,33 @@ def test_restart_mid_flight_resumes_persisted_stage_without_double_work(tmp_path
     assert graph.calls == ["spec"]
 
 
+def test_advance_one_stage_injects_goose_runner_and_repo_path(tmp_path, cfg: Config) -> None:
+    class InspectingGraph(Graph):
+        def __init__(self) -> None:
+            super().__init__()
+            self.seen_state = None
+
+        def spec(self, state):
+            self.calls.append("spec")
+            self.seen_state = dict(state)
+            return {**state, "spec_path": "specs/issue-17-spec.md"}
+
+    graph = InspectingGraph()
+    repo_path = tmp_path / "wgmesh"
+    runner = object()
+    spec_only = Config(target_repo=cfg.target_repo, mode="spec-only", repo_path=str(repo_path))
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(17, "Already triaged", stage="triaged")
+    p = Poller(config=spec_only, store=store, client=EmptyClient(spec_only), graph=graph, goose_runner=runner)
+
+    p._advance_one_stage(store.get_issue(17))
+
+    assert graph.seen_state is not None
+    assert graph.seen_state["goose_runner"] is runner
+    assert graph.seen_state["repo_path"] == repo_path
+    assert graph.seen_state["config"] is spec_only
+
+
 def test_specced_issue_opens_spec_pr_then_stops_in_spec_only(tmp_path, cfg: Config) -> None:
     spec_only = Config(target_repo=cfg.target_repo, mode="spec-only", max_files=cfg.max_files)
     p = poller(tmp_path, spec_only)

--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.graph.nodes.spec import spec_node
+from wgmesh_pipeline.goose.runner import GooseResult
+
+
+@dataclass
+class FakeRunner:
+    calls: list[dict[str, Any]]
+
+    def run_recipe(self, *, recipe, workdir, params, expected_output):
+        output = Path(workdir) / expected_output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            "# Issue 17 Spec\n\n"
+            "## Summary\nWrite the spec.\n\n"
+            "## Context\nIssue context.\n\n"
+            "## Requirements\n- Requirement.\n\n"
+            "## Acceptance Criteria\n- Passes.\n\n"
+            "## Out of scope\n- Nothing else.\n"
+        )
+        self.calls.append(
+            {
+                "recipe": recipe,
+                "workdir": workdir,
+                "params": params,
+                "expected_output": expected_output,
+            }
+        )
+        return GooseResult(ok=True, output_path=output, duration_seconds=0.01, raw_log="ok")
+
+
+def test_spec_node_writes_spec_file_with_goose_runner(tmp_path: Path) -> None:
+    runner = FakeRunner(calls=[])
+    result = spec_node(
+        {
+            "issue": GitHubIssue(number=17, title="Fix mesh discovery", labels=(), state="open"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+
+    spec_path = Path(result["spec_path"])
+    assert spec_path == tmp_path / "specs/issue-17-spec.md"
+    assert spec_path.exists()
+    assert "## Acceptance Criteria" in spec_path.read_text()
+
+
+def test_spec_node_resolves_recipe_path_and_passes_issue_params(tmp_path: Path) -> None:
+    runner = FakeRunner(calls=[])
+    config = Config(target_repo="atvirokodosprendimai/wgmesh", recipes_dir=str(tmp_path / "recipes"))
+    (tmp_path / "recipes").mkdir()
+
+    spec_node(
+        {
+            "issue": GitHubIssue(number=18, title="Add managed ingress", labels=(), state="open"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": config,
+        }
+    )
+
+    call = runner.calls[0]
+    assert call["recipe"] == tmp_path / "recipes" / "wgmesh-triage-spec.yaml"
+    assert call["params"] == {
+        "issue_number": "18",
+        "issue_title": "Add managed ingress",
+        "spec_file": "specs/issue-18-spec.md",
+    }

--- a/pipeline/tests/test_spec_pr.py
+++ b/pipeline/tests/test_spec_pr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -9,7 +10,9 @@ import pytest
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubIssue
 from wgmesh_pipeline.graph.build import CompiledGraph
+from wgmesh_pipeline.graph.nodes.spec import spec_node
 from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
+from wgmesh_pipeline.goose.runner import GooseResult
 
 
 class RecordingClient:
@@ -19,6 +22,7 @@ class RecordingClient:
         self.prs: list[dict[str, Any]] = []
         self.added: list[tuple[int, str]] = []
         self.removed: list[tuple[int, str]] = []
+        self.create_pr_targets: list[str] = []
 
     def push_branch(self, clone_path: str, branch: str, *, spec_pr: bool = False) -> dict[str, Any]:
         self.pushed.append((clone_path, branch))
@@ -26,6 +30,7 @@ class RecordingClient:
 
     def create_pr(self, **kwargs: Any) -> dict[str, Any]:
         self.prs.append(kwargs)
+        self.create_pr_targets.append(self.config.target_repo)
         return {"number": 42}
 
     def remove_label(self, issue_number: int, label: str, *, spec_pr: bool = False) -> dict[str, Any]:
@@ -76,6 +81,60 @@ def test_spec_pr_node_creates_exact_spec_title_and_swaps_labels(tmp_path: Path, 
     assert client.removed == [(17, "needs-triage")]
     assert client.added == [(17, "copilot-triaging")]
     assert result["visited"] == ["spec_pr"]
+
+
+class WritingRunner:
+    def run_recipe(self, *, recipe, workdir, params, expected_output):
+        output = Path(workdir) / expected_output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            "# Issue 17 Spec\n\n"
+            "## Summary\nFix mesh discovery.\n\n"
+            "## Context\nThe issue needs a structured implementation spec.\n\n"
+            "## Requirements\n- Preserve existing discovery behavior.\n\n"
+            "## Acceptance Criteria\n- The discovery fix is covered.\n\n"
+            "## Out of scope\n- Unrelated networking changes.\n"
+        )
+        return GooseResult(ok=True, output_path=output, duration_seconds=0.01, raw_log="ok")
+
+
+def test_spec_to_spec_pr_commits_spec_file_and_targets_wgmesh(tmp_path: Path) -> None:
+    cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="spec-only", repo_path=str(tmp_path))
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "bot@example.invalid")
+    _git(tmp_path, "config", "user.name", "wgmesh bot")
+    _git(tmp_path, "remote", "add", "origin", "https://github.com/atvirokodosprendimai/wgmesh.git")
+
+    client = RecordingClient(cfg)
+    issue_17 = issue()
+    spec_state = spec_node(
+        {
+            "issue": issue_17,
+            "repo_path": tmp_path,
+            "goose_runner": WritingRunner(),
+            "config": cfg,
+        }
+    )
+    result = spec_pr_node({**spec_state, "github": client})
+
+    assert result["spec_pr"] == 42
+    assert result["spec_branch"] == "bot/spec-17"
+    assert client.create_pr_targets == ["atvirokodosprendimai/wgmesh"]
+    assert client.prs[0]["head"] == "bot/spec-17"
+    assert client.pushed == [(str(tmp_path), "bot/spec-17")]
+    assert (tmp_path / "specs/issue-17-spec.md").exists()
+    assert _git(tmp_path, "branch", "--show-current").stdout.strip() == "bot/spec-17"
+    assert _git(tmp_path, "log", "--format=%s", "-1").stdout.strip() == "spec: Issue #17 - Fix mesh discovery"
+
+
+def _git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
 
 def test_spec_only_graph_halts_after_spec_pr_before_implementation(cfg: Config) -> None:

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Mapping
 
 
@@ -11,6 +12,10 @@ DEFAULT_ANTHROPIC_HOST = "https://api.z.ai/api/anthropic"
 DEFAULT_TARGET_REPO = "atvirokodosprendimai/wgmesh"
 DEFAULT_POLL_INTERVAL_SECONDS = 300
 DEFAULT_MAX_FILES = 20
+DEFAULT_REPO_PATH = "/opt/wgmesh-checkout"
+DEFAULT_RECIPES_DIR = str(Path(__file__).resolve().parents[1] / "recipes")
+DEFAULT_GOOSE_PROVIDER = "anthropic"
+DEFAULT_GOOSE_MODEL = "GLM-4.7"
 
 
 @dataclass(frozen=True)
@@ -23,6 +28,10 @@ class Config:
     langsmith_api_key: str | None = None
     poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS
     max_files: int = DEFAULT_MAX_FILES
+    repo_path: str = DEFAULT_REPO_PATH
+    recipes_dir: str = DEFAULT_RECIPES_DIR
+    goose_provider: str = DEFAULT_GOOSE_PROVIDER
+    goose_model: str = DEFAULT_GOOSE_MODEL
     database_mode: str = "local"
     database_path: str = "pipeline/state.db"
     turso_url: str | None = None
@@ -76,6 +85,10 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         langsmith_api_key=_get_nonempty(source, "LANGSMITH_API_KEY"),
         poll_interval_seconds=_get_int(source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
         max_files=_get_int(source, "MAX_FILES", DEFAULT_MAX_FILES),
+        repo_path=_get_nonempty(source, "WGMESH_CHECKOUT_PATH") or DEFAULT_REPO_PATH,
+        recipes_dir=_get_nonempty(source, "RECIPES_DIR") or DEFAULT_RECIPES_DIR,
+        goose_provider=_get_nonempty(source, "GOOSE_PROVIDER") or DEFAULT_GOOSE_PROVIDER,
+        goose_model=_get_nonempty(source, "GOOSE_MODEL") or DEFAULT_GOOSE_MODEL,
         database_mode=db_mode,
         database_path=_get_nonempty(source, "PIPELINE_DB_PATH") or "pipeline/state.db",
         turso_url=turso_url,
@@ -112,4 +125,3 @@ def _get_int(env: Mapping[str, str], name: str, default: int) -> int:
     if value <= 0:
         raise ValueError(f"{name} must be positive")
     return value
-

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
-from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.config import Config, DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -95,6 +95,8 @@ def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -
     if config.zai_api_key:
         env["ANTHROPIC_API_KEY"] = config.zai_api_key
     env["ANTHROPIC_HOST"] = config.anthropic_host
+    env["GOOSE_PROVIDER"] = source.get("GOOSE_PROVIDER") or getattr(config, "goose_provider", DEFAULT_GOOSE_PROVIDER)
+    env["GOOSE_MODEL"] = source.get("GOOSE_MODEL") or getattr(config, "goose_model", DEFAULT_GOOSE_MODEL)
     return env
 
 

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
 from wgmesh_pipeline.graph.state import GraphState
 
 
@@ -19,10 +20,17 @@ def spec_node(state: GraphState) -> GraphState:
         next_state["spec_path"] = str(spec_rel)
         return next_state
 
+    config = next_state.get("config")
+    recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
+    recipe_path = recipes_dir / "wgmesh-triage-spec.yaml"
     result = runner.run_recipe(
-        recipe="wgmesh-triage-spec.yaml",
+        recipe=recipe_path,
         workdir=repo_path,
-        params={"spec_file": str(spec_rel)},
+        params={
+            "issue_number": str(issue.number),
+            "issue_title": issue.title,
+            "spec_file": str(spec_rel),
+        },
         expected_output=spec_rel,
     )
     if not result.ok:
@@ -33,4 +41,3 @@ def spec_node(state: GraphState) -> GraphState:
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
-

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
+from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 
 
@@ -30,3 +31,4 @@ class GraphState(TypedDict, total=False):
     repo_path: str | Path
     goose_runner: Any
     impl_pr: int
+    config: Config

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from wgmesh_pipeline.config import load_config
 from wgmesh_pipeline.github.client import GitHubClient
+from wgmesh_pipeline.goose.runner import GooseRunner
 from wgmesh_pipeline.graph.build import build_graph
 from wgmesh_pipeline.poller import Poller
 from wgmesh_pipeline.scoring import init_scoring
@@ -45,7 +46,13 @@ async def async_main(*, reset_queue: bool = False) -> None:
             f"[pipeline] reset_queue cleared issues={cleared['issues']} runs={cleared['runs']}",
             file=sys.stderr,
         )
-    poller = Poller(config=config, store=store, client=GitHubClient(config), graph=build_graph(config))
+    poller = Poller(
+        config=config,
+        store=store,
+        client=GitHubClient(config),
+        graph=build_graph(config),
+        goose_runner=GooseRunner(config),
+    )
 
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
@@ -21,6 +22,7 @@ class Poller:
     store: StateStore
     client: GitHubClient
     graph: object
+    goose_runner: object | None = None
     scratch: dict[int, dict] = field(default_factory=dict)
     last_reconcile_error: str | None = None
 
@@ -69,7 +71,15 @@ class Poller:
 
     def _advance_one_stage(self, issue: IssueRecord) -> IssueRecord:
         graph_issue = GitHubIssue(number=issue.number, title=issue.title, labels=(), state=issue.status)
-        state = {**self.scratch.get(issue.number, {}), "issue": graph_issue, "github": self.client}
+        state = {
+            **self.scratch.get(issue.number, {}),
+            "issue": graph_issue,
+            "github": self.client,
+            "config": self.config,
+            "repo_path": Path(self.config.repo_path),
+        }
+        if self.goose_runner is not None:
+            state["goose_runner"] = self.goose_runner
         if issue.impl_pr is not None:
             state["impl_pr"] = issue.impl_pr
         if issue.spec_pr is not None:


### PR DESCRIPTION
## Summary
- inject GooseRunner and checkout path into every poller graph stage
- add the wgmesh triage spec Goose recipe and resolve it from config
- provision /opt/wgmesh-checkout for spec PR git operations
- pass Goose provider/model env for z.ai Anthropic-compatible headless runs

## Verification
- /Users/oldroot/orca/workspaces/ai-pipeline-template/brill/pipeline/.venv/bin/python -m pytest: 104 passed
- goose recipe validate pipeline/recipes/wgmesh-triage-spec.yaml: valid (Goose warned that local CLI logging directory could not be created)

## UNVERIFIED
- Live Hetzner box provisioning and real goose run against z.ai provider were not executed.
- Real wgmesh PAT-backed push/PR creation was verified by source/test path, not against the live box.