### PR TITLE
feat(pipeline): escalate-on-fail model ladder (price/perf #3)

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -168,6 +168,7 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MODEL_REGISTRY: ${{ secrets.MODEL_REGISTRY }}
           STAGE_ROUTING: ${{ secrets.STAGE_ROUTING }}
+          MAX_ESCALATION_ATTEMPTS: ${{ vars.MAX_ESCALATION_ATTEMPTS }}
           MODE: ${{ github.event.inputs.pipeline_mode }}
           DBMODE: ${{ github.event.inputs.database_mode }}
           RESET_QUEUE_INPUT: ${{ github.event.inputs.reset_queue }}
@@ -193,6 +194,7 @@ jobs:
           MINIMAX_API_KEY=$MINIMAX_API_KEY
           MODEL_REGISTRY='$MODEL_REGISTRY'
           STAGE_ROUTING='$STAGE_ROUTING'
+          MAX_ESCALATION_ATTEMPTS=$MAX_ESCALATION_ATTEMPTS
           WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
           DATABASE_MODE=$DBMODE
           PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,16 +124,26 @@ optional env vars (`pipeline/wgmesh_pipeline/models.py`):
   `billing` is `native` (subscription endpoint, e.g. z.ai/MiniMax — flat-rate only works
   on their own host) or `openrouter` (metered models — DeepSeek/OpenAI/Anthropic — through
   one `OPENROUTER_API_KEY` gateway).
-- `STAGE_ROUTING` — JSON `{stage: registry_key}`. Stages today: `spec`, `implement`.
-  An unmapped stage falls back to a registry `default` profile, else fails closed.
+- `STAGE_ROUTING` — JSON `{stage: registry_key}` for a single model, OR
+  `{stage: [key0, key1, ...]}` for an **escalation ladder** (cheap→capable→premium).
+  Stages today: `spec`, `implement`. An unmapped stage falls back to a registry `default`
+  profile, else fails closed.
 
 **Both unset → single z.ai model, exactly as before (zero-config default).** Credentials
 are read from the process env named by `credential_env`; they reach Goose only when a
 routed profile names them (the fail-closed allowlist in `goose/runner.py` strips everything
 else). Per-stage/per-model cost lands in Langfuse — slice the Scores dashboard by
-`spec_model_key` / `implement_model_key`. Escalate-on-fail (retry a failed stage on a
-stronger model) is **not** built yet — the map is static. See
-`docs/solutions/design-decisions/multi-model-routing.md`.
+`spec_model_key` / `implement_model_key`.
+
+**Escalate-on-fail (shipped).** When a `STAGE_ROUTING` value is a list, `implement`
+auto-climbs the ladder: a **quality-only** gate rejection (tests failed / blocking review
+finding, `risk_tier` low, `sanitise` ok) re-runs implement→review→gate on the next model up,
+bounded by `min(ladder_length-1, MAX_ESCALATION_ATTEMPTS)` (default 2). **Hard gates are never
+climbed** — a `sanitise` failure (security) or any structural high-risk reason goes straight
+to `needs-human`. A retry updates the existing impl PR (no duplicate). Escalation is attributed
+in Langfuse (`escalation_tier`, `escalated_recovered`). A scalar route → no ladder → single-shot,
+exactly as before. The "cost ceiling" is bounded attempts, not a live $-cap (Goose reports cost
+to Langfuse asynchronously). See `docs/solutions/design-decisions/multi-model-routing.md`.
 
 ## Working memory
 

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -43,6 +43,11 @@ clears its quality bar (cheap models for spec authoring, capable models only whe
 demands it). Prefer flat-rate subscription models over metered API; reserve premium metered
 models for capability-critical stages. Per-model cost is tracked in Langfuse.
 
+The pipeline self-recovers within hard safety gates: a build that fails on a cheap model for a
+quality reason (failing tests / blocking review) auto-escalates up a model ladder before asking
+a human — but a security (`sanitise`) or high-risk failure always goes straight to a human,
+never brute-forced on a bigger model.
+
 ### Public/private boundary
 You write to a public repo. **NEVER** write:
 - API keys, tokens, credentials, secrets of any kind

--- a/docs/plans/2026-06-09-002-feat-escalate-on-fail-ladder-plan.md
+++ b/docs/plans/2026-06-09-002-feat-escalate-on-fail-ladder-plan.md
@@ -1,0 +1,413 @@
+---
+title: "feat: Escalate-on-fail model ladder (price/perf #3, multi-model routing Phase 2)"
+status: active
+date: 2026-06-09
+type: feat
+origin: docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md (Deferred → Phase 2)
+---
+
+# feat: Escalate-on-fail model ladder (price/perf #3)
+
+## Summary
+
+The merged static routing layer (#1580) picks one model per stage. This plan makes the
+**implement** stage *dynamic*: when the gate rejects a build for a **quality** reason
+(tests failed / blocking review finding), the graph automatically re-runs
+implement→review→gate on the **next model up an ordered ladder** — cheap → capable →
+premium — instead of immediately labeling `needs-human`. It keeps climbing until the build
+passes the gate or the ladder is exhausted.
+
+Autonomy lives **inside** the safety gates, never around them. A `sanitise` failure
+(security) or any structural high-risk reason (too many files, high-risk paths, net-new
+network call) goes **straight** to `needs-human` — the ladder is never climbed to brute-force
+a security or scope violation past the gate.
+
+Fail-safe-off: a stage with no ladder configured (single model) behaves exactly as today —
+one attempt, escalate-to-human on failure. The "cost ceiling" is bounded attempts (ladder
+length + a hard max-attempts guard), not a live dollar cap — see Risks for why in-process
+$-metering isn't available.
+
+---
+
+## Problem Frame
+
+Today the build graph is linear (`graph/build.py` `CompiledGraph.invoke`):
+`triage → spec → spec_pr → implement → review → gate`, and `gate` is terminal — `merge` or
+`add needs-human`. A weak cheap model that fails tests on `implement` dead-ends at
+`needs-human` even when a stronger model would have produced a mergeable diff. That wastes
+the whole spec+implement investment and dumps work on a human for a *recoverable* quality
+miss.
+
+Two facts make a clean retry loop possible:
+
+- **`decide_gate` is already pure** and `gate_node(..., apply_side_effects=False)` exists —
+  the gate decision can be computed without committing the `needs-human`/`merge` side-effect,
+  so intermediate ladder attempts don't pollute labels.
+- **`classify_risk` already separates** structural/security reasons (high tier) from the
+  quality signals (`tests_passed`, `review_findings`) — so "retryable quality failure" vs
+  "hard-gate failure" is a classification over data the gate already has.
+
+**In scope:** gate reason-classification (retryable vs hard-gate); a per-stage ordered model
+ladder in routing; tier-indexed model resolution; a bounded escalation loop in `invoke`;
+impl-PR update (not duplicate) on retry; escalation attribution in scoring.
+
+**Out of scope:** live token/dollar budget accounting (not available in-process — see Risks);
+escalation on `spec` or `triage` (only `implement` retries); changing the funnel topology or
+the gate's *merge* criteria; re-speccing (retry reuses the same spec).
+
+---
+
+## Requirements
+
+- **R1** A quality-only gate rejection on `implement` triggers an automatic re-run on the
+  next ladder model, up to ladder exhaustion.
+- **R2** Hard-gate rejections — `sanitise failed` OR any structural high-risk reason — go
+  straight to `needs-human`, never climbing the ladder.
+- **R3** The loop is bounded: at most `min(ladder_length-1, MAX_ESCALATION_ATTEMPTS)` retries
+  per issue; the counter lives in run state and cannot loop forever.
+- **R4** Fail-safe-off: a stage with a single-model route (or no ladder) behaves exactly as
+  today — one attempt, then escalate-to-human. Zero-config unchanged.
+- **R5** A retry updates the **existing** impl PR/branch, never opens a duplicate PR per tier.
+- **R6** Escalation is observable: which tiers were tried, the terminal tier, and the terminal
+  outcome are recorded in Langfuse so escalation rate and tier-resolution can be charted.
+- **R7** Fail-closed config: a malformed ladder, a ladder key absent from the registry, or a
+  tier index out of range raises — never silently routes to the wrong/no model.
+
+---
+
+## High-Level Technical Design
+
+The escalation loop wraps the existing `implement → review → gate` segment. The gate is
+evaluated **without** side-effects on each pass; side-effects apply once, on the terminal
+decision.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Implement: tier = 0
+    Implement --> Review
+    Review --> GateEval: gate(apply_side_effects=false)
+    GateEval --> Merge: decision = merge
+    GateEval --> HardEscalate: hard-gate reason\n(sanitise / structural high-risk)
+    GateEval --> Retryable: quality-only reason\n(tests failed / blocking finding)
+    Retryable --> NextTier: tier+1 ≤ ladder_top\nAND attempts < MAX
+    Retryable --> HumanEscalate: ladder exhausted\nOR attempts == MAX
+    NextTier --> Implement: tier = tier+1\n(update same PR)
+    Merge --> ApplyMerge: apply_gate_side_effects
+    HardEscalate --> ApplyHuman: add needs-human
+    HumanEscalate --> ApplyHuman: add needs-human
+    ApplyMerge --> [*]
+    ApplyHuman --> [*]
+```
+
+**Reason classification** (directional, not final signature):
+
+```
+retryable_quality(decision) :=
+    decision == escalate
+    AND risk_tier == "low"            # no structural high-risk reason fired
+    AND sanitise_ok == true           # security gate never brute-forced
+    AND reasons ⊆ { "tests failed", "blocking review finding" }
+```
+
+If any reason falls outside that set, the rejection is a **hard gate** → human.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Ladder as an ordered list in `STAGE_ROUTING`.** A stage's route value may be a
+  string (single model, escalation off) OR an ordered list of registry keys
+  (`["impl-cheap","impl-capable","impl-premium"]`). Tier index selects the entry. This keeps
+  one config surface, makes "off" the natural default (scalar), and lets the operator define
+  the climb. Rejected: a separate `ESCALATION_LADDER` env (two sources of truth) and a
+  per-profile `escalate_to` pointer (can't express a >2-rung ladder cleanly).
+- **KTD2 — Loop in `invoke`, gate evaluated side-effect-free.** The retry lives in the
+  hand-rolled `CompiledGraph.invoke` (no LangGraph StateGraph today), using the existing
+  `apply_side_effects=False` seam. Intermediate gate passes compute a decision only; the
+  terminal pass applies `merge`/`needs-human` once. Avoids label churn and double PRs.
+- **KTD3 — Retry classification reads gate output, doesn't re-derive.** `decide_gate` gains a
+  `retryable` flag computed from `risk_tier`/`sanitise_ok`/`reasons`. The loop branches on
+  that flag — it never re-inspects the diff. Single source of truth for "is this recoverable".
+- **KTD4 — Bounded by ladder length AND a hard guard.** `MAX_ESCALATION_ATTEMPTS` (config,
+  small default) caps retries even if a ladder is long; the loop also stops at ladder top.
+  This *is* the cost ceiling (see Risks for why a $-cap isn't feasible in-process).
+- **KTD5 — Retry updates the same impl branch/PR.** The second+ implement pass pushes the new
+  diff to the existing `bot/impl-<n>` branch and reuses the open PR, rather than creating a
+  per-tier PR. The reviewer/merge lane sees one PR that improved.
+- **KTD6 — Fail-safe-off default.** No ladder configured → single-entry ladder → zero retries
+  → today's behavior. The feature cannot change behavior for an un-migrated deploy.
+
+---
+
+## Implementation Units
+
+### U1. Classify gate rejections as retryable-quality vs hard-gate
+
+**Goal:** `decide_gate` labels each `escalate` decision as retryable (quality-only) or not,
+so the loop can branch without re-inspecting the diff.
+
+**Requirements:** R1, R2, KTD3
+
+**Dependencies:** none
+
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/nodes/gate.py` (modify — add `retryable: bool` to `GateDecision`; compute it)
+- `pipeline/tests/test_gate.py` (modify)
+
+**Approach:** Extend `GateDecision` with `retryable`. Compute `retryable = (decision ==
+"escalate") and (risk_tier == "low") and sanitise_ok and reasons ⊆ {"tests failed","blocking
+review finding"}`. The structural reasons come from `classify_risk` (already folded into
+`reasons` when `risk.high`); `risk_tier == "low"` is the clean discriminator since any risk
+reason sets tier `high`. `gate_node` surfaces `retryable` into state (`state["retryable"]`).
+`merge` decisions are never retryable.
+
+**Patterns to follow:** existing `GateDecision` dataclass + `decide_gate` reason assembly in
+`gate.py`.
+
+**Test scenarios:**
+- tests failed only, low risk, sanitise ok → escalate, `retryable=True`.
+- blocking review finding only, low risk, sanitise ok → `retryable=True`.
+- tests failed AND sanitise failed → escalate, `retryable=False` (security gate).
+- tests failed AND high-risk path present (risk_tier high) → `retryable=False`.
+- net-new network call (risk high) with tests passing → escalate, `retryable=False`.
+- clean build → merge, `retryable=False`.
+- `retryable` is surfaced into state by `gate_node`.
+
+### U2. Ordered model ladder in routing config
+
+**Goal:** Let a stage route to an ordered list of model keys; resolve a profile by tier index;
+keep scalar routes working unchanged.
+
+**Requirements:** R4, R7, KTD1, KTD6
+
+**Dependencies:** none
+
+**Files:**
+- `pipeline/wgmesh_pipeline/models.py` (modify — accept list route values; `resolve_profile_for_tier`; `ladder_length_for`)
+- `pipeline/wgmesh_pipeline/config.py` (modify — `MAX_ESCALATION_ATTEMPTS` parse)
+- `pipeline/tests/test_models.py` (modify)
+- `pipeline/tests/test_config.py` (modify)
+
+**Approach:** `parse_stage_routing` accepts a value that is a string OR a non-empty list of
+strings; normalize internally to a list (scalar → 1-element ladder). Add
+`resolve_profile_for_tier(registry, routing, stage, tier)` — fail-closed on out-of-range tier,
+missing key, or unroutable stage — and `ladder_length_for(routing, stage)`. Existing
+`resolve_profile` keeps working as `tier=0`. `MAX_ESCALATION_ATTEMPTS` parses as a positive
+int (small default, e.g. 2), bounding retries regardless of ladder length.
+
+**Patterns to follow:** existing `parse_stage_routing`/`resolve_profile` fail-closed style in
+`models.py`; `_get_int` in `config.py`.
+
+**Test scenarios:**
+- list route `["a","b","c"]` → `ladder_length_for == 3`; `resolve_profile_for_tier(...,1)` → key `b`.
+- scalar route `"a"` → ladder length 1; tier 0 → `a`; tier 1 → raises (out of range).
+- list with a key absent from registry → raises naming the key.
+- empty list route → raises (invalid).
+- `resolve_profile(...)` (no tier) still resolves tier 0 unchanged (back-compat).
+- `MAX_ESCALATION_ATTEMPTS` unset → default; invalid/zero → raises.
+
+### U3. Tier-aware implement execution
+
+**Goal:** `implement` runs the model for the current escalation tier.
+
+**Requirements:** R1, KTD2
+
+**Dependencies:** U2
+
+**Files:**
+- `pipeline/wgmesh_pipeline/goose/runner.py` (modify — `run_recipe(..., tier=0)`; resolve by tier)
+- `pipeline/wgmesh_pipeline/graph/nodes/implement.py` (modify — read `state["escalation_tier"]`, pass it; re-run clears stale diff)
+- `pipeline/tests/test_runner_routing.py` (modify)
+
+**Approach:** `run_recipe` takes `tier: int = 0`; `_resolve_profile` becomes
+`_resolve_profile(stage, tier)` using `resolve_profile_for_tier`. `implement_node` reads
+`state.get("escalation_tier", 0)` and passes it; on a retry pass it must clear the prior
+`diff`/`changed_files` so it actually re-runs Goose (today it short-circuits when `diff` is
+present). `model_key` on the result still flows to attribution (U6).
+
+**Patterns to follow:** the stage-threading from the merged routing work (`run_recipe(stage=...)`).
+
+**Test scenarios:**
+- `run_recipe(stage="implement", tier=2)` resolves the 3rd ladder model (assert via captured env).
+- tier defaults to 0 when unspecified (back-compat).
+- `implement_node` with `escalation_tier=1` requests tier 1.
+- retry pass with a stale `diff` in state re-runs Goose rather than short-circuiting.
+
+### U4. Bounded escalation loop in the graph
+
+**Goal:** Wrap implement→review→gate in a bounded climb that retries quality failures on the
+next tier and applies side-effects only once, terminally.
+
+**Requirements:** R1, R2, R3, R4, KTD2, KTD4
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/build.py` (modify — escalation loop in `invoke`)
+- `pipeline/wgmesh_pipeline/graph/state.py` (modify — `escalation_tier`, `escalation_attempts`, `escalation_history`)
+- `pipeline/tests/test_build_escalation.py` (create)
+
+**Approach:** Replace the linear `implement → review → gate` tail with a loop. Each pass runs
+implement(tier)→review→`gate(apply_side_effects=False)`. Branch on the gate result:
+`merge` → break; `retryable AND tier+1 < ladder_length AND attempts < MAX` → bump tier,
+increment attempts, record the tier in `escalation_history`, loop; otherwise (hard-gate OR
+exhausted) → break. After the loop, apply side-effects once for the terminal decision
+(`apply_gate_side_effects`). State carries `escalation_tier`, `escalation_attempts`,
+`escalation_history`. `spec-only` mode and the `wont-do`/`needs-info` early-escalate path are
+untouched.
+
+**Execution note:** Start with a failing integration test that drives a fake runner returning
+fail-then-pass across tiers and asserts the loop climbs exactly once and merges.
+
+**Patterns to follow:** existing `CompiledGraph.invoke` sequencing and the
+`apply_side_effects` flag on `gate_node`.
+
+**Test scenarios:**
+- tier 0 fails tests, tier 1 passes → loop climbs once, terminal `merge`, side-effects applied
+  ONCE, `escalation_history == [0,1]`.
+- tier 0 fails, ladder length 1 → no retry, terminal `needs-human`.
+- tier 0 hard-gate (sanitise failed) → no retry even though tiers remain; `needs-human`.
+- ladder length 3 but `MAX_ESCALATION_ATTEMPTS=1` → at most one retry, then `needs-human`.
+- all tiers fail quality → exhausted → `needs-human`, history records every tier.
+- no needs-human label is applied on intermediate failing passes (side-effect-free gate).
+- `spec-only` mode never enters the loop.
+- clean tier-0 build → merge, no escalation, history `[0]`.
+
+### U5. Update the impl PR on retry instead of duplicating
+
+**Goal:** A retry pushes the improved diff to the existing impl branch/PR; no per-tier PR.
+
+**Requirements:** R5
+
+**Dependencies:** U4
+
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/nodes/implement.py` (modify — reuse existing `impl_pr`/branch on retry)
+- `pipeline/wgmesh_pipeline/github/client.py` (modify if needed — update-branch/PR-body affordance)
+- `pipeline/tests/test_implement_retry_pr.py` (create)
+
+**Approach:** `_ensure_impl_pr` already no-ops when `impl_pr` is set — good for not creating a
+second PR, but the *new diff* must reach the branch. On a retry pass, push the new diff to the
+existing `bot/impl-<n>` branch (force or new commit) and optionally update the PR body to note
+the escalated tier. Keep the single PR number in state. Verify the GitHub client exposes a
+branch-update path; if not, add a minimal one mirroring existing client methods.
+
+**Patterns to follow:** existing `_ensure_impl_pr` + `GitHubClient.create_pr`/`merge_pr` shapes.
+
+**Test scenarios:**
+- retry with `impl_pr` already set → no second `create_pr` call; branch receives the new diff.
+- PR body reflects the terminal tier (e.g. "escalated to impl-capable").
+- first-pass behavior (no prior `impl_pr`) unchanged — one PR created.
+- `Covers` the R5 no-duplicate-PR guarantee.
+
+### U6. Escalation attribution in scoring
+
+**Goal:** Record escalation history + terminal tier so Langfuse charts escalation rate and
+which tier resolves builds.
+
+**Requirements:** R6
+
+**Dependencies:** U4
+
+**Files:**
+- `pipeline/wgmesh_pipeline/scoring.py` (modify — tags/scores for escalation)
+- `pipeline/tests/test_scoring.py` (modify)
+
+**Approach:** Extend `_tags_from_state` / `_scores_from_state` to include
+`escalation_attempts`, terminal `escalation_tier`, and a boolean `escalated_recovered`
+(escalation happened AND terminal outcome merged). Builds on the `implement_model_key`
+attribution already shipped — now the tag reflects the *winning* tier's model.
+
+**Patterns to follow:** the per-model attribution tags added in the merged routing work
+(`spec_model_key`/`implement_model_key` in `scoring.py`).
+
+**Test scenarios:**
+- a run that climbed 0→1 and merged → `escalation_attempts=1`, `escalation_tier=1`,
+  `escalated_recovered=True`, `implement_model_key` = tier-1 model.
+- a run that exhausted the ladder and escalated to human → `escalated_recovered=False`.
+- a clean tier-0 merge → `escalation_attempts=0`, no recovery flag set true.
+
+### U7. Config defaults, docs, operating-prompt note
+
+**Goal:** Document the ladder config + the autonomy/safety boundary; provision the new env.
+
+**Requirements:** R4
+
+**Dependencies:** U1–U6
+
+**Files:**
+- `AGENTS.md` (modify — extend the Model routing section with the escalation ladder)
+- `company/system-prompt.md` (modify — one line: pipeline self-escalates quality failures within gates)
+- `.github/workflows/provision-pipeline-box.yml` (modify — `MAX_ESCALATION_ATTEMPTS` passthrough)
+- `docs/solutions/design-decisions/multi-model-routing.md` (modify — flip escalate-on-fail from "deferred" to "shipped", describe the ladder + hard-gate boundary)
+
+**Approach:** Document the list-form `STAGE_ROUTING`, `MAX_ESCALATION_ATTEMPTS`, the
+quality-only-retry rule, and the never-climb-on-security/structural boundary. State the cost
+ceiling honestly (bounded attempts, no live $-cap).
+
+**Test scenarios:** `Test expectation: none — docs/config only.`
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- **Live cost/token budget enforcement.** A real per-issue dollar cap needs in-process token
+  accounting the current Goose-subprocess boundary doesn't expose (see Risks). If wanted later:
+  parse Goose's usage output or read Langfuse synchronously before each climb — its own plan.
+- **Escalation on `spec`.** Only `implement` retries here. A weak spec could also be re-run on
+  a stronger model, but spec failures surface differently (no test signal) — separate work.
+- **Adaptive ladder selection.** Choosing the *starting* tier from issue difficulty (skip cheap
+  for known-hard issues) is a future optimization; this plan always starts at tier 0.
+
+### Outside this product's identity
+
+- **Model-ranking / eval harness.** Deciding ladder *membership/order* stays a human decision
+  fed by the Langfuse escalation+cost data, not an automated ranker.
+
+---
+
+## Risks & Dependencies
+
+- **No in-process dollar ceiling — the honest limitation.** Goose runs as a subprocess and
+  reports token cost to Langfuse *asynchronously*; the runner gets no synchronous usage number
+  back. So a true "$X per issue then stop" cap is not implementable without new plumbing. The
+  enforced ceiling is **bounded attempts** (`MAX_ESCALATION_ATTEMPTS` + ladder length) plus
+  **quality-only triggering**. This is a deliberate, documented bound — not an oversight.
+- **Premium-tier spend is operator-gated by config.** Escalation only reaches a premium model
+  if the operator put it on the ladder. With the routing defaults (cheap subscription tiers),
+  the ladder can stay entirely flat-rate; a metered top rung is an explicit opt-in. Pairs with
+  the operator LLM budget posture (premium reserved for safety-critical work).
+- **Retry latency.** Each climb re-runs implement (a full Goose invocation, up to the 1800s
+  timeout) + review. A 3-rung ladder triples worst-case wall-clock for a failing issue. The
+  `MAX_ESCALATION_ATTEMPTS` guard bounds this.
+- **PR-update correctness (U5).** Pushing a new diff to an existing branch must not orphan the
+  prior commit or confuse the reviewer lane. Verify the branch-update path against the existing
+  bot-review-merge flow.
+
+### Execution-time unknowns (resolve during implementation)
+
+- Whether `GitHubClient` already exposes a branch-update/force-push affordance or U5 must add one.
+- Exact default for `MAX_ESCALATION_ATTEMPTS` (proposed 2) — tune against observed ladder depth.
+- Whether `review_findings` `blocking` flags are populated today or need a producer before
+  "blocking review finding" is a live retry trigger (may be latent until a review producer exists).
+
+---
+
+## Sources & Research
+
+Grounded entirely in local code read (internal refactor of the just-merged routing layer; no
+external research needed):
+
+- `pipeline/wgmesh_pipeline/graph/nodes/gate.py` — `decide_gate`/`GateDecision`,
+  `apply_side_effects` seam, reason assembly.
+- `pipeline/wgmesh_pipeline/risk.py` — `classify_risk` high-vs-low tiering (the structural/
+  security discriminator U1 keys on).
+- `pipeline/wgmesh_pipeline/graph/build.py` — hand-rolled `CompiledGraph.invoke` (loop site).
+- `pipeline/wgmesh_pipeline/graph/state.py` — `GraphState` TypedDict (`total=False`).
+- `pipeline/wgmesh_pipeline/models.py`, `goose/runner.py`, `graph/nodes/implement.py` — the
+  merged routing layer this builds on (#1580).
+- `pipeline/wgmesh_pipeline/poller.py`, `scoring.py` — escalate/score side-effect path.
+- Predecessor plan: `docs/plans/2026-06-09-001-feat-multi-model-routing-plan.md` (Phase 2
+  deferral); learning doc `docs/solutions/design-decisions/multi-model-routing.md`.

--- a/docs/solutions/design-decisions/multi-model-routing.md
+++ b/docs/solutions/design-decisions/multi-model-routing.md
@@ -55,12 +55,29 @@ mechanisms:
   resource attributes onto its OTLP spans is an unverified execution-time detail — do not
   rely on it for attribution; the scoring path is the source of truth.
 
+## Escalate-on-fail ladder (Phase 2 — shipped, price/perf #3)
+
+`STAGE_ROUTING` values may be a **list** of registry keys (cheap→capable→premium). When a
+gate rejection is **quality-only** (tests failed / blocking review finding, `risk_tier` low,
+`sanitise` ok), the graph re-runs implement→review→gate on the next model up the ladder,
+bounded by `min(ladder_length-1, MAX_ESCALATION_ATTEMPTS)` (default 2). The gate is evaluated
+side-effect-free (`apply_side_effects=False`) on intermediate passes; the merge/`needs-human`
+side-effect applies once, terminally.
+
+**Autonomy lives inside the safety gates.** A `sanitise` failure (security) or any structural
+high-risk reason (`risk_tier` high) goes **straight** to `needs-human` — never climbed. A
+retry updates the existing impl PR (no per-tier duplicate). Escalation is attributed in
+Langfuse (`escalation_tier`, `escalated_recovered`) so escalation rate and tier-resolution
+chart out. A scalar route → single-shot, exactly as before (fail-safe-off).
+
+**Cost ceiling is bounded attempts, not a live $-cap.** Goose runs as a subprocess and reports
+token cost to Langfuse *asynchronously* — the runner gets no synchronous usage number — so a
+true per-issue dollar cap isn't implementable without new plumbing. The enforced bound is
+attempt-count + quality-only triggering. Plan:
+`docs/plans/2026-06-09-002-feat-escalate-on-fail-ladder-plan.md`.
+
 ## Deferred
 
-- **Escalate-on-fail (Phase 2).** When the gate escalates for a *quality* reason (tests
-  failed / blocking finding) rather than a structural high-risk one, re-run the stage once
-  on a stronger model before labeling `needs-human`. Needs a retry budget, loop-guard, and
-  cost ceiling — its own plan. The static map here is the precondition.
 - **Native non-Anthropic providers.** Only `native` Anthropic and `openrouter` are wired;
   any other native provider raises with "route it via OpenRouter". Add native support per
   provider when a subscription's own API proves worth the credential.

--- a/pipeline/tests/test_build_escalation.py
+++ b/pipeline/tests/test_build_escalation.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
+from wgmesh_pipeline.graph.build import CompiledGraph
+from wgmesh_pipeline.graph.nodes.gate import gate_node
+
+
+def _cfg(
+    *,
+    mode: str = "shadow",
+    ladder: tuple[str, ...] = ("cheap", "capable"),
+    max_attempts: int = 2,
+) -> Config:
+    return Config(
+        target_repo="atvirokodosprendimai/wgmesh",
+        mode=mode,
+        max_files=3,
+        stage_routing={"implement": ladder},
+        max_escalation_attempts=max_attempts,
+    )
+
+
+def _graph(config: Config, *, implement, review) -> CompiledGraph:
+    return CompiledGraph(
+        config=config,
+        triage=_node("triage", classification="fix"),
+        spec=_node("spec", spec_path="specs/issue-1-spec.md"),
+        spec_pr=_node("spec_pr", spec_pr=101),
+        implement=implement,
+        review=review,
+        gate=gate_node,
+    )
+
+
+def _node(name: str, **updates):
+    def run(state):
+        next_state = dict(state)
+        next_state.setdefault("visited", []).append(name)
+        next_state.update(updates)
+        return next_state
+
+    return run
+
+
+def _implement():
+    def run(state):
+        next_state = dict(state)
+        tier = int(next_state.get("escalation_tier", 0))
+        next_state.setdefault("visited", []).append("implement")
+        next_state["diff"] = f"diff --git a/docs/tier-{tier}.md b/docs/tier-{tier}.md\n+docs\n"
+        next_state["changed_files"] = [f"docs/tier-{tier}.md"]
+        next_state["impl_pr"] = 123
+        return next_state
+
+    return run
+
+
+def _review_by_tier(results: dict[int, dict]):
+    def run(state):
+        next_state = dict(state)
+        tier = int(next_state.get("escalation_tier", 0))
+        next_state.setdefault("visited", []).append("review")
+        next_state.update(
+            {
+                "tests_passed": True,
+                "sanitise_ok": True,
+                "review_findings": [],
+                **results.get(tier, {}),
+            }
+        )
+        return next_state
+
+    return run
+
+
+def _state(client: GitHubClient | None = None):
+    return {
+        "issue": GitHubIssue(number=1, title="Fix docs", labels=("needs-triage",), state="open"),
+        "github": client,
+    }
+
+
+def test_tier_zero_fails_tests_tier_one_passes_merges_once() -> None:
+    client = GitHubClient(_cfg())
+    graph = _graph(
+        _cfg(),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": False}, 1: {"tests_passed": True}}),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "merge"
+    assert result["escalation_history"] == [0, 1]
+    assert result["escalation_attempts"] == 1
+    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+
+
+def test_tier_zero_fails_ladder_length_one_does_not_retry() -> None:
+    client = GitHubClient(_cfg(ladder=("cheap",)))
+    graph = _graph(
+        _cfg(ladder=("cheap",)),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": False}}),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "escalate"
+    assert result["escalation_history"] == [0]
+    assert [record.operation for record in client.dry_run_records] == ["add_label"]
+
+
+def test_hard_gate_sanitise_failure_does_not_retry() -> None:
+    client = GitHubClient(_cfg(ladder=("cheap", "capable", "premium")))
+    graph = _graph(
+        _cfg(ladder=("cheap", "capable", "premium")),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": False, "sanitise_ok": False}}),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "escalate"
+    assert result["retryable"] is False
+    assert result["escalation_history"] == [0]
+    assert [record.operation for record in client.dry_run_records] == ["add_label"]
+
+
+def test_max_escalation_attempts_caps_retries_before_ladder_top() -> None:
+    client = GitHubClient(_cfg(ladder=("cheap", "capable", "premium"), max_attempts=1))
+    graph = _graph(
+        _cfg(ladder=("cheap", "capable", "premium"), max_attempts=1),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": False}, 1: {"tests_passed": False}}),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "escalate"
+    assert result["escalation_history"] == [0, 1]
+    assert result["escalation_attempts"] == 1
+    assert [record.operation for record in client.dry_run_records] == ["add_label"]
+
+
+def test_all_tiers_fail_quality_exhausts_to_human() -> None:
+    client = GitHubClient(_cfg(ladder=("cheap", "capable", "premium"), max_attempts=2))
+    graph = _graph(
+        _cfg(ladder=("cheap", "capable", "premium"), max_attempts=2),
+        implement=_implement(),
+        review=_review_by_tier(
+            {
+                0: {"tests_passed": False},
+                1: {"tests_passed": False},
+                2: {"tests_passed": False},
+            }
+        ),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "escalate"
+    assert result["escalation_history"] == [0, 1, 2]
+    assert [record.operation for record in client.dry_run_records] == ["add_label"]
+
+
+def test_no_needs_human_label_on_intermediate_failing_pass() -> None:
+    client = GitHubClient(_cfg())
+    graph = _graph(
+        _cfg(),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": False}, 1: {"tests_passed": True}}),
+    )
+
+    graph.invoke(_state(client))
+
+    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+
+
+def test_spec_only_mode_never_enters_escalation_loop() -> None:
+    calls: list[str] = []
+
+    def implement(state):
+        calls.append("implement")
+        return dict(state)
+
+    config = replace(_cfg(mode="spec-only"), mode="spec-only")
+    graph = _graph(config, implement=implement, review=_review_by_tier({}))
+
+    result = graph.invoke(_state(GitHubClient(config)))
+
+    assert calls == []
+    assert result["visited"] == ["triage", "spec", "spec_pr"]
+    assert "escalation_history" not in result
+
+
+def test_clean_tier_zero_build_merges_without_escalation() -> None:
+    client = GitHubClient(_cfg())
+    graph = _graph(
+        _cfg(),
+        implement=_implement(),
+        review=_review_by_tier({0: {"tests_passed": True}}),
+    )
+
+    result = graph.invoke(_state(client))
+
+    assert result["decision"] == "merge"
+    assert result["escalation_history"] == [0]
+    assert result["escalation_attempts"] == 0
+    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -27,6 +27,7 @@ def test_full_env_loads_frozen_config_with_shadow_default() -> None:
     assert cfg.repo == "wgmesh"
     assert cfg.poll_interval_seconds == 60
     assert cfg.max_files == 5
+    assert cfg.max_escalation_attempts == 2
     assert cfg.database_mode == "local"
     assert cfg.repo_path == "/opt/wgmesh-checkout"
     assert Path(cfg.recipes_dir).name == "recipes"
@@ -106,6 +107,7 @@ def test_zero_config_synthesizes_default_profile_matching_goose_fields() -> None
     assert default.credential_env == "ZAI_API_KEY"
     assert default.host == cfg.anthropic_host
     assert cfg.stage_routing == {}
+    assert cfg.max_escalation_attempts == 2
 
 
 def test_explicit_registry_and_routing_parse_into_config() -> None:
@@ -123,9 +125,32 @@ def test_explicit_registry_and_routing_parse_into_config() -> None:
         }
     )
     assert set(cfg.model_registry) == {"cheap", "capable"}
-    assert cfg.stage_routing == {"spec": "cheap", "implement": "capable"}
+    assert cfg.stage_routing == {"spec": ("cheap",), "implement": ("capable",)}
     # explicit registry is NOT overwritten by the zero-config default
     assert "default" not in cfg.model_registry
+
+
+def test_max_escalation_attempts_unset_defaults_and_invalid_values_raise() -> None:
+    cfg = load_config({"TARGET_REPO": "atvirokodosprendimai/wgmesh", "DATABASE_MODE": "local"})
+    assert cfg.max_escalation_attempts == 2
+
+    with pytest.raises(ValueError, match="MAX_ESCALATION_ATTEMPTS must be an integer"):
+        load_config(
+            {
+                "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+                "DATABASE_MODE": "local",
+                "MAX_ESCALATION_ATTEMPTS": "nope",
+            }
+        )
+
+    with pytest.raises(ValueError, match="MAX_ESCALATION_ATTEMPTS must be positive"):
+        load_config(
+            {
+                "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+                "DATABASE_MODE": "local",
+                "MAX_ESCALATION_ATTEMPTS": "0",
+            }
+        )
 
 
 def test_malformed_registry_env_fails_loud() -> None:

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -26,6 +26,84 @@ def test_gate_merges_low_risk_green_clean_review() -> None:
 
     assert decision.decision == "merge"
     assert decision.risk_tier == "low"
+    assert decision.retryable is False
+
+
+def test_gate_tests_failed_only_low_risk_is_retryable() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=False,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert decision.reasons == ("tests failed",)
+    assert decision.retryable is True
+
+
+def test_gate_blocking_review_finding_only_low_risk_is_retryable() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[{"blocking": True, "message": "missing test"}],
+    )
+
+    assert decision.decision == "escalate"
+    assert decision.reasons == ("blocking review finding",)
+    assert decision.retryable is True
+
+
+def test_gate_tests_failed_with_sanitise_failure_is_not_retryable() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=False,
+        sanitise_ok=False,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert set(decision.reasons) == {"tests failed", "sanitise failed"}
+    assert decision.retryable is False
+
+
+def test_gate_tests_failed_with_high_risk_path_is_not_retryable() -> None:
+    decision = decide_gate(
+        changed_files=["internal/auth/login.go"],
+        diff="+return nil\n",
+        max_files=3,
+        tests_passed=False,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert decision.risk_tier == "high"
+    assert "tests failed" in decision.reasons
+    assert decision.retryable is False
+
+
+def test_gate_net_new_network_call_with_passing_tests_is_not_retryable() -> None:
+    decision = decide_gate(
+        changed_files=["internal/client.go"],
+        diff="+resp, err := http.Get(url)\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "escalate"
+    assert decision.risk_tier == "high"
+    assert "net-new outbound network call" in decision.reasons
+    assert decision.retryable is False
 
 
 def test_gate_escalates_high_risk_path_even_when_green() -> None:
@@ -40,6 +118,7 @@ def test_gate_escalates_high_risk_path_even_when_green() -> None:
 
     assert decision.decision == "escalate"
     assert decision.risk_tier == "high"
+    assert decision.retryable is False
 
 
 def test_implement_derives_changed_files_from_existing_diff_for_gate() -> None:
@@ -123,6 +202,7 @@ def test_review_failed_verification_escalates_at_gate(monkeypatch) -> None:
     assert reviewed["tests_passed"] is False
     assert decision.decision == "escalate"
     assert "tests failed" in decision.reasons
+    assert decision.retryable is True
 
 
 def test_gate_escalates_blocking_review_finding() -> None:
@@ -137,6 +217,7 @@ def test_gate_escalates_blocking_review_finding() -> None:
 
     assert decision.decision == "escalate"
     assert "blocking review finding" in decision.reasons
+    assert decision.retryable is True
 
 
 def test_gate_escalates_sanitise_failure() -> None:
@@ -151,6 +232,25 @@ def test_gate_escalates_sanitise_failure() -> None:
 
     assert decision.decision == "escalate"
     assert "sanitise failed" in decision.reasons
+    assert decision.retryable is False
+
+
+def test_gate_node_surfaces_retryable_in_state() -> None:
+    result = gate_node(
+        {
+            "issue": GitHubIssue(number=10, title="Fix docs", labels=("needs-triage",), state="open"),
+            "diff": "+docs\n",
+            "changed_files": ["docs/readme.md"],
+            "tests_passed": False,
+            "sanitise_ok": True,
+            "review_findings": [],
+        },
+        max_files=3,
+        apply_side_effects=False,
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["retryable"] is True
 
 
 def test_graph_wont_do_routes_to_escalate_and_skips_spec_implement() -> None:

--- a/pipeline/tests/test_implement_retry_pr.py
+++ b/pipeline/tests/test_implement_retry_pr.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+
+
+class _Issue:
+    def __init__(self, number: int) -> None:
+        self.number = number
+        self.title = "t"
+
+
+class _RecordingClient:
+    """Records create_pr / update_pr_body calls so the test can assert R5:
+    a retry updates the existing PR, never creates a duplicate."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+
+    def create_pr(self, *, title, head, base, body) -> dict[str, Any]:
+        self.create_calls.append({"title": title, "head": head, "base": base, "body": body})
+        return {"number": 4242}
+
+    def update_pr_body(self, pr_number: int, body: str) -> dict[str, Any]:
+        self.update_calls.append({"pr_number": pr_number, "body": body})
+        return {"number": pr_number}
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.tiers: list[int] = []
+
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
+        self.tiers.append(tier)
+        out = Path(workdir) / expected_output
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text("diff --git a/x.go b/x.go\n+++ b/x.go\n+changed\n")
+
+        class _R:
+            ok = True
+            output_path = out
+            model_key = f"impl-tier-{tier}"
+            error = None
+
+        return _R()
+
+
+def _base_state(client, runner, tmp_path, *, tier):
+    return {
+        "issue": _Issue(77),
+        "github": client,
+        "goose_runner": runner,
+        "repo_path": tmp_path,
+        "spec_path": "specs/issue-77-spec.md",
+        "escalation_tier": tier,
+    }
+
+
+def test_first_pass_creates_one_pr_no_update(tmp_path) -> None:
+    client = _RecordingClient()
+    runner = _FakeRunner()
+    out = implement_node(_base_state(client, runner, tmp_path, tier=0))
+    assert len(client.create_calls) == 1
+    assert client.update_calls == []
+    assert out["impl_pr"] == 4242
+
+
+def test_retry_updates_existing_pr_no_duplicate(tmp_path) -> None:
+    client = _RecordingClient()
+    runner = _FakeRunner()
+    # simulate a retry: PR already exists, tier bumped to 1
+    state = _base_state(client, runner, tmp_path, tier=1)
+    state["impl_pr"] = 4242
+    out = implement_node(state)
+    # R5: no second PR created
+    assert client.create_calls == []
+    # PR body updated, noting the escalated tier + model
+    assert len(client.update_calls) == 1
+    assert client.update_calls[0]["pr_number"] == 4242
+    assert "tier 1" in client.update_calls[0]["body"]
+    assert "impl-tier-1" in client.update_calls[0]["body"]
+    assert out["impl_pr"] == 4242
+
+
+def test_retry_reruns_goose_even_with_stale_diff(tmp_path) -> None:
+    client = _RecordingClient()
+    runner = _FakeRunner()
+    state = _base_state(client, runner, tmp_path, tier=2)
+    state["impl_pr"] = 4242
+    state["diff"] = "stale\n"  # must NOT short-circuit on a retry pass
+    implement_node(state)
+    assert runner.tiers == [2]  # Goose re-ran at tier 2

--- a/pipeline/tests/test_models.py
+++ b/pipeline/tests/test_models.py
@@ -5,9 +5,11 @@ import pytest
 from wgmesh_pipeline.models import (
     ModelProfile,
     credential_for,
+    ladder_length_for,
     parse_registry,
     parse_stage_routing,
     resolve_profile,
+    resolve_profile_for_tier,
 )
 
 
@@ -32,7 +34,62 @@ def test_parse_registry_two_profiles() -> None:
 
 def test_parse_stage_routing_maps_stage_to_key() -> None:
     routing = parse_stage_routing('{"spec": "spec-cheap", "implement": "impl-capable"}')
-    assert routing == {"spec": "spec-cheap", "implement": "impl-capable"}
+    assert routing == {"spec": ("spec-cheap",), "implement": ("impl-capable",)}
+
+
+def test_list_route_resolves_requested_tier() -> None:
+    registry = {
+        key: ModelProfile(
+            key=key,
+            provider="anthropic",
+            model=f"model-{key}",
+            billing="native",
+            credential_env="ZAI_API_KEY",
+        )
+        for key in ("a", "b", "c")
+    }
+    routing = parse_stage_routing('{"implement": ["a", "b", "c"]}')
+
+    assert ladder_length_for(routing, "implement") == 3
+    assert resolve_profile_for_tier(registry, routing, "implement", 1).key == "b"
+
+
+def test_scalar_route_is_single_entry_ladder() -> None:
+    registry = {
+        "a": ModelProfile(
+            key="a",
+            provider="anthropic",
+            model="model-a",
+            billing="native",
+            credential_env="ZAI_API_KEY",
+        )
+    }
+    routing = parse_stage_routing('{"implement": "a"}')
+
+    assert ladder_length_for(routing, "implement") == 1
+    assert resolve_profile_for_tier(registry, routing, "implement", 0).key == "a"
+    with pytest.raises(ValueError, match="tier 1 is out of range"):
+        resolve_profile_for_tier(registry, routing, "implement", 1)
+
+
+def test_ladder_route_to_missing_key_raises() -> None:
+    registry = {
+        "a": ModelProfile(
+            key="a",
+            provider="anthropic",
+            model="model-a",
+            billing="native",
+            credential_env="ZAI_API_KEY",
+        )
+    }
+    routing = parse_stage_routing('{"implement": ["a", "missing"]}')
+    with pytest.raises(ValueError, match="model key 'missing'"):
+        resolve_profile_for_tier(registry, routing, "implement", 1)
+
+
+def test_empty_list_route_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty route"):
+        parse_stage_routing('{"implement": []}')
 
 
 def test_resolve_profile_by_stage() -> None:

--- a/pipeline/tests/test_runner_routing.py
+++ b/pipeline/tests/test_runner_routing.py
@@ -8,12 +8,16 @@ import pytest
 
 from wgmesh_pipeline.config import load_config
 from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+from wgmesh_pipeline.github.client import GitHubIssue
 
 
 _REGISTRY = (
     '{"cheap": {"provider": "anthropic", "model": "GLM-4.7", "billing": "native",'
     ' "credential_env": "ZAI_API_KEY", "host": "https://api.z.ai/api/anthropic"},'
     ' "capable": {"provider": "openrouter", "model": "deepseek/deepseek-chat",'
+    ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"},'
+    ' "premium": {"provider": "openrouter", "model": "openai/gpt-5",'
     ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}}'
 )
 
@@ -57,6 +61,17 @@ def _run(config, stage: str, tmp_path, calls):
         params={"spec_file": "s.md"},
         expected_output="out.txt",
         stage=stage,
+    )
+
+
+def _run_tier(config, stage: str, tier: int, tmp_path, calls):
+    return GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
+        recipe="r.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "s.md"},
+        expected_output="out.txt",
+        stage=stage,
+        tier=tier,
     )
 
 
@@ -131,3 +146,85 @@ def test_unmapped_stage_no_default_raises(tmp_path, monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
     with pytest.raises(ValueError, match="no model route for stage 'implement'"):
         _run(config, "implement", tmp_path, calls)
+
+
+def test_run_recipe_resolves_third_ladder_model_for_tier_two(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _routed_config('{"implement": ["cheap", "capable", "premium"]}', monkeypatch)
+    result = _run_tier(config, "implement", 2, tmp_path, calls)
+
+    assert result.ok is True
+    env = calls[0]["env"]
+    assert env["GOOSE_MODEL"] == "openai/gpt-5"
+    assert env["OPENROUTER_API_KEY"] == "or-key"
+    assert result.model_key == "premium"
+
+
+def test_run_recipe_tier_defaults_to_zero(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _routed_config('{"implement": ["cheap", "capable"]}', monkeypatch)
+    result = _run(config, "implement", tmp_path, calls)
+
+    assert result.ok is True
+    assert calls[0]["env"]["GOOSE_MODEL"] == "GLM-4.7"
+    assert result.model_key == "cheap"
+
+
+def test_implement_node_passes_escalation_tier_to_runner(tmp_path) -> None:
+    runner = _RecordingGooseRunner(tmp_path, "diff --git a/docs/a.md b/docs/a.md\n+new\n")
+
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=9, title="Fix docs", labels=("needs-triage",), state="open"),
+            "spec_path": "specs/issue-9-spec.md",
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "escalation_tier": 1,
+        }
+    )
+
+    assert runner.calls[0]["tier"] == 1
+    assert result["diff"] == "diff --git a/docs/a.md b/docs/a.md\n+new\n"
+
+
+def test_implement_node_retry_with_stale_diff_reruns_goose(tmp_path) -> None:
+    runner = _RecordingGooseRunner(tmp_path, "diff --git a/docs/new.md b/docs/new.md\n+fresh\n")
+
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=10, title="Fix docs", labels=("needs-triage",), state="open"),
+            "spec_path": "specs/issue-10-spec.md",
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "escalation_tier": 1,
+            "diff": "diff --git a/docs/old.md b/docs/old.md\n+stale\n",
+            "changed_files": ["docs/old.md"],
+        }
+    )
+
+    assert len(runner.calls) == 1
+    assert result["diff"] == "diff --git a/docs/new.md b/docs/new.md\n+fresh\n"
+    assert result["changed_files"] == ["docs/new.md"]
+
+
+class _RecordingGooseRunner:
+    def __init__(self, tmp_path, diff: str):
+        self.tmp_path = tmp_path
+        self.diff = diff
+        self.calls: list[dict[str, Any]] = []
+
+    def run_recipe(self, **kwargs):
+        self.calls.append(kwargs)
+        output = self.tmp_path / kwargs["expected_output"]
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(self.diff)
+        return type(
+            "Result",
+            (),
+            {
+                "ok": True,
+                "output_path": output,
+                "error": None,
+                "model_key": f"tier-{kwargs['tier']}",
+            },
+        )()

--- a/pipeline/tests/test_scoring.py
+++ b/pipeline/tests/test_scoring.py
@@ -106,6 +106,59 @@ def test_score_run_records_merged_outcome() -> None:
     assert rec.calls[0]["tags"]["outcome"] == "merged"
 
 
+def test_score_run_records_escalation_recovery() -> None:
+    # R6: a run that climbed the ladder (0->1) and merged is attributed as recovered.
+    rec = _RecordingScorer()
+    state = {
+        "issue": _Issue(610),
+        "decision": "merge",
+        "risk_tier": "low",
+        "review_findings": [],
+        "escalation_attempts": 1,
+        "escalation_tier": 1,
+        "implement_model_key": "impl-capable",
+    }
+    scores = score_run(state, outcome="merged", scorer=rec)
+    assert scores["escalation_attempts"] == 1
+    assert scores["escalation_tier"] == 1
+    assert scores["escalated_recovered"] == 1
+    tags = rec.calls[0]["tags"]
+    assert tags["escalation_tier"] == "1"
+    assert tags["escalated_recovered"] == "true"
+    assert tags["implement_model_key"] == "impl-capable"
+
+
+def test_score_run_exhausted_ladder_not_recovered() -> None:
+    rec = _RecordingScorer()
+    state = {
+        "issue": _Issue(611),
+        "decision": "escalate",
+        "risk_tier": "low",
+        "review_findings": [],
+        "escalation_attempts": 2,
+        "escalation_tier": 2,
+    }
+    scores = score_run(state, outcome="escalated", scorer=rec)
+    assert scores["escalation_attempts"] == 2
+    assert scores["escalated_recovered"] == 0
+    assert rec.calls[0]["tags"]["escalated_recovered"] == "false"
+
+
+def test_score_run_clean_tier0_merge_no_escalation() -> None:
+    rec = _RecordingScorer()
+    state = {
+        "issue": _Issue(612),
+        "decision": "merge",
+        "risk_tier": "low",
+        "review_findings": [],
+        "escalation_attempts": 0,
+        "escalation_tier": 0,
+    }
+    scores = score_run(state, outcome="merged", scorer=rec)
+    assert scores["escalation_attempts"] == 0
+    assert scores["escalated_recovered"] == 0
+
+
 def test_score_run_tags_include_per_stage_model_keys() -> None:
     # R5: the model that handled each LLM stage is attributed in the score tags.
     rec = _RecordingScorer()

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -22,6 +22,7 @@ DEFAULT_REPO_PATH = "/opt/wgmesh-checkout"
 DEFAULT_RECIPES_DIR = str(Path(__file__).resolve().parents[1] / "recipes")
 DEFAULT_GOOSE_PROVIDER = "anthropic"
 DEFAULT_GOOSE_MODEL = "GLM-4.7"
+DEFAULT_MAX_ESCALATION_ATTEMPTS = 2
 
 
 @dataclass(frozen=True)
@@ -48,7 +49,8 @@ class Config:
     # Multi-model routing (price/perf #2). Empty by default → callers synthesize
     # a zero-config default profile from the goose_* fields above (R7).
     model_registry: Mapping[str, ModelProfile] = field(default_factory=dict)
-    stage_routing: Mapping[str, str] = field(default_factory=dict)
+    stage_routing: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    max_escalation_attempts: int = DEFAULT_MAX_ESCALATION_ATTEMPTS
 
     @property
     def owner(self) -> str:
@@ -118,6 +120,11 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         langfuse_secret_key=_get_nonempty(source, "LANGFUSE_SECRET_KEY"),
         model_registry=model_registry,
         stage_routing=stage_routing,
+        max_escalation_attempts=_get_int(
+            source,
+            "MAX_ESCALATION_ATTEMPTS",
+            DEFAULT_MAX_ESCALATION_ATTEMPTS,
+        ),
     )
 
 
@@ -131,7 +138,7 @@ def _build_routing(
     goose_provider: str,
     goose_model: str,
     anthropic_host: str,
-) -> tuple[Mapping[str, ModelProfile], Mapping[str, str]]:
+) -> tuple[Mapping[str, ModelProfile], Mapping[str, tuple[str, ...]]]:
     """Registry + stage map from env, with a zero-config fallback (R7).
 
     When MODEL_REGISTRY is unset, synthesize a single ``default`` profile from

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -141,6 +141,14 @@ class GitHubClient:
             spec_pr=spec_pr,
         )
 
+    def update_pr_body(self, pr_number: int, body: str) -> Any:
+        return self._write(
+            "update_pr",
+            "PATCH",
+            f"/repos/{self.config.owner}/{self.config.repo}/pulls/{pr_number}",
+            payload={"body": body},
+        )
+
     def merge_pr(self, pr_number: int, *, commit_title: str | None = None) -> Any:
         return self._write(
             "merge_pr",
@@ -231,6 +239,8 @@ class GitHubClient:
         elif operation == "create_pr":
             self._require_clean("create_pr title", str(payload.get("title", "")))
             self._require_clean("create_pr body", str(payload.get("body", "")))
+        elif operation == "update_pr":
+            self._require_clean("update_pr body", str(payload.get("body", "")))
 
     def _sanitise_spec_files(self, clone_path: Path) -> None:
         specs_dir = clone_path / "specs"

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 from wgmesh_pipeline.config import Config, DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER
-from wgmesh_pipeline.models import ModelProfile, credential_for, resolve_profile
+from wgmesh_pipeline.models import ModelProfile, credential_for, resolve_profile_for_tier
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -215,7 +215,7 @@ class GooseRunner:
         self.config = config
         self._runner = runner or subprocess.run
 
-    def _resolve_profile(self, stage: str | None) -> ModelProfile | None:
+    def _resolve_profile(self, stage: str | None, tier: int) -> ModelProfile | None:
         """Pick the model profile for ``stage`` from the config registry/map.
 
         Returns None when no stage is given or the config carries no registry
@@ -226,7 +226,7 @@ class GooseRunner:
         routing = getattr(self.config, "stage_routing", {}) or {}
         if stage is None or not registry:
             return None
-        return resolve_profile(registry, routing, stage)
+        return resolve_profile_for_tier(registry, routing, stage, tier)
 
     def run_recipe(
         self,
@@ -236,6 +236,7 @@ class GooseRunner:
         params: Mapping[str, str],
         expected_output: str | Path,
         stage: str | None = None,
+        tier: int = 0,
     ) -> GooseResult:
         workdir_path = Path(workdir)
         output_path = Path(expected_output)
@@ -246,7 +247,7 @@ class GooseRunner:
         for key, value in params.items():
             command.extend(["--params", f"{key}={value}"])
 
-        profile = self._resolve_profile(stage)
+        profile = self._resolve_profile(stage, tier)
         model_key = profile.key if profile is not None else None
         env = build_goose_env(self.config, profile=profile, stage=stage)
 

--- a/pipeline/wgmesh_pipeline/graph/build.py
+++ b/pipeline/wgmesh_pipeline/graph/build.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import Callable
 
 from wgmesh_pipeline.config import Config
-from wgmesh_pipeline.graph.nodes.gate import gate_node
+from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
 from wgmesh_pipeline.graph.nodes.implement import implement_node
 from wgmesh_pipeline.graph.nodes.review import review_node
 from wgmesh_pipeline.graph.nodes.spec import spec_node
 from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
 from wgmesh_pipeline.graph.nodes.triage import triage_node
 from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.models import ladder_length_for
 from wgmesh_pipeline.tracing import trace_node
 
 
@@ -38,9 +40,51 @@ class CompiledGraph:
         current = self.spec_pr(current)
         if self.config.mode == "spec-only":
             return current
-        current = self.implement(current)
-        current = self.review(current)
-        return self.gate(current, max_files=self.config.max_files)
+        current = self._run_implementation_ladder(current)
+        apply_gate_side_effects(current)
+        return current
+
+    def _run_implementation_ladder(self, state: GraphState) -> GraphState:
+        current = dict(state)
+        tier = int(current.get("escalation_tier", 0))
+        attempts = int(current.get("escalation_attempts", 0))
+        history = list(current.get("escalation_history", []))
+        ladder_length = ladder_length_for(self.config.stage_routing, "implement")
+
+        while True:
+            current["escalation_tier"] = tier
+            current["escalation_attempts"] = attempts
+            history.append(tier)
+            current["escalation_history"] = list(history)
+
+            current = self.implement(current)
+            current = self.review(current)
+            current = self._evaluate_gate(current)
+
+            if current.get("decision") == "merge":
+                return current
+
+            can_retry = (
+                bool(current.get("retryable", False))
+                and tier + 1 < ladder_length
+                and attempts < self.config.max_escalation_attempts
+            )
+            if not can_retry:
+                return current
+
+            tier += 1
+            attempts += 1
+            current = dict(current)
+
+    def _evaluate_gate(self, state: GraphState) -> GraphState:
+        parameters = inspect.signature(self.gate).parameters
+        if "apply_side_effects" in parameters:
+            return self.gate(
+                state,
+                max_files=self.config.max_files,
+                apply_side_effects=False,
+            )
+        return self.gate(state, max_files=self.config.max_files)
 
 
 def build_graph(config: Config) -> CompiledGraph:

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -11,6 +11,7 @@ class GateDecision:
     decision: Decision
     risk_tier: str
     reasons: tuple[str, ...]
+    retryable: bool = False
 
 
 def decide_gate(
@@ -32,8 +33,19 @@ def decide_gate(
         reasons.append("blocking review finding")
 
     if risk.high or reasons:
-        return GateDecision(decision="escalate", risk_tier=risk.tier, reasons=tuple(reasons))
-    return GateDecision(decision="merge", risk_tier="low", reasons=())
+        retryable_reasons = {"tests failed", "blocking review finding"}
+        retryable = (
+            risk.tier == "low"
+            and sanitise_ok
+            and set(reasons).issubset(retryable_reasons)
+        )
+        return GateDecision(
+            decision="escalate",
+            risk_tier=risk.tier,
+            reasons=tuple(reasons),
+            retryable=retryable,
+        )
+    return GateDecision(decision="merge", risk_tier="low", reasons=(), retryable=False)
 
 
 def gate_node(state: GraphState, *, max_files: int, apply_side_effects: bool = True) -> GraphState:
@@ -50,6 +62,7 @@ def gate_node(state: GraphState, *, max_files: int, apply_side_effects: bool = T
     next_state["decision"] = decision.decision
     next_state["risk_tier"] = decision.risk_tier
     next_state["risk_reasons"] = list(decision.reasons)
+    next_state["retryable"] = decision.retryable
 
     if apply_side_effects:
         apply_gate_side_effects(next_state)

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -10,7 +10,8 @@ from wgmesh_pipeline.graph.state import GraphState
 def implement_node(state: GraphState) -> GraphState:
     next_state = dict(state)
     _visit(next_state, "implement")
-    if next_state.get("diff"):
+    tier = int(next_state.get("escalation_tier", 0))
+    if next_state.get("diff") and tier == 0:
         next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
         _ensure_impl_pr(next_state)
         return next_state
@@ -25,6 +26,7 @@ def implement_node(state: GraphState) -> GraphState:
             params={"spec_file": str(next_state["spec_path"])},
             expected_output=diff_rel,
             stage="implement",
+            tier=tier,
         )
         if not result.ok:
             raise RuntimeError(result.error or "goose implementation failed")

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -37,7 +37,24 @@ def implement_node(state: GraphState) -> GraphState:
         next_state["diff"] = "+docs-only change\n"
     next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
     _ensure_impl_pr(next_state)
+    if tier > 0:
+        _note_escalation_on_pr(next_state, tier)
     return next_state
+
+
+def _note_escalation_on_pr(state: dict, tier: int) -> None:
+    """On a retry pass, annotate the EXISTING impl PR with the escalated tier
+    rather than opening a second PR (R5). The body text is static (no LLM
+    content), but update_pr_body still routes through the sanitise gate."""
+    client = state.get("github")
+    impl_pr = state.get("impl_pr")
+    if client is None or impl_pr is None:
+        return
+    model = state.get("implement_model_key") or f"tier {tier}"
+    issue_number = state["issue"].number
+    body = _impl_pr_body(issue_number, state.get("changed_files", []))
+    body += f"\nEscalated to model `{model}` (tier {tier}) after a quality-gate failure.\n"
+    client.update_pr_body(int(impl_pr), body)
 
 
 def changed_files_from_diff(diff: str) -> list[str]:

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -22,10 +22,14 @@ class GraphState(TypedDict, total=False):
     changed_files: list[str]
     risk_tier: str
     risk_reasons: list[str]
+    retryable: bool
     review_findings: list[dict[str, Any]]
     tests_passed: bool
     sanitise_ok: bool
     decision: Decision
+    escalation_tier: int
+    escalation_attempts: int
+    escalation_history: list[int]
     visited: list[str]
     github: GitHubClient
     repo_path: str | Path

--- a/pipeline/wgmesh_pipeline/models.py
+++ b/pipeline/wgmesh_pipeline/models.py
@@ -99,8 +99,15 @@ def parse_registry(raw: str | None) -> dict[str, ModelProfile]:
     return registry
 
 
-def parse_stage_routing(raw: str | None) -> dict[str, str]:
-    """Parse the ``STAGE_ROUTING`` env JSON into ``{stage: registry_key}``."""
+StageRouting = Mapping[str, tuple[str, ...]]
+
+
+def parse_stage_routing(raw: str | None) -> dict[str, tuple[str, ...]]:
+    """Parse ``STAGE_ROUTING`` into ``{stage: (registry_key, ...)}``.
+
+    Each route value may be either a scalar registry key or a non-empty ordered
+    list of registry keys. Scalars normalize to a one-entry ladder.
+    """
     if raw is None or not raw.strip():
         return {}
     try:
@@ -109,34 +116,71 @@ def parse_stage_routing(raw: str | None) -> dict[str, str]:
         raise ValueError(f"STAGE_ROUTING must be valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError("STAGE_ROUTING must be a JSON object of {stage: key}")
-    for stage, key in data.items():
-        if not isinstance(key, str) or not key:
-            raise ValueError(f"STAGE_ROUTING[{stage!r}] must be a non-empty string key")
-    return dict(data)
+    routing: dict[str, tuple[str, ...]] = {}
+    for stage, route in data.items():
+        if isinstance(route, str) and route:
+            routing[stage] = (route,)
+            continue
+        if isinstance(route, list):
+            if not route:
+                raise ValueError(f"STAGE_ROUTING[{stage!r}] must be a non-empty route")
+            if not all(isinstance(key, str) and key for key in route):
+                raise ValueError(
+                    f"STAGE_ROUTING[{stage!r}] list entries must be non-empty string keys"
+                )
+            routing[stage] = tuple(route)
+            continue
+        raise ValueError(
+            f"STAGE_ROUTING[{stage!r}] must be a non-empty string key or list of keys"
+        )
+    return routing
 
 
 def resolve_profile(
     registry: Mapping[str, ModelProfile],
-    routing: Mapping[str, str],
+    routing: StageRouting,
     stage: str,
+) -> ModelProfile:
+    return resolve_profile_for_tier(registry, routing, stage, 0)
+
+
+def resolve_profile_for_tier(
+    registry: Mapping[str, ModelProfile],
+    routing: StageRouting,
+    stage: str,
+    tier: int,
 ) -> ModelProfile:
     """Pick the ModelProfile for ``stage``. Fail-closed (KTD5).
 
     Resolution order: the stage's mapped key, else a registry ``"default"``
     entry, else raise. A stage mapped to a key absent from the registry raises.
     """
-    key = routing.get(stage)
-    if key is None:
+    if tier < 0:
+        raise ValueError(f"stage {stage!r} tier {tier} is out of range")
+    route = routing.get(stage)
+    if route is None:
         if "default" in registry:
+            if tier != 0:
+                raise ValueError(f"stage {stage!r} tier {tier} is out of range")
             return registry["default"]
         raise ValueError(
             f"no model route for stage {stage!r} and no 'default' profile in registry"
         )
+    if tier >= len(route):
+        raise ValueError(f"stage {stage!r} tier {tier} is out of range")
+    key = route[tier]
     if key not in registry:
         raise ValueError(
             f"stage {stage!r} routes to model key {key!r} which is not in the registry"
         )
     return registry[key]
+
+
+def ladder_length_for(routing: StageRouting, stage: str) -> int:
+    route = routing.get(stage)
+    if route is None:
+        return 1
+    return len(route)
 
 
 def credential_for(profile: ModelProfile, env: Mapping[str, str]) -> str:

--- a/pipeline/wgmesh_pipeline/scoring.py
+++ b/pipeline/wgmesh_pipeline/scoring.py
@@ -184,6 +184,7 @@ def score_run(state: dict, *, outcome: str, scorer: Scorer | None = None) -> dic
 
 def _scores_from_state(state: dict, outcome: str) -> dict[str, Any]:
     review = state.get("review_findings") or []
+    attempts = int(state.get("escalation_attempts", 0))
     return {
         "outcome": outcome,
         "decision": state.get("decision"),
@@ -193,6 +194,11 @@ def _scores_from_state(state: dict, outcome: str) -> dict[str, Any]:
         "review_findings_count": len(review),
         "auto_merged": 1 if outcome == "merged" else 0,
         "escalated": 1 if outcome == "escalated" else 0,
+        # Escalation-ladder attribution (R6): how far the climb went and whether
+        # it recovered a build that tier 0 failed.
+        "escalation_attempts": attempts,
+        "escalation_tier": int(state.get("escalation_tier", 0)),
+        "escalated_recovered": 1 if (attempts > 0 and outcome == "merged") else 0,
     }
 
 
@@ -219,6 +225,12 @@ def _tags_from_state(state: dict, outcome: str) -> dict[str, str]:
         value = state.get(key)
         if value is not None:
             tags[key] = str(value)[:200]
+    # Escalation-ladder attribution (R6): group runs by terminal tier and whether
+    # the climb recovered a tier-0 failure.
+    if "escalation_attempts" in state:
+        attempts = int(state.get("escalation_attempts", 0))
+        tags["escalation_tier"] = str(state.get("escalation_tier", 0))
+        tags["escalated_recovered"] = str(bool(attempts > 0 and outcome == "merged")).lower()
     return tags
 
 


### PR DESCRIPTION
Multi-model routing **Phase 2** — the implement stage now self-recovers within hard safety gates. Builds on the merged static routing layer (#1580).

## What

When the gate rejects a build for a **quality** reason (tests failed / blocking review finding), the graph automatically re-runs implement→review→gate on the **next model up an ordered ladder** (cheap→capable→premium) instead of immediately escalating to a human. It climbs until the build passes or the ladder is exhausted.

**Autonomy lives inside the safety gates.** A `sanitise` failure (security) or any structural high-risk reason (too many files, high-risk paths, net-new network call) goes **straight** to `needs-human` — never climbed to brute-force a violation past the gate.

## Design

- `STAGE_ROUTING` value may be a **list** of model keys (the ladder); scalar → single-shot, exactly as today (fail-safe-off).
- Gate evaluated side-effect-free on intermediate passes; merge/`needs-human` applied once, terminally.
- Bounded by `min(ladder_length-1, MAX_ESCALATION_ATTEMPTS)` (default 2).
- Retry updates the existing impl PR (no per-tier duplicate); `update_pr_body` routes through the sanitise gate.
- Escalation attributed in Langfuse (`escalation_tier`, `escalated_recovered`).
- **Cost ceiling = bounded attempts, not a live $-cap** — Goose reports cost to Langfuse asynchronously, so per-issue dollar enforcement isn't available in-process (documented limitation).

## Units

- U1 gate classifies retryable-quality vs hard-gate rejections
- U2 ordered model ladder in `STAGE_ROUTING` + `MAX_ESCALATION_ATTEMPTS`
- U3 tier-aware implement execution
- U4 bounded escalation loop in graph `invoke`
- U5 retry updates existing impl PR (no duplicate)
- U6 escalation attribution in scoring
- U7 docs + provision

## Test plan

- [x] `198 passed` (+29 new tests over the 169 baseline)
- [x] hard gates never climbed (sanitise / structural high-risk → human, verified)
- [x] no `needs-human` label on intermediate failing passes (side-effect-free gate)
- [x] bounded loop (ladder exhaustion + MAX_ESCALATION_ATTEMPTS guard)
- [x] fail-safe-off: scalar route → single-shot, zero-config unchanged
- [x] no duplicate PR per tier
- [ ] `blocking review finding` trigger is latent until a review-finding producer exists (noted in plan; the path is correct, just not yet exercised live)

Plan: `docs/plans/2026-06-09-002-feat-escalate-on-fail-ladder-plan.md`

Note: implemented via Codex (plan-Opus/execute-Codex); Codex stalled on the shared runtime at ~U1-U4, so U5-U7 + review/ship completed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)