### PR TITLE
fix(pipeline): ship the missing implementation recipe (live implement died 'goose exited 1')

### DIFF
--- a/pipeline/recipes/wgmesh-implementation.yaml
+++ b/pipeline/recipes/wgmesh-implementation.yaml
@@ -1,0 +1,58 @@
+version: "1.0.0"
+title: "wgmesh Implementation"
+description: "Implement a wgmesh issue from its approved spec and emit a unified diff."
+parameters:
+  - key: spec_file
+    input_type: string
+    requirement: required
+    description: "Repository-relative path to the specification (specs/issue-N-spec.md)."
+  - key: diff_file
+    input_type: string
+    requirement: required
+    description: "Repository-relative path where the unified diff of all changes must be written."
+prompt: |
+  You are implementing changes for wgmesh, a Go-based WireGuard mesh network
+  builder with managed ingress.
+
+  Project context:
+  - Language: Go 1.25, module github.com/atvirokodosprendimai/wgmesh
+  - go build ./... must succeed, go test ./... must pass, go vet ./... must be clean
+  - Code must be gofmt formatted; handle errors with context wrapping
+  - Use the standard library where possible
+  - Do NOT modify files outside the scope of the specification
+  - Never reference a type, field, or function you have not verified exists by
+    reading the source. If the spec suggests code that does not match the real
+    codebase, adapt to match reality.
+
+  Steps:
+  1. Read the specification at {{ spec_file }} thoroughly.
+  2. Read every file the spec touches; understand the real types and signatures.
+  3. Read existing tests in the same packages to learn the test patterns.
+  4. Implement the spec, including tests.
+  5. Iterate until go build ./... && go test ./... && go vet ./... are all clean,
+     then run gofmt -w on files you changed.
+  6. Write the unified diff of ALL your changes to {{ diff_file }}:
+     - Create the parent directory if needed.
+     - Run exactly: git add -A && git reset -q -- "$(dirname {{ diff_file }})" && git diff --cached > {{ diff_file }}
+     - The diff file must be non-empty and must not include itself.
+  7. Do not commit and do not push; the pipeline handles both from the diff.
+
+  Keep all content public-repo safe: no secrets, no customer PII, no exact
+  revenue figures.
+
+# The developer extension provides the shell/file tools goose needs; the box is
+# installed CONFIGURE=false, so no extensions are enabled unless declared here.
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+# Pin provider/model like wgmesh-triage-spec.yaml: goose honors recipe settings
+# even when env GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session
+# runs. z.ai is Anthropic-compatible via ANTHROPIC_HOST; glm-4.6 is the current
+# valid model id.
+settings:
+  goose_provider: anthropic
+  goose_model: glm-4.6

--- a/pipeline/tests/test_recipes_exist.py
+++ b/pipeline/tests/test_recipes_exist.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+RECIPES_DIR = PIPELINE_ROOT / "recipes"
+NODES_DIR = PIPELINE_ROOT / "wgmesh_pipeline" / "graph" / "nodes"
+
+# Wall: live mode shipped referencing wgmesh-implementation.yaml while only
+# wgmesh-triage-spec.yaml existed — every implement attempt died 'goose exited
+# 1' and node tests (fake runners) never noticed. Any recipe a node names must
+# exist on disk, and its prompt must template every param the node passes.
+
+
+def _referenced_recipes() -> dict[str, Path]:
+    refs: dict[str, Path] = {}
+    for node_file in NODES_DIR.glob("*.py"):
+        for match in re.findall(r"[\"']([\w-]+\.yaml)[\"']", node_file.read_text()):
+            refs[match] = node_file
+    return refs
+
+
+def test_every_node_referenced_recipe_exists() -> None:
+    refs = _referenced_recipes()
+    assert refs, "no recipe references found — extraction regex broke"
+    missing = {name: str(src) for name, src in refs.items() if not (RECIPES_DIR / name).exists()}
+    assert not missing, f"recipes referenced by nodes but absent from {RECIPES_DIR}: {missing}"
+
+
+def test_implementation_recipe_declares_node_params() -> None:
+    text = (RECIPES_DIR / "wgmesh-implementation.yaml").read_text()
+    for param in ("spec_file", "diff_file"):
+        assert f"key: {param}" in text
+        assert "{{ " + param + " }}" in text
+
+
+def test_implementation_recipe_pins_known_good_model() -> None:
+    text = (RECIPES_DIR / "wgmesh-implementation.yaml").read_text()
+    assert "goose_provider: anthropic" in text
+    assert "goose_model: glm-4.6" in text

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
 from wgmesh_pipeline.graph.state import GraphState
 
 
@@ -20,10 +21,21 @@ def implement_node(state: GraphState) -> GraphState:
     repo_path = Path(next_state.get("repo_path", "."))
     diff_rel = Path("pipeline-output") / f"issue-{next_state['issue'].number}.diff"
     if runner is not None:
+        # Resolve against the pipeline's recipes dir (mirrors spec_node): goose
+        # runs with cwd=repo_path (the wgmesh clone), where a bare recipe name
+        # does not exist — that was the live-mode 'goose exited 1' on every
+        # implement attempt.
+        config = next_state.get("config")
+        recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
         result = runner.run_recipe(
-            recipe="wgmesh-implementation.yaml",
+            recipe=recipes_dir / "wgmesh-implementation.yaml",
             workdir=repo_path,
-            params={"spec_file": str(next_state["spec_path"])},
+            # diff_file mirrors expected_output: the recipe instructs goose to
+            # write the unified diff there, the runner verifies it appeared.
+            params={
+                "spec_file": str(next_state["spec_path"]),
+                "diff_file": str(diff_rel),
+            },
             expected_output=diff_rel,
             stage="implement",
             tier=tier,


### PR DESCRIPTION
## Problem
First live implement wave: all 5 issues failed 3 attempts each, terminal `failed`, `last_error='goose exited 1'`. Root: `implement_node` references `wgmesh-implementation.yaml` — **the file never existed in `pipeline/recipes/`** (only the triage-spec recipe shipped), and the bare name was resolved by goose against the wgmesh clone cwd anyway. Node tests use fake runners, so nothing noticed (hollow-green, same family as the spec-contract bug).

## Fix
- `pipeline/recipes/wgmesh-implementation.yaml`: ported from wgmesh's Actions-lane recipe, adapted to the box contract — implements from `{{ spec_file }}`, writes a unified diff to `{{ diff_file }}` (the runner's `expected_output`), go build/test/vet loop, public-repo-safe rules, `anthropic/glm-4.6` pinned like the proven spec recipe.
- `implement_node`: resolves the recipe via `recipes_dir` (mirrors `spec_node`) and passes `diff_file`.
- Wall: `test_recipes_exist.py` — every node-referenced recipe must exist; implementation recipe must template the node's params. Delete-recipe→RED proven.

## Verification
206 passed, 2 skipped.

## Deploy
Provision live with `reset_queue=true` — the 5 issues are terminal-`failed` (by design, no resume path); full requeue re-runs triage→spec→implement with the recipe present. Known cost: re-burns ~2h of ticks + z.ai flat-rate calls.