### PR TITLE
fix(tracing): announce tracer selection + probe full-body list parsing

### DIFF
--- a/.github/workflows/langfuse-probe.yml
+++ b/.github/workflows/langfuse-probe.yml
@@ -38,7 +38,10 @@ jobs:
           sk = os.environ["LANGFUSE_SECRET_KEY"]
           auth = base64.b64encode(f"{pk}:{sk}".encode()).decode()
 
-          def call(method, path, body=None):
+          def call(method, path, body=None, full=False):
+              # full=True: return the whole body — list endpoints exceed 800
+              # chars and a truncated body parses as "unparseable", which read
+              # as "no traces" during the 2026-06-10 no-sessions investigation.
               data = json.dumps(body).encode() if body is not None else None
               req = urllib.request.Request(
                   host + path, method=method, data=data,
@@ -47,7 +50,8 @@ jobs:
               )
               try:
                   with urllib.request.urlopen(req, timeout=25) as r:
-                      return r.status, r.read().decode()[:800]
+                      text = r.read().decode()
+                      return r.status, text if full else text[:800]
               except urllib.error.HTTPError as e:
                   return e.code, e.read().decode()[:800]
               except Exception as e:
@@ -66,24 +70,25 @@ jobs:
               "name": "probe_no_link", "value": 1, "dataType": "NUMERIC"}))
 
           print("\n=== GET recent scores (are the box's pipeline_outcome/auto_merged landing?) ===")
-          status, bodytext = call("GET", "/api/public/scores?limit=10")
+          status, bodytext = call("GET", "/api/public/scores?limit=10", full=True)
           print("status:", status)
           try:
               data = json.loads(bodytext)
+              print("  total:", data.get("meta", {}).get("totalItems"))
               for s in data.get("data", [])[:10]:
-                  print(f"  - {s.get('name')} = {s.get('value')} "
-                        f"session={s.get('sessionId')} trace={s.get('traceId')} "
-                        f"type={s.get('dataType')}")
+                  print(f"  - {s.get('timestamp')} {s.get('name')} = {s.get('value')} "
+                        f"session={s.get('sessionId')} type={s.get('dataType')}")
           except Exception:
               print("  (unparseable response; status above — body withheld to avoid re-logging old trace inputs)")
 
           print("\n=== GET recent traces (sessions wired?) ===")
-          status, bodytext = call("GET", "/api/public/traces?limit=8")
+          status, bodytext = call("GET", "/api/public/traces?limit=10", full=True)
           print("status:", status)
           try:
               data = json.loads(bodytext)
-              for t in data.get("data", [])[:8]:
-                  print(f"  - {t.get('name')} session={t.get('sessionId')}")
+              print("  total:", data.get("meta", {}).get("totalItems"))
+              for t in data.get("data", [])[:10]:
+                  print(f"  - {t.get('timestamp')} {t.get('name')} session={t.get('sessionId')}")
           except Exception:
               print("  (unparseable response; status above — body withheld to avoid re-logging old trace inputs)")
           PY

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 import time
 from contextlib import AbstractContextManager, nullcontext
@@ -8,6 +9,7 @@ from typing import Any, Callable, Protocol, TypeVar
 
 from wgmesh_pipeline.config import Config
 
+log = logging.getLogger("wgmesh_pipeline.tracing")
 
 T = TypeVar("T")
 
@@ -122,6 +124,9 @@ _tracer: Tracer = NoopTracer()
 
 
 def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
+    # Announce the selected tracer and WHY. A silent fallback here cost a full
+    # day of "no traces in Langfuse" with no way to tell missing-env from
+    # SDK-init failure without SSH to the box.
     global _tracer
     if tracer is not None:
         _tracer = tracer
@@ -129,11 +134,20 @@ def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
         try:
             _tracer = LangfuseTracer(config)
         except Exception:
+            log.exception(
+                "tracing: Langfuse init FAILED (host=%s) — falling back to NoopTracer, no traces will be emitted",
+                config.langfuse_host,
+            )
             _tracer = NoopTracer()
     elif config.langsmith_api_key:
         _tracer = LangSmithTracer(config.langsmith_api_key)
     else:
+        log.info(
+            "tracing: Langfuse env incomplete (host=%s public_key=%s secret_key=%s) — NoopTracer",
+            bool(config.langfuse_host), bool(config.langfuse_public_key), bool(config.langfuse_secret_key),
+        )
         _tracer = NoopTracer()
+    log.info("tracing: active tracer=%s", type(_tracer).__name__)
     return _tracer
 
 


### PR DESCRIPTION
Two observability gaps found chasing 'no new sessions in Langfuse':

1. **init_tracing silent fallback** — Langfuse init failure or incomplete env silently selects NoopTracer; the box emits nothing and the journal says nothing. Now: `tracing: active tracer=...` always logged; init failure logs exception + host; incomplete env logs which of host/public/secret is missing (bools only).
2. **Probe false 'unparseable'** — `call()` truncated bodies to 800 chars; any non-empty `/api/public/traces` list got cut mid-JSON → 'unparseable' → read as 'no traces'. List GETs now fetch full bodies, print `meta.totalItems` + per-item timestamp/name/session (no inputs/outputs re-logged — PII posture unchanged).

Tests: tracing/main suites green. Probe re-dispatch after merge answers whether box traces exist server-side.