### PR TITLE
fix(security): strip config secrets from Langfuse traces (bug #13)

### DIFF
--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -169,3 +169,31 @@ def test_langfuse_span_no_issue_uses_no_session(monkeypatch) -> None:
     _LangfuseSpan(lf, "triage", {}, {"stage": "triage"})  # no issue tag
     assert calls["used"] is False
     assert lf.record["name"] == "triage"  # span still created
+
+
+def test_safe_state_strips_config_secrets_from_trace(monkeypatch) -> None:
+    """config carries zai_api_key/wgmesh_bot_pat in plaintext — it must never be
+    serialized into a Langfuse trace input/output (bug #13 secret leak)."""
+    tracer = FakeTracer()
+    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"), tracer=tracer)
+
+    class _Cfg:
+        zai_api_key = "secret-zai-key"
+        wgmesh_bot_pat = "secret-pat"
+
+    def node(state):
+        return {**state, "classification": "fix"}
+
+    state = {
+        "issue": GitHubIssue(number=510, title="x", labels=(), state="open"),
+        "config": _Cfg(),
+        "github": object(),
+        "goose_runner": object(),
+    }
+    trace_node("triage", node)(state)
+    rec = tracer.records[0]
+    assert "config" not in rec["inputs"]
+    assert "github" not in rec["inputs"]
+    assert "goose_runner" not in rec["inputs"]
+    # and the outputs side too
+    assert "config" not in rec["outputs"]

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -164,11 +164,17 @@ def _tags_for_state(state: Any, stage: str) -> dict[str, str]:
     return tags
 
 
+# Keys whose values carry secrets or live objects and must never be serialized
+# into a Langfuse trace input/output. `config` holds zai_api_key / wgmesh_bot_pat
+# in plaintext — leaking it into trace input was bug #13.
+_UNSAFE_STATE_KEYS = ("github", "goose_runner", "config")
+
+
 def _safe_state(value: Any) -> Any:
     if not isinstance(value, dict):
         return value
     safe = dict(value)
-    safe.pop("github", None)
-    safe.pop("goose_runner", None)
+    for key in _UNSAFE_STATE_KEYS:
+        safe.pop(key, None)
     return safe
 


### PR DESCRIPTION
_safe_state did not strip config -> zai_api_key/wgmesh_bot_pat serialized into trace input in plaintext. Strip config. z.ai key rotation tracked separately (exposed in existing traces). Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>