### PR TITLE
feat(pipeline): live mode — resume spec_opened rows + mark live in docs

### DIFF
--- a/docs/plans/2026-06-07-001-feat-langgraph-hetzner-pipeline-plan.md
+++ b/docs/plans/2026-06-07-001-feat-langgraph-hetzner-pipeline-plan.md
@@ -8,6 +8,9 @@ deepened: 2026-06-07
 
 # feat: Self-hosted LangGraph autonomous pipeline on Hetzner (wgmesh)
 
+**Status 2026-06-10:** phases complete; production flipped to `PIPELINE_MODE=live`
+on the Hetzner `wgmesh-pipeline` box.
+
 **Target repo:** this repo (`ai-pipeline-template`). New component dir `pipeline/`. Operates on `atvirokodosprendimai/wgmesh`.
 
 ---

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -39,3 +39,4 @@ Last consolidated: 2026-04-10.
 - Public repo: never commit secrets, PII, or exact revenue figures
 - Assessment PRs auto-merge only if Copilot review has zero comments and zero blocking reviews
 - Multi-model routing: `STAGE_ROUTING`+`MODEL_REGISTRY` env (`pipeline/wgmesh_pipeline/models.py`) pick a model per stage (cheap=spec, capable=implement); hybrid billing (subs native, metered via OpenRouter); both unset → zero-config single z.ai model; fail-closed; per-model cost in Langfuse. Escalate-on-fail = Phase 2. Doc: `docs/solutions/design-decisions/multi-model-routing.md`
+- Pipeline live mode since 2026-06-10: durable `spec_opened` rows resume at `spec_ready` when live/shadow boxes claim them; `goose-build.yml`/`goose-review.yml` GitHub-Actions lanes are legacy/bridge while the box implements via `bot/impl-N` branches.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,8 +1,12 @@
 # wgmesh pipeline
 
-Shadow-mode Python service for the autonomous wgmesh pipeline.
+Python service for the autonomous wgmesh pipeline.
 
-Phase 1 is intentionally safe by default:
+`PIPELINE_MODE=live` is the current production mode for the `wgmesh-pipeline`
+box on Hetzner. `spec-only` and `shadow` remain fallback/rollback modes.
+`spec_opened` rows resume at `spec_ready` when a live-mode box picks them up.
+
+Phase 1 was intentionally safe by default:
 
 - `PIPELINE_MODE` defaults to `shadow`.
 - GitHub writes must route through `wgmesh_pipeline.github.client.GitHubClient`.
@@ -18,10 +22,10 @@ pip install -e pipeline/
 pytest pipeline/tests/
 ```
 
-## Phase 2: spec-only live
+## Fallback: spec-only live
 
-Phase 2 lets the box open real spec PRs for wgmesh and then stop. GitHub Actions still
-own spec review, build, code review, and merge.
+Spec-only lets the box open real spec PRs for wgmesh and then stop. It is now a
+rollback mode; GitHub Actions own spec review, build, code review, and merge.
 
 Run from the repo root:
 

--- a/pipeline/docs/PHASE3-CUTOVER.md
+++ b/pipeline/docs/PHASE3-CUTOVER.md
@@ -1,5 +1,9 @@
 # Phase 3 — Full-Live Cutover Runbook
 
+**Status 2026-06-10:** cutover to live executed. The box was redeployed via
+Provision Pipeline Box with `pipeline_mode=live`; the spec-only run from
+2026-06-09 to 2026-06-10 produced 7 specs and validated the flow end-to-end.
+
 This is the operational procedure to take the self-hosted LangGraph pipeline
 from spec-only to **full live** (box owns the loop through merge). The code is
 ready and tested (shadow + spec-only + live paths, 79 tests). Nothing here is

--- a/pipeline/docs/PHASE4-DEPLOY.md
+++ b/pipeline/docs/PHASE4-DEPLOY.md
@@ -1,8 +1,9 @@
 # Phase 4 — Hetzner Deployment
 
 Stand up the wgmesh-pipeline as a long-running service. All artifacts are in
-`pipeline/deploy/`. Code is ready; this is the operational step (needs a host +
-secrets). Two host options — a dedicated Hetzner VM, or co-locate on chimney.
+`pipeline/deploy/`. Production now runs in `PIPELINE_MODE=live` on the Hetzner
+`wgmesh-pipeline` box. Two host options remain documented for rebuilds or
+rollback — a dedicated Hetzner VM, or co-locate on chimney.
 
 ## What ships in this phase
 
@@ -47,10 +48,12 @@ REPO_URL=<this repo> bash pipeline/deploy/deploy.sh
 
 ## Bring-up sequence
 
-Start in **shadow** (`PIPELINE_MODE=shadow`, the env default) — the service runs
-the full loop against real wgmesh issues with zero GitHub writes. Watch the logs
-/ LangSmith. Then walk **spec-only → live** per `PHASE3-CUTOVER.md` (which also
-covers disabling the three wgmesh Actions workflows and rollback).
+Current production is **live** (`PIPELINE_MODE=live`). For a fresh rebuild or
+rollback rehearsal, start in **shadow** (`PIPELINE_MODE=shadow`, the env
+default) — the service runs the full loop against real wgmesh issues with zero
+GitHub writes. Watch the logs / LangSmith. Then walk **spec-only → live** per
+`PHASE3-CUTOVER.md` (which also covers disabling the three wgmesh Actions
+workflows and rollback).
 
 ## Observability
 

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -129,6 +129,34 @@ def test_spec_only_wont_do_issue_escalates_and_is_not_reclaimed(tmp_path, cfg: C
     assert session.calls[0]["kwargs"]["json"] == {"labels": ["needs-human"]}
 
 
+def test_live_mode_resumes_spec_opened_issue(tmp_path, cfg: Config) -> None:
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(12, "Implement approved spec", stage="spec_opened", spec_pr=99)
+    p = Poller(config=live, store=store, client=EmptyClient(live), graph=Graph())
+
+    result = asyncio.run(p.tick())
+
+    assert result is not None
+    assert result.stage == "spec_ready"
+    assert store.get_issue(12).stage == "spec_ready"
+    assert store.list_runs()[0]["node"] == "spec_opened"
+    assert store.list_runs()[0]["outcome"] == "ok"
+
+
+def test_spec_only_mode_never_claims_spec_opened(tmp_path, cfg: Config) -> None:
+    spec_only = Config(target_repo=cfg.target_repo, mode="spec-only", max_files=cfg.max_files)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(12, "Spec already opened", stage="spec_opened", spec_pr=99)
+    p = Poller(config=spec_only, store=store, client=EmptyClient(spec_only), graph=Graph())
+
+    result = asyncio.run(p.tick())
+
+    assert result is None
+    assert store.get_issue(12).stage == "spec_opened"
+    assert store.list_runs() == []
+
+
 def test_tick_no_actionable_issue_is_noop(tmp_path, cfg: Config) -> None:
     p = poller(tmp_path, cfg)
 

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -123,6 +123,17 @@ def test_illegal_transition_rejected(tmp_path) -> None:
         db.transition(1, "merged", "queued")
 
 
+def test_spec_opened_transitions_to_spec_ready_only(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(1, "Spec opened", stage="spec_opened")
+
+    assert db.transition(1, "spec_opened", "spec_ready").stage == "spec_ready"
+
+    db.upsert_issue(2, "Spec opened", stage="spec_opened")
+    with pytest.raises(TransitionError, match="spec_opened->implemented"):
+        db.transition(2, "spec_opened", "implemented")
+
+
 def test_claim_next_skips_cooldown_and_returns_eldest_eligible(tmp_path) -> None:
     db = store(tmp_path)
     now = datetime(2026, 6, 7, 12, tzinfo=timezone.utc)

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -11,7 +11,7 @@ from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 from wgmesh_pipeline.github.reconcile import reconcile_issues
 from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
 from wgmesh_pipeline.scoring import score_run
-from wgmesh_pipeline.state.store import IssueRecord, StateStore
+from wgmesh_pipeline.state.store import ACTIONABLE_STAGES, IssueRecord, StateStore
 
 log = logging.getLogger("wgmesh_pipeline.poller")
 
@@ -38,7 +38,10 @@ class Poller:
     async def tick(self) -> IssueRecord | None:
         try:
             result = reconcile_issues(self.client, self.store)
-            issue = self.store.claim_next(now=datetime.now(timezone.utc))
+            claim_stages = ACTIONABLE_STAGES
+            if self.config.mode != "spec-only":
+                claim_stages = ACTIONABLE_STAGES + ("spec_opened",)
+            issue = self.store.claim_next(now=datetime.now(timezone.utc), stages=claim_stages)
         except Exception as exc:
             # Never silently swallow: a reconcile/claim failure here previously
             # left the loop reconciling-but-never-advancing with the cause
@@ -126,6 +129,11 @@ class Poller:
             if next_stage == "spec_opened":
                 score_run(self.scratch[issue.number], outcome="spec_opened")
             return advanced
+
+        if issue.stage == "spec_opened":
+            # spec-only terminal; in live mode the spec PR is already open, so the
+            # issue resumes at implementation.
+            return self.store.transition(issue.number, "spec_opened", "spec_ready")
 
         if issue.stage == "spec_ready":
             self.scratch[issue.number] = dict(self.graph.implement(state))

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -15,7 +15,7 @@ ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "spec_ready": {"implemented", "escalated", "failed"},
     "implemented": {"reviewed", "escalated", "failed"},
     "reviewed": {"merged", "escalated", "failed"},
-    "spec_opened": set(),
+    "spec_opened": {"spec_ready"},
     "merged": set(),
     "escalated": set(),
     "failed": set(),
@@ -188,16 +188,21 @@ class StateStore:
         self._conn.commit()
         return self.get_issue(number)
 
-    def claim_next(self, *, now: datetime | None = None) -> IssueRecord | None:
+    def claim_next(
+        self,
+        *,
+        now: datetime | None = None,
+        stages: tuple[str, ...] = ACTIONABLE_STAGES,
+    ) -> IssueRecord | None:
         current = _dt(now)
         rows = self._conn.execute(
             f"""
             SELECT * FROM issues
              WHERE status = 'open'
-               AND stage IN ({",".join("?" for _ in ACTIONABLE_STAGES)})
+               AND stage IN ({",".join("?" for _ in stages)})
              ORDER BY updated_at ASC, number ASC
             """,
-            ACTIONABLE_STAGES,
+            stages,
         ).fetchall()
         for row in rows:
             issue = _issue(row)


### PR DESCRIPTION
## Why
Operator flipped the box to live mode. Five issues sit at `spec_opened` (the spec-only terminal) in durable Turso state; in live mode they must resume at implementation. But `spec_opened` is not claimable (`ACTIONABLE_STAGES`) and has no allowed outbound transition — they would strand silently.

## Changes
- `store.py`: `spec_opened → spec_ready` allowed; `claim_next(stages=...)` override (default unchanged).
- `poller.py`: non-spec-only modes claim `spec_opened` too; new stage branch transitions it to `spec_ready` → next tick implements. Spec-only never claims it (claim filter is the gate).
- Tests: live-mode resume, spec-only non-claim, transition matrix — revert→RED verified.
- Docs: README modes (live = current production), PHASE3-CUTOVER status note, PHASE4-DEPLOY, plan doc status line, memory/MEMORY.md entry. goose-build.yml/goose-review.yml Actions lanes marked legacy/bridge.

## Verification
203 passed, 2 skipped.

## Deploy
After merge: Provision Pipeline Box with `pipeline_mode=live`, `reset_queue=false` (keep state — the whole point is resuming it).