### PR TITLE
fix(pr-review-merge): one-reset-per-SHA + Copilot commit-author bot recognition

### DIFF
--- a/company/scripts/pr-review-merge.sh
+++ b/company/scripts/pr-review-merge.sh
@@ -207,6 +207,7 @@ check_unresolved_threads() {
   owner="${TARGET_REPO%%/*}"
   repo="${TARGET_REPO##*/}"
   local count
+  # shellcheck disable=SC2016  # GraphQL variables are bound by gh -F flags.
   if ! count=$(gh api graphql \
     -F owner="$owner" \
     -F repo="$repo" \
@@ -468,24 +469,53 @@ merge_pr() {
 # ---------------------------------------------------------------------------
 check_manual_push() {
   local pr="$1"
-  local latest_author
-  if ! latest_author=$(gh api "repos/${TARGET_REPO}/pulls/${pr}/commits" --jq '.[-1].author.login // empty' 2>/dev/null); then
-    echo "::warning::Failed to check latest commit author for PR #${pr}"
+  local latest_commit latest_sha latest_author
+  if ! latest_commit=$(gh api "repos/${TARGET_REPO}/pulls/${pr}/commits" --jq '.[-1] | [.sha, (.author.login // "")] | @tsv' 2>/dev/null); then
+    echo "::warning::Failed to check latest commit for PR #${pr}"
     ERRORS=$((ERRORS + 1))
     check_circuit_breaker
     return 1  # can't determine, continue normally
   fi
 
-  # If author is empty/null, can't determine — skip reset
+  IFS=$'\t' read -r latest_sha latest_author <<< "$latest_commit"
+
+  # If SHA is empty/null, can't track distinct pushes — skip reset.
+  if [[ -z "$latest_sha" ]]; then
+    return 1
+  fi
+
+  local last_var="LAST_MANUAL_PUSH_SHA_${pr//[^A-Za-z0-9_]/_}"
+  local last_sha="${!last_var-}"
+  if [[ "$latest_sha" == "$last_sha" ]]; then
+    return 1
+  fi
+  printf -v "$last_var" "%s" "$latest_sha"
+
+  # If author is empty/null, can't determine whether this was manual — skip reset.
   if [[ -z "$latest_author" ]]; then
     return 1
   fi
 
   # Check if author is NOT a known bot
   local is_bot="false"
+  local latest_author_normalized
+  latest_author_normalized=$(printf '%s' "$latest_author" | sed 's/\[bot\]$//' | tr '[:upper:]' '[:lower:]')
+
   IFS=',' read -ra approved_list <<< "$APPROVED_AUTHORS"
   for approved in "${approved_list[@]}"; do
-    if [[ "$latest_author" == "$approved" ]]; then
+    local approved_normalized
+    approved_normalized=$(printf '%s' "$approved" | sed 's/\[bot\]$//' | tr '[:upper:]' '[:lower:]')
+    if [[ "$latest_author_normalized" == "$approved_normalized" ]]; then
+      is_bot="true"
+      break
+    fi
+  done
+
+  local known_bot_commit_authors="copilot,goose"
+  local known_bot
+  IFS=',' read -ra known_bot_list <<< "$known_bot_commit_authors"
+  for known_bot in "${known_bot_list[@]}"; do
+    if [[ "$latest_author_normalized" == "$known_bot" ]]; then
       is_bot="true"
       break
     fi
@@ -493,7 +523,7 @@ check_manual_push() {
 
   if [[ "$is_bot" != "true" ]]; then
     echo "Manual push detected by ${latest_author} — resetting retry counter"
-    log_audit "manual_push" "Non-bot commit by ${latest_author}, retry counter reset"
+    log_audit "manual_push" "Non-bot commit by ${latest_author} (${latest_sha}), retry counter reset"
     return 0
   fi
   return 1

--- a/company/scripts/test-pr-review-merge.sh
+++ b/company/scripts/test-pr-review-merge.sh
@@ -398,7 +398,7 @@ echo "12. test_check_manual_push_bot"
 setup_test_env
 create_mock_gh '
 if [[ "$1" == "api" && "$*" == *"commits"* ]]; then
-  echo "copilot-swe-agent[bot]"
+  printf "botsha\tcopilot-swe-agent[bot]\n"
   exit 0
 fi
 exit 0
@@ -414,7 +414,7 @@ echo "13. test_check_manual_push_human"
 setup_test_env
 create_mock_gh '
 if [[ "$1" == "api" && "$*" == *"commits"* ]]; then
-  echo "human-dev"
+  printf "humansha\thuman-dev\n"
   exit 0
 fi
 exit 0
@@ -424,6 +424,67 @@ exit_code=0
 check_manual_push 42 || exit_code=$?
 assert_eq "returns 0 for human commit" "0" "$exit_code"
 assert_contains "audit logs manual_push" '"manual_push"' "$(cat "$TEST_AUDIT_LOG")"
+
+# --- Test 14: check_manual_push — same Copilot SHA does not reset repeatedly ---
+echo ""
+echo "14. test_check_manual_push_same_copilot_sha_at_most_once"
+setup_test_env
+create_mock_gh '
+if [[ "$1" == "api" && "$*" == *"commits"* ]]; then
+  printf "copilotsha\tCopilot\n"
+  exit 0
+fi
+exit 0
+'
+eval_functions
+reset_count=0
+if check_manual_push 42; then reset_count=$((reset_count + 1)); fi
+if check_manual_push 42; then reset_count=$((reset_count + 1)); fi
+assert_eq "same Copilot SHA resets at most once" "0" "$reset_count"
+
+# --- Test 15: check_manual_push — bare Copilot commit author is bot ---
+echo ""
+echo "15. test_check_manual_push_bare_copilot_author_is_bot"
+setup_test_env
+create_mock_gh '
+if [[ "$1" == "api" && "$*" == *"commits"* ]]; then
+  printf "copilotsha\tCopilot\n"
+  exit 0
+fi
+exit 0
+'
+eval_functions
+exit_code=0
+check_manual_push 42 || exit_code=$?
+assert_eq "returns 1 for bare Copilot author" "1" "$exit_code"
+assert_not_contains "does not audit Copilot as manual push" '"manual_push"' "$(cat "$TEST_AUDIT_LOG")"
+
+# --- Test 16: check_manual_push — new human SHA resets once ---
+echo ""
+echo "16. test_check_manual_push_new_human_sha_resets_once"
+setup_test_env
+touch "$TMPDIR/manual-push-gh-count"
+create_mock_gh '
+if [[ "$1" == "api" && "$*" == *"commits"* ]]; then
+  count_file="'"$TMPDIR"'/manual-push-gh-count"
+  count=$(cat "$count_file")
+  count=$((count + 1))
+  echo "$count" > "$count_file"
+  if [[ "$count" -eq 1 ]]; then
+    printf "oldbotsha\tgoose[bot]\n"
+  else
+    printf "newhumansha\thuman-dev\n"
+  fi
+  exit 0
+fi
+exit 0
+'
+eval_functions
+reset_count=0
+if check_manual_push 42; then reset_count=$((reset_count + 1)); fi
+if check_manual_push 42; then reset_count=$((reset_count + 1)); fi
+if check_manual_push 42; then reset_count=$((reset_count + 1)); fi
+assert_eq "new human SHA resets once" "1" "$reset_count"
 
 # ── Summary (TEST-2) ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Track the latest checked commit SHA per PR so manual-push retry resets happen once per distinct commit.
- Normalize commit author bot identities and recognize bare Copilot/goose commit authors.
- Add coverage for repeated Copilot commits, bare Copilot author handling, and one reset for a new human SHA.

## Validation
- bash -n company/scripts/pr-review-merge.sh
- bash -n company/scripts/test-pr-review-merge.sh
- shellcheck company/scripts/pr-review-merge.sh company/scripts/test-pr-review-merge.sh
- bash company/scripts/test-pr-review-merge.sh (27 passed, 0 failed)
