### PR TITLE
feat(pipeline): enrich spec span with authored spec text (LLM-judge input)

### DIFF
--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -74,3 +74,30 @@ def test_spec_node_resolves_recipe_path_and_passes_issue_params(tmp_path: Path) 
         "issue_title": "Add managed ingress",
         "spec_file": "specs/issue-18-spec.md",
     }
+
+
+def test_spec_node_puts_spec_content_in_state_for_judge(tmp_path: Path) -> None:
+    """The authored spec text rides in state -> trace_node includes it in the
+    'spec' span output so a managed Langfuse LLM-as-a-Judge can score it."""
+    runner = FakeRunner(calls=[])
+    result = spec_node(
+        {
+            "issue": GitHubIssue(number=17, title="Fix mesh discovery", labels=(), state="open"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+    assert "## Acceptance Criteria" in result["spec_content"]
+    assert result["spec_content"].startswith("# Issue 17 Spec")
+
+
+def test_spec_node_no_runner_has_no_spec_content(tmp_path: Path) -> None:
+    result = spec_node(
+        {
+            "issue": GitHubIssue(number=18, title="x", labels=(), state="open"),
+            "repo_path": tmp_path,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+    assert "spec_content" not in result  # no-op path writes no file

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -51,7 +51,22 @@ def spec_node(state: GraphState) -> GraphState:
         )
         raise RuntimeError(result.error or "goose spec failed")
     next_state["spec_path"] = str(result.output_path)
+    # Put the authored spec text into state so trace_node includes it in the
+    # "spec" span output — this is what a managed Langfuse LLM-as-a-Judge reads
+    # to score spec quality. Capped + best-effort (a read failure must not break
+    # the loop). Traced to private Langfuse only; never committed from here.
+    next_state["spec_content"] = _read_excerpt(result.output_path)
     return next_state
+
+
+_SPEC_EXCERPT_LIMIT = 6000
+
+
+def _read_excerpt(path) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")[:_SPEC_EXCERPT_LIMIT]
+    except Exception:
+        return ""
 
 
 def _visit(state: dict, node: str) -> None:


### PR DESCRIPTION
spec_node puts the authored spec markdown into the 'spec' span output (capped, best-effort) so a managed Langfuse LLM-as-a-Judge can score spec quality. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>