### PR TITLE
fix(pipeline): make /opt/wgmesh-checkout writable for goose (bug #8)

### DIFF
--- a/pipeline/deploy/wgmesh-pipeline.service
+++ b/pipeline/deploy/wgmesh-pipeline.service
@@ -25,7 +25,11 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
-ReadWritePaths=/opt/wgmesh-pipeline
+# /opt/wgmesh-checkout is the wgmesh working tree goose writes specs into and
+# spec_pr commits/pushes from. ProtectSystem=strict makes everything outside
+# ReadWritePaths read-only, so goose hit "Read-only file system (os error 30)"
+# and fell back to /tmp, tripping the empty-output guard. Whitelist it.
+ReadWritePaths=/opt/wgmesh-pipeline /opt/wgmesh-checkout
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
goose authored the spec but ProtectSystem=strict made the checkout read-only (os error 30) → wrote to /tmp → empty-output guard. Whitelist the checkout in ReadWritePaths. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>