### PR TITLE
feat(pipeline): Langfuse sessions per issue + fix score 400 link (bug #7)

### DIFF
--- a/pipeline/tests/test_scoring.py
+++ b/pipeline/tests/test_scoring.py
@@ -122,6 +122,7 @@ def test_langfuse_record_creates_pipeline_outcome_score_and_flushes(monkeypatch)
             "name": "pipeline_outcome",
             "value": "merged",
             "data_type": "CATEGORICAL",
+            "session_id": "issue-584",
             "metadata": {
                 "issue": 584,
                 "auto_merged": 1,
@@ -132,6 +133,16 @@ def test_langfuse_record_creates_pipeline_outcome_score_and_flushes(monkeypatch)
         }
     ]
     assert client.flushed is True
+
+
+def test_langfuse_record_attaches_session_id_link(monkeypatch) -> None:
+    """create_score needs a link (trace_id/session_id) or langfuse returns 400.
+    session_id=issue-<N> is the link AND groups the issue's scores+traces into
+    one session. This is the fix for the dormant langfuse-400."""
+    client = _FakeLangfuse()
+    scorer = _install_fake_langfuse(monkeypatch, client)
+    scorer.record(issue=652, outcome="escalated", scores={}, tags={})
+    assert client.scores[0]["session_id"] == "issue-652"
 
 
 def test_score_run_passes_trace_id_to_langfuse_when_present(monkeypatch) -> None:

--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -129,3 +129,41 @@ def test_key_unset_noop_still_runs_node_normally() -> None:
 
     assert result["classification"] == "feature"
 
+
+
+def test_langfuse_span_groups_into_issue_session(monkeypatch) -> None:
+    """All of an issue's stage spans are created inside
+    propagate_attributes(session_id=issue-<N>) so they group into one Langfuse
+    session (the issue's pipeline lifecycle)."""
+    import contextlib
+    import langfuse as lf_mod
+
+    calls = {}
+
+    @contextlib.contextmanager
+    def fake_propagate(*, session_id=None, **kw):
+        calls["session_id"] = session_id
+        yield
+
+    monkeypatch.setattr(lf_mod, "propagate_attributes", fake_propagate, raising=False)
+
+    _LangfuseSpan(_FakeLangfuseV4(), "triage", {"x": 1}, {"stage": "triage", "issue": "584"})
+    assert calls.get("session_id") == "issue-584"
+
+
+def test_langfuse_span_no_issue_uses_no_session(monkeypatch) -> None:
+    import contextlib
+    import langfuse as lf_mod
+
+    calls = {"used": False}
+
+    @contextlib.contextmanager
+    def fake_propagate(*, session_id=None, **kw):
+        calls["used"] = True
+        yield
+
+    monkeypatch.setattr(lf_mod, "propagate_attributes", fake_propagate, raising=False)
+    lf = _FakeLangfuseV4()
+    _LangfuseSpan(lf, "triage", {}, {"stage": "triage"})  # no issue tag
+    assert calls["used"] is False
+    assert lf.record["name"] == "triage"  # span still created

--- a/pipeline/wgmesh_pipeline/scoring.py
+++ b/pipeline/wgmesh_pipeline/scoring.py
@@ -89,10 +89,15 @@ class LangfuseScorer:
         try:
             # outcome as a categorical score + the numeric auto-merge signal,
             # tagged by issue. Visible in the Langfuse Scores view.
+            # session_id groups every score (and trace) for one issue's pipeline
+            # lifecycle into a single Langfuse session, AND is the required link:
+            # create_score rejects a score with no trace_id/session_id/etc as a
+            # 400 Bad request. issue-keyed session is the natural per-workflow id.
             kwargs: dict[str, Any] = {
                 "name": "pipeline_outcome",
                 "value": outcome,
                 "data_type": "CATEGORICAL",
+                "session_id": f"issue-{issue}",
                 "metadata": {"issue": issue, **scores, **tags},
             }
             if trace_id:

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 import time
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol, TypeVar
 
@@ -10,6 +10,21 @@ from wgmesh_pipeline.config import Config
 
 
 T = TypeVar("T")
+
+
+def _session_ctx(issue: str | None):
+    """Group all of an issue's stage spans under one Langfuse session.
+    propagate_attributes(session_id=...) tags every span created within the
+    context; one session per issue = that issue's full pipeline lifecycle.
+    Guarded: a missing/changed SDK symbol must never break tracing."""
+    if not issue:
+        return nullcontext()
+    try:
+        from langfuse import propagate_attributes  # public v4 API
+
+        return propagate_attributes(session_id=f"issue-{issue}")
+    except Exception:
+        return nullcontext()
 
 
 class Span(Protocol):
@@ -59,11 +74,13 @@ class _LangfuseSpan:
         try:
             # langfuse v4 dropped the client-level `start_span`; the equivalent
             # is `start_observation(..., as_type="span")`. Fall back to the v3
-            # name so a downgraded SDK keeps working.
-            if hasattr(lf, "start_observation"):
-                self._span = lf.start_observation(name=name, as_type="span", input=inputs, metadata=tags)
-            else:
-                self._span = lf.start_span(name=name, input=inputs, metadata=tags)
+            # name so a downgraded SDK keeps working. Create the span inside the
+            # issue's session context so all its stage spans group together.
+            with _session_ctx(tags.get("issue")):
+                if hasattr(lf, "start_observation"):
+                    self._span = lf.start_observation(name=name, as_type="span", input=inputs, metadata=tags)
+                else:
+                    self._span = lf.start_span(name=name, input=inputs, metadata=tags)
         except Exception as exc:  # never raise into the loop
             self._span = None
             self._announce(exc)


### PR DESCRIPTION
One Langfuse session per wgmesh issue (session_id=issue-<N>) groups the issue's full lifecycle (stage spans + outcome score). Also fixes the dormant langfuse-400: create_score requires a trace_id/session_id link — session_id supplies it, so scores finally land in the Scores view. Guarded (nullcontext fallback). 124 tests. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>