### PR TITLE
fix(pipeline): pin goose provider/model + full raw_log (bug #6)

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -173,7 +173,7 @@ jobs:
           ZAI_API_KEY=$ANTHROPIC_API_KEY
           ANTHROPIC_HOST=https://api.z.ai/api/anthropic
           GOOSE_PROVIDER=anthropic
-          GOOSE_MODEL=GLM-4.7
+          GOOSE_MODEL=glm-4.6
           WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
           DATABASE_MODE=$DBMODE
           PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -46,3 +46,11 @@ extensions:
     display_name: Developer
     timeout: 300
     bundled: true
+
+# Pin provider/model in the recipe (goose honors recipe settings even when env
+# GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session runs). z.ai is
+# Anthropic-compatible via ANTHROPIC_HOST; glm-4.6 is the current valid model id
+# (GLM-4.7 did not exist — goose loaded the recipe then no-opped).
+settings:
+  goose_provider: anthropic
+  goose_model: glm-4.6

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -39,10 +39,15 @@ def spec_node(state: GraphState) -> GraphState:
     if not result.ok:
         # Surface goose's actual output so a write-tool/model/recipe failure is
         # diagnosable from the journal instead of just "empty output guard".
-        raw = (getattr(result, "raw_log", "") or "")[-2000:]
+        raw = getattr(result, "raw_log", "") or ""
+        # Log head AND tail: the provider/API error appears at the START of
+        # goose's output; the tail-only view missed it last cycle.
+        head = raw[:6000]
+        tail = raw[-2000:] if len(raw) > 8000 else ""
         log.error(
-            "goose spec failed for #%s: error=%s recipe=%s workdir=%s\n--- goose raw_log (tail) ---\n%s",
-            issue.number, result.error, recipe_path, repo_path, raw,
+            "goose spec failed for #%s: error=%s recipe=%s workdir=%s len(raw)=%d\n"
+            "--- goose raw_log (head) ---\n%s\n--- goose raw_log (tail) ---\n%s",
+            issue.number, result.error, recipe_path, repo_path, len(raw), head, tail,
         )
         raise RuntimeError(result.error or "goose spec failed")
     next_state["spec_path"] = str(result.output_path)


### PR DESCRIPTION
goose no-opped (recipe loaded, exit 0, no agent run) — pin provider/model in recipe settings, fix GLM-4.7→glm-4.6, log raw_log head+tail. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>