### PR TITLE
fix(deploy): safe.directory for in-place update

### DIFF
--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -60,6 +60,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
             "set -euo pipefail
+             git config --global --add safe.directory /opt/wgmesh-pipeline
              cd /opt/wgmesh-pipeline
              git fetch origin main
              OLD=\$(git rev-parse --short HEAD)


### PR DESCRIPTION
First live run of Update Pipeline Box failed: `fatal: detected dubious ownership in repository at '/opt/wgmesh-pipeline'` — the checkout is chowned to `wgmesh` while the update SSHes as root. Mark it safe.directory before git operations.