### PR TITLE
fix(pipeline): idempotent spec_pr (bug #10)

### DIFF
--- a/pipeline/tests/test_spec_pr.py
+++ b/pipeline/tests/test_spec_pr.py
@@ -238,3 +238,38 @@ def test_live_graph_continues_past_spec_pr_to_gate(cfg: Config) -> None:
 
     assert result["decision"] == "merge"
     assert calls == ["triage", "spec", "spec_pr", "implement", "review", "gate"]
+
+
+def _resp(code: int):
+    import requests
+    r = requests.Response()
+    r.status_code = code
+    return r
+
+
+def test_spec_pr_idempotent_reuses_existing_pr_on_422(tmp_path: Path) -> None:
+    """Retry after a partial run: create_pr 422 -> reuse the existing PR
+    instead of failing the node forever (bug #10)."""
+    from requests import HTTPError
+
+    cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="spec-only")
+
+    class Reraiser(RecordingClient):
+        def create_pr(self, **kwargs):
+            raise HTTPError(response=_resp(422))
+
+        def find_open_pr_number(self, head_branch: str):
+            return 667
+
+        def remove_label(self, issue_number, label, *, spec_pr=False):
+            raise HTTPError(response=_resp(404))  # label already gone -> tolerated
+
+    client = Reraiser(cfg)
+    state = {
+        "issue": GitHubIssue(number=652, title="Fix CI", labels=(), state="open"),
+        "github": client,
+        "repo_path": str(tmp_path),
+        "spec_path": "specs/issue-652-spec.md",
+    }
+    result = spec_pr_node(state)  # must not raise
+    assert result["spec_pr"] == 667

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -73,6 +73,19 @@ class GitHubClient:
     def get_pr(self, number: int) -> dict[str, Any]:
         return self._request("GET", f"/repos/{self.config.owner}/{self.config.repo}/pulls/{number}")
 
+    def find_open_pr_number(self, head_branch: str) -> int | None:
+        """Open PR number for a head branch, or None. Used to make spec PR
+        creation idempotent: a retry after a partial run hits create_pr 422
+        ('a pull request already exists') and reuses the existing PR."""
+        owner = self.config.owner
+        resp = self._request(
+            "GET",
+            f"/repos/{owner}/{self.config.repo}/pulls?head={owner}:{head_branch}&state=open",
+        )
+        if isinstance(resp, list) and resp and resp[0].get("number") is not None:
+            return int(resp[0]["number"])
+        return None
+
     def get_diff(self, pr_number: int) -> str:
         return self._request(
             "GET",

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec_pr.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec_pr.py
@@ -4,7 +4,14 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from requests import HTTPError
+
 from wgmesh_pipeline.graph.state import GraphState
+
+
+def _status(exc: HTTPError) -> int | None:
+    resp = getattr(exc, "response", None)
+    return getattr(resp, "status_code", None) if resp is not None else None
 
 
 GIT_TIMEOUT_SECONDS = 120
@@ -35,18 +42,32 @@ def spec_pr_node(state: GraphState) -> GraphState:
         _prepare_spec_branch(repo_path, branch, spec_rel, title)
 
     client.push_branch(str(repo_path), branch, spec_pr=True)
-    result = client.create_pr(
-        title=title,
-        head=branch,
-        base="main",
-        body=_spec_pr_body(issue.number, spec_rel),
-        spec_pr=True,
-    )
-    pr_number = _pr_number(result)
+    # Idempotent create: a retry after a partial run (PR already opened, then a
+    # later step failed) hits 422 "a pull request already exists"; reuse it
+    # instead of failing the node forever.
+    try:
+        result = client.create_pr(
+            title=title,
+            head=branch,
+            base="main",
+            body=_spec_pr_body(issue.number, spec_rel),
+            spec_pr=True,
+        )
+        pr_number = _pr_number(result)
+    except HTTPError as exc:
+        if _status(exc) == 422:
+            pr_number = client.find_open_pr_number(branch)
+        else:
+            raise
     if pr_number is None:
         raise RuntimeError("spec PR creation did not return a PR number")
 
-    client.remove_label(issue.number, "needs-triage", spec_pr=True)
+    # needs-triage may already be gone from a prior partial run -> tolerate 404.
+    try:
+        client.remove_label(issue.number, "needs-triage", spec_pr=True)
+    except HTTPError as exc:
+        if _status(exc) != 404:
+            raise
     client.add_label(issue.number, "copilot-triaging", spec_pr=True)
     next_state["spec_branch"] = branch
     next_state["spec_pr"] = pr_number


### PR DESCRIPTION
First spec PRs landed (#667/#668) but spec_pr retried forever (422 PR-exists + 404 label-gone). Make it idempotent so the issue reaches spec_opened. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>