### PR TITLE
fix(pipeline): reconcile skips PRs (bug #11 runaway spec-of-spec flood)

### DIFF
--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -209,3 +209,27 @@ def test_spec_only_allows_spec_branch_push_and_label_swap(cfg: Config, tmp_path,
 
     assert pushes == [(["git", "push", "origin", "bot/spec-17"], str(tmp_path))]
     assert [call["method"] for call in session.calls] == ["DELETE", "POST"]
+
+
+def test_list_open_issues_filters_out_pull_requests(cfg: Config) -> None:
+    """GitHub's issues endpoint returns PRs too (they carry a pull_request
+    key). They must be filtered, else the box reconciles its own spec PRs as
+    issues and recurses into spec-of-spec PRs (bug #11)."""
+    session = Session(
+        Response(
+            [
+                {"number": 10, "title": "Real issue", "labels": [], "state": "open"},
+                {
+                    "number": 667,
+                    "title": "spec: Issue #652 - ...",
+                    "labels": [],
+                    "state": "open",
+                    "pull_request": {"url": "https://api.github.com/.../pulls/667"},
+                },
+            ]
+        )
+    )
+
+    issues = GitHubClient(cfg, session=session).list_open_issues()
+
+    assert [i.number for i in issues] == [10]

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -68,7 +68,11 @@ class GitHubClient:
             f"/repos/{self.config.owner}/{self.config.repo}/issues",
             params={"state": "open"},
         )
-        return [_parse_issue(item) for item in data]
+        # GitHub's issues endpoint returns pull requests too (they carry a
+        # "pull_request" key). Skip them — reconciling the box's own spec PRs
+        # as issues caused a runaway: spec-of-spec PRs with exploding chained
+        # titles (bug #11).
+        return [_parse_issue(item) for item in data if "pull_request" not in item]
 
     def get_pr(self, number: int) -> dict[str, Any]:
         return self._request("GET", f"/repos/{self.config.owner}/{self.config.repo}/pulls/{number}")


### PR DESCRIPTION
GitHub /issues returns PRs (pull_request key); the box reconciled its own spec PRs as issues -> recursive spec-of-spec PRs with exploding titles, flooding wgmesh. Filter PRs out. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>