### PR TITLE
ci(langfuse-probe): sessions endpoint check

### DIFF
--- a/.github/workflows/langfuse-probe.yml
+++ b/.github/workflows/langfuse-probe.yml
@@ -91,4 +91,15 @@ jobs:
                   print(f"  - {t.get('timestamp')} {t.get('name')} session={t.get('sessionId')}")
           except Exception:
               print("  (unparseable response; status above — body withheld to avoid re-logging old trace inputs)")
+
+          print("\n=== GET sessions (UI sessions click errors — server-side or UI-side?) ===")
+          status, bodytext = call("GET", "/api/public/sessions?limit=10", full=True)
+          print("status:", status)
+          try:
+              data = json.loads(bodytext)
+              print("  total:", data.get("meta", {}).get("totalItems"))
+              for s in data.get("data", [])[:10]:
+                  print(f"  - {s.get('createdAt')} id={s.get('id')}")
+          except Exception:
+              print("  body head:", bodytext[:300])
           PY


### PR DESCRIPTION
Operator reports the Langfuse UI sessions view errors and shows no traces, while the API returns 139 traces with sessionIds. Add `GET /api/public/sessions` to the probe to split server-side (sessions query 5xx → version/CH issue) from UI-side (stale project/bookmark/auth) — prints status, totalItems, createdAt+id only.