### PR TITLE
fix(routing): per-run goose recipe overrides — registry profiles actually take effect

### DIFF
--- a/pipeline/tests/test_runner_routing.py
+++ b/pipeline/tests/test_runner_routing.py
@@ -21,6 +21,11 @@ _REGISTRY = (
     ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}}'
 )
 
+_OVERRIDE_REGISTRY = (
+    '{"spec-model": {"provider": "openrouter", "model": "deepseek/deepseek-v3.2",'
+    ' "billing": "openrouter", "credential_env": "OPENROUTER_API_KEY"}}'
+)
+
 
 def _routed_config(routing: str, monkeypatch):
     # Credentials live in the PROCESS env on the box (the runner reads
@@ -40,13 +45,33 @@ def _routed_config(routing: str, monkeypatch):
     )
 
 
+def _override_config(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    return load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "MODEL_REGISTRY": _OVERRIDE_REGISTRY,
+            "STAGE_ROUTING": '{"spec": "spec-model"}',
+            "OPENROUTER_API_KEY": "or-key",
+        }
+    )
+
+
 def _completed(stdout: str = "ok") -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=["goose"], returncode=0, stdout=stdout, stderr="")
 
 
 def _capture_runner(calls: list[dict[str, Any]]):
     def run(command, **kwargs):
-        calls.append({"command": command, "env": kwargs["env"]})
+        recipe_path = Path(command[command.index("--recipe") + 1])
+        calls.append(
+            {
+                "command": command,
+                "env": kwargs["env"],
+                "recipe_exists_at_invocation": recipe_path.exists(),
+            }
+        )
         out = Path(kwargs["cwd"]) / "out.txt"
         out.write_text("content")
         return _completed()
@@ -55,8 +80,14 @@ def _capture_runner(calls: list[dict[str, Any]]):
 
 
 def _run(config, stage: str, tmp_path, calls):
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text(
+        "settings:\n"
+        "  goose_provider: anthropic\n"
+        "  goose_model: glm-4.6\n"
+    )
     return GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
-        recipe="r.yaml",
+        recipe=recipe,
         workdir=tmp_path,
         params={"spec_file": "s.md"},
         expected_output="out.txt",
@@ -65,8 +96,14 @@ def _run(config, stage: str, tmp_path, calls):
 
 
 def _run_tier(config, stage: str, tier: int, tmp_path, calls):
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text(
+        "settings:\n"
+        "  goose_provider: anthropic\n"
+        "  goose_model: glm-4.6\n"
+    )
     return GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
-        recipe="r.yaml",
+        recipe=recipe,
         workdir=tmp_path,
         params={"spec_file": "s.md"},
         expected_output="out.txt",
@@ -168,6 +205,92 @@ def test_run_recipe_tier_defaults_to_zero(tmp_path, monkeypatch) -> None:
     assert result.ok is True
     assert calls[0]["env"]["GOOSE_MODEL"] == "GLM-4.7"
     assert result.model_key == "cheap"
+
+
+def test_recipe_override_written_with_profile_model(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _override_config(monkeypatch)
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "instructions: test\n"
+        "settings:\n"
+        "  goose_provider: anthropic\n"
+        "  goose_model: glm-4.6\n"
+    )
+
+    result = GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "s.md"},
+        expected_output="out.txt",
+        stage="spec",
+    )
+
+    assert result.ok is True
+    command = calls[0]["command"]
+    override_path = Path(command[command.index("--recipe") + 1])
+    assert override_path == tmp_path / "pipeline-output" / "recipe-override-spec.yaml"
+    assert calls[0]["recipe_exists_at_invocation"] is True
+    assert override_path.exists()
+    override_text = override_path.read_text()
+    assert 'goose_provider: "openrouter"' in override_text
+    assert 'goose_model: "deepseek/deepseek-v3.2"' in override_text
+    assert "goose_provider: anthropic" in recipe.read_text()
+    assert "goose_model: glm-4.6" in recipe.read_text()
+
+
+def test_recipe_without_settings_gets_block_appended(tmp_path, monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    config = _override_config(monkeypatch)
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text("instructions: test\n")
+
+    result = GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "s.md"},
+        expected_output="out.txt",
+        stage="spec",
+    )
+
+    assert result.ok is True
+    command = calls[0]["command"]
+    override_path = Path(command[command.index("--recipe") + 1])
+    override_text = override_path.read_text()
+    assert "settings:\n" in override_text
+    assert '  goose_provider: "openrouter"' in override_text
+    assert '  goose_model: "deepseek/deepseek-v3.2"' in override_text
+
+
+def test_no_profile_uses_original_recipe(tmp_path) -> None:
+    calls: list[dict[str, Any]] = []
+    config = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "ZAI_API_KEY": "zai-key",
+        }
+    )
+    object.__setattr__(config, "model_registry", {})
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "settings:\n"
+        "  goose_provider: anthropic\n"
+        "  goose_model: glm-4.6\n"
+    )
+
+    result = GooseRunner(config, runner=_capture_runner(calls)).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "s.md"},
+        expected_output="out.txt",
+        stage="spec",
+    )
+
+    assert result.ok is True
+    command = calls[0]["command"]
+    assert command[command.index("--recipe") + 1] == str(recipe)
+    assert not (tmp_path / "pipeline-output" / "recipe-override-spec.yaml").exists()
 
 
 def test_implement_node_passes_escalation_tier_to_runner(tmp_path) -> None:

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -262,12 +262,28 @@ class GooseRunner:
         if not output_path.is_absolute():
             output_path = workdir_path / output_path
 
-        command = ["goose", "run", "--no-session", "--recipe", str(recipe)]
+        profile = self._resolve_profile(stage, tier)
+        model_key = profile.key if profile is not None else None
+        recipe_path = Path(recipe)
+        command_recipe = recipe_path
+        if profile is not None:
+            command_recipe = _write_recipe_override(
+                recipe_path=recipe_path,
+                workdir=workdir_path,
+                stage=stage,
+                profile=profile,
+            )
+            log.info(
+                "goose recipe override: stage=%s provider=%s model=%s",
+                stage,
+                profile.provider,
+                profile.model,
+            )
+
+        command = ["goose", "run", "--no-session", "--recipe", str(command_recipe)]
         for key, value in params.items():
             command.extend(["--params", f"{key}={value}"])
 
-        profile = self._resolve_profile(stage, tier)
-        model_key = profile.key if profile is not None else None
         resolved_model = _resolved_model(self.config, profile)
         env = build_goose_env(self.config, profile=profile, stage=stage)
         logs_dir: Path | None = None
@@ -364,6 +380,43 @@ class GooseRunner:
 
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_GOOSE_PROVIDER_RE = re.compile(r"^(\s*goose_provider:).*$", re.MULTILINE)
+_GOOSE_MODEL_RE = re.compile(r"^(\s*goose_model:).*$", re.MULTILINE)
+
+
+def _write_recipe_override(
+    *,
+    recipe_path: Path,
+    workdir: Path,
+    stage: str | None,
+    profile: ModelProfile,
+) -> Path:
+    source_path = recipe_path if recipe_path.is_absolute() else workdir / recipe_path
+    text = source_path.read_text(encoding="utf-8")
+    text, provider_count = _GOOSE_PROVIDER_RE.subn(
+        lambda match: f'{match.group(1)} "{_yaml_scalar(profile.provider)}"',
+        text,
+    )
+    text, model_count = _GOOSE_MODEL_RE.subn(
+        lambda match: f'{match.group(1)} "{_yaml_scalar(profile.model)}"',
+        text,
+    )
+    if provider_count == 0 or model_count == 0:
+        if text and not text.endswith("\n"):
+            text += "\n"
+        text += (
+            "settings:\n"
+            f'  goose_provider: "{_yaml_scalar(profile.provider)}"\n'
+            f'  goose_model: "{_yaml_scalar(profile.model)}"\n'
+        )
+    override_path = workdir / "pipeline-output" / f"recipe-override-{stage or 'run'}.yaml"
+    override_path.parent.mkdir(parents=True, exist_ok=True)
+    override_path.write_text(text, encoding="utf-8")
+    return override_path
+
+
+def _yaml_scalar(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _strip_ansi(text: str) -> str:


### PR DESCRIPTION
## Problem
Recipes pin `goose_provider/goose_model` (headless goose ignores the env vars), so a configured `MODEL_REGISTRY`/`STAGE_ROUTING` profile was silently ignored — routing and the #1583 escalation ladder were cosmetic in live runs.

## Fix
When a profile resolves, the runner writes `pipeline-output/recipe-override-<stage>.yaml` with the profile's provider/model substituted into the settings block (appended if absent) and runs goose with that. Zero-config path byte-identical. Routing decisions announce: `goose recipe override: stage=... provider=... model=...`.

Same approach the wgmesh Actions cascade uses (sed on recipe settings) — now in the runner where every stage gets it.

## Verification
222 passed, 2 skipped; new tests assert override content + original recipe untouched + no-profile passthrough.

## Next (config, separate)
MODEL_REGISTRY: all 7 z.ai models (anthropic-compat, flat-rate) + deepseek-v3.2 + minimax-m3 via OpenRouter; STAGE_ROUTING ladders; Langfuse price entries.