### PR TITLE
fix(provision): default server_type cx22 -> cpx22

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -27,7 +27,8 @@ on:
         default: 'wgmesh-pipeline'
       server_type:
         description: 'Hetzner server type'
-        default: 'cx22'
+        # cpx22 (AMD) is available at hel1; cx22 is not (hcloud: "Server Type not found").
+        default: 'cpx22'
       location:
         description: 'Hetzner location'
         default: 'hel1'


### PR DESCRIPTION
## Problem

`Provision Pipeline Box` (no-arg, run 27206724583) failed at **Create server**:
```
hcloud: Server Type not found: cx22
```

## Fix

Default `server_type` `cx22` -> `cpx22`. cx22 is not offered at hel1; the live pipeline box has always been cpx22 (AMD shared vCPU). No-arg dispatch now provisions instead of erroring.

## Test plan
- [x] yaml parses
- [x] re-dispatch with `-f server_type=cpx22` (run 27206780885) — in progress, validates the type
- [ ] confirm no-arg dispatch provisions after merge

Pulse follow-up, 2026-06-09.