### PR TITLE
fix(workflows): guard MentisDB append steps (timeout + continue-on-error) (#752)

### DIFF
--- a/.github/workflows/approve-build.yml
+++ b/.github/workflows/approve-build.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Append spec-approval outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}
@@ -201,6 +203,8 @@ jobs:
 
       - name: Append spec-approval outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/copilot-triage.yml
+++ b/.github/workflows/copilot-triage.yml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Append issue-triage outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/copilot-undraft.yml
+++ b/.github/workflows/copilot-undraft.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Append undraft outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Append endpoint-health failure to MentisDB
         if: steps.health.outputs.down_count != '0'
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -266,6 +266,8 @@ jobs:
 
       - name: Append heartbeat-merge outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/impl-merged-close.yml
+++ b/.github/workflows/impl-merged-close.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Append impl-close outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -562,6 +562,8 @@ jobs:
           mv /tmp/new-state.json company/loop-state.json
 
       - name: Append assessment to MentisDB
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -896,6 +896,8 @@ jobs:
 
       - name: Append pipeline-health outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/spec-merged-build.yml
+++ b/.github/workflows/spec-merged-build.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Append spec-merge-build outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Append spec-validation outcome to MentisDB
         if: always()
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}

--- a/.github/workflows/strategy-audit.yml
+++ b/.github/workflows/strategy-audit.yml
@@ -409,6 +409,8 @@ jobs:
 
       - name: Append audit outcome to MentisDB
         if: "always() && steps.skip-guard.outputs.skip != 'true'"
+        continue-on-error: true
+        timeout-minutes: 1
         env:
           MENTISDB_URL: ${{ secrets.MENTISDB_URL }}
           MENTISDB_USER: ${{ secrets.MENTISDB_USER }}


### PR DESCRIPTION
## Problem

Six spec PRs were blocked 3+ hours when the `Append ... to MentisDB` GitHub Actions step hung indefinitely — MentisDB was alive but auth-rejecting, and the step had no runner-level timeout or `continue-on-error` to absorb the failure. Telemetry writes were able to block the whole pipeline.

## Fix

Add `continue-on-error: true` + `timeout-minutes: 1` to all **12 dedicated MentisDB append steps across 11 workflows**. The curl already had `--max-time 15` + a `|| ::warning::` guard; only the step-level YAML fields were missing. Telemetry is best-effort — a MentisDB outage must never block convergence.

`+24 / -0`, two YAML fields per step, no curl/URL/auth changes.

**Intentionally not guarded** (sound reasons): `mentisdb-smoketest.yml` (must stay fatal), embedded curl in `bot-pr-review-merge.yml` (not a dedicated step — a 1-min cap would truncate unrelated work), `terraform-deploy.yml` (infra refs only).

Implements `specs/issue-752-spec.md` (supersedes draft #753).

## Test plan
- [x] all 11 edited workflows pass `yaml.safe_load`
- [x] `git diff --check` clean
- [x] diff verified: only the 2 fields added, attached to `Append ... to MentisDB` steps
- [ ] sanitise + pii gates green

Closes #752