### PR TITLE
feat(gate): real go build/test/vet verification — merge path becomes reachable

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -121,6 +121,13 @@ jobs:
             # service user) — the default ~/.local/bin lands in root's home and
             # is unreachable by the service + the non-interactive SSH PATH.
             - curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | HOME=/root GOOSE_BIN_DIR=/usr/local/bin CONFIGURE=false bash
+            # Go toolchain: review_node runs the REAL go build/test/vet gate on
+            # bot/impl-N branches (the tests_passed signal). Pinned to the
+            # wgmesh go.mod toolchain line.
+            - curl -fsSL https://go.dev/dl/go1.25.5.linux-amd64.tar.gz -o /tmp/go.tgz
+            - tar -C /usr/local -xzf /tmp/go.tgz
+            - ln -sf /usr/local/go/bin/go /usr/local/bin/go
+            - rm -f /tmp/go.tgz
             - install -d -m 700 /etc/wgmesh-pipeline
             - touch /etc/wgmesh-pipeline/.cloud-init-done
           CLOUD

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -205,6 +205,59 @@ def test_review_failed_verification_escalates_at_gate(monkeypatch) -> None:
     assert decision.retryable is True
 
 
+def test_live_review_uses_verification_result_and_gate_can_merge(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
+    calls = []
+
+    def fake_run_verification(repo_path, branch):
+        calls.append({"repo_path": repo_path, "branch": branch})
+        return {
+            "tests_passed": True,
+            "steps": [{"cmd": "go build", "returncode": 0, "duration_seconds": 0.01}],
+            "failed_step": None,
+            "output_tail": "",
+        }
+
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_verification", fake_run_verification)
+    client = GitHubClient(cfg(mode="live"), session=SessionForPr({"number": 456}), sanitiser=lambda text: True)
+
+    reviewed = review_node(
+        {
+            "issue": GitHubIssue(number=11, title="Fix docs", labels=("needs-triage",), state="open"),
+            "github": client,
+            "goose_runner": object(),
+            "repo_path": tmp_path,
+            "impl_branch": "bot/impl-11",
+            "impl_pr": 456,
+            "diff": "+docs\n",
+            "changed_files": ["docs/readme.md"],
+        }
+    )
+    gated = gate_node(reviewed, max_files=3)
+
+    assert calls == [{"repo_path": tmp_path, "branch": "bot/impl-11"}]
+    assert reviewed["tests_passed"] is True
+    assert reviewed["verification"]["tests_passed"] is True
+    assert gated["decision"] == "merge"
+    assert client.session.calls[-1]["url"].endswith("/pulls/456/merge")
+
+
+def test_non_live_review_keeps_tests_passed_fallback(monkeypatch) -> None:
+    monkeypatch.setattr("wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda text: True)
+
+    reviewed = review_node(
+        {
+            "issue": GitHubIssue(number=12, title="Fix docs", labels=("needs-triage",), state="open"),
+            "goose_runner": object(),
+            "diff": "+docs\n",
+            "verification": {"tests_passed": True},
+        }
+    )
+
+    assert reviewed["tests_passed"] is True
+    assert reviewed["verification"] == {"tests_passed": True}
+
+
 def test_gate_escalates_blocking_review_finding() -> None:
     decision = decide_gate(
         changed_files=["docs/readme.md"],

--- a/pipeline/tests/test_verification.py
+++ b/pipeline/tests/test_verification.py
@@ -58,17 +58,17 @@ def test_run_verification_stops_on_go_test_failure_and_captures_tail(tmp_path: P
 
 def test_run_verification_checkout_failure_returns_reason(tmp_path: Path) -> None:
     failures = {
+        ("git", "fetch", "origin", "bot/impl-7"): subprocess.CompletedProcess(
+            ["git", "fetch", "origin", "bot/impl-7"],
+            1,
+            stdout="",
+            stderr="no remote",
+        ),
         ("git", "checkout", "bot/impl-7"): subprocess.CompletedProcess(
             ["git", "checkout", "bot/impl-7"],
             1,
             stdout="",
             stderr="local missing",
-        ),
-        ("git", "checkout", "-B", "bot/impl-7", "origin/bot/impl-7"): subprocess.CompletedProcess(
-            ["git", "checkout", "-B", "bot/impl-7", "origin/bot/impl-7"],
-            1,
-            stdout="",
-            stderr="remote missing",
         ),
     }
     runner = FakeRunner(failures)
@@ -77,7 +77,19 @@ def test_run_verification_checkout_failure_returns_reason(tmp_path: Path) -> Non
 
     assert result["tests_passed"] is False
     assert "branch checkout failed" in result["reason"]
-    assert "remote missing" in result["reason"]
+    assert "local missing" in result["reason"]
+
+
+def test_run_verification_prefers_remote_state_when_fetch_succeeds(tmp_path: Path) -> None:
+    # The gate merges the REMOTE branch; a stale local branch must not vouch
+    # for code it does not match.
+    runner = FakeRunner()
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=runner, go_bin="/bin/go")
+
+    assert result["tests_passed"] is True
+    assert ["git", "checkout", "-B", "bot/impl-7", "FETCH_HEAD"] in runner.commands
+    assert ["git", "checkout", "bot/impl-7"] not in runner.commands
 
 
 def test_run_verification_missing_go_binary_returns_failure(tmp_path: Path, monkeypatch) -> None:

--- a/pipeline/tests/test_verification.py
+++ b/pipeline/tests/test_verification.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from wgmesh_pipeline import verification
+from wgmesh_pipeline.verification import run_verification
+
+
+class FakeRunner:
+    def __init__(self, failures: dict[tuple[str, ...], subprocess.CompletedProcess[str]] | None = None):
+        self.failures = failures or {}
+        self.commands: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        command = [str(part) for part in cmd]
+        self.commands.append(command)
+        key = tuple(command)
+        if key in self.failures:
+            return self.failures[key]
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+
+def test_run_verification_success_runs_go_steps_in_order(tmp_path: Path) -> None:
+    runner = FakeRunner()
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=runner, go_bin="/bin/go")
+
+    assert result["tests_passed"] is True
+    assert result["failed_step"] is None
+    assert result["output_tail"] == ""
+    assert [step["cmd"] for step in result["steps"]] == ["go build", "go test", "go vet"]
+    assert runner.commands[-3:] == [
+        ["/bin/go", "build", "./..."],
+        ["/bin/go", "test", "./..."],
+        ["/bin/go", "vet", "./..."],
+    ]
+
+
+def test_run_verification_stops_on_go_test_failure_and_captures_tail(tmp_path: Path) -> None:
+    failure = subprocess.CompletedProcess(
+        ["/bin/go", "test", "./..."],
+        1,
+        stdout="test stdout\n",
+        stderr="test stderr\n",
+    )
+    runner = FakeRunner({("/bin/go", "test", "./..."): failure})
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=runner, go_bin="/bin/go")
+
+    assert result["tests_passed"] is False
+    assert result["failed_step"] == "go test"
+    assert "test stdout" in result["output_tail"]
+    assert "test stderr" in result["output_tail"]
+    assert [step["cmd"] for step in result["steps"]] == ["go build", "go test"]
+    assert ["/bin/go", "vet", "./..."] not in runner.commands
+
+
+def test_run_verification_checkout_failure_returns_reason(tmp_path: Path) -> None:
+    failures = {
+        ("git", "checkout", "bot/impl-7"): subprocess.CompletedProcess(
+            ["git", "checkout", "bot/impl-7"],
+            1,
+            stdout="",
+            stderr="local missing",
+        ),
+        ("git", "checkout", "-B", "bot/impl-7", "origin/bot/impl-7"): subprocess.CompletedProcess(
+            ["git", "checkout", "-B", "bot/impl-7", "origin/bot/impl-7"],
+            1,
+            stdout="",
+            stderr="remote missing",
+        ),
+    }
+    runner = FakeRunner(failures)
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=runner, go_bin="/bin/go")
+
+    assert result["tests_passed"] is False
+    assert "branch checkout failed" in result["reason"]
+    assert "remote missing" in result["reason"]
+
+
+def test_run_verification_missing_go_binary_returns_failure(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(verification.shutil, "which", lambda name: None)
+    monkeypatch.setattr(verification, "DEFAULT_GO_BIN", tmp_path / "missing-go")
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=FakeRunner(), go_bin=None)
+
+    assert result["tests_passed"] is False
+    assert result["reason"] == "go binary not found"
+
+
+def test_run_verification_timeout_records_failed_step(tmp_path: Path) -> None:
+    class TimeoutRunner(FakeRunner):
+        def __call__(self, cmd, **kwargs):
+            command = [str(part) for part in cmd]
+            self.commands.append(command)
+            if command == ["/bin/go", "test", "./..."]:
+                raise subprocess.TimeoutExpired(command, timeout=600, output="partial", stderr="slow")
+            return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = run_verification(tmp_path, "bot/impl-7", runner=TimeoutRunner(), go_bin="/bin/go")
+
+    assert result["tests_passed"] is False
+    assert result["failed_step"] == "go test"
+    assert result["reason"] == "timeout"
+    assert [step["cmd"] for step in result["steps"]] == ["go build", "go test"]

--- a/pipeline/wgmesh_pipeline/graph/nodes/review.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/review.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.verification import run_verification
 
 
 SANITISE_SCRIPT = Path(__file__).resolve().parents[4] / "company" / "scripts" / "sanitise.sh"
@@ -15,7 +16,15 @@ def review_node(state: GraphState) -> GraphState:
     _visit(next_state, "review")
     diff = next_state.get("diff", "")
     next_state["sanitise_ok"] = run_sanitise(diff)
-    next_state["tests_passed"] = _tests_passed(next_state)
+    issue = next_state["issue"]
+    real_path = next_state.get("goose_runner") is not None and next_state.get("github") is not None
+    if real_path:
+        branch = str(next_state.get("impl_branch") or f"bot/impl-{issue.number}")
+        verification = run_verification(Path(next_state.get("repo_path", ".")), branch)
+        next_state["tests_passed"] = verification["tests_passed"]
+        next_state["verification"] = verification
+    else:
+        next_state["tests_passed"] = _tests_passed(next_state)
     next_state.setdefault("review_findings", [])
     return next_state
 

--- a/pipeline/wgmesh_pipeline/verification.py
+++ b/pipeline/wgmesh_pipeline/verification.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("wgmesh_pipeline.verification")
+
+DEFAULT_GO_BIN = Path("/usr/local/bin/go")
+OUTPUT_TAIL_CHARS = 2000
+
+
+def run_verification(
+    repo_path: Path,
+    branch: str,
+    *,
+    runner=subprocess.run,
+    timeout: int = 600,
+    go_bin: str | None = None,
+) -> dict:
+    go = _resolve_go(go_bin)
+    if go is None:
+        log.error("verification: go binary not found")
+        return {
+            "tests_passed": False,
+            "steps": [],
+            "failed_step": None,
+            "output_tail": "",
+            "reason": "go binary not found",
+        }
+
+    _run(runner, ["git", "fetch", "origin", branch], repo_path, timeout)
+    checkout = _run(runner, ["git", "checkout", branch], repo_path, timeout)
+    if checkout.returncode != 0:
+        fallback = _run(runner, ["git", "checkout", "-B", branch, f"origin/{branch}"], repo_path, timeout)
+        if fallback.returncode != 0:
+            stderr = fallback.stderr or checkout.stderr or ""
+            reason = f"branch checkout failed: {stderr}"
+            log.error("verification: %s", reason)
+            return {
+                "tests_passed": False,
+                "steps": [],
+                "failed_step": None,
+                "output_tail": _tail((fallback.stdout or "") + stderr),
+                "reason": reason,
+            }
+
+    steps: list[dict[str, Any]] = []
+    started = time.monotonic()
+    for name, args in (
+        ("go build", [go, "build", "./..."]),
+        ("go test", [go, "test", "./..."]),
+        ("go vet", [go, "vet", "./..."]),
+    ):
+        step_started = time.monotonic()
+        try:
+            completed = _run(runner, args, repo_path, timeout)
+        except subprocess.TimeoutExpired as exc:
+            duration = time.monotonic() - step_started
+            output = _timeout_output(exc)
+            steps.append({"cmd": name, "returncode": -1, "duration_seconds": duration})
+            _log_failure(name, output)
+            return {
+                "tests_passed": False,
+                "steps": steps,
+                "failed_step": name,
+                "output_tail": _tail(output),
+                "reason": "timeout",
+            }
+        duration = time.monotonic() - step_started
+        steps.append({"cmd": name, "returncode": completed.returncode, "duration_seconds": duration})
+        if completed.returncode != 0:
+            output = (completed.stdout or "") + (completed.stderr or "")
+            _log_failure(name, output)
+            return {
+                "tests_passed": False,
+                "steps": steps,
+                "failed_step": name,
+                "output_tail": _tail(output),
+            }
+
+    total = time.monotonic() - started
+    log.info("verification: go build/test/vet green on %s in %.2fs", branch, total)
+    return {
+        "tests_passed": True,
+        "steps": steps,
+        "failed_step": None,
+        "output_tail": "",
+    }
+
+
+def _resolve_go(go_bin: str | None) -> str | None:
+    if go_bin:
+        return go_bin
+    found = shutil.which("go")
+    if found:
+        return found
+    if DEFAULT_GO_BIN.exists():
+        return str(DEFAULT_GO_BIN)
+    return None
+
+
+def _run(runner, cmd: list[str], cwd: Path, timeout: int):
+    return runner(
+        cmd,
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def _timeout_output(exc: subprocess.TimeoutExpired) -> str:
+    output = _to_text(exc.output)
+    stderr = _to_text(exc.stderr)
+    return output + stderr
+
+
+def _to_text(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _tail(output: str) -> str:
+    return output[-OUTPUT_TAIL_CHARS:]
+
+
+def _log_failure(step: str, output: str) -> None:
+    head = output[:6000]
+    tail = output[-OUTPUT_TAIL_CHARS:] if len(output) > 8000 else ""
+    log.error(
+        "verification failed at %s len(output)=%d\n"
+        "--- verification output (head) ---\n%s\n--- verification output (tail) ---\n%s",
+        step,
+        len(output),
+        head,
+        tail,
+    )

--- a/pipeline/wgmesh_pipeline/verification.py
+++ b/pipeline/wgmesh_pipeline/verification.py
@@ -32,10 +32,17 @@ def run_verification(
             "reason": "go binary not found",
         }
 
-    _run(runner, ["git", "fetch", "origin", branch], repo_path, timeout)
-    checkout = _run(runner, ["git", "checkout", branch], repo_path, timeout)
+    # The gate merges the REMOTE branch (the GitHub PR head), so verify that
+    # exact state when it is reachable; a stale local branch must not vouch
+    # for code it doesn't match. Local checkout is only a fallback for
+    # remoteless test repos / network blips.
+    fetch = _run(runner, ["git", "fetch", "origin", branch], repo_path, timeout)
+    if fetch.returncode == 0:
+        checkout = _run(runner, ["git", "checkout", "-B", branch, "FETCH_HEAD"], repo_path, timeout)
+    else:
+        checkout = _run(runner, ["git", "checkout", branch], repo_path, timeout)
     if checkout.returncode != 0:
-        fallback = _run(runner, ["git", "checkout", "-B", branch, f"origin/{branch}"], repo_path, timeout)
+        fallback = _run(runner, ["git", "checkout", branch], repo_path, timeout)
         if fallback.returncode != 0:
             stderr = fallback.stderr or checkout.stderr or ""
             reason = f"branch checkout failed: {stderr}"
@@ -80,6 +87,7 @@ def run_verification(
                 "steps": steps,
                 "failed_step": name,
                 "output_tail": _tail(output),
+                "reason": f"{name} failed",
             }
 
     total = time.monotonic() - started


### PR DESCRIPTION
## Why
Every gate decision escalated: `tests_passed` had no setter anywhere in the live pipeline — `review_node` defaulted it False, so 'tests failed' was a permanent escalation reason and the autonomous merge path was unreachable. (Surviving half of the Phase-1 hollow-green finding: fabricated signals were removed, the real signal was never built.)

## What
- `verification.py`: checks out `bot/impl-N` in the shared clone (a later tick may have switched branches), runs `go build ./... && go test ./... && go vet ./...` with timeouts; structured result (steps, failed_step, output_tail); every failure mode announces (missing go, checkout fail, step fail w/ output head+tail, timeout).
- `review_node`: live path (github+goose_runner present) sets `tests_passed` + `verification` from the real run; shadow/test fallback unchanged.
- Provision cloud-init installs Go 1.25.5 (pinned to wgmesh's toolchain); already hand-installed on the live box (build verified green as service user).

High-risk diffs (keys/crypto/wireguard paths) still escalate by design — this only opens the low-risk + green-tests + sanitise-ok lane.

## Verification
229 passed, 2 skipped; revert→RED confirmed; new gate test proves review(live, green) → gate → decision=merge is reachable.

## Deploy
Fast update path (Update Pipeline Box) — env unchanged.