### PR TITLE
fix(goose): salvage printed spec from stdout when model skips write tool

### DIFF
--- a/pipeline/tests/test_goose_runner.py
+++ b/pipeline/tests/test_goose_runner.py
@@ -92,6 +92,49 @@ def test_goose_zero_exit_empty_output_fails_loudly(tmp_path) -> None:
     assert "empty output guard" in result.error
 
 
+def test_printed_only_spec_is_salvaged_from_stdout(tmp_path) -> None:
+    # glm-4.6 often PRINTS the spec instead of calling the developer write tool.
+    # goose exits 0, stdout carries the markdown, file is never written. The
+    # runner must salvage stdout to the expected path rather than fail.
+    spec_text = "# Summary\n\n" + ("Concrete spec body line.\n" * 40)
+    assert len(spec_text) >= 200
+
+    def run(command, **kwargs):
+        # Note: does NOT write the file — model printed instead.
+        return completed(0, stdout="\x1b[32m" + spec_text + "\x1b[0m")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-651-spec.md"},
+        expected_output="specs/issue-651-spec.md",
+    )
+
+    assert result.ok is True
+    written = tmp_path / "specs/issue-651-spec.md"
+    assert written.exists()
+    body = written.read_text()
+    assert "# Summary" in body
+    assert "\x1b[" not in body  # ANSI stripped
+
+
+def test_trivial_stdout_still_fails_guard_no_junk_salvage(tmp_path) -> None:
+    # A short acknowledgement line is NOT a spec — must not be salvaged.
+    def run(command, **kwargs):
+        return completed(0, stdout="done, no file written")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-17-spec.md"},
+        expected_output="specs/issue-17-spec.md",
+    )
+
+    assert result.ok is False
+    assert "empty output guard" in (result.error or "")
+    assert not (tmp_path / "specs/issue-17-spec.md").exists()
+
+
 def test_near_zero_duration_is_surfaced(tmp_path, monkeypatch) -> None:
     output = tmp_path / "specs/issue-18-spec.md"
     times = iter([10.0, 10.0001])

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -13,6 +14,12 @@ from wgmesh_pipeline.models import ModelProfile, credential_for, resolve_profile
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
 GOOSE_TIMEOUT_SECONDS = 1800
+
+# Minimum stripped-stdout length to treat a printed-only goose run as a real
+# deliverable worth salvaging to the output file. A genuine spec/diff is KB-scale;
+# a stray "done"/acknowledgement line is not — below this we still fire the
+# empty-output guard so a true no-op fails loudly instead of writing junk.
+_MIN_SALVAGE_CHARS = 200
 
 # Substrings that mark an env var as secret. Goose is an LLM agent — it must NOT
 # inherit the box's PAT, LangSmith key, or any other credential (it could echo
@@ -286,6 +293,29 @@ class GooseRunner:
             )
 
         if not output_path.exists() or output_path.stat().st_size == 0:
+            # Weaker models (glm-4.6 on z.ai) frequently PRINT the deliverable as
+            # their assistant text instead of invoking the developer write tool,
+            # even when the recipe says "write the file; do not only print".
+            # goose `run --no-session` emits assistant text to stdout (diagnostics
+            # go to stderr), so salvage it: persist stdout to the expected path.
+            # This keeps the write-tool happy-path intact (file already present →
+            # we never reach here) AND makes printed-only runs succeed.
+            salvaged = _strip_ansi(completed.stdout or "")
+            if len(salvaged.strip()) >= _MIN_SALVAGE_CHARS:
+                try:
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    output_path.write_text(salvaged, encoding="utf-8")
+                except OSError as exc:
+                    return GooseResult(
+                        ok=False,
+                        output_path=output_path,
+                        duration_seconds=duration,
+                        raw_log=raw_log,
+                        error=f"empty output + salvage write failed for {output_path}: {exc}",
+                        model_key=model_key,
+                    )
+
+        if not output_path.exists() or output_path.stat().st_size == 0:
             return GooseResult(
                 ok=False,
                 output_path=output_path,
@@ -302,6 +332,15 @@ class GooseRunner:
             raw_log=raw_log,
             model_key=model_key,
         )
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Drop terminal escape sequences goose may emit so the salvaged file is
+    clean markdown, not color-coded console output."""
+    return _ANSI_RE.sub("", text)
 
 
 def _join_log(*parts: str | None) -> str:


### PR DESCRIPTION
## Problem

The live shadow box (run 27208735405) ticks and runs goose, but **every spec stage errors**:
```
ERROR poller tick: advance #651@triaged failed:
  empty output guard fired for /opt/wgmesh-checkout/specs/issue-651-spec.md
RuntimeError: goose spec failed
```
goose's `raw_log` is the **entire spec as plain assistant text** — glm-4.6 (z.ai) *printed* the spec instead of calling the developer write tool, even though the recipe says "write the file; do not only print". goose exits 0, stdout holds the markdown, the file is never created → guard fires → no spec PRs ever land. Weak-model headless tool-calling is unreliable.

## Fix

`run_recipe` salvages a printed-only run: when goose exits 0 but the expected file is missing/empty, write stripped stdout (ANSI removed) to the path. goose `run --no-session` emits assistant text to stdout (diagnostics → stderr), so stdout ≈ the deliverable.

- Gated on `_MIN_SALVAGE_CHARS=200` — a stray "done" line is NOT salvaged as a spec; a genuine no-op still fails the guard loudly.
- Write-tool happy-path untouched (file present → salvage never reached).
- Model-agnostic: works whether the model writes OR prints.

## Test plan
- [x] `test_printed_only_spec_is_salvaged_from_stdout` — KB printed spec → salvaged, ANSI stripped, ok
- [x] `test_trivial_stdout_still_fails_guard_no_junk_salvage` — short stdout → guard fires, no file
- [x] existing empty-output + write-tool tests stay green
- [x] 200 pipeline tests pass
- [ ] re-provision shadow reset_queue=true → spec stage advances → wgmesh spec PR appears

Found via langfuse ticking-verification follow-up, 2026-06-09.