### PR TITLE
feat(pipeline): multi-model routing — static stage→model map (price/perf #2)

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -11,6 +11,11 @@ name: Provision Pipeline Box
 #   ZAI_API_KEY                  — Goose LLM (z.ai)
 #   TURSO_DATABASE_URL          — durable state (when database_mode=turso)
 #   TURSO_AUTH_TOKEN
+# Optional (multi-model routing, price/perf #2 — absent → single z.ai model):
+#   OPENROUTER_API_KEY           — metered-tier gateway (DeepSeek/OpenAI/Anthropic)
+#   DEEPSEEK_API_KEY / OPENAI_API_KEY / MINIMAX_API_KEY  — native provider keys
+#   MODEL_REGISTRY               — JSON: {key: {provider,model,billing,credential_env,host?}}
+#   STAGE_ROUTING                — JSON: {stage: registry_key}
 # wgmesh is PUBLIC, so shadow needs no GitHub token (reads only). Live (later)
 # needs WGMESH_BOT_PAT.
 
@@ -155,6 +160,14 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           WGMESH_BOT_PAT: ${{ secrets.WGMESH_BOT_PAT }}
+          # Multi-model routing (price/perf #2): metered-tier creds + the
+          # registry/route map. All optional — absent → zero-config single model.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          MODEL_REGISTRY: ${{ secrets.MODEL_REGISTRY }}
+          STAGE_ROUTING: ${{ secrets.STAGE_ROUTING }}
           MODE: ${{ github.event.inputs.pipeline_mode }}
           DBMODE: ${{ github.event.inputs.database_mode }}
           RESET_QUEUE_INPUT: ${{ github.event.inputs.reset_queue }}
@@ -174,6 +187,12 @@ jobs:
           ANTHROPIC_HOST=https://api.z.ai/api/anthropic
           GOOSE_PROVIDER=anthropic
           GOOSE_MODEL=glm-4.6
+          OPENROUTER_API_KEY=$OPENROUTER_API_KEY
+          DEEPSEEK_API_KEY=$DEEPSEEK_API_KEY
+          OPENAI_API_KEY=$OPENAI_API_KEY
+          MINIMAX_API_KEY=$MINIMAX_API_KEY
+          MODEL_REGISTRY='$MODEL_REGISTRY'
+          STAGE_ROUTING='$STAGE_ROUTING'
           WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
           DATABASE_MODE=$DBMODE
           PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,28 @@ Bias toward correctness, small diffs, and verified changes.
 - Conventional commits (`feat|fix|refactor|docs|test|chore|perf|ci`). Branch off `main`;
   open a PR — `main` requires one review.
 
+## Model routing (price/performance)
+
+The LangGraph pipeline routes each LLM stage to a model picked for that stage's
+cost/capability. Cheap, structured stages (spec authoring) run cheap models; the
+capability-critical stage (implementation) runs a more capable one. Configured by two
+optional env vars (`pipeline/wgmesh_pipeline/models.py`):
+
+- `MODEL_REGISTRY` — JSON `{key: {provider, model, billing, credential_env, host?}}`.
+  `billing` is `native` (subscription endpoint, e.g. z.ai/MiniMax — flat-rate only works
+  on their own host) or `openrouter` (metered models — DeepSeek/OpenAI/Anthropic — through
+  one `OPENROUTER_API_KEY` gateway).
+- `STAGE_ROUTING` — JSON `{stage: registry_key}`. Stages today: `spec`, `implement`.
+  An unmapped stage falls back to a registry `default` profile, else fails closed.
+
+**Both unset → single z.ai model, exactly as before (zero-config default).** Credentials
+are read from the process env named by `credential_env`; they reach Goose only when a
+routed profile names them (the fail-closed allowlist in `goose/runner.py` strips everything
+else). Per-stage/per-model cost lands in Langfuse — slice the Scores dashboard by
+`spec_model_key` / `implement_model_key`. Escalate-on-fail (retry a failed stage on a
+stronger model) is **not** built yet — the map is static. See
+`docs/solutions/design-decisions/multi-model-routing.md`.
+
 ## Working memory
 
 `memory/MEMORY.md` is the index of hard-won learnings — consult it before changing a

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -38,6 +38,11 @@ Track runway (available capital / monthly burn) and report it in every assessmen
 
 Human approves any new recurring cost above zero.
 
+The build pipeline applies this per LLM call: each stage routes to the cheapest model that
+clears its quality bar (cheap models for spec authoring, capable models only where the work
+demands it). Prefer flat-rate subscription models over metered API; reserve premium metered
+models for capability-critical stages. Per-model cost is tracked in Langfuse.
+
 ### Public/private boundary
 You write to a public repo. **NEVER** write:
 - API keys, tokens, credentials, secrets of any kind

--- a/docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md
+++ b/docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md
@@ -1,0 +1,406 @@
+---
+title: "feat: Multi-model routing for the pipeline (price/perf #2)"
+status: active
+date: 2026-06-09
+type: feat
+origin: none (solo ce-plan from price/perf series)
+---
+
+# feat: Multi-model routing for the pipeline (price/perf #2)
+
+## Summary
+
+Today every LLM-invoking pipeline stage runs one hardcoded model (`GLM-4.7` via
+z.ai's Anthropic-compatible endpoint). This plan turns that single model into a
+**model registry + static stage→model routing map**: register every model we can
+reach (z.ai/GLM and MiniMax subscriptions, DeepSeek and OpenAI/Anthropic metered
+API), assign a model to each LLM stage by cost/capability, and route each Goose
+invocation to its assigned model. Plumbing is **hybrid** — flat-rate subscriptions
+keep their native endpoints, metered models go through one OpenRouter gateway.
+
+This is the routing half of price/performance. The measurement half (Goose →
+Langfuse per-model cost capture) already landed in commit `0c11c3b`. Routing
+makes the cost data actionable: cheap models on cheap stages, capable models where
+quality matters, every choice attributed in Langfuse by stage **and** model.
+
+Escalate-on-fail (run cheap, retry on a stronger model when the gate fails) is
+**explicitly Phase 2** — deferred to follow-up. This plan ships the static map only.
+
+---
+
+## Problem Frame
+
+`GooseRunner` is constructed once from a single `Config` and every node that calls
+`run_recipe` inherits the same `GOOSE_MODEL` / `GOOSE_PROVIDER`. Two stages actually
+hit the LLM today:
+
+- **spec** (`spec_node`, recipe `wgmesh-triage-spec.yaml`) — issue → spec authoring
+- **implement** (`implement_node`, recipe `wgmesh-implementation.yaml`) — spec → diff
+
+`triage`, `review`, and `gate` are deterministic (heuristics, `sanitise.sh`, risk
+rules) — no LLM, not in routing scope yet. Spec authoring is cheap, structured work;
+implementation is the capability-critical stage. Running both on the same model
+either overpays on spec or underdelivers on implement. There is no mechanism to
+assign different models per stage, and the z.ai path currently **hijacks**
+`ANTHROPIC_API_KEY` + `ANTHROPIC_HOST` globally — so a second Anthropic-family model
+(real Anthropic) cannot coexist with z.ai under the current env build.
+
+**In scope:** model registry, static stage→model map, per-call model resolution in
+the Goose env builder, threading stage identity from the two LLM nodes, credential
+allowlist + provision wiring, per-stage/per-model cost attribution.
+
+**Out of scope:** changing the LangGraph topology or funnel logic; escalate-on-fail
+retry (Phase 2); any model-ranking/eval harness; routing the deterministic nodes.
+
+---
+
+## Requirements
+
+- **R1** Each LLM-invoking stage resolves its model from a config-driven routing map,
+  not a single global.
+- **R2** Multiple models from different providers coexist — including two
+  Anthropic-family models (z.ai-as-Anthropic and real Anthropic) without env collision.
+- **R3** Hybrid billing: subscription models (z.ai, MiniMax) use their native
+  endpoints; metered models (DeepSeek, OpenAI, Anthropic) route via OpenRouter.
+- **R4** Fail-closed: an unknown/misconfigured model key raises, never silently falls
+  back to the global default (mailservice lesson: misconfig must fail, not drift).
+- **R5** Every Goose generation is attributed in Langfuse by **stage** and **model
+  key**, so price/perf dashboards slice both ways.
+- **R6** Credentials for new providers are added to the fail-closed allowlist
+  explicitly and never leak to the LLM agent's general env.
+- **R7** Default behavior with no routing config matches today exactly (single global
+  model) — zero-config backward compatibility.
+
+---
+
+## High-Level Technical Design
+
+Model selection moves from "one global env" to "resolve a profile per call":
+
+```
+                    ┌──────────────── Config ────────────────┐
+                    │  model_registry: {key → ModelProfile}   │
+                    │  stage_routing:  {stage → key}          │
+                    └──────────────────┬──────────────────────┘
+                                       │
+  spec_node ──run_recipe(stage="spec")─┤
+                                       ├─► GooseRunner.resolve(stage)
+  implement_node ─(stage="implement")──┘        │
+                                                ▼
+                                   ModelProfile{provider, model,
+                                     host, credential_env, billing}
+                                                │
+                                   build_goose_env(profile)
+                                                │
+                            ┌───────────────────┴───────────────────┐
+                        native (subscription)              openrouter (metered)
+                   GOOSE_PROVIDER=anthropic|...       GOOSE_PROVIDER=openrouter
+                   ANTHROPIC_HOST=<z.ai|...>          OPENROUTER_API_KEY=<key>
+                   <CRED>=<key>                       GOOSE_MODEL=<or-slug>
+```
+
+A `ModelProfile` is the unit of routing. The registry maps a logical key
+(`"spec-cheap"`, `"impl-capable"`) to a profile. The stage map binds stages to keys.
+`build_goose_env` becomes a pure function of `(safe base env, profile, langfuse
+creds)` instead of reading model fields off `Config` directly.
+
+`ModelProfile` (directional shape, not final signature):
+
+```python
+@dataclass(frozen=True)
+class ModelProfile:
+    key: str                 # logical name, e.g. "impl-capable"
+    provider: str            # goose provider id: anthropic | openrouter | ...
+    model: str               # goose model id / openrouter slug
+    billing: str             # "native" | "openrouter"
+    host: str | None         # endpoint for native non-default (z.ai, minimax)
+    credential_env: str      # env var name holding this model's key
+```
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Profile-per-call, not runner-per-stage.** Keep one `GooseRunner`; pass a
+  stage/model key into `run_recipe` and resolve a `ModelProfile` at env-build time.
+  Avoids N runner instances and keeps the Langfuse/timeout/guard logic single-sourced.
+- **KTD2 — `build_goose_env` parametrized by profile.** Each profile sets its OWN
+  provider + host + credential at env-build time. This is what lets z.ai-as-Anthropic
+  and real-Anthropic coexist (R2): the global `ANTHROPIC_API_KEY` hijack is removed;
+  the credential is written per-call from `profile.credential_env`.
+- **KTD3 — OpenRouter as the metered gateway.** `OPENROUTER_API_KEY` is already in the
+  runner's `_KNOWN_SECRET_NAMES`. One key reaches DeepSeek/OpenAI/Anthropic via slugs
+  — minimal new-credential surface for the metered tier (R3). Subscriptions stay
+  native because flat-rate billing only applies on their own endpoints.
+- **KTD4 — Zero-config fallback.** When no registry/routing is configured, synthesize a
+  single implicit profile from today's `goose_provider`/`goose_model`/`anthropic_host`
+  fields and route all stages to it. Existing deploys behave identically (R7).
+- **KTD5 — Fail-closed resolution.** A stage mapped to a missing registry key, or a
+  profile missing its credential, raises at resolution — no silent global fallback (R4).
+- **KTD6 — Registry/map via env JSON.** Provide registry + stage map as JSON env vars
+  (`MODEL_REGISTRY`, `STAGE_ROUTING`) parsed in `load_config`, mirroring the existing
+  env-driven config style. Keeps secrets out of the JSON (only key *names* referenced;
+  values come from their own env vars).
+
+---
+
+## Output Structure
+
+No new top-level directories. Touches existing `pipeline/wgmesh_pipeline/` modules and
+adds focused test files alongside the current `pipeline/tests/` suite.
+
+---
+
+## Implementation Units
+
+### U1. Model registry + stage routing in config
+
+**Goal:** Define `ModelProfile`, parse a model registry and stage→key map from env,
+expose them on `Config` with a zero-config fallback profile.
+
+**Requirements:** R1, R3, R4, R7, KTD4, KTD6
+
+**Dependencies:** none
+
+**Files:**
+- `pipeline/wgmesh_pipeline/config.py` (modify — add `ModelProfile`, registry/map fields, parsing)
+- `pipeline/wgmesh_pipeline/models.py` (create — `ModelProfile`, registry resolution, fallback synthesis)
+- `pipeline/tests/test_models.py` (create)
+- `pipeline/tests/test_config.py` (modify — registry/map parsing cases)
+
+**Approach:** New `models.py` owns `ModelProfile`, `parse_registry(json)`,
+`parse_stage_routing(json)`, and `resolve_profile(registry, routing, stage)` with
+fail-closed errors. `load_config` reads `MODEL_REGISTRY` / `STAGE_ROUTING` (optional
+JSON). When both absent, build a one-entry registry `{"default": <profile from
+goose_provider/goose_model/anthropic_host/ZAI_API_KEY>}` and route every stage to it.
+Billing field is `"native"` for the fallback.
+
+**Patterns to follow:** `_get_nonempty` / `_get_int` env helpers and the explicit
+`ValueError` raising style already in `config.py`; `@dataclass(frozen=True)` like `Config`.
+
+**Test scenarios:**
+- Happy: valid `MODEL_REGISTRY` JSON with two profiles parses to two `ModelProfile`s.
+- Happy: `STAGE_ROUTING` `{"spec":"a","implement":"b"}` resolves each stage to its key.
+- Zero-config: both env vars unset → single `default` profile synthesized from existing
+  goose fields; `resolve_profile(...,"implement")` returns it.
+- Edge: registry present, routing maps a stage to a key not in registry → raises (R4).
+- Edge: profile references `credential_env` whose env var is unset → resolution raises.
+- Edge: malformed JSON in `MODEL_REGISTRY` → `ValueError` naming the var.
+- `billing` accepts only `native|openrouter`; other value → raises.
+
+### U2. Parametrize Goose env build by ModelProfile
+
+**Goal:** Make `build_goose_env` a function of a `ModelProfile`, removing the global
+`ANTHROPIC_API_KEY` hijack so multiple providers (incl. two Anthropic-family) coexist.
+
+**Requirements:** R2, R3, R5, R6, KTD1, KTD2
+
+**Dependencies:** U1
+
+**Files:**
+- `pipeline/wgmesh_pipeline/goose/runner.py` (modify — `build_goose_env(profile, base_env, langfuse)`, profile→provider/host/cred mapping)
+- `pipeline/tests/test_goose_env.py` (modify — per-profile env cases)
+
+**Approach:** `build_goose_env` takes a `ModelProfile`. For `billing="native"`: set
+`GOOSE_PROVIDER=profile.provider`, `GOOSE_MODEL=profile.model`, write the credential to
+the provider's expected var (Anthropic family → `ANTHROPIC_API_KEY` + `ANTHROPIC_HOST`
+from `profile.host`). For `billing="openrouter"`: `GOOSE_PROVIDER=openrouter`,
+`GOOSE_MODEL=profile.model` (slug), `OPENROUTER_API_KEY` from the profile credential.
+Langfuse cost-capture block (the landed `0c11c3b` logic) stays, plus add the model key
+as metadata so generations are attributable (R5 — see U5). Credential value is read from
+`os.environ[profile.credential_env]` via the safe base env, never globally pinned.
+
+**Patterns to follow:** existing allowlist `build_goose_env` structure; keep the
+fail-closed `_is_safe_var` filter and re-add only profile + langfuse vars.
+
+**Test scenarios:**
+- Native Anthropic profile (z.ai) → env has `GOOSE_PROVIDER=anthropic`, `ANTHROPIC_HOST`
+  = z.ai host, `ANTHROPIC_API_KEY` = that profile's key.
+- Second native Anthropic profile (real Anthropic, different host/key) built in the same
+  process → distinct env, no collision with z.ai (R2 regression guard).
+- OpenRouter profile → `GOOSE_PROVIDER=openrouter`, `OPENROUTER_API_KEY` set,
+  `GOOSE_MODEL` = slug, no `ANTHROPIC_*`.
+- Box PAT / unrelated secret in base env → still stripped (allowlist intact).
+- Langfuse creds present → `LANGFUSE_URL/PUBLIC_KEY/SECRET_KEY` still exported.
+- Profile credential env var missing → raises (matches U1 fail-closed).
+- Covers AE: a single run building envs for two stages yields two different `GOOSE_MODEL`s.
+
+### U3. Thread stage identity through the runner and LLM nodes
+
+**Goal:** `run_recipe` accepts a stage/model key, resolves the profile, and builds env
+from it; `spec_node` and `implement_node` declare their stage.
+
+**Requirements:** R1, KTD1, KTD5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `pipeline/wgmesh_pipeline/goose/runner.py` (modify — `run_recipe(..., stage: str)`, resolve via config registry/map)
+- `pipeline/wgmesh_pipeline/graph/nodes/spec.py` (modify — pass `stage="spec"`)
+- `pipeline/wgmesh_pipeline/graph/nodes/implement.py` (modify — pass `stage="implement"`)
+- `pipeline/tests/test_runner_routing.py` (create)
+
+**Approach:** `GooseRunner` resolves `ModelProfile` from `config` registry/map using the
+`stage` arg, then calls `build_goose_env(profile, ...)`. Default `stage` resolution falls
+through to the zero-config `default` profile (U1) so callers without a mapped stage still
+work. Nodes pass a literal stage string; no other node logic changes.
+
+**Patterns to follow:** existing `run_recipe` signature and `GooseResult` flow; keep
+subprocess/timeout/guard code untouched — only the `env=` source changes.
+
+**Test scenarios:**
+- `run_recipe(stage="spec")` with a routed registry uses the spec profile's model
+  (assert via injected `SubprocessRunner` capturing `env`).
+- `run_recipe(stage="implement")` uses the implement profile's model.
+- Stage not in routing map but `default` exists → uses default (zero-config path).
+- Stage not in map and no default → raises (R4/KTD5).
+- `spec_node` end-to-end with a fake runner records `stage="spec"` was requested.
+- `implement_node` likewise for `stage="implement"`.
+
+### U4. Credentials allowlist + provision wiring
+
+**Goal:** Admit the new provider credentials through the fail-closed allowlist and supply
+them to the box, without leaking to the agent's general env.
+
+**Requirements:** R3, R6
+
+**Dependencies:** U2
+
+**Files:**
+- `pipeline/wgmesh_pipeline/goose/runner.py` (modify — add new cred names to `_KNOWN_SECRET_NAMES`)
+- `.github/workflows/provision-pipeline-box.yml` (modify — pass new secrets to box env)
+- `pipeline/tests/test_goose_env.py` (modify — leak-guard for new creds)
+
+**Approach:** Add `MINIMAX_API_KEY`, `DEEPSEEK_API_KEY`, `OPENAI_API_KEY` to
+`_KNOWN_SECRET_NAMES` (so the allowlist strips them by default; `OPENROUTER_API_KEY` and
+`ANTHROPIC`-family markers already covered). Each is re-added to the subprocess env ONLY
+when a routed profile names it as its `credential_env` (U2). Provision workflow forwards
+the secrets to the box's environment/secret store the same way `ZAI_API_KEY` is handled
+today. No secret values appear in registry JSON — only var names.
+
+**Patterns to follow:** the existing `_KNOWN_SECRET_NAMES` set and the secret-forwarding
+block for `ZAI_API_KEY` in the provision workflow.
+
+**Test scenarios:**
+- Each new cred in base env is stripped from a profile env that does NOT reference it.
+- A profile that references `DEEPSEEK_API_KEY` (via OpenRouter slug or native) gets only
+  the one credential it needs, not the others.
+- `Test expectation: workflow YAML` change verified by U1–U3 unit coverage + a lint that
+  the new secrets are referenced; no behavioral unit test for the YAML itself.
+
+### U5. Per-stage / per-model cost attribution
+
+**Goal:** Tag Goose's Langfuse generations with stage + model key so price/perf
+dashboards slice by both.
+
+**Requirements:** R5
+
+**Dependencies:** U2, U3
+
+**Files:**
+- `pipeline/wgmesh_pipeline/goose/runner.py` (modify — set Langfuse metadata/tags env for stage+model_key)
+- `pipeline/wgmesh_pipeline/scoring.py` (modify — include `model_key` in score tags where a stage's model is known)
+- `pipeline/tests/test_goose_env.py` (modify — assert attribution env present)
+- `pipeline/tests/test_scoring.py` (modify — `model_key` in tags)
+
+**Approach:** When building env for a stage, export the stage name and resolved
+`model_key` as Langfuse metadata (via Goose's supported metadata/tags env, or a
+`LANGFUSE_*` tag var Goose honors — verify identifier at impl, see Deferred). Extend
+`LangfuseScorer.record` tags to carry `model_key` so the online score and the cost trace
+join on stage+model.
+
+**Patterns to follow:** the landed cost-capture block in `build_goose_env`
+(`0c11c3b`); existing `tags` dict shape in `scoring.py`.
+
+**Test scenarios:**
+- Env for `stage="implement"` includes stage + model_key attribution metadata.
+- Scorer `record(...)` tags include `model_key` for a routed run.
+- Zero-config run still records a stable `model_key` (`"default"`), not empty.
+
+### U6. Defaults, docs, and operating-prompt note
+
+**Goal:** Document the routing map, record the default stage→model assignments, and note
+the price/perf boundary (static now, escalate-on-fail later) where operators read it.
+
+**Requirements:** R7
+
+**Dependencies:** U1–U5
+
+**Files:**
+- `AGENTS.md` (modify — model routing section: how to configure registry/map)
+- `company/system-prompt.md` (modify — one line on frugality: cheap stages get cheap models)
+- `docs/solutions/` (create — short learning doc on the routing design + hybrid billing)
+- `memory/MEMORY.md` (modify — index entry if a memory file is added)
+
+**Approach:** Document `MODEL_REGISTRY` / `STAGE_ROUTING` JSON shape, the recommended
+default map (spec → cheapest subscription model; implement → most capable available
+within budget), and the hybrid-billing rule (subscriptions native, metered via
+OpenRouter). State plainly that escalate-on-fail is Phase 2.
+
+**Patterns to follow:** existing AGENTS.md section style; `docs/solutions/` learning-doc
+frontmatter convention.
+
+**Test scenarios:** `Test expectation: none — docs only.`
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- **Escalate-on-fail (Phase 2).** When `gate` decides `escalate` for a *quality* reason
+  (`tests failed` / `blocking review finding`) rather than a structural high-risk reason,
+  re-run `implement` once on a stronger model before labeling `needs-human`. This is the
+  dynamic quality floor; it needs a retry budget, loop-guard, and cost ceiling — its own
+  plan. The static map here is the precondition.
+- **LLM review/judge stage routing.** If a future LLM-backed review node lands, add it to
+  the stage map; out of scope now (review is deterministic today).
+
+### Outside this product's identity
+
+- **Model-ranking / eval harness.** Automatically scoring models against each other to
+  pick the map is a separate capability, not part of routing. The Langfuse cost+score
+  data feeds a human decision for now.
+
+---
+
+## Risks & Dependencies
+
+- **Goose provider identifiers are unverified at plan time.** The exact `GOOSE_PROVIDER`
+  ids and credential env names for `openrouter` / `deepseek` / `minimax`, and whether
+  Goose honors per-run Langfuse metadata env, must be confirmed against the installed
+  Goose version during U2/U5. Treated as an execution-time unknown (below), not a
+  planning blocker. If a provider isn't natively supported, route it via OpenRouter.
+- **Subscription API access.** Hybrid native billing assumes the z.ai and MiniMax
+  *subscriptions* expose API endpoints usable by Goose (z.ai already proven via the
+  Anthropic adapter). If MiniMax subscription gives no API, it routes via OpenRouter
+  (metered) instead — a config change, no code change.
+- **Credential blast radius.** More provider keys on the box = more to rotate. Mitigated
+  by the fail-closed allowlist (U4): each key reaches the agent only when a profile names
+  it.
+
+### Execution-time unknowns (resolve during implementation, not now)
+
+- Exact Goose provider ids + per-provider credential env var names.
+- Whether Goose emits per-run Langfuse metadata via env or requires a config-file knob.
+- The concrete default model choices for the shipped map (a budget/quality call the
+  operator makes with the cost data).
+
+---
+
+## Sources & Research
+
+Grounded in local code read (no external research run — the design is an internal
+refactor of known modules):
+
+- `pipeline/wgmesh_pipeline/goose/runner.py` — `build_goose_env` allowlist + landed
+  Langfuse cost capture (`0c11c3b`); `_KNOWN_SECRET_NAMES` already lists `OPENROUTER_API_KEY`.
+- `pipeline/wgmesh_pipeline/config.py` — single `goose_provider`/`goose_model` fields,
+  `DEFAULT_ANTHROPIC_HOST = https://api.z.ai/api/anthropic`.
+- `pipeline/wgmesh_pipeline/graph/nodes/spec.py`, `implement.py` — the only two
+  `run_recipe` callers (LLM stages); `triage.py`/`review.py`/`gate.py` deterministic.
+- `pipeline/wgmesh_pipeline/graph/build.py` — graph topology (unchanged by this plan).
+- Memory: hybrid plumbing and fail-closed allowlist reuse the
+  `feedback_agent_env_allowlist_not_denylist` and `feedback_pin_thirdparty_infra_images`
+  lessons; backward-compat fallback follows the `reference_mailservice_sqlite_pattern`
+  no-silent-fallback discipline (inverted: explicit default IS allowed here for R7).

--- a/docs/solutions/design-decisions/multi-model-routing.md
+++ b/docs/solutions/design-decisions/multi-model-routing.md
@@ -1,0 +1,74 @@
+---
+title: "Multi-model routing: static per-stage map with hybrid billing"
+category: design-decisions
+date: 2026-06-09
+tags: [pipeline, langgraph, goose, price-performance, langfuse, models, routing]
+---
+
+## Problem
+
+Every LLM stage in the pipeline ran one hardcoded model (`GLM-4.7` via z.ai's
+Anthropic-compatible endpoint), built once from a single `Config` and shared by every
+node. Two stages actually call the LLM — spec authoring (cheap, structured) and
+implementation (capability-critical). Running both on the same model either overpays on
+spec or underdelivers on implement, and there was no way to use the other models we can
+reach (z.ai/MiniMax subscriptions, DeepSeek/OpenAI/Anthropic metered API).
+
+## Decision
+
+A **model registry** plus a **static stage→model routing map** (`models.py`):
+
+- `ModelProfile{key, provider, model, billing, credential_env, host?}` is the unit of
+  routing. `MODEL_REGISTRY` (env JSON) maps logical keys to profiles; `STAGE_ROUTING`
+  (env JSON) binds stages to keys. Each LLM node passes its `stage` into `run_recipe`,
+  which resolves the profile and builds the Goose env from it.
+- **Hybrid billing.** `billing="native"` keeps subscription models on their own endpoint
+  (flat-rate only works there); `billing="openrouter"` routes metered models through one
+  `OPENROUTER_API_KEY` gateway — minimal new-credential surface.
+- **Zero-config default (R7).** Both env vars unset → a single synthesized `default`
+  profile from the existing `goose_*` fields. Existing deploys behave identically.
+
+## Why these choices
+
+- **Profile-per-call, not runner-per-stage.** One `GooseRunner`; the model is resolved at
+  env-build time. Keeps the timeout/guard/Langfuse logic single-sourced.
+- **Killed the global `ANTHROPIC_API_KEY` hijack.** The old code pinned
+  `ANTHROPIC_API_KEY`/`ANTHROPIC_HOST` globally, so a second Anthropic-family model
+  couldn't coexist with z.ai. Now each profile writes its own provider/host/credential
+  per call — z.ai-as-Anthropic and real Anthropic live side by side.
+- **Fail-closed.** An unroutable stage, an unknown registry key, or a missing credential
+  raises — it never silently falls back to the wrong model (mailservice no-silent-fallback
+  lesson). The one allowed implicit default is the zero-config fallback.
+- **Credential allowlist intact.** New provider keys are stripped from Goose's general env
+  by the fail-closed allowlist and re-added only when a routed profile names them.
+
+## Attribution
+
+Per-model cost/quality must be sliceable to make the routing decisions data-driven. Two
+mechanisms:
+
+- **Authoritative (our code):** `scoring.py` tags each run with `spec_model_key` /
+  `implement_model_key`, so the Langfuse Scores dashboard slices outcome by model. This
+  lands regardless of Goose internals.
+- **Best-effort (Goose telemetry):** `build_goose_env` sets `OTEL_RESOURCE_ATTRIBUTES`
+  with `wgmesh.stage` + `wgmesh.model_key`. Whether the installed Goose version forwards
+  resource attributes onto its OTLP spans is an unverified execution-time detail — do not
+  rely on it for attribution; the scoring path is the source of truth.
+
+## Deferred
+
+- **Escalate-on-fail (Phase 2).** When the gate escalates for a *quality* reason (tests
+  failed / blocking finding) rather than a structural high-risk one, re-run the stage once
+  on a stronger model before labeling `needs-human`. Needs a retry budget, loop-guard, and
+  cost ceiling — its own plan. The static map here is the precondition.
+- **Native non-Anthropic providers.** Only `native` Anthropic and `openrouter` are wired;
+  any other native provider raises with "route it via OpenRouter". Add native support per
+  provider when a subscription's own API proves worth the credential.
+- **Model-ranking / eval harness.** Choosing the map is a human decision fed by the
+  Langfuse cost+score data, not an automated ranker.
+
+## References
+
+- Plan: `docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md`
+- Code: `pipeline/wgmesh_pipeline/models.py`, `goose/runner.py`, `config.py`
+- Builds on: goose Langfuse cost capture (commit `0c11c3b`, price/perf #1)

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -38,3 +38,4 @@ Last consolidated: 2026-04-10.
 - All code needs tests (80%+ coverage target), table-driven t.Parallel() patterns in Go
 - Public repo: never commit secrets, PII, or exact revenue figures
 - Assessment PRs auto-merge only if Copilot review has zero comments and zero blocking reviews
+- Multi-model routing: `STAGE_ROUTING`+`MODEL_REGISTRY` env (`pipeline/wgmesh_pipeline/models.py`) pick a model per stage (cheap=spec, capable=implement); hybrid billing (subs native, metered via OpenRouter); both unset → zero-config single z.ai model; fail-closed; per-model cost in Langfuse. Escalate-on-fail = Phase 2. Doc: `docs/solutions/design-decisions/multi-model-routing.md`

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -88,6 +88,57 @@ def test_database_mode_explicit_no_silent_fallback() -> None:
     assert cfg.turso_url == "libsql://db.turso.io"
 
 
+def test_zero_config_synthesizes_default_profile_matching_goose_fields() -> None:
+    # R7: with no MODEL_REGISTRY env, routing falls back to a single 'default'
+    # profile built from the goose_* fields — pipeline behaves as before.
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "ZAI_API_KEY": "zai",
+        }
+    )
+    assert set(cfg.model_registry) == {"default"}
+    default = cfg.model_registry["default"]
+    assert default.provider == cfg.goose_provider
+    assert default.model == cfg.goose_model
+    assert default.billing == "native"
+    assert default.credential_env == "ZAI_API_KEY"
+    assert default.host == cfg.anthropic_host
+    assert cfg.stage_routing == {}
+
+
+def test_explicit_registry_and_routing_parse_into_config() -> None:
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "MODEL_REGISTRY": (
+                '{"cheap": {"provider": "anthropic", "model": "GLM-4.7", "billing": "native",'
+                ' "credential_env": "ZAI_API_KEY", "host": "https://api.z.ai/api/anthropic"},'
+                ' "capable": {"provider": "openrouter", "model": "deepseek/v3",'
+                ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}}'
+            ),
+            "STAGE_ROUTING": '{"spec": "cheap", "implement": "capable"}',
+        }
+    )
+    assert set(cfg.model_registry) == {"cheap", "capable"}
+    assert cfg.stage_routing == {"spec": "cheap", "implement": "capable"}
+    # explicit registry is NOT overwritten by the zero-config default
+    assert "default" not in cfg.model_registry
+
+
+def test_malformed_registry_env_fails_loud() -> None:
+    with pytest.raises(ValueError, match="MODEL_REGISTRY"):
+        load_config(
+            {
+                "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+                "DATABASE_MODE": "local",
+                "MODEL_REGISTRY": "{bad json",
+            }
+        )
+
+
 def test_wgmesh_checkout_path_env_and_recipes_dir_override() -> None:
     cfg = load_config(
         {

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pytest
+
 from wgmesh_pipeline.goose.runner import _is_secret_var, build_goose_env
+from wgmesh_pipeline.models import ModelProfile
 
 
 @dataclass(frozen=True)
@@ -122,3 +125,108 @@ def test_build_goose_env_omits_langfuse_when_unconfigured() -> None:
     env = build_goose_env(_Cfg(), base_env={"PATH": "/usr/bin"})
     assert "LANGFUSE_URL" not in env
     assert "LANGFUSE_SECRET_KEY" not in env
+
+
+# --- profile-driven routing (U2) ---------------------------------------------
+
+_ZAI = ModelProfile(
+    key="spec-cheap",
+    provider="anthropic",
+    model="GLM-4.7",
+    billing="native",
+    credential_env="ZAI_API_KEY",
+    host="https://api.z.ai/api/anthropic",
+)
+_REAL_ANTHROPIC = ModelProfile(
+    key="impl-claude",
+    provider="anthropic",
+    model="claude-sonnet-4-6",
+    billing="native",
+    credential_env="ANTHROPIC_API_KEY",
+    host="https://api.anthropic.com",
+)
+_OPENROUTER = ModelProfile(
+    key="impl-or",
+    provider="openrouter",
+    model="deepseek/deepseek-chat",
+    billing="openrouter",
+    credential_env="OPENROUTER_API_KEY",
+)
+
+
+def test_profile_native_anthropic_zai() -> None:
+    env = build_goose_env(
+        _Cfg(), base_env={"PATH": "/usr/bin", "ZAI_API_KEY": "zai-key"}, profile=_ZAI
+    )
+    assert env["GOOSE_PROVIDER"] == "anthropic"
+    assert env["GOOSE_MODEL"] == "GLM-4.7"
+    assert env["ANTHROPIC_API_KEY"] == "zai-key"
+    assert env["ANTHROPIC_HOST"] == "https://api.z.ai/api/anthropic"
+
+
+def test_two_anthropic_profiles_do_not_collide() -> None:
+    # R2 regression guard: z.ai-as-Anthropic and real Anthropic built in the
+    # same process produce distinct envs — no global ANTHROPIC_API_KEY hijack.
+    base = {"PATH": "/usr/bin", "ZAI_API_KEY": "zai-key", "ANTHROPIC_API_KEY": "real-key"}
+    zai_env = build_goose_env(_Cfg(), base_env=base, profile=_ZAI)
+    real_env = build_goose_env(_Cfg(), base_env=base, profile=_REAL_ANTHROPIC)
+    assert zai_env["ANTHROPIC_API_KEY"] == "zai-key"
+    assert zai_env["ANTHROPIC_HOST"] == "https://api.z.ai/api/anthropic"
+    assert real_env["ANTHROPIC_API_KEY"] == "real-key"
+    assert real_env["ANTHROPIC_HOST"] == "https://api.anthropic.com"
+    assert real_env["GOOSE_MODEL"] == "claude-sonnet-4-6"
+
+
+def test_profile_openrouter() -> None:
+    env = build_goose_env(
+        _Cfg(),
+        base_env={"PATH": "/usr/bin", "OPENROUTER_API_KEY": "or-key"},
+        profile=_OPENROUTER,
+    )
+    assert env["GOOSE_PROVIDER"] == "openrouter"
+    assert env["GOOSE_MODEL"] == "deepseek/deepseek-chat"
+    assert env["OPENROUTER_API_KEY"] == "or-key"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_HOST" not in env
+
+
+def test_profile_still_strips_box_secrets() -> None:
+    base = {"PATH": "/usr/bin", "ZAI_API_KEY": "zai-key", "WGMESH_BOT_PAT": "ghp_x", "DB_PASSWORD": "p"}
+    env = build_goose_env(_Cfg(), base_env=base, profile=_ZAI)
+    assert "WGMESH_BOT_PAT" not in env
+    assert "DB_PASSWORD" not in env
+
+
+def test_profile_keeps_langfuse_creds() -> None:
+    @dataclass(frozen=True)
+    class _LfCfg:
+        zai_api_key: str | None = None
+        anthropic_host: str = "https://api.z.ai/api/anthropic"
+        langfuse_host: str | None = "http://lf:3000"
+        langfuse_public_key: str | None = "pk"
+        langfuse_secret_key: str | None = "sk"
+
+    env = build_goose_env(
+        _LfCfg(), base_env={"PATH": "/usr/bin", "ZAI_API_KEY": "zai-key"}, profile=_ZAI
+    )
+    assert env["LANGFUSE_URL"] == "http://lf:3000"
+    assert env["LANGFUSE_SECRET_KEY"] == "sk"
+
+
+def test_profile_missing_credential_raises() -> None:
+    with pytest.raises(ValueError, match="ZAI_API_KEY, which is unset"):
+        build_goose_env(_Cfg(), base_env={"PATH": "/usr/bin"}, profile=_ZAI)
+
+
+def test_profile_unsupported_native_provider_raises() -> None:
+    minimax_native = ModelProfile(
+        key="minimax",
+        provider="minimax",
+        model="abab6.5",
+        billing="native",
+        credential_env="MINIMAX_API_KEY",
+    )
+    with pytest.raises(ValueError, match="route it via OpenRouter"):
+        build_goose_env(
+            _Cfg(), base_env={"PATH": "/usr/bin", "MINIMAX_API_KEY": "m"}, profile=minimax_native
+        )

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -218,6 +218,28 @@ def test_profile_missing_credential_raises() -> None:
         build_goose_env(_Cfg(), base_env={"PATH": "/usr/bin"}, profile=_ZAI)
 
 
+def test_new_provider_creds_stripped_when_profile_does_not_reference_them() -> None:
+    # U4 leak-guard: the openrouter profile pulls in ONLY OPENROUTER_API_KEY;
+    # every other provider key in the box env is dropped by the allowlist.
+    base = {
+        "PATH": "/usr/bin",
+        "OPENROUTER_API_KEY": "or-key",
+        "DEEPSEEK_API_KEY": "ds-key",
+        "OPENAI_API_KEY": "oa-key",
+        "MINIMAX_API_KEY": "mm-key",
+        "ANTHROPIC_API_KEY": "real-anthropic",
+    }
+    env = build_goose_env(_Cfg(zai_api_key=None), base_env=base, profile=_OPENROUTER)
+    assert env["OPENROUTER_API_KEY"] == "or-key"
+    for leaked in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "MINIMAX_API_KEY", "ANTHROPIC_API_KEY"):
+        assert leaked not in env
+
+
+def test_new_provider_cred_names_are_secret_shaped() -> None:
+    for name in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "MINIMAX_API_KEY", "OPENROUTER_API_KEY"):
+        assert _is_secret_var(name) is True
+
+
 def test_profile_unsupported_native_provider_raises() -> None:
     minimax_native = ModelProfile(
         key="minimax",

--- a/pipeline/tests/test_goose_env.py
+++ b/pipeline/tests/test_goose_env.py
@@ -240,6 +240,23 @@ def test_new_provider_cred_names_are_secret_shaped() -> None:
         assert _is_secret_var(name) is True
 
 
+def test_attribution_otel_attrs_carry_stage_and_model_key() -> None:
+    env = build_goose_env(
+        _Cfg(),
+        base_env={"PATH": "/usr/bin", "ZAI_API_KEY": "zai-key"},
+        profile=_ZAI,
+        stage="spec",
+    )
+    attrs = env["OTEL_RESOURCE_ATTRIBUTES"]
+    assert "wgmesh.stage=spec" in attrs
+    assert "wgmesh.model_key=spec-cheap" in attrs
+
+
+def test_attribution_absent_without_stage_or_profile() -> None:
+    env = build_goose_env(_Cfg(), base_env={"PATH": "/usr/bin"})
+    assert "OTEL_RESOURCE_ATTRIBUTES" not in env
+
+
 def test_profile_unsupported_native_provider_raises() -> None:
     minimax_native = ModelProfile(
         key="minimax",

--- a/pipeline/tests/test_models.py
+++ b/pipeline/tests/test_models.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.models import (
+    ModelProfile,
+    credential_for,
+    parse_registry,
+    parse_stage_routing,
+    resolve_profile,
+)
+
+
+_TWO_PROFILE_JSON = """
+{
+  "spec-cheap":   {"provider": "anthropic",  "model": "GLM-4.7",      "billing": "native",     "credential_env": "ZAI_API_KEY", "host": "https://api.z.ai/api/anthropic"},
+  "impl-capable": {"provider": "openrouter", "model": "deepseek/v3",  "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}
+}
+"""
+
+
+def test_parse_registry_two_profiles() -> None:
+    registry = parse_registry(_TWO_PROFILE_JSON)
+    assert set(registry) == {"spec-cheap", "impl-capable"}
+    assert registry["spec-cheap"].provider == "anthropic"
+    assert registry["spec-cheap"].host == "https://api.z.ai/api/anthropic"
+    assert registry["impl-capable"].billing == "openrouter"
+    assert registry["impl-capable"].host is None
+    # the map key becomes the profile key
+    assert registry["impl-capable"].key == "impl-capable"
+
+
+def test_parse_stage_routing_maps_stage_to_key() -> None:
+    routing = parse_stage_routing('{"spec": "spec-cheap", "implement": "impl-capable"}')
+    assert routing == {"spec": "spec-cheap", "implement": "impl-capable"}
+
+
+def test_resolve_profile_by_stage() -> None:
+    registry = parse_registry(_TWO_PROFILE_JSON)
+    routing = parse_stage_routing('{"spec": "spec-cheap", "implement": "impl-capable"}')
+    assert resolve_profile(registry, routing, "spec").key == "spec-cheap"
+    assert resolve_profile(registry, routing, "implement").key == "impl-capable"
+
+
+def test_resolve_profile_falls_back_to_registry_default() -> None:
+    registry = {
+        "default": ModelProfile(
+            key="default",
+            provider="anthropic",
+            model="GLM-4.7",
+            billing="native",
+            credential_env="ZAI_API_KEY",
+            host="https://api.z.ai/api/anthropic",
+        )
+    }
+    # no routing entry for this stage, but a 'default' profile exists
+    assert resolve_profile(registry, {}, "implement").key == "default"
+
+
+def test_resolve_profile_unmapped_stage_no_default_raises() -> None:
+    registry = parse_registry(_TWO_PROFILE_JSON)
+    routing = parse_stage_routing('{"spec": "spec-cheap"}')
+    with pytest.raises(ValueError, match="no model route for stage 'implement'"):
+        resolve_profile(registry, routing, "implement")
+
+
+def test_resolve_profile_route_to_missing_key_raises() -> None:
+    registry = parse_registry(_TWO_PROFILE_JSON)
+    routing = parse_stage_routing('{"implement": "does-not-exist"}')
+    with pytest.raises(ValueError, match="not in the registry"):
+        resolve_profile(registry, routing, "implement")
+
+
+def test_malformed_registry_json_names_the_var() -> None:
+    with pytest.raises(ValueError, match="MODEL_REGISTRY must be valid JSON"):
+        parse_registry("{not json")
+
+
+def test_registry_rejects_bad_billing() -> None:
+    with pytest.raises(ValueError, match="billing must be one of"):
+        parse_registry(
+            '{"x": {"provider": "p", "model": "m", "billing": "flat", "credential_env": "K"}}'
+        )
+
+
+def test_registry_rejects_missing_required_field() -> None:
+    with pytest.raises(ValueError, match="missing required fields"):
+        parse_registry('{"x": {"provider": "p", "model": "m", "billing": "native"}}')
+
+
+def test_registry_rejects_unknown_field() -> None:
+    with pytest.raises(ValueError, match="unknown fields"):
+        parse_registry(
+            '{"x": {"provider": "p", "model": "m", "billing": "native", "credential_env": "K", "temp": 1}}'
+        )
+
+
+def test_credential_for_reads_value() -> None:
+    profile = parse_registry(_TWO_PROFILE_JSON)["impl-capable"]
+    assert credential_for(profile, {"OPENROUTER_API_KEY": "or-key"}) == "or-key"
+
+
+def test_credential_for_missing_var_raises() -> None:
+    profile = parse_registry(_TWO_PROFILE_JSON)["impl-capable"]
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY, which is unset"):
+        credential_for(profile, {"PATH": "/usr/bin"})
+
+
+def test_empty_inputs_yield_empty_collections() -> None:
+    assert parse_registry(None) == {}
+    assert parse_registry("   ") == {}
+    assert parse_stage_routing(None) == {}

--- a/pipeline/tests/test_runner_routing.py
+++ b/pipeline/tests/test_runner_routing.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.config import load_config
+from wgmesh_pipeline.goose.runner import GooseRunner
+
+
+_REGISTRY = (
+    '{"cheap": {"provider": "anthropic", "model": "GLM-4.7", "billing": "native",'
+    ' "credential_env": "ZAI_API_KEY", "host": "https://api.z.ai/api/anthropic"},'
+    ' "capable": {"provider": "openrouter", "model": "deepseek/deepseek-chat",'
+    ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}}'
+)
+
+
+def _routed_config(routing: str, monkeypatch):
+    # Credentials live in the PROCESS env on the box (the runner reads
+    # os.environ at env-build time), so set them there — not just in the
+    # load_config dict — to mirror production.
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    return load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "MODEL_REGISTRY": _REGISTRY,
+            "STAGE_ROUTING": routing,
+            "ZAI_API_KEY": "zai-key",
+            "OPENROUTER_API_KEY": "or-key",
+        }
+    )
+
+
+def _completed(stdout: str = "ok") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["goose"], returncode=0, stdout=stdout, stderr="")
+
+
+def _capture_runner(calls: list[dict[str, Any]]):
+    def run(command, **kwargs):
+        calls.append({"command": command, "env": kwargs["env"]})
+        out = Path(kwargs["cwd"]) / "out.txt"
+        out.write_text("content")
+        return _completed()
+
+    return run
+
+
+def _run(config, stage: str, tmp_path, calls):
+    return GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
+        recipe="r.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "s.md"},
+        expected_output="out.txt",
+        stage=stage,
+    )
+
+
+def test_spec_stage_uses_cheap_model(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _routed_config('{"spec": "cheap", "implement": "capable"}', monkeypatch)
+    result = _run(config, "spec", tmp_path, calls)
+    assert result.ok is True
+    env = calls[0]["env"]
+    assert env["GOOSE_MODEL"] == "GLM-4.7"
+    assert env["GOOSE_PROVIDER"] == "anthropic"
+    assert env["ANTHROPIC_API_KEY"] == "zai-key"
+
+
+def test_implement_stage_uses_capable_model(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _routed_config('{"spec": "cheap", "implement": "capable"}', monkeypatch)
+    result = _run(config, "implement", tmp_path, calls)
+    assert result.ok is True
+    env = calls[0]["env"]
+    assert env["GOOSE_MODEL"] == "deepseek/deepseek-chat"
+    assert env["GOOSE_PROVIDER"] == "openrouter"
+    assert env["OPENROUTER_API_KEY"] == "or-key"
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_zero_config_run_uses_default_profile(tmp_path, monkeypatch) -> None:
+    # No MODEL_REGISTRY env → load_config synthesizes the 'default' profile;
+    # any stage resolves to it.
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    config = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "ZAI_API_KEY": "zai-key",
+        }
+    )
+    calls: list[dict[str, Any]] = []
+    result = _run(config, "implement", tmp_path, calls)
+    assert result.ok is True
+    env = calls[0]["env"]
+    assert env["GOOSE_MODEL"]  # the default GLM model
+    assert env["ANTHROPIC_API_KEY"] == "zai-key"
+
+
+def test_unmapped_stage_no_default_raises(tmp_path, monkeypatch) -> None:
+    # registry has no 'default' and routing omits 'implement' → fail-closed.
+    config = _routed_config('{"spec": "cheap"}', monkeypatch)
+    calls: list[dict[str, Any]] = []
+    with pytest.raises(ValueError, match="no model route for stage 'implement'"):
+        _run(config, "implement", tmp_path, calls)

--- a/pipeline/tests/test_runner_routing.py
+++ b/pipeline/tests/test_runner_routing.py
@@ -102,6 +102,29 @@ def test_zero_config_run_uses_default_profile(tmp_path, monkeypatch) -> None:
     assert env["ANTHROPIC_API_KEY"] == "zai-key"
 
 
+def test_result_carries_model_key_for_attribution(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _routed_config('{"spec": "cheap", "implement": "capable"}', monkeypatch)
+    spec_result = _run(config, "spec", tmp_path, calls)
+    impl_result = _run(config, "implement", tmp_path, calls)
+    assert spec_result.model_key == "cheap"
+    assert impl_result.model_key == "capable"
+
+
+def test_zero_config_result_model_key_is_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    config = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "ZAI_API_KEY": "zai-key",
+        }
+    )
+    calls: list[dict[str, Any]] = []
+    result = _run(config, "implement", tmp_path, calls)
+    assert result.model_key == "default"
+
+
 def test_unmapped_stage_no_default_raises(tmp_path, monkeypatch) -> None:
     # registry has no 'default' and routing omits 'implement' → fail-closed.
     config = _routed_config('{"spec": "cheap"}', monkeypatch)

--- a/pipeline/tests/test_scoring.py
+++ b/pipeline/tests/test_scoring.py
@@ -106,6 +106,35 @@ def test_score_run_records_merged_outcome() -> None:
     assert rec.calls[0]["tags"]["outcome"] == "merged"
 
 
+def test_score_run_tags_include_per_stage_model_keys() -> None:
+    # R5: the model that handled each LLM stage is attributed in the score tags.
+    rec = _RecordingScorer()
+    state = {
+        "issue": _Issue(601),
+        "decision": "merge",
+        "risk_tier": "low",
+        "tests_passed": True,
+        "sanitise_ok": True,
+        "review_findings": [],
+        "spec_model_key": "spec-cheap",
+        "implement_model_key": "impl-capable",
+    }
+    score_run(state, outcome="merged", scorer=rec)
+    tags = rec.calls[0]["tags"]
+    assert tags["spec_model_key"] == "spec-cheap"
+    assert tags["implement_model_key"] == "impl-capable"
+
+
+def test_score_run_omits_model_keys_when_absent() -> None:
+    # Zero-config / legacy runs that never recorded a model key don't emit empty tags.
+    rec = _RecordingScorer()
+    state = {"issue": _Issue(602), "review_findings": []}
+    score_run(state, outcome="failed", scorer=rec)
+    tags = rec.calls[0]["tags"]
+    assert "spec_model_key" not in tags
+    assert "implement_model_key" not in tags
+
+
 def test_langfuse_record_creates_pipeline_outcome_score_and_flushes(monkeypatch) -> None:
     client = _FakeLangfuse()
     scorer = _install_fake_langfuse(monkeypatch, client)

--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -14,7 +14,7 @@ from wgmesh_pipeline.goose.runner import GooseResult
 class FakeRunner:
     calls: list[dict[str, Any]]
 
-    def run_recipe(self, *, recipe, workdir, params, expected_output):
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None):
         output = Path(workdir) / expected_output
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(

--- a/pipeline/tests/test_spec_pr.py
+++ b/pipeline/tests/test_spec_pr.py
@@ -84,7 +84,7 @@ def test_spec_pr_node_creates_exact_spec_title_and_swaps_labels(tmp_path: Path, 
 
 
 class WritingRunner:
-    def run_recipe(self, *, recipe, workdir, params, expected_output):
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None):
         output = Path(workdir) / expected_output
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping
+
+from wgmesh_pipeline.models import (
+    ModelProfile,
+    parse_registry,
+    parse_stage_routing,
+)
 
 
 VALID_MODES = frozenset({"shadow", "spec-only", "live"})
@@ -39,6 +45,10 @@ class Config:
     langfuse_host: str | None = None
     langfuse_public_key: str | None = None
     langfuse_secret_key: str | None = None
+    # Multi-model routing (price/perf #2). Empty by default → callers synthesize
+    # a zero-config default profile from the goose_* fields above (R7).
+    model_registry: Mapping[str, ModelProfile] = field(default_factory=dict)
+    stage_routing: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def owner(self) -> str:
@@ -76,19 +86,29 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
     if db_mode == "turso" and not turso_url:
         raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
 
+    goose_provider = _get_nonempty(source, "GOOSE_PROVIDER") or DEFAULT_GOOSE_PROVIDER
+    goose_model = _get_nonempty(source, "GOOSE_MODEL") or DEFAULT_GOOSE_MODEL
+    anthropic_host = _get_nonempty(source, "ANTHROPIC_HOST") or DEFAULT_ANTHROPIC_HOST
+    model_registry, stage_routing = _build_routing(
+        source,
+        goose_provider=goose_provider,
+        goose_model=goose_model,
+        anthropic_host=anthropic_host,
+    )
+
     return Config(
         target_repo=target_repo,
         mode=mode,
         wgmesh_bot_pat=pat,
         zai_api_key=_get_nonempty(source, "ZAI_API_KEY"),
-        anthropic_host=_get_nonempty(source, "ANTHROPIC_HOST") or DEFAULT_ANTHROPIC_HOST,
+        anthropic_host=anthropic_host,
         langsmith_api_key=_get_nonempty(source, "LANGSMITH_API_KEY"),
         poll_interval_seconds=_get_int(source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS),
         max_files=_get_int(source, "MAX_FILES", DEFAULT_MAX_FILES),
         repo_path=_get_nonempty(source, "WGMESH_CHECKOUT_PATH") or DEFAULT_REPO_PATH,
         recipes_dir=_get_nonempty(source, "RECIPES_DIR") or DEFAULT_RECIPES_DIR,
-        goose_provider=_get_nonempty(source, "GOOSE_PROVIDER") or DEFAULT_GOOSE_PROVIDER,
-        goose_model=_get_nonempty(source, "GOOSE_MODEL") or DEFAULT_GOOSE_MODEL,
+        goose_provider=goose_provider,
+        goose_model=goose_model,
         database_mode=db_mode,
         database_path=_get_nonempty(source, "PIPELINE_DB_PATH") or "pipeline/state.db",
         turso_url=turso_url,
@@ -96,7 +116,43 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         langfuse_host=_get_nonempty(source, "LANGFUSE_HOST"),
         langfuse_public_key=_get_nonempty(source, "LANGFUSE_PUBLIC_KEY"),
         langfuse_secret_key=_get_nonempty(source, "LANGFUSE_SECRET_KEY"),
+        model_registry=model_registry,
+        stage_routing=stage_routing,
     )
+
+
+# Goose provider id the zero-config fallback profile uses ANTHROPIC_API_KEY for.
+_DEFAULT_CREDENTIAL_ENV = "ZAI_API_KEY"
+
+
+def _build_routing(
+    source: Mapping[str, str],
+    *,
+    goose_provider: str,
+    goose_model: str,
+    anthropic_host: str,
+) -> tuple[Mapping[str, ModelProfile], Mapping[str, str]]:
+    """Registry + stage map from env, with a zero-config fallback (R7).
+
+    When MODEL_REGISTRY is unset, synthesize a single ``default`` profile from
+    the goose_* fields so the pipeline behaves exactly as it did before routing
+    existed: one model, every stage. When set, parse both and trust the
+    fail-closed validation in models.py (an unset STAGE_ROUTING is valid as long
+    as the registry carries a ``default`` profile)."""
+    registry = parse_registry(_get_nonempty(source, "MODEL_REGISTRY"))
+    routing = parse_stage_routing(_get_nonempty(source, "STAGE_ROUTING"))
+    if not registry:
+        registry = {
+            "default": ModelProfile(
+                key="default",
+                provider=goose_provider,
+                model=goose_model,
+                billing="native",
+                credential_env=_DEFAULT_CREDENTIAL_ENV,
+                host=anthropic_host,
+            )
+        }
+    return registry, routing
 
 
 def _required(env: Mapping[str, str], name: str) -> str:

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 from wgmesh_pipeline.config import Config, DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER
-from wgmesh_pipeline.models import ModelProfile, credential_for
+from wgmesh_pipeline.models import ModelProfile, credential_for, resolve_profile
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -177,6 +177,19 @@ class GooseRunner:
         self.config = config
         self._runner = runner or subprocess.run
 
+    def _resolve_profile(self, stage: str | None) -> ModelProfile | None:
+        """Pick the model profile for ``stage`` from the config registry/map.
+
+        Returns None when no stage is given or the config carries no registry
+        (e.g. minimal test configs) — build_goose_env then uses the legacy
+        single-model path. When a registry IS present, resolution is fail-closed
+        (an unroutable stage raises in resolve_profile)."""
+        registry = getattr(self.config, "model_registry", {}) or {}
+        routing = getattr(self.config, "stage_routing", {}) or {}
+        if stage is None or not registry:
+            return None
+        return resolve_profile(registry, routing, stage)
+
     def run_recipe(
         self,
         *,
@@ -184,6 +197,7 @@ class GooseRunner:
         workdir: str | Path,
         params: Mapping[str, str],
         expected_output: str | Path,
+        stage: str | None = None,
     ) -> GooseResult:
         workdir_path = Path(workdir)
         output_path = Path(expected_output)
@@ -194,7 +208,7 @@ class GooseRunner:
         for key, value in params.items():
             command.extend(["--params", f"{key}={value}"])
 
-        env = build_goose_env(self.config)
+        env = build_goose_env(self.config, profile=self._resolve_profile(stage))
 
         started = time.monotonic()
         try:

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 from wgmesh_pipeline.config import Config, DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER
+from wgmesh_pipeline.models import ModelProfile, credential_for
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -85,18 +86,69 @@ def _is_safe_var(name: str) -> bool:
     return name in _SAFE_ENV_NAMES or name.startswith(_SAFE_ENV_PREFIXES)
 
 
-def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -> dict[str, str]:
+def build_goose_env(
+    config: Config,
+    base_env: Mapping[str, str] | None = None,
+    *,
+    profile: ModelProfile | None = None,
+) -> dict[str, str]:
     """Subprocess env for Goose: fail-closed allowlist of known-safe vars, then
-    the single LLM credential Goose legitimately needs added back explicitly.
+    the single LLM credential the selected model needs added back explicitly.
     Anything not on the allowlist (incl. the box's PAT and any unknown secret)
-    is dropped — the LLM agent never sees it."""
+    is dropped — the LLM agent never sees it.
+
+    When ``profile`` is given, the model's provider/model/credential/host come
+    from that profile and the credential value is read from the (filtered)
+    source env named by ``profile.credential_env``. This is what lets multiple
+    providers — including two Anthropic-family models (z.ai and real Anthropic)
+    — coexist in one process: each call writes only its OWN credential, so there
+    is no global ANTHROPIC_API_KEY hijack.
+
+    When ``profile`` is None, the legacy zero-config behavior applies (single
+    z.ai model from the config fields) so existing call sites are unchanged."""
     source = os.environ if base_env is None else base_env
     env = {key: value for key, value in source.items() if _is_safe_var(key)}
+    if profile is None:
+        _apply_legacy_default(env, config, source)
+    else:
+        _apply_profile(env, profile, source)
+    _apply_langfuse(env, config)
+    return env
+
+
+def _apply_legacy_default(env: dict[str, str], config: Config, source: Mapping[str, str]) -> None:
+    """Pre-routing behavior: one z.ai model from config, provider/model
+    overridable via the source env. Kept verbatim for backward compatibility."""
     if config.zai_api_key:
         env["ANTHROPIC_API_KEY"] = config.zai_api_key
     env["ANTHROPIC_HOST"] = config.anthropic_host
     env["GOOSE_PROVIDER"] = source.get("GOOSE_PROVIDER") or getattr(config, "goose_provider", DEFAULT_GOOSE_PROVIDER)
     env["GOOSE_MODEL"] = source.get("GOOSE_MODEL") or getattr(config, "goose_model", DEFAULT_GOOSE_MODEL)
+
+
+def _apply_profile(env: dict[str, str], profile: ModelProfile, source: Mapping[str, str]) -> None:
+    """Profile-driven model selection. Fail-closed: an unsupported provider/
+    billing combo or a missing credential raises rather than silently running
+    Goose against the wrong (or no) model."""
+    env["GOOSE_PROVIDER"] = profile.provider
+    env["GOOSE_MODEL"] = profile.model
+    cred = credential_for(profile, source)  # raises if the named var is unset
+    if profile.billing == "openrouter":
+        env["OPENROUTER_API_KEY"] = cred
+    elif profile.billing == "native" and profile.provider == "anthropic":
+        # z.ai today, real Anthropic later — distinguished only by host + key,
+        # both written per-call so the two never collide.
+        env["ANTHROPIC_API_KEY"] = cred
+        if profile.host:
+            env["ANTHROPIC_HOST"] = profile.host
+    else:
+        raise ValueError(
+            f"model profile {profile.key!r}: unsupported native provider "
+            f"{profile.provider!r}; route it via OpenRouter (billing='openrouter')"
+        )
+
+
+def _apply_langfuse(env: dict[str, str], config: Config) -> None:
     # Cost-capture: hand Goose the Langfuse creds so it exports its OWN LLM
     # generations (model + token usage + cost) to Langfuse -> populates the
     # per-model cost dashboards (the price half of price/performance routing).
@@ -109,7 +161,6 @@ def build_goose_env(config: Config, base_env: Mapping[str, str] | None = None) -
         env["LANGFUSE_URL"] = lf_host
         env["LANGFUSE_PUBLIC_KEY"] = lf_pub
         env["LANGFUSE_SECRET_KEY"] = lf_sec
-    return env
 
 
 @dataclass(frozen=True)

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -34,8 +34,20 @@ _SECRET_MARKERS = (
 # Known sensitive var names that the substring markers miss — notably
 # WGMESH_BOT_PAT (the box's GitHub token; "PAT" can't be a marker because it
 # would also strip PATH).
+# Provider API keys all match the "API_KEY" marker already, but list the
+# multi-model routing creds explicitly so the intent is documented and a future
+# marker refactor can't silently fail-open on them (R6).
 _KNOWN_SECRET_NAMES = frozenset(
-    {"WGMESH_BOT_PAT", "BOT_PAT", "GH_PAT", "HCLOUD_TOKEN", "OPENROUTER_API_KEY"}
+    {
+        "WGMESH_BOT_PAT",
+        "BOT_PAT",
+        "GH_PAT",
+        "HCLOUD_TOKEN",
+        "OPENROUTER_API_KEY",
+        "MINIMAX_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "OPENAI_API_KEY",
+    }
 )
 
 

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -103,6 +103,7 @@ def build_goose_env(
     base_env: Mapping[str, str] | None = None,
     *,
     profile: ModelProfile | None = None,
+    stage: str | None = None,
 ) -> dict[str, str]:
     """Subprocess env for Goose: fail-closed allowlist of known-safe vars, then
     the single LLM credential the selected model needs added back explicitly.
@@ -125,7 +126,28 @@ def build_goose_env(
     else:
         _apply_profile(env, profile, source)
     _apply_langfuse(env, config)
+    _apply_attribution(env, stage, profile)
     return env
+
+
+def _apply_attribution(env: dict[str, str], stage: str | None, profile: ModelProfile | None) -> None:
+    """Tag Goose's telemetry with the pipeline stage and resolved model key so
+    cost/latency can be sliced by stage AND model in Langfuse (R5).
+
+    Emitted as OTEL resource attributes — Goose exports its generations over
+    OTLP, so a Goose build that forwards resource attributes will carry these
+    onto every span. Whether the installed Goose version forwards them is the
+    execution-time unknown noted in the plan; the authoritative per-model
+    attribution lands via scoring.py regardless (our code writes it directly)."""
+    if not stage and profile is None:
+        return
+    attrs = []
+    if stage:
+        attrs.append(f"wgmesh.stage={stage}")
+    if profile is not None:
+        attrs.append(f"wgmesh.model_key={profile.key}")
+    if attrs:
+        env["OTEL_RESOURCE_ATTRIBUTES"] = ",".join(attrs)
 
 
 def _apply_legacy_default(env: dict[str, str], config: Config, source: Mapping[str, str]) -> None:
@@ -182,6 +204,10 @@ class GooseResult:
     duration_seconds: float
     raw_log: str
     error: str | None = None
+    # Which model profile handled this stage — recorded into run state so the
+    # online score (scoring.py) attributes the outcome by model (R5). None when
+    # the runner used the legacy single-model path (no registry configured).
+    model_key: str | None = None
 
 
 class GooseRunner:
@@ -220,7 +246,9 @@ class GooseRunner:
         for key, value in params.items():
             command.extend(["--params", f"{key}={value}"])
 
-        env = build_goose_env(self.config, profile=self._resolve_profile(stage))
+        profile = self._resolve_profile(stage)
+        model_key = profile.key if profile is not None else None
+        env = build_goose_env(self.config, profile=profile, stage=stage)
 
         started = time.monotonic()
         try:
@@ -241,6 +269,7 @@ class GooseRunner:
                 duration_seconds=duration,
                 raw_log=_join_log(_decode_timeout_output(exc.output), _decode_timeout_output(exc.stderr)),
                 error=f"goose timed out after {GOOSE_TIMEOUT_SECONDS}s",
+                model_key=model_key,
             )
         duration = time.monotonic() - started
         raw_log = _join_log(completed.stdout, completed.stderr)
@@ -252,6 +281,7 @@ class GooseRunner:
                 duration_seconds=duration,
                 raw_log=raw_log,
                 error=f"goose exited {completed.returncode}",
+                model_key=model_key,
             )
 
         if not output_path.exists() or output_path.stat().st_size == 0:
@@ -261,6 +291,7 @@ class GooseRunner:
                 duration_seconds=duration,
                 raw_log=raw_log,
                 error=f"empty output guard fired for {output_path}",
+                model_key=model_key,
             )
 
         return GooseResult(
@@ -268,6 +299,7 @@ class GooseRunner:
             output_path=output_path,
             duration_seconds=duration,
             raw_log=raw_log,
+            model_key=model_key,
         )
 
 

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -24,6 +24,7 @@ def implement_node(state: GraphState) -> GraphState:
             workdir=repo_path,
             params={"spec_file": str(next_state["spec_path"])},
             expected_output=diff_rel,
+            stage="implement",
         )
         if not result.ok:
             raise RuntimeError(result.error or "goose implementation failed")

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -28,6 +28,8 @@ def implement_node(state: GraphState) -> GraphState:
         )
         if not result.ok:
             raise RuntimeError(result.error or "goose implementation failed")
+        if result.model_key is not None:
+            next_state["implement_model_key"] = result.model_key
         next_state["diff"] = Path(result.output_path).read_text()
     else:
         next_state["diff"] = "+docs-only change\n"

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -35,6 +35,7 @@ def spec_node(state: GraphState) -> GraphState:
             "spec_file": str(spec_rel),
         },
         expected_output=spec_rel,
+        stage="spec",
     )
     if not result.ok:
         # Surface goose's actual output so a write-tool/model/recipe failure is

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -52,6 +52,8 @@ def spec_node(state: GraphState) -> GraphState:
         )
         raise RuntimeError(result.error or "goose spec failed")
     next_state["spec_path"] = str(result.output_path)
+    if result.model_key is not None:
+        next_state["spec_model_key"] = result.model_key
     # Put the authored spec text into state so trace_node includes it in the
     # "spec" span output — this is what a managed Langfuse LLM-as-a-Judge reads
     # to score spec quality. Capped + best-effort (a read failure must not break

--- a/pipeline/wgmesh_pipeline/models.py
+++ b/pipeline/wgmesh_pipeline/models.py
@@ -1,0 +1,151 @@
+"""Model registry and per-stage routing (price/performance #2).
+
+Turns the pipeline's single hardcoded model into a registry of model *profiles*
+plus a static stage->model map. Each LLM-invoking stage (spec, implement)
+resolves its own profile, so cheap stages run cheap models and capability-
+critical stages run capable ones — every choice attributable in Langfuse.
+
+This module is intentionally standalone (no config import) to avoid a circular
+dependency: config.py builds Config from these primitives, not the reverse.
+
+Fail-closed throughout (mailservice lesson, inverted for the explicit default):
+a misconfigured registry/route raises; it never silently routes to the wrong
+model. The ONE allowed implicit default is the zero-config fallback that
+config.load_config synthesizes when no registry is configured (R7).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Mapping
+
+
+VALID_BILLING = frozenset({"native", "openrouter"})
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """One routable model. The unit of routing.
+
+    ``credential_env`` names the env var holding this model's API key — the
+    value is read at Goose-env-build time, never stored here, so secrets stay
+    out of the registry JSON and out of this object.
+    """
+
+    key: str
+    provider: str  # goose provider id: anthropic | openrouter | ...
+    model: str  # goose model id / openrouter slug
+    billing: str  # "native" | "openrouter"
+    credential_env: str  # env var name holding this model's key
+    host: str | None = None  # endpoint for native non-default (z.ai, minimax)
+
+    def __post_init__(self) -> None:
+        if self.billing not in VALID_BILLING:
+            valid = ", ".join(sorted(VALID_BILLING))
+            raise ValueError(
+                f"model profile {self.key!r}: billing must be one of {valid}; got {self.billing!r}"
+            )
+        if not self.provider:
+            raise ValueError(f"model profile {self.key!r}: provider is required")
+        if not self.model:
+            raise ValueError(f"model profile {self.key!r}: model is required")
+        if not self.credential_env:
+            raise ValueError(f"model profile {self.key!r}: credential_env is required")
+
+
+_PROFILE_FIELDS = frozenset({"provider", "model", "billing", "credential_env", "host"})
+
+
+def parse_registry(raw: str | None) -> dict[str, ModelProfile]:
+    """Parse the ``MODEL_REGISTRY`` env JSON into ``{key: ModelProfile}``.
+
+    Shape: ``{"<key>": {"provider": ..., "model": ..., "billing": ...,
+    "credential_env": ..., "host": <optional>}}``. The map key becomes the
+    profile key. Empty/None input → empty registry (zero-config path handled by
+    the caller).
+    """
+    if raw is None or not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"MODEL_REGISTRY must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("MODEL_REGISTRY must be a JSON object of {key: profile}")
+
+    registry: dict[str, ModelProfile] = {}
+    for key, spec in data.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"MODEL_REGISTRY[{key!r}] must be a JSON object")
+        unknown = set(spec) - _PROFILE_FIELDS
+        if unknown:
+            raise ValueError(
+                f"MODEL_REGISTRY[{key!r}] has unknown fields: {', '.join(sorted(unknown))}"
+            )
+        missing = {"provider", "model", "billing", "credential_env"} - set(spec)
+        if missing:
+            raise ValueError(
+                f"MODEL_REGISTRY[{key!r}] missing required fields: {', '.join(sorted(missing))}"
+            )
+        registry[key] = ModelProfile(
+            key=key,
+            provider=spec["provider"],
+            model=spec["model"],
+            billing=spec["billing"],
+            credential_env=spec["credential_env"],
+            host=spec.get("host"),
+        )
+    return registry
+
+
+def parse_stage_routing(raw: str | None) -> dict[str, str]:
+    """Parse the ``STAGE_ROUTING`` env JSON into ``{stage: registry_key}``."""
+    if raw is None or not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"STAGE_ROUTING must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("STAGE_ROUTING must be a JSON object of {stage: key}")
+    for stage, key in data.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"STAGE_ROUTING[{stage!r}] must be a non-empty string key")
+    return dict(data)
+
+
+def resolve_profile(
+    registry: Mapping[str, ModelProfile],
+    routing: Mapping[str, str],
+    stage: str,
+) -> ModelProfile:
+    """Pick the ModelProfile for ``stage``. Fail-closed (KTD5).
+
+    Resolution order: the stage's mapped key, else a registry ``"default"``
+    entry, else raise. A stage mapped to a key absent from the registry raises.
+    """
+    key = routing.get(stage)
+    if key is None:
+        if "default" in registry:
+            return registry["default"]
+        raise ValueError(
+            f"no model route for stage {stage!r} and no 'default' profile in registry"
+        )
+    if key not in registry:
+        raise ValueError(
+            f"stage {stage!r} routes to model key {key!r} which is not in the registry"
+        )
+    return registry[key]
+
+
+def credential_for(profile: ModelProfile, env: Mapping[str, str]) -> str:
+    """Read the profile's credential value from ``env``. Fail-closed: raises if
+    the named var is unset or empty, so a misconfigured profile never runs
+    Goose with no key."""
+    value = env.get(profile.credential_env)
+    if value is None or not value.strip():
+        raise ValueError(
+            f"model profile {profile.key!r} needs env var {profile.credential_env}, which is unset"
+        )
+    return value

--- a/pipeline/wgmesh_pipeline/scoring.py
+++ b/pipeline/wgmesh_pipeline/scoring.py
@@ -212,6 +212,13 @@ def _tags_from_state(state: dict, outcome: str) -> dict[str, str]:
         value = state.get(key)
         if value is not None:
             tags[key] = str(value)[:200]
+    # Per-model attribution (R5): which model handled each LLM stage, so the
+    # Scores dashboard can slice outcome/quality by model — the perf half of
+    # price/performance routing.
+    for key in ("spec_model_key", "implement_model_key"):
+        value = state.get(key)
+        if value is not None:
+            tags[key] = str(value)[:200]
     return tags
 
 


### PR DESCRIPTION
**Stacked on `feat/goose-langfuse-cost-capture` (price/perf #1).** Base this PR on that branch; review #1 first. Once #1 merges, rebase this onto `main`.

## What

Turns the pipeline's single hardcoded model (`GLM-4.7` via z.ai) into a **model registry + static stage→model routing map**. Each LLM stage picks a model by cost/capability: spec authoring runs a cheap model, implementation runs a capable one. Builds on the Langfuse cost capture from #1 — that's the measurement half; this is the routing half.

## Design

- **Static map first** (`STAGE_ROUTING` over `MODEL_REGISTRY`, both env JSON). Escalate-on-fail deferred to Phase 2.
- **Hybrid billing** — subscription models (z.ai/MiniMax) stay on native endpoints (flat-rate only works there); metered models (DeepSeek/OpenAI/Anthropic) route through one OpenRouter gateway.
- **Killed the global `ANTHROPIC_API_KEY` hijack** — each profile writes its own provider/host/credential per call, so z.ai-as-Anthropic and real Anthropic coexist.
- **Fail-closed** — unknown route / missing credential / unsupported native provider raises; never silently routes to the wrong model.
- **Zero-config backward compat** — both env vars unset → single z.ai model, exactly as before.

## Units

- **U1** `pipeline/wgmesh_pipeline/models.py` — `ModelProfile`, registry/route parsers, `resolve_profile`; config parsing + zero-config fallback
- **U2** `goose/runner.py` — `build_goose_env` profile-driven (no global hijack)
- **U3** `stage` threaded through `run_recipe` + the two LLM nodes (`spec`, `implement`)
- **U4** provider-cred allowlist + `provision-pipeline-box.yml` wiring
- **U5** per-stage/per-model attribution → Langfuse (`spec_model_key`/`implement_model_key` tags; OTEL best-effort)
- **U6** docs (AGENTS.md, system-prompt, `docs/solutions/design-decisions/multi-model-routing.md`)

## Test plan

- [x] `169 passed` (full pipeline suite, +35 new tests)
- [x] Two-Anthropic coexistence regression guard
- [x] Credential leak-guard (box secrets + new provider keys stripped unless a profile names them)
- [x] Fail-closed: unroutable stage / missing cred / unsupported native provider all raise
- [x] Zero-config path produces today's env exactly
- [ ] Verify Goose provider ids for `openrouter`/`deepseek` against installed Goose version at deploy (execution-time unknown, noted in plan)

Plan: `docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)