### PR TITLE
fix(pipeline): enable goose developer extension (bug #6 empty spec output)

### DIFF
--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -35,3 +35,14 @@ prompt: |
     - Out of scope
   - Keep the spec concrete enough for an implementation agent to build from it.
   - Do not modify unrelated files.
+
+# The developer extension provides the filesystem write tool goose needs to
+# actually create the spec file. Without it goose only prints text and the
+# empty-output guard fires (the box is installed CONFIGURE=false, so no
+# extensions are enabled unless the recipe declares them).
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true


### PR DESCRIPTION
goose ran but wrote no file (empty-output guard) because CONFIGURE=false left it with no filesystem tool. Declare the builtin developer extension in the recipe. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>