### PR TITLE
fix(pipeline): implement runs goose in a clean workspace, commits the tree (drops git-apply)

### DIFF
--- a/pipeline/tests/test_implement_retry_pr.py
+++ b/pipeline/tests/test_implement_retry_pr.py
@@ -37,12 +37,27 @@ class _RecordingClient:
 
 
 class _FakeRunner:
-    def __init__(self, diff: str | None = None) -> None:
+    def __init__(self, diff: str | None = None, edit_file: str | None = None, edit_content: str | None = None) -> None:
         self.tiers: list[int] = []
         self.diff = diff or "diff --git a/x.go b/x.go\n+++ b/x.go\n+changed\n"
+        self.edit_file = edit_file
+        self.edit_content = edit_content
+        self.calls: list[dict[str, Any]] = []
 
     def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
         self.tiers.append(tier)
+        self.calls.append(
+            {
+                "recipe": recipe,
+                "workdir": workdir,
+                "params": params,
+                "expected_output": expected_output,
+                "stage": stage,
+                "tier": tier,
+            }
+        )
+        if self.edit_file is not None:
+            (Path(workdir) / self.edit_file).write_text(self.edit_content or "")
         out = Path(workdir) / expected_output
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(self.diff)
@@ -57,6 +72,15 @@ class _FakeRunner:
 
 
 def _base_state(client, runner, tmp_path, *, tier):
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "bot@example.invalid")
+    _git(tmp_path, "config", "user.name", "wgmesh bot")
+    (tmp_path / "README.md").write_text("wgmesh\n")
+    spec_path = tmp_path / "specs" / "issue-77-spec.md"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text("spec\n")
+    _git(tmp_path, "add", "README.md", "specs/issue-77-spec.md")
+    _git(tmp_path, "commit", "-m", "initial")
     return {
         "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
         "github": client,
@@ -69,7 +93,7 @@ def _base_state(client, runner, tmp_path, *, tier):
 
 def test_first_pass_creates_one_pr_no_update(tmp_path) -> None:
     client = _RecordingClient()
-    runner = _FakeRunner()
+    runner = _FakeRunner(edit_file="README.md", edit_content="wgmesh fixed\n")
     out = implement_node(_base_state(client, runner, tmp_path, tier=0))
     assert len(client.create_calls) == 1
     assert client.push_calls == [(str(tmp_path), "bot/impl-77")]
@@ -79,7 +103,7 @@ def test_first_pass_creates_one_pr_no_update(tmp_path) -> None:
 
 def test_retry_updates_existing_pr_no_duplicate(tmp_path) -> None:
     client = _RecordingClient()
-    runner = _FakeRunner()
+    runner = _FakeRunner(edit_file="README.md", edit_content="wgmesh fixed\n")
     # simulate a retry: PR already exists, tier bumped to 1
     state = _base_state(client, runner, tmp_path, tier=1)
     state["impl_pr"] = 4242
@@ -97,7 +121,7 @@ def test_retry_updates_existing_pr_no_duplicate(tmp_path) -> None:
 
 def test_retry_reruns_goose_even_with_stale_diff(tmp_path) -> None:
     client = _RecordingClient()
-    runner = _FakeRunner()
+    runner = _FakeRunner(edit_file="README.md", edit_content="wgmesh fixed\n")
     state = _base_state(client, runner, tmp_path, tier=2)
     state["impl_pr"] = 4242
     state["diff"] = "stale\n"  # must NOT short-circuit on a retry pass
@@ -108,20 +132,8 @@ def test_retry_reruns_goose_even_with_stale_diff(tmp_path) -> None:
 def test_implement_pushes_branch_before_pr(tmp_path: Path) -> None:
     origin = tmp_path / "origin"
     clone = tmp_path / "clone"
-    origin.mkdir()
-    _git(origin, "init", "-b", "main")
-    _git(origin, "config", "user.email", "bot@example.invalid")
-    _git(origin, "config", "user.name", "wgmesh bot")
-    (origin / "README.md").write_text("wgmesh\n")
-    _git(origin, "add", "README.md")
-    _git(origin, "commit", "-m", "initial")
-
-    subprocess.run(
-        ["git", "clone", str(origin), str(clone)],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    _init_origin_with_spec_branch(origin)
+    _clone(origin, clone)
 
     diff = """diff --git a/README.md b/README.md
 --- a/README.md
@@ -131,7 +143,7 @@ def test_implement_pushes_branch_before_pr(tmp_path: Path) -> None:
 +wgmesh fixed
 """
     client = _RecordingClient()
-    runner = _FakeRunner(diff)
+    runner = _FakeRunner(diff, edit_file="README.md", edit_content="wgmesh fixed\n")
 
     result = implement_node(
         {
@@ -151,37 +163,102 @@ def test_implement_pushes_branch_before_pr(tmp_path: Path) -> None:
     assert _git(clone, "log", "--format=%s", "-1").stdout.strip() == "impl: Issue #77 - Fix relay"
 
 
-def test_implement_unappliable_diff_fails_loudly(tmp_path: Path) -> None:
+def test_implement_starts_from_clean_workspace(tmp_path: Path) -> None:
     origin = tmp_path / "origin"
     clone = tmp_path / "clone"
-    origin.mkdir()
-    _git(origin, "init", "-b", "main")
-    _git(origin, "config", "user.email", "bot@example.invalid")
-    _git(origin, "config", "user.name", "wgmesh bot")
-    (origin / "README.md").write_text("wgmesh\n")
-    _git(origin, "add", "README.md")
-    _git(origin, "commit", "-m", "initial")
-    subprocess.run(
-        ["git", "clone", str(origin), str(clone)],
-        check=True,
-        text=True,
-        capture_output=True,
+    _init_origin_with_spec_branch(origin)
+    _clone(origin, clone)
+    _git(clone, "checkout", "-B", "bot/spec-77", "origin/bot/spec-77")
+    (clone / "main.go").write_text("package main\n\nfunc main() { println(\"contaminated\") }\n")
+
+    diff = """diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1 +1 @@
+-wgmesh
++wgmesh fixed
+"""
+    client = _RecordingClient()
+    runner = _FakeRunner(diff, edit_file="README.md", edit_content="wgmesh fixed\n")
+
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "goose_runner": runner,
+            "repo_path": clone,
+            "spec_path": "specs/issue-77-spec.md",
+        }
     )
 
-    diff = """diff --git a/MISSING.md b/MISSING.md
---- a/MISSING.md
-+++ b/MISSING.md
-@@ -1 +1 @@
--old
-+new
-"""
+    assert result["impl_pr"] == 4242
+    assert client.calls[:2] == [("push_branch", "bot/impl-77"), ("create_pr", "bot/impl-77")]
+    assert _git(clone, "diff", "--name-only", "origin/main..HEAD").stdout.splitlines() == ["README.md"]
+    assert _git(clone, "show", "HEAD:README.md").stdout == "wgmesh fixed\n"
+    assert _git(clone, "show", "HEAD:main.go").stdout == "package main\n\nfunc main() {}\n"
+    assert result["diff"].startswith("diff --git a/README.md b/README.md")
+    assert "main.go" not in result["diff"]
+    assert result["changed_files"] == ["README.md"]
 
-    with pytest.raises(RuntimeError, match="apply"):
+
+def test_implement_materializes_spec_from_spec_branch(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    _init_origin_with_spec_branch(origin)
+    _clone(origin, clone)
+    seen: dict[str, str] = {}
+
+    class SpecAssertingRunner(_FakeRunner):
+        def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
+            spec_file = Path(params["spec_file"])
+            assert spec_file.parts[0] == "pipeline-output"
+            materialized = Path(workdir) / spec_file
+            assert materialized.exists()
+            seen["spec_file"] = str(spec_file)
+            seen["content"] = materialized.read_text()
+            return super().run_recipe(
+                recipe=recipe,
+                workdir=workdir,
+                params=params,
+                expected_output=expected_output,
+                stage=stage,
+                tier=tier,
+            )
+
+    runner = SpecAssertingRunner(
+        "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-wgmesh\n+wgmesh fixed\n",
+        edit_file="README.md",
+        edit_content="wgmesh fixed\n",
+    )
+
+    implement_node(
+        {
+            "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": _RecordingClient(),
+            "goose_runner": runner,
+            "repo_path": clone,
+            "spec_path": "specs/issue-77-spec.md",
+        }
+    )
+
+    assert seen == {
+        "spec_file": "pipeline-output/issue-77-spec.md",
+        "content": "spec branch content\n",
+    }
+
+
+def test_implement_no_changes_fails_loudly(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    _init_origin_with_spec_branch(origin)
+    _clone(origin, clone)
+
+    with pytest.raises(RuntimeError, match="no tree changes"):
         implement_node(
             {
                 "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
                 "github": _RecordingClient(),
-                "goose_runner": _FakeRunner(diff),
+                "goose_runner": _FakeRunner(),
                 "repo_path": clone,
                 "spec_path": "specs/issue-77-spec.md",
             }
@@ -225,3 +302,29 @@ def _git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         text=True,
         capture_output=True,
     )
+
+
+def _clone(origin: Path, clone: Path) -> None:
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _init_origin_with_spec_branch(origin: Path) -> None:
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "bot@example.invalid")
+    _git(origin, "config", "user.name", "wgmesh bot")
+    (origin / "README.md").write_text("wgmesh\n")
+    (origin / "main.go").write_text("package main\n\nfunc main() {}\n")
+    _git(origin, "add", "README.md", "main.go")
+    _git(origin, "commit", "-m", "initial")
+    _git(origin, "checkout", "-b", "bot/spec-77")
+    (origin / "specs").mkdir()
+    (origin / "specs" / "issue-77-spec.md").write_text("spec branch content\n")
+    _git(origin, "add", "specs/issue-77-spec.md")
+    _git(origin, "commit", "-m", "spec")
+    _git(origin, "checkout", "main")

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -22,7 +22,14 @@ def implement_node(state: GraphState) -> GraphState:
 
     runner = next_state.get("goose_runner")
     repo_path = Path(next_state.get("repo_path", "."))
+    real_path = runner is not None and next_state.get("github") is not None
+    issue = next_state["issue"]
+    branch = str(next_state.get("impl_branch") or f"bot/impl-{issue.number}")
     diff_rel = Path("pipeline-output") / f"issue-{next_state['issue'].number}.diff"
+    spec_rel = Path("pipeline-output") / f"issue-{issue.number}-spec.md"
+    if real_path:
+        _materialize_spec(repo_path, next_state, spec_rel)
+        _prepare_impl_workspace(repo_path, branch)
     if runner is not None:
         # Resolve against the pipeline's recipes dir (mirrors spec_node): goose
         # runs with cwd=repo_path (the wgmesh clone), where a bare recipe name
@@ -36,7 +43,7 @@ def implement_node(state: GraphState) -> GraphState:
             # diff_file mirrors expected_output: the recipe instructs goose to
             # write the unified diff there, the runner verifies it appeared.
             params={
-                "spec_file": str(next_state["spec_path"]),
+                "spec_file": str(spec_rel if real_path else next_state["spec_path"]),
                 "diff_file": str(diff_rel),
             },
             expected_output=diff_rel,
@@ -47,14 +54,23 @@ def implement_node(state: GraphState) -> GraphState:
             raise RuntimeError(result.error or "goose implementation failed")
         if result.model_key is not None:
             next_state["implement_model_key"] = result.model_key
-        next_state["diff"] = Path(result.output_path).read_text()
+        if real_path:
+            _stage_impl_tree(repo_path)
+            if _git(repo_path, "diff", "--cached", "--quiet", check=False).returncode == 0:
+                raise RuntimeError("goose implementation produced no tree changes")
+            next_state["diff"] = _git(repo_path, "diff", "--cached").stdout
+            _git(
+                repo_path,
+                "-c", f"user.name={GIT_AUTHOR_NAME}",
+                "-c", f"user.email={GIT_AUTHOR_EMAIL}",
+                "commit", "-m", f"impl: Issue #{issue.number} - {issue.title}",
+            )
+        else:
+            next_state["diff"] = Path(result.output_path).read_text()
     else:
         next_state["diff"] = "+docs-only change\n"
     next_state["changed_files"] = changed_files_from_diff(next_state["diff"])
-    if runner is not None and next_state.get("github") is not None:
-        issue = next_state["issue"]
-        branch = str(next_state.get("impl_branch") or f"bot/impl-{issue.number}")
-        _prepare_impl_branch(repo_path, branch, diff_rel, issue.number, issue.title)
+    if real_path:
         next_state["github"].push_branch(str(repo_path), branch)
         next_state["impl_branch"] = branch
     _ensure_impl_pr(next_state)
@@ -110,28 +126,37 @@ def _normalise_diff_path(path: str) -> str | None:
     return path
 
 
-def _prepare_impl_branch(repo_path: Path, branch: str, diff_rel: Path, issue_number: int, title: str) -> None:
-    if not (repo_path / ".git").exists():
-        return
+def _materialize_spec(repo_path: Path, state: dict, spec_rel: Path) -> None:
+    issue_number = state["issue"].number
+    content: str | None = None
+    fetched = _git(repo_path, "fetch", "origin", f"bot/spec-{issue_number}", check=False)
+    if fetched.returncode == 0:
+        shown = _git(repo_path, "show", f"FETCH_HEAD:specs/issue-{issue_number}-spec.md", check=False)
+        if shown.returncode == 0:
+            content = shown.stdout
+    if content is None:
+        current_spec = repo_path / str(state["spec_path"])
+        if current_spec.exists():
+            content = current_spec.read_text()
+    if content is None:
+        raise RuntimeError("spec file unavailable for implement")
+    spec_path = repo_path / spec_rel
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(content)
+
+
+def _prepare_impl_workspace(repo_path: Path, branch: str) -> None:
     _git(repo_path, "fetch", "origin", "main", check=False)
     checkout = _git(repo_path, "checkout", "-B", branch, "origin/main", check=False)
     if checkout.returncode != 0:
         _git(repo_path, "checkout", "-B", branch)
     _git(repo_path, "checkout", "--", ".")
     _git(repo_path, "clean", "-fd", "--exclude=pipeline-output")
-    applied = _git(repo_path, "apply", "--index", str(diff_rel), check=False)
-    if applied.returncode != 0:
-        detail = applied.stderr.strip() or f"git apply --index {diff_rel} failed"
-        raise RuntimeError(f"git apply failed: {detail}")
-    diff = _git(repo_path, "diff", "--cached", "--quiet", check=False)
-    if diff.returncode == 0:
-        return
-    _git(
-        repo_path,
-        "-c", f"user.name={GIT_AUTHOR_NAME}",
-        "-c", f"user.email={GIT_AUTHOR_EMAIL}",
-        "commit", "-m", f"impl: Issue #{issue_number} - {title}",
-    )
+
+
+def _stage_impl_tree(repo_path: Path) -> None:
+    _git(repo_path, "add", "-A")
+    _git(repo_path, "reset", "-q", "--", "pipeline-output")
 
 
 def _ensure_impl_pr(state: dict) -> None:


### PR DESCRIPTION
## Problem (live)
First post-#1621 implement: `git apply failed: error: patch failed: main.go:1` on a well-formed diff. Root: goose runs in the SHARED wgmesh clone whose tree still carries the previous issue's uncommitted edits — its diff bases on contaminated blobs that don't exist on clean origin/main. Latent second hazard: the spec only exists on the unmerged bot/spec-N branch, so any pre-goose reset would delete it.

## Redesign
- Materialize the spec OUTSIDE the tracked tree (fetch bot/spec-N → `pipeline-output/issue-N-spec.md`, tree-copy fallback, loud failure if unavailable); recipe gets that path.
- `_prepare_impl_workspace`: branch from origin/main + full reset/clean (keep pipeline-output) BEFORE goose — every implement starts clean; cross-issue contamination impossible.
- After goose: stage tree (minus pipeline-output), loud-fail on zero changes, capture `state.diff` from `git diff --cached` (tree is the truth — recipe's diff file may be salvaged stdout), commit w/ bot identity, push, PR (422-reuse kept).
- `git apply` step deleted.

Shadow/fake-runner paths byte-identical.

## Verification
213 passed, 2 skipped; revert→RED confirmed (5 fail on old implement.py).

## Deploy
Provision live, reset_queue=false.