### PR TITLE
fix(pipeline): push bot/impl-N before PR + surface HTTP error bodies

### DIFF
--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from typing import Any
 
 import pytest
+import requests
 
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import DryRunResult, GitHubClient
@@ -32,6 +33,15 @@ class Session:
         return self.response
 
 
+class ErrorResponse(Response):
+    def __init__(self, status_code: int, text: str):
+        super().__init__(text=text)
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        raise requests.HTTPError(f"{self.status_code} Error", response=self)
+
+
 @pytest.fixture
 def cfg() -> Config:
     return Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", wgmesh_bot_pat="pat")
@@ -57,6 +67,18 @@ def test_list_needs_triage_returns_parsed_issues(cfg: Config) -> None:
     assert issues[0].labels == ("needs-triage", "fn:dev")
     assert session.calls[0]["method"] == "GET"
     assert session.calls[0]["kwargs"]["params"]["labels"] == "needs-triage"
+
+
+def test_request_http_error_includes_response_body(cfg: Config) -> None:
+    body = '{"message":"Validation Failed","errors":[{"message":"Head does not exist"}]}'
+    session = Session(ErrorResponse(422, body))
+    client = GitHubClient(cfg, session=session)
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        client.list_needs_triage()
+
+    assert body in str(exc_info.value)
+    assert exc_info.value.response is session.response
 
 
 def test_shadow_create_pr_dry_runs_with_no_network_write(cfg: Config) -> None:
@@ -211,6 +233,21 @@ def test_spec_only_allows_spec_branch_push_and_label_swap(cfg: Config, tmp_path,
     # prior run's remote branch -> plain push rejected non-fast-forward).
     assert pushes == [(["git", "push", "--force", "origin", "bot/spec-17"], str(tmp_path))]
     assert [call["method"] for call in session.calls] == ["DELETE", "POST"]
+
+
+def test_live_impl_branch_push_is_force_updated(cfg: Config, tmp_path, monkeypatch) -> None:
+    client = GitHubClient(replace(cfg, mode="live"), sanitiser=lambda text: True)
+    pushes: list[tuple[list[str], str]] = []
+
+    def fake_run(command, *, cwd, check, text, capture_output, timeout):
+        pushes.append((command, cwd))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("wgmesh_pipeline.github.client.subprocess.run", fake_run)
+
+    client.push_branch(str(tmp_path), "bot/impl-17")
+
+    assert pushes == [(["git", "push", "--force", "origin", "bot/impl-17"], str(tmp_path))]
 
 
 def test_list_open_issues_filters_out_pull_requests(cfg: Config) -> None:

--- a/pipeline/tests/test_implement_retry_pr.py
+++ b/pipeline/tests/test_implement_retry_pr.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
+from requests import HTTPError
+
+from wgmesh_pipeline.github.client import GitHubIssue
 from wgmesh_pipeline.graph.nodes.implement import implement_node
-
-
-class _Issue:
-    def __init__(self, number: int) -> None:
-        self.number = number
-        self.title = "t"
 
 
 class _RecordingClient:
@@ -17,10 +16,18 @@ class _RecordingClient:
     a retry updates the existing PR, never creates a duplicate."""
 
     def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
         self.create_calls: list[dict[str, Any]] = []
+        self.push_calls: list[tuple[str, str]] = []
         self.update_calls: list[dict[str, Any]] = []
 
+    def push_branch(self, clone_path: str, branch: str) -> dict[str, Any]:
+        self.calls.append(("push_branch", branch))
+        self.push_calls.append((clone_path, branch))
+        return {"ok": True}
+
     def create_pr(self, *, title, head, base, body) -> dict[str, Any]:
+        self.calls.append(("create_pr", head))
         self.create_calls.append({"title": title, "head": head, "base": base, "body": body})
         return {"number": 4242}
 
@@ -30,14 +37,15 @@ class _RecordingClient:
 
 
 class _FakeRunner:
-    def __init__(self) -> None:
+    def __init__(self, diff: str | None = None) -> None:
         self.tiers: list[int] = []
+        self.diff = diff or "diff --git a/x.go b/x.go\n+++ b/x.go\n+changed\n"
 
     def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
         self.tiers.append(tier)
         out = Path(workdir) / expected_output
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text("diff --git a/x.go b/x.go\n+++ b/x.go\n+changed\n")
+        out.write_text(self.diff)
 
         class _R:
             ok = True
@@ -50,7 +58,7 @@ class _FakeRunner:
 
 def _base_state(client, runner, tmp_path, *, tier):
     return {
-        "issue": _Issue(77),
+        "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
         "github": client,
         "goose_runner": runner,
         "repo_path": tmp_path,
@@ -64,6 +72,7 @@ def test_first_pass_creates_one_pr_no_update(tmp_path) -> None:
     runner = _FakeRunner()
     out = implement_node(_base_state(client, runner, tmp_path, tier=0))
     assert len(client.create_calls) == 1
+    assert client.push_calls == [(str(tmp_path), "bot/impl-77")]
     assert client.update_calls == []
     assert out["impl_pr"] == 4242
 
@@ -77,6 +86,7 @@ def test_retry_updates_existing_pr_no_duplicate(tmp_path) -> None:
     out = implement_node(state)
     # R5: no second PR created
     assert client.create_calls == []
+    assert client.push_calls == [(str(tmp_path), "bot/impl-77")]
     # PR body updated, noting the escalated tier + model
     assert len(client.update_calls) == 1
     assert client.update_calls[0]["pr_number"] == 4242
@@ -93,3 +103,125 @@ def test_retry_reruns_goose_even_with_stale_diff(tmp_path) -> None:
     state["diff"] = "stale\n"  # must NOT short-circuit on a retry pass
     implement_node(state)
     assert runner.tiers == [2]  # Goose re-ran at tier 2
+
+
+def test_implement_pushes_branch_before_pr(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "bot@example.invalid")
+    _git(origin, "config", "user.name", "wgmesh bot")
+    (origin / "README.md").write_text("wgmesh\n")
+    _git(origin, "add", "README.md")
+    _git(origin, "commit", "-m", "initial")
+
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    diff = """diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1 +1 @@
+-wgmesh
++wgmesh fixed
+"""
+    client = _RecordingClient()
+    runner = _FakeRunner(diff)
+
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "goose_runner": runner,
+            "repo_path": clone,
+            "spec_path": "specs/issue-77-spec.md",
+        }
+    )
+
+    assert result["impl_pr"] == 4242
+    assert client.calls[:2] == [("push_branch", "bot/impl-77"), ("create_pr", "bot/impl-77")]
+    assert _git(clone, "branch", "--show-current").stdout.strip() == "bot/impl-77"
+    assert _git(clone, "diff", "--name-only", "origin/main..HEAD").stdout.splitlines() == ["README.md"]
+    assert _git(clone, "show", "HEAD:README.md").stdout == "wgmesh fixed\n"
+    assert _git(clone, "log", "--format=%s", "-1").stdout.strip() == "impl: Issue #77 - Fix relay"
+
+
+def test_implement_unappliable_diff_fails_loudly(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "bot@example.invalid")
+    _git(origin, "config", "user.name", "wgmesh bot")
+    (origin / "README.md").write_text("wgmesh\n")
+    _git(origin, "add", "README.md")
+    _git(origin, "commit", "-m", "initial")
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    diff = """diff --git a/MISSING.md b/MISSING.md
+--- a/MISSING.md
++++ b/MISSING.md
+@@ -1 +1 @@
+-old
++new
+"""
+
+    with pytest.raises(RuntimeError, match="apply"):
+        implement_node(
+            {
+                "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+                "github": _RecordingClient(),
+                "goose_runner": _FakeRunner(diff),
+                "repo_path": clone,
+                "spec_path": "specs/issue-77-spec.md",
+            }
+        )
+
+
+def test_ensure_impl_pr_reuses_existing_on_422(tmp_path: Path) -> None:
+    response = type("Response", (), {"status_code": 422})()
+
+    class ExistingPrClient(_RecordingClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lookups: list[str] = []
+
+        def create_pr(self, *, title, head, base, body):
+            raise HTTPError("422 :: A pull request already exists", response=response)
+
+        def find_open_pr_number(self, head_branch: str) -> int:
+            self.lookups.append(head_branch)
+            return 909
+
+    client = ExistingPrClient()
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "diff": "diff --git a/README.md b/README.md\n+++ b/README.md\n+changed\n",
+            "repo_path": tmp_path,
+        }
+    )
+
+    assert result["impl_pr"] == 909
+    assert client.lookups == ["bot/impl-77"]
+
+
+def _git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        check=True,
+        text=True,
+        capture_output=True,
+    )

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -159,6 +159,7 @@ class GitHubClient:
 
     def push_branch(self, clone_path: str, branch: str, *, spec_pr: bool = False) -> Any:
         is_spec_branch = spec_pr or branch.startswith("bot/spec-")
+        is_force_updated_bot_branch = is_spec_branch or branch.startswith("bot/impl-")
         payload = {"clone_path": clone_path, "branch": branch}
         if is_spec_branch:
             self._sanitise_spec_branch_files(Path(clone_path), branch)
@@ -168,14 +169,12 @@ class GitHubClient:
             return self._write("push_branch", "GIT", "git push", payload=payload, spec_pr=spec_pr)
         if self.config.mode == "spec-only" and not spec_pr:
             return self._write("push_branch", "GIT", "git push", payload=payload, spec_pr=spec_pr)
-        # bot/spec-* branches are exclusively bot-owned and re-authored from a
-        # fresh checkout each pass (e.g. after a queue reset). A prior run's
-        # remote branch diverges -> a plain push is rejected non-fast-forward
-        # (bug #12) -> the issue fails. Force-update the bot branch so re-spec
-        # updates the existing spec PR's branch in place. (force-with-lease
+        # bot/spec-* and bot/impl-* branches are exclusively bot-owned and
+        # re-authored from the base branch each pass. A prior remote branch can
+        # diverge, so force-update the bot branch in place. (force-with-lease
         # would need a remote-tracking ref the shallow clone never fetched.)
         push_cmd = ["git", "push", "origin", branch]
-        if is_spec_branch:
+        if is_force_updated_bot_branch:
             push_cmd.insert(2, "--force")
         try:
             completed = subprocess.run(
@@ -226,7 +225,11 @@ class GitHubClient:
             response = self.session.request(method, f"{self.api_root}{path}", headers=headers, **kwargs)
         except requests.Timeout as exc:
             raise RuntimeError(f"GitHub request timed out after {kwargs['timeout']}s") from exc
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            detail = (response.text or "")[:300]
+            raise requests.HTTPError(f"{exc} :: {detail}", response=response) from None
         if raw_text:
             return response.text
         if response.text:

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -4,8 +4,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+from requests import HTTPError
+
 from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
 from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.graph.nodes.spec_pr import GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME, _git
 
 
 def implement_node(state: GraphState) -> GraphState:
@@ -48,6 +51,12 @@ def implement_node(state: GraphState) -> GraphState:
     else:
         next_state["diff"] = "+docs-only change\n"
     next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
+    if runner is not None and next_state.get("github") is not None:
+        issue = next_state["issue"]
+        branch = str(next_state.get("impl_branch") or f"bot/impl-{issue.number}")
+        _prepare_impl_branch(repo_path, branch, diff_rel, issue.number, issue.title)
+        next_state["github"].push_branch(str(repo_path), branch)
+        next_state["impl_branch"] = branch
     _ensure_impl_pr(next_state)
     if tier > 0:
         _note_escalation_on_pr(next_state, tier)
@@ -101,17 +110,48 @@ def _normalise_diff_path(path: str) -> str | None:
     return path
 
 
+def _prepare_impl_branch(repo_path: Path, branch: str, diff_rel: Path, issue_number: int, title: str) -> None:
+    if not (repo_path / ".git").exists():
+        return
+    _git(repo_path, "fetch", "origin", "main", check=False)
+    checkout = _git(repo_path, "checkout", "-B", branch, "origin/main", check=False)
+    if checkout.returncode != 0:
+        _git(repo_path, "checkout", "-B", branch)
+    _git(repo_path, "checkout", "--", ".")
+    _git(repo_path, "clean", "-fd", "--exclude=pipeline-output")
+    applied = _git(repo_path, "apply", "--index", str(diff_rel), check=False)
+    if applied.returncode != 0:
+        detail = applied.stderr.strip() or f"git apply --index {diff_rel} failed"
+        raise RuntimeError(f"git apply failed: {detail}")
+    diff = _git(repo_path, "diff", "--cached", "--quiet", check=False)
+    if diff.returncode == 0:
+        return
+    _git(
+        repo_path,
+        "-c", f"user.name={GIT_AUTHOR_NAME}",
+        "-c", f"user.email={GIT_AUTHOR_EMAIL}",
+        "commit", "-m", f"impl: Issue #{issue_number} - {title}",
+    )
+
+
 def _ensure_impl_pr(state: dict) -> None:
     if state.get("impl_pr") is not None or state.get("github") is None:
         return
     issue = state["issue"]
-    result = state["github"].create_pr(
-        title=f"fix: Issue #{issue.number} - {issue.title}",
-        head=f"bot/impl-{issue.number}",
-        base="main",
-        body=_impl_pr_body(issue.number, state.get("changed_files", [])),
-    )
-    pr_number = _pr_number(result)
+    branch = str(state.get("impl_branch") or f"bot/impl-{issue.number}")
+    try:
+        result = state["github"].create_pr(
+            title=f"fix: Issue #{issue.number} - {issue.title}",
+            head=branch,
+            base="main",
+            body=_impl_pr_body(issue.number, state.get("changed_files", [])),
+        )
+        pr_number = _pr_number(result)
+    except HTTPError as exc:
+        if _status(exc) == 422 and "already exists" in str(exc).lower():
+            pr_number = state["github"].find_open_pr_number(branch)
+        else:
+            raise
     if pr_number is None:
         raise RuntimeError("implementation PR creation did not return a PR number")
     state["impl_pr"] = pr_number
@@ -129,6 +169,11 @@ def _pr_number(result: Any) -> int | None:
     if isinstance(payload, dict) and payload.get("number") is not None:
         return int(payload["number"])
     return None
+
+
+def _status(exc: HTTPError) -> int | None:
+    resp = getattr(exc, "response", None)
+    return getattr(resp, "status_code", None) if resp is not None else None
 
 
 def _visit(state: dict, node: str) -> None:


### PR DESCRIPTION
## Problem (live, burning attempts now)
Implement stage works since #1616 — goose writes the diff — but `_ensure_impl_pr` creates a PR for `bot/impl-N` that nothing ever committed or pushed. GitHub 422 on every attempt (#651/#584/#540, 3 attempts each ≈25min apart). `git ls-remote`: zero `bot/impl-*` refs. Fourth dormant-path twin: spec_pr had branch preparation, implement didn't.
Compounding: `_request` raised HTTPError without the response body — the 422's reason was invisible in the journal.

## Fix
- `_prepare_impl_branch` (mirrors `_prepare_spec_branch`): fetch, branch from origin/main, reset goose tree edits (`checkout -- .` + `clean -fd --exclude=pipeline-output`), `git apply --index` the canonical diff (RuntimeError w/ git stderr if unappliable — never push an unaudited tree), commit w/ bot identity; `push_branch` before `create_pr`.
- `push_branch`: `bot/impl-*` joins the bot-owned force-push carve-out (bug #12 family — re-implement diverges from prior attempt's remote).
- `_ensure_impl_pr` idempotent on 422 'already exists' → `find_open_pr_number`.
- `_request`: HTTPError message now carries response-body head (≤300 chars).

## Verification
211 passed, 2 skipped. Revert→RED: 5 fail without the implementation.

## Deploy
Provision live, reset_queue=false — diffs regenerate on next claim; attempts counters survive (all ≤2 of 3).