### PR TITLE
feat(deploy): fast in-place box update workflow

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -242,6 +242,19 @@ jobs:
                sed -i 's/^RESET_QUEUE=.*/RESET_QUEUE=0/' /etc/wgmesh-pipeline/env
              fi"
 
+      - name: Install deploy key (enables fast Update Pipeline Box workflow)
+        env:
+          DEPLOY_PUBKEY: ${{ vars.DEPLOY_SSH_PUBKEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_PUBKEY:-}" ]; then
+            echo "DEPLOY_SSH_PUBKEY var unset — in-place updates unavailable until set"
+            exit 0
+          fi
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$RUNNER_TEMP/box_key" root@"$BOX_IP" \
+            "grep -qF '$DEPLOY_PUBKEY' /root/.ssh/authorized_keys 2>/dev/null || printf '%s\n' '$DEPLOY_PUBKEY' >> /root/.ssh/authorized_keys
+             echo 'deploy key installed'"
+
       - name: Capture journal after ticks (diagnostic)
         run: |
           set -euo pipefail

--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -252,7 +252,9 @@ jobs:
             exit 0
           fi
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$RUNNER_TEMP/box_key" root@"$BOX_IP" \
-            "grep -qF '$DEPLOY_PUBKEY' /root/.ssh/authorized_keys 2>/dev/null || printf '%s\n' '$DEPLOY_PUBKEY' >> /root/.ssh/authorized_keys
+            "set -euo pipefail
+             grep -qF '$DEPLOY_PUBKEY' /root/.ssh/authorized_keys 2>/dev/null || printf '%s\n' '$DEPLOY_PUBKEY' >> /root/.ssh/authorized_keys
+             grep -qF '$DEPLOY_PUBKEY' /root/.ssh/authorized_keys
              echo 'deploy key installed'"
 
       - name: Capture journal after ticks (diagnostic)

--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -45,7 +45,8 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          echo "BOX_IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")" >> "$GITHUB_ENV"
+          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          echo "BOX_IP=$IP" >> "$GITHUB_ENV"
 
       - name: Update + restart
         env:

--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -1,0 +1,76 @@
+name: Update Pipeline Box
+
+# Fast in-place deploy (~1 min): git reset to origin/main + pip install +
+# service restart over SSH. Use for CODE changes. Full "Provision Pipeline
+# Box" (~13 min, server recreate) is still required when the /etc env file
+# must change (new secrets, MODEL_REGISTRY/STAGE_ROUTING edits, mode flips)
+# or the box is gone/broken.
+#
+# Auth: DEPLOY_SSH_KEY secret (dedicated deploy keypair); its public half is
+# installed at provision time (vars.DEPLOY_SSH_PUBKEY) and was hand-added to
+# the current box 2026-06-10.
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
+          : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Resolve box IP
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "BOX_IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")" >> "$GITHUB_ENV"
+
+      - name: Update + restart
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          # UserKnownHostsFile=/dev/null: provision recreates the server, which
+          # rotates the host key; the deploy key is the real gate.
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+            "set -euo pipefail
+             cd /opt/wgmesh-pipeline
+             git fetch origin main
+             OLD=\$(git rev-parse --short HEAD)
+             git reset --hard origin/main
+             NEW=\$(git rev-parse --short HEAD)
+             echo \"code: \$OLD -> \$NEW\"
+             .venv/bin/pip install -q -e '/opt/wgmesh-pipeline/pipeline[turso,trace]'
+             chown -R wgmesh:wgmesh /opt/wgmesh-pipeline
+             systemctl restart wgmesh-pipeline
+             sleep 8
+             systemctl is-active wgmesh-pipeline
+             journalctl -u wgmesh-pipeline -n 5 --no-pager"
+
+      - name: Report
+        run: echo "Box updated in place at $BOX_IP — service restarted on latest main."


### PR DESCRIPTION
## Why
Every code fix today cost a ~13 min full Hetzner re-provision (server delete+create+cloud-init+pip). Most deploys only change code.

## What
- **Update Pipeline Box** workflow: resolve box IP via hcloud → SSH with dedicated deploy key → `git reset --hard origin/main` + `pip install -e pipeline[turso,trace]` + `systemctl restart` + health check. ~1 min.
- Provision installs `vars.DEPLOY_SSH_PUBKEY` into authorized_keys so recreated boxes keep accepting updates (no-op with a notice if unset).
- Key material: fresh dedicated keypair generated today; private → `DEPLOY_SSH_KEY` secret, public → `DEPLOY_SSH_PUBKEY` var + hand-installed on the live box.

## Boundaries
Env-file changes (new secrets, MODEL_REGISTRY/STAGE_ROUTING, PIPELINE_MODE) still require full provision — documented in the workflow header.

## Re: docker image
Considered (pipeline/deploy/Dockerfile exists); pull-based image deploys would be similarly fast but add registry auth + service migration. This gets the same latency win with zero new infra; image route stays open if we want immutability later.