### PR TITLE
feat(telemetry): goose token usage → Langfuse generations (cost capture)

### DIFF
--- a/pipeline/tests/test_goose_runner.py
+++ b/pipeline/tests/test_goose_runner.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.goose.usage import UsageTotals
 
 
 def cfg() -> Config:
@@ -154,3 +155,77 @@ def test_near_zero_duration_is_surfaced(tmp_path, monkeypatch) -> None:
 
     assert result.ok is True
     assert 0 < result.duration_seconds < 0.001
+
+
+def test_goose_runner_populates_usage_and_emits_generation(tmp_path, monkeypatch) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    output = tmp_path / "specs/issue-19-spec.md"
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        output.parent.mkdir()
+        output.write_text("content")
+        (logs / "llm_request.1.jsonl").write_text(
+            '{"usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19}}\n',
+            encoding="utf-8",
+        )
+        return completed(stdout="wrote spec")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="recipe.yaml",
+        workdir=tmp_path,
+        params={},
+        expected_output=output,
+        stage="spec",
+        session_id="issue-19",
+    )
+
+    assert result.ok is True
+    assert result.usage == UsageTotals(input_tokens=12, output_tokens=7, total_tokens=19, requests=1, skipped=0)
+    assert emitted == [
+        {
+            "session_id": "issue-19",
+            "stage": "spec",
+            "model": cfg().goose_model,
+            "usage": result.usage,
+        }
+    ]
+
+
+def test_goose_runner_usage_collection_exception_does_not_break_run(tmp_path, monkeypatch) -> None:
+    output = tmp_path / "specs/issue-20-spec.md"
+    emitted: list[dict[str, Any]] = []
+
+    def boom():
+        raise OSError("logs unavailable")
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", boom)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        output.parent.mkdir()
+        output.write_text("content")
+        return completed(stdout="wrote spec")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="recipe.yaml",
+        workdir=tmp_path,
+        params={},
+        expected_output=output,
+        stage="spec",
+        session_id="issue-20",
+    )
+
+    assert result.ok is True
+    assert result.usage is None
+    assert emitted == []

--- a/pipeline/tests/test_goose_usage.py
+++ b/pipeline/tests/test_goose_usage.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+
+from wgmesh_pipeline.goose.usage import collect_usage_delta, snapshot_usage_logs
+
+
+def _append_jsonl(path, rows) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            if isinstance(row, str):
+                fh.write(row + "\n")
+            else:
+                fh.write(json.dumps(row) + "\n")
+
+
+def test_snapshot_and_delta_reads_only_appended_bytes_and_new_shards(tmp_path) -> None:
+    shard = tmp_path / "llm_request.1.jsonl"
+    _append_jsonl(
+        shard,
+        [
+            {"usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}},
+            {"usage": {"input_tokens": 4, "output_tokens": 5, "total_tokens": 9}},
+        ],
+    )
+    snapshot = snapshot_usage_logs(tmp_path)
+
+    _append_jsonl(
+        shard,
+        [
+            {"usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}},
+            "not-json",
+            {"data": {"id": "x"}, "usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}},
+        ],
+    )
+    _append_jsonl(
+        tmp_path / "llm_request.2.jsonl",
+        [{"usage": {"input_tokens": 5, "output_tokens": 6, "total_tokens": 11}}],
+    )
+
+    totals = collect_usage_delta(tmp_path, snapshot)
+
+    assert totals.input_tokens == 18
+    assert totals.output_tokens == 30
+    assert totals.total_tokens == 48
+    assert totals.requests == 3
+    assert totals.skipped == 1
+
+
+def test_missing_logs_dir_has_empty_snapshot_and_zero_totals(tmp_path) -> None:
+    missing = tmp_path / "missing"
+
+    assert snapshot_usage_logs(missing) == {}
+    assert collect_usage_delta(missing, {}).total_tokens == 0

--- a/pipeline/tests/test_implement_retry_pr.py
+++ b/pipeline/tests/test_implement_retry_pr.py
@@ -44,7 +44,7 @@ class _FakeRunner:
         self.edit_content = edit_content
         self.calls: list[dict[str, Any]] = []
 
-    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0, session_id=None):
         self.tiers.append(tier)
         self.calls.append(
             {
@@ -209,7 +209,7 @@ def test_implement_materializes_spec_from_spec_branch(tmp_path: Path) -> None:
     seen: dict[str, str] = {}
 
     class SpecAssertingRunner(_FakeRunner):
-        def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0):
+        def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, tier=0, session_id=None):
             spec_file = Path(params["spec_file"])
             assert spec_file.parts[0] == "pipeline-output"
             materialized = Path(workdir) / spec_file

--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -14,7 +14,7 @@ from wgmesh_pipeline.goose.runner import GooseResult
 class FakeRunner:
     calls: list[dict[str, Any]]
 
-    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None):
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, session_id=None):
         output = Path(workdir) / expected_output
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(

--- a/pipeline/tests/test_spec_pr.py
+++ b/pipeline/tests/test_spec_pr.py
@@ -84,7 +84,7 @@ def test_spec_pr_node_creates_exact_spec_title_and_swaps_labels(tmp_path: Path, 
 
 
 class WritingRunner:
-    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None):
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, session_id=None):
         output = Path(workdir) / expected_output
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(

--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
+
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubIssue
-from wgmesh_pipeline.tracing import _LangfuseSpan, init_tracing, trace_node
+from wgmesh_pipeline.goose.usage import UsageTotals
+from wgmesh_pipeline import tracing
+from wgmesh_pipeline.tracing import _LangfuseSpan, LangfuseTracer, NoopTracer, init_tracing, trace_node
 
 
 class _FakeSdkSpan:
@@ -197,3 +201,57 @@ def test_safe_state_strips_config_secrets_from_trace(monkeypatch) -> None:
     assert "goose_runner" not in rec["inputs"]
     # and the outputs side too
     assert "config" not in rec["outputs"]
+
+
+def test_emit_generation_noop_tracer_is_silent_noop(caplog) -> None:
+    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh"), tracer=NoopTracer())
+
+    with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.tracing"):
+        tracing.emit_generation(
+            session_id="issue-21",
+            stage="spec",
+            model="GLM-4.7",
+            usage=UsageTotals(input_tokens=1, output_tokens=2, total_tokens=3, requests=1, skipped=0),
+        )
+
+    assert "generation emitted" not in caplog.text
+
+
+def test_emit_generation_langfuse_tracer_starts_generation_observation(monkeypatch) -> None:
+    class _FakeGeneration:
+        def __init__(self, record):
+            self.record = record
+
+        def end(self):
+            self.record["ended"] = True
+
+    class _FakeLf:
+        def __init__(self):
+            self.record = {}
+            self.flushed = False
+
+        def start_observation(self, **kwargs):
+            self.record.update(kwargs)
+            return _FakeGeneration(self.record)
+
+        def flush(self):
+            self.flushed = True
+
+    fake_lf = _FakeLf()
+    tracer = object.__new__(LangfuseTracer)
+    tracer._lf = fake_lf
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+
+    tracing.emit_generation(
+        session_id="issue-22",
+        stage="implement",
+        model="openai/gpt-5-mini",
+        usage=UsageTotals(input_tokens=10, output_tokens=4, total_tokens=14, requests=1, skipped=0),
+    )
+
+    assert fake_lf.record["name"] == "implement-llm"
+    assert fake_lf.record["as_type"] == "generation"
+    assert fake_lf.record["model"] == "openai/gpt-5-mini"
+    assert fake_lf.record["usage_details"] == {"input": 10, "output": 4}
+    assert fake_lf.record["ended"] is True
+    assert fake_lf.flushed is True

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import subprocess
@@ -8,12 +9,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+from wgmesh_pipeline import tracing
 from wgmesh_pipeline.config import Config, DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER
+from wgmesh_pipeline.goose.usage import (
+    UsageTotals,
+    collect_usage_delta,
+    default_logs_dir,
+    snapshot_usage_logs,
+)
 from wgmesh_pipeline.models import ModelProfile, credential_for, resolve_profile_for_tier
 
 
 SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
 GOOSE_TIMEOUT_SECONDS = 1800
+log = logging.getLogger("wgmesh_pipeline.goose.runner")
+_USAGE_WARNING_EMITTED = False
 
 # Minimum stripped-stdout length to treat a printed-only goose run as a real
 # deliverable worth salvaging to the output file. A genuine spec/diff is KB-scale;
@@ -215,6 +225,7 @@ class GooseResult:
     # online score (scoring.py) attributes the outcome by model (R5). None when
     # the runner used the legacy single-model path (no registry configured).
     model_key: str | None = None
+    usage: UsageTotals | None = None
 
 
 class GooseRunner:
@@ -244,6 +255,7 @@ class GooseRunner:
         expected_output: str | Path,
         stage: str | None = None,
         tier: int = 0,
+        session_id: str | None = None,
     ) -> GooseResult:
         workdir_path = Path(workdir)
         output_path = Path(expected_output)
@@ -256,7 +268,15 @@ class GooseRunner:
 
         profile = self._resolve_profile(stage, tier)
         model_key = profile.key if profile is not None else None
+        resolved_model = _resolved_model(self.config, profile)
         env = build_goose_env(self.config, profile=profile, stage=stage)
+        logs_dir: Path | None = None
+        usage_snapshot: dict[str, int] | None = None
+        try:
+            logs_dir = default_logs_dir()
+            usage_snapshot = snapshot_usage_logs(logs_dir)
+        except Exception as exc:  # telemetry must never break goose
+            _warn_usage_once("snapshot", exc)
 
         started = time.monotonic()
         try:
@@ -271,6 +291,8 @@ class GooseRunner:
             )
         except subprocess.TimeoutExpired as exc:
             duration = time.monotonic() - started
+            usage = _collect_usage_safely(logs_dir, usage_snapshot)
+            _emit_usage_safely(session_id=session_id, stage=stage, model=resolved_model, usage=usage)
             return GooseResult(
                 ok=False,
                 output_path=None,
@@ -278,8 +300,11 @@ class GooseRunner:
                 raw_log=_join_log(_decode_timeout_output(exc.output), _decode_timeout_output(exc.stderr)),
                 error=f"goose timed out after {GOOSE_TIMEOUT_SECONDS}s",
                 model_key=model_key,
+                usage=usage,
             )
         duration = time.monotonic() - started
+        usage = _collect_usage_safely(logs_dir, usage_snapshot)
+        _emit_usage_safely(session_id=session_id, stage=stage, model=resolved_model, usage=usage)
         raw_log = _join_log(completed.stdout, completed.stderr)
 
         if completed.returncode != 0:
@@ -290,6 +315,7 @@ class GooseRunner:
                 raw_log=raw_log,
                 error=f"goose exited {completed.returncode}",
                 model_key=model_key,
+                usage=usage,
             )
 
         if not output_path.exists() or output_path.stat().st_size == 0:
@@ -313,6 +339,7 @@ class GooseRunner:
                         raw_log=raw_log,
                         error=f"empty output + salvage write failed for {output_path}: {exc}",
                         model_key=model_key,
+                        usage=usage,
                     )
 
         if not output_path.exists() or output_path.stat().st_size == 0:
@@ -323,6 +350,7 @@ class GooseRunner:
                 raw_log=raw_log,
                 error=f"empty output guard fired for {output_path}",
                 model_key=model_key,
+                usage=usage,
             )
 
         return GooseResult(
@@ -331,6 +359,7 @@ class GooseRunner:
             duration_seconds=duration,
             raw_log=raw_log,
             model_key=model_key,
+            usage=usage,
         )
 
 
@@ -351,3 +380,39 @@ def _decode_timeout_output(value: str | bytes | None) -> str | None:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return value
+
+
+def _resolved_model(config: Config, profile: ModelProfile | None) -> str:
+    if profile is not None:
+        return profile.model
+    return getattr(config, "goose_model", DEFAULT_GOOSE_MODEL)
+
+
+def _collect_usage_safely(logs_dir: Path | None, snapshot: dict[str, int] | None) -> UsageTotals | None:
+    if logs_dir is None or snapshot is None:
+        return None
+    try:
+        return collect_usage_delta(logs_dir, snapshot)
+    except Exception as exc:  # telemetry must never break goose
+        _warn_usage_once("collect", exc)
+        return None
+
+
+def _emit_usage_safely(
+    *,
+    session_id: str | None,
+    stage: str | None,
+    model: str,
+    usage: UsageTotals | None,
+) -> None:
+    if usage is None or usage.total_tokens <= 0:
+        return
+    tracing.emit_generation(session_id=session_id, stage=stage, model=model, usage=usage)
+
+
+def _warn_usage_once(phase: str, exc: BaseException) -> None:
+    global _USAGE_WARNING_EMITTED
+    if _USAGE_WARNING_EMITTED:
+        return
+    _USAGE_WARNING_EMITTED = True
+    log.warning("goose usage %s failed; continuing without token cost capture: %r", phase, exc)

--- a/pipeline/wgmesh_pipeline/goose/usage.py
+++ b/pipeline/wgmesh_pipeline/goose/usage.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class UsageTotals:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    requests: int
+    skipped: int
+
+
+def default_logs_dir() -> Path:
+    return Path.home() / ".local/state/goose/logs"
+
+
+def snapshot_usage_logs(logs_dir: Path) -> dict[str, int]:
+    if not logs_dir.exists():
+        return {}
+    return {
+        path.name: path.stat().st_size
+        for path in logs_dir.glob("llm_request.*.jsonl")
+        if path.is_file()
+    }
+
+
+def collect_usage_delta(logs_dir: Path, snapshot: dict[str, int]) -> UsageTotals:
+    if not logs_dir.exists():
+        return UsageTotals(input_tokens=0, output_tokens=0, total_tokens=0, requests=0, skipped=0)
+
+    input_tokens = 0
+    output_tokens = 0
+    total_tokens = 0
+    requests = 0
+    skipped = 0
+
+    for path in sorted(logs_dir.glob("llm_request.*.jsonl")):
+        if not path.is_file():
+            continue
+        offset = snapshot.get(path.name, 0)
+        try:
+            size = path.stat().st_size
+            if offset < 0 or offset > size:
+                offset = 0
+            with path.open("rb") as fh:
+                fh.seek(offset)
+                lines = fh.readlines()
+        except OSError:
+            skipped += 1
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                usage = _usage_from_line(line)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                skipped += 1
+                continue
+            input_tokens += usage["input_tokens"]
+            output_tokens += usage["output_tokens"]
+            total_tokens += usage["total_tokens"]
+            requests += 1
+
+    return UsageTotals(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        requests=requests,
+        skipped=skipped,
+    )
+
+
+def _usage_from_line(line: bytes) -> dict[str, int]:
+    payload = json.loads(line.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("usage log line must be an object")
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        raise TypeError("usage log line missing usage object")
+    return {
+        "input_tokens": _int_usage(usage, "input_tokens"),
+        "output_tokens": _int_usage(usage, "output_tokens"),
+        "total_tokens": _int_usage(usage, "total_tokens"),
+    }
+
+
+def _int_usage(usage: dict[str, Any], key: str) -> int:
+    value = usage.get(key)
+    if not isinstance(value, int):
+        raise TypeError(f"usage.{key} must be an int")
+    return value

--- a/pipeline/wgmesh_pipeline/goose/usage.py
+++ b/pipeline/wgmesh_pipeline/goose/usage.py
@@ -47,24 +47,25 @@ def collect_usage_delta(logs_dir: Path, snapshot: dict[str, int]) -> UsageTotals
             size = path.stat().st_size
             if offset < 0 or offset > size:
                 offset = 0
+            # Iterate lazily: a busy implement run appends megabytes of request
+            # payloads between snapshot and collection.
             with path.open("rb") as fh:
                 fh.seek(offset)
-                lines = fh.readlines()
+                for line in fh:
+                    if not line.strip():
+                        continue
+                    try:
+                        usage = _usage_from_line(line)
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        skipped += 1
+                        continue
+                    input_tokens += usage["input_tokens"]
+                    output_tokens += usage["output_tokens"]
+                    total_tokens += usage["total_tokens"]
+                    requests += 1
         except OSError:
             skipped += 1
             continue
-        for line in lines:
-            if not line.strip():
-                continue
-            try:
-                usage = _usage_from_line(line)
-            except (TypeError, ValueError, json.JSONDecodeError):
-                skipped += 1
-                continue
-            input_tokens += usage["input_tokens"]
-            output_tokens += usage["output_tokens"]
-            total_tokens += usage["total_tokens"]
-            requests += 1
 
     return UsageTotals(
         input_tokens=input_tokens,

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -37,8 +37,7 @@ def implement_node(state: GraphState) -> GraphState:
         # implement attempt.
         config = next_state.get("config")
         recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
-        result = _run_recipe(
-            runner,
+        result = runner.run_recipe(
             recipe=recipes_dir / "wgmesh-implementation.yaml",
             workdir=repo_path,
             # diff_file mirrors expected_output: the recipe instructs goose to
@@ -205,13 +204,3 @@ def _status(exc: HTTPError) -> int | None:
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
-
-
-def _run_recipe(runner, **kwargs):
-    try:
-        return runner.run_recipe(**kwargs)
-    except TypeError as exc:
-        if "session_id" not in str(exc) or "unexpected keyword argument" not in str(exc):
-            raise
-        kwargs.pop("session_id", None)
-        return runner.run_recipe(**kwargs)

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -37,7 +37,8 @@ def implement_node(state: GraphState) -> GraphState:
         # implement attempt.
         config = next_state.get("config")
         recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
-        result = runner.run_recipe(
+        result = _run_recipe(
+            runner,
             recipe=recipes_dir / "wgmesh-implementation.yaml",
             workdir=repo_path,
             # diff_file mirrors expected_output: the recipe instructs goose to
@@ -49,6 +50,7 @@ def implement_node(state: GraphState) -> GraphState:
             expected_output=diff_rel,
             stage="implement",
             tier=tier,
+            session_id=f"issue-{issue.number}",
         )
         if not result.ok:
             raise RuntimeError(result.error or "goose implementation failed")
@@ -203,3 +205,13 @@ def _status(exc: HTTPError) -> int | None:
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
+
+
+def _run_recipe(runner, **kwargs):
+    try:
+        return runner.run_recipe(**kwargs)
+    except TypeError as exc:
+        if "session_id" not in str(exc) or "unexpected keyword argument" not in str(exc):
+            raise
+        kwargs.pop("session_id", None)
+        return runner.run_recipe(**kwargs)

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -26,8 +26,7 @@ def spec_node(state: GraphState) -> GraphState:
     config = next_state.get("config")
     recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
     recipe_path = recipes_dir / "wgmesh-triage-spec.yaml"
-    result = _run_recipe(
-        runner,
+    result = runner.run_recipe(
         recipe=recipe_path,
         workdir=repo_path,
         params={
@@ -76,13 +75,3 @@ def _read_excerpt(path) -> str:
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
-
-
-def _run_recipe(runner, **kwargs):
-    try:
-        return runner.run_recipe(**kwargs)
-    except TypeError as exc:
-        if "session_id" not in str(exc) or "unexpected keyword argument" not in str(exc):
-            raise
-        kwargs.pop("session_id", None)
-        return runner.run_recipe(**kwargs)

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -26,7 +26,8 @@ def spec_node(state: GraphState) -> GraphState:
     config = next_state.get("config")
     recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
     recipe_path = recipes_dir / "wgmesh-triage-spec.yaml"
-    result = runner.run_recipe(
+    result = _run_recipe(
+        runner,
         recipe=recipe_path,
         workdir=repo_path,
         params={
@@ -36,6 +37,7 @@ def spec_node(state: GraphState) -> GraphState:
         },
         expected_output=spec_rel,
         stage="spec",
+        session_id=f"issue-{issue.number}",
     )
     if not result.ok:
         # Surface goose's actual output so a write-tool/model/recipe failure is
@@ -74,3 +76,13 @@ def _read_excerpt(path) -> str:
 
 def _visit(state: dict, node: str) -> None:
     state.setdefault("visited", []).append(node)
+
+
+def _run_recipe(runner, **kwargs):
+    try:
+        return runner.run_recipe(**kwargs)
+    except TypeError as exc:
+        if "session_id" not in str(exc) or "unexpected keyword argument" not in str(exc):
+            raise
+        kwargs.pop("session_id", None)
+        return runner.run_recipe(**kwargs)

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -29,6 +29,20 @@ def _session_ctx(issue: str | None):
         return nullcontext()
 
 
+def _session_id_ctx(session_id: str | None):
+    """Group an observation under an already-formed Langfuse session id.
+    Guarded the same way as _session_ctx: telemetry context setup must never
+    break the pipeline."""
+    if not session_id:
+        return nullcontext()
+    try:
+        from langfuse import propagate_attributes  # public v4 API
+
+        return propagate_attributes(session_id=session_id)
+    except Exception:
+        return nullcontext()
+
+
 class Span(Protocol):
     def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
         ...
@@ -121,6 +135,7 @@ class LangfuseTracer:
 
 
 _tracer: Tracer = NoopTracer()
+_generation_warned = False
 
 
 def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
@@ -168,6 +183,38 @@ def trace_node(name: str, fn: Callable[[T], T]) -> Callable[[T], T]:
     return wrapped
 
 
+def emit_generation(*, session_id: str | None, stage: str | None, model: str, usage) -> None:
+    if not isinstance(_tracer, LangfuseTracer):
+        return
+    try:
+        lf = _tracer._lf
+        with _session_id_ctx(session_id):
+            observation = lf.start_observation(
+                name=f"{stage or 'goose'}-llm",
+                as_type="generation",
+                model=model,
+                usage_details={"input": usage.input_tokens, "output": usage.output_tokens},
+            )
+            observation.end()
+        lf.flush()
+        log.info(
+            "tracing: generation emitted stage=%s model=%s tokens=%d/%d",
+            stage,
+            model,
+            usage.input_tokens,
+            usage.output_tokens,
+        )
+    except Exception as exc:
+        _announce_generation(exc)
+
+
+def _announce_generation(exc: BaseException) -> None:
+    global _generation_warned
+    if not _generation_warned:
+        _generation_warned = True
+        print(f"[tracing] langfuse generation creation failed, tracing degraded: {exc!r}", file=sys.stderr)
+
+
 def _tags_for_state(state: Any, stage: str) -> dict[str, str]:
     tags = {"stage": stage}
     if isinstance(state, dict) and "issue" in state:
@@ -191,4 +238,3 @@ def _safe_state(value: Any) -> Any:
     for key in _UNSAFE_STATE_KEYS:
         safe.pop(key, None)
     return safe
-


### PR DESCRIPTION
## Why
Sessions show $0.00: goose's native langfuse export emits spans with zeroed usage (verified: `usage: {input: 0, output: 0}` on every goose span, model None). Real counts live in goose's local request log (`llm_request.*.jsonl`, verified on box: `{"usage": {"input_tokens": 64846, ...}}`).

## How
- `goose/usage.py`: shard-offset snapshot + delta collector (malformed lines counted, never raised).
- Runner: collects delta around every `goose run` (even failures), result carries `UsageTotals`, emits `emit_generation` when tokens > 0 with the resolved profile model and the caller's `session_id`.
- `tracing.emit_generation`: v4 `start_observation(as_type='generation', usage_details=...)` inside the session context; announce-once on failure, INFO per emission.
- spec + implement nodes pass `session_id=issue-N` (triage doesn't shell to goose).

## Cost prices
Langfuse needs a model-price entry for `glm-4.6` to turn usage into $ — applied separately via API to the langfuse box (z.ai pay-as-you-go list price; we're flat-rate so it's a comparable-value metric, noted in the model entry).

## Verification
219 passed, 2 skipped; new tests RED without implementation (verified).