### PR TITLE
fix(pipeline): survive model-improvised go-cache + invalid UTF-8 goose output

### DIFF
--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -143,6 +143,10 @@ def build_goose_env(
     else:
         _apply_profile(env, profile, source)
     _apply_langfuse(env, config)
+    # Any go invocation goose makes must leave a removable module cache —
+    # the default cache is write-protected and breaks git clean when the
+    # model points GOMODCACHE inside the checkout.
+    env["GOFLAGS"] = (env.get("GOFLAGS", "") + " -modcacherw").strip()
     _apply_attribution(env, stage, profile)
     return env
 
@@ -301,6 +305,9 @@ class GooseRunner:
                 cwd=str(workdir_path),
                 env=env,
                 text=True,
+                # goose output can carry invalid UTF-8 (binary tool output);
+                # strict decoding crashed a live run 2026-06-10 18:11Z.
+                errors="replace",
                 capture_output=True,
                 check=False,
                 timeout=GOOSE_TIMEOUT_SECONDS,

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -152,7 +152,10 @@ def _prepare_impl_workspace(repo_path: Path, branch: str) -> None:
     if checkout.returncode != 0:
         _git(repo_path, "checkout", "-B", branch)
     _git(repo_path, "checkout", "--", ".")
-    _git(repo_path, "clean", "-fd", "--exclude=pipeline-output")
+    # go-cache: goose's model has improvised GOMODCACHE=go-cache inside the
+    # checkout; Go module caches are write-protected, so git clean dies on
+    # them (live incident 2026-06-10 18:29Z). Exclude rather than fight.
+    _git(repo_path, "clean", "-fd", "--exclude=pipeline-output", "--exclude=go-cache")
 
 
 def _stage_impl_tree(repo_path: Path) -> None:


### PR DESCRIPTION
Live incident (pulse, 18:11-18:45Z): three implement preps failing `git clean` on a write-protected `go-cache/` module cache the goose model improvised inside the checkout (`GOMODCACHE=go-cache` — no config sets it; pure model behavior, can recur any run), plus one tick crashed on strict UTF-8 decode of goose output containing binary bytes.

- `_prepare_impl_workspace` clean excludes `go-cache` (like pipeline-output)
- `build_goose_env` forces `GOFLAGS=-modcacherw` — any cache the model creates stays removable
- goose subprocess decode `errors='replace'`

Box already hand-unblocked (`chmod -R u+w && rm`). 230 tests green.