### PR TITLE
feat(pipeline): goose Langfuse cost-capture (price half of price/perf routing)

### DIFF
--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -96,3 +96,29 @@ def test_build_goose_env_prefers_explicit_goose_provider_model_from_base_env() -
 
     assert env["GOOSE_PROVIDER"] == "anthropic"
     assert env["GOOSE_MODEL"] == "custom-zai-model"
+
+
+def test_build_goose_env_passes_langfuse_creds_for_cost_capture() -> None:
+    """Goose gets LANGFUSE_URL/PUBLIC_KEY/SECRET_KEY so it exports its own LLM
+    generations (model + token usage + cost) to Langfuse — the price half of
+    price/performance. SECRET_KEY is re-added past the allowlist."""
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class _LfCfg:
+        zai_api_key: str | None = "zai-secret"
+        anthropic_host: str = "https://api.z.ai/api/anthropic"
+        langfuse_host: str | None = "http://lf:3000"
+        langfuse_public_key: str | None = "pk-lf-x"
+        langfuse_secret_key: str | None = "sk-lf-x"
+
+    env = build_goose_env(_LfCfg(), base_env={"PATH": "/usr/bin"})
+    assert env["LANGFUSE_URL"] == "http://lf:3000"
+    assert env["LANGFUSE_PUBLIC_KEY"] == "pk-lf-x"
+    assert env["LANGFUSE_SECRET_KEY"] == "sk-lf-x"
+
+
+def test_build_goose_env_omits_langfuse_when_unconfigured() -> None:
+    env = build_goose_env(_Cfg(), base_env={"PATH": "/usr/bin"})
+    assert "LANGFUSE_URL" not in env
+    assert "LANGFUSE_SECRET_KEY" not in env

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -97,6 +97,18 @@ def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -
     env["ANTHROPIC_HOST"] = config.anthropic_host
     env["GOOSE_PROVIDER"] = source.get("GOOSE_PROVIDER") or getattr(config, "goose_provider", DEFAULT_GOOSE_PROVIDER)
     env["GOOSE_MODEL"] = source.get("GOOSE_MODEL") or getattr(config, "goose_model", DEFAULT_GOOSE_MODEL)
+    # Cost-capture: hand Goose the Langfuse creds so it exports its OWN LLM
+    # generations (model + token usage + cost) to Langfuse -> populates the
+    # per-model cost dashboards (the price half of price/performance routing).
+    # The allowlist strips LANGFUSE_SECRET_KEY by default, so re-add explicitly.
+    # goose expects LANGFUSE_URL (not LANGFUSE_HOST).
+    lf_host = getattr(config, "langfuse_host", None)
+    lf_pub = getattr(config, "langfuse_public_key", None)
+    lf_sec = getattr(config, "langfuse_secret_key", None)
+    if lf_host and lf_pub and lf_sec:
+        env["LANGFUSE_URL"] = lf_host
+        env["LANGFUSE_PUBLIC_KEY"] = lf_pub
+        env["LANGFUSE_SECRET_KEY"] = lf_sec
     return env
 
 


### PR DESCRIPTION
Pass Langfuse creds to goose so it exports model+token+cost generations -> per-model cost dashboards. Prereq for multi-model price/performance routing. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>