### PR TITLE
ci(langfuse-probe): single-session detail check

### DIFF
--- a/.github/workflows/langfuse-probe.yml
+++ b/.github/workflows/langfuse-probe.yml
@@ -102,4 +102,13 @@ jobs:
                   print(f"  - {s.get('createdAt')} id={s.get('id')}")
           except Exception:
               print("  body head:", bodytext[:300])
+
+          print("\n=== GET single session detail (UI byIdWithScores 404s — does public API?) ===")
+          status, bodytext = call("GET", "/api/public/sessions/issue-510", full=True)
+          print("status:", status)
+          try:
+              data = json.loads(bodytext)
+              print("  id:", data.get("id"), "traces:", len(data.get("traces", [])))
+          except Exception:
+              print("  body head:", bodytext[:300])
           PY


### PR DESCRIPTION
UI `sessions.byIdWithScores` returns 'Session not found in project' while the sessions LIST works. Add `GET /api/public/sessions/issue-510` — if 200 with traces, data is intact and it's a web-UI (3.179.1) tRPC-path bug (cf. langfuse#11924 family); fix would be pinning web/worker to a known-good release.