### PR TITLE
docs(pulse): 2026-06-10 23:25 delta

### DIFF
--- a/docs/pulse-reports/2026-06-10_23-25.md
+++ b/docs/pulse-reports/2026-06-10_23-25.md
@@ -1,0 +1,15 @@
+# Pulse — ai-pipeline-template — 2026-06-10 23:25 (delta since 22:10 report)
+
+## Headlines
+- **The real verification gate ran and discriminated.** #540 review: `go build` PASS (1.2s), `go test` FAIL → escalate. The failure is legitimate: goose's implement litter (a `go/` toolchain tree it materialized in the checkout) got swept into the impl commit by `git add -A`, and the suite correctly rejected the contaminated branch. First-ever gate decision backed by executed tests — it blocked a bad merge, which is the half of the job that matters most.
+- Two issues (#651, #584) escalated on a **go-binary race**: the 15:56 box recreation predated #1633's cloud-init Go step, wiping the hand-install; reinstalled 19:50, but their review ticks hit the 70-second gap. Verification announced it exactly (`reason: go binary not found`) — the announce discipline paid for itself.
+- Queue fully terminal again: 540/539 escalated on the litter-contamination test failure, 651/584 on the go race, 510 terminal (model produced no tree changes twice), 714/652/573 escalated earlier. **No autonomous impl merge yet** — every escalation traceable to a named cause, none to bad gate logic.
+
+## Action-success
+- 0 new Actions failures since 22:10 in either repo. The two box-side incident classes (go race, litter contamination) never reached Actions — journal+Langfuse-only. OPEN items unchanged: PUSH_TOKEN final-8, error-rate step (5th).
+
+## Followups (ordered)
+1. **Stage-litter exclusion**: `_stage_impl_tree` must deny-list model-materialized dirs (`go/`, `go-cache/`) before commit — same class as #1639, one tick from a clean verification pass. Then requeue (strip needs-human first, then reset).
+2. **Go install belongs to the box update path too**: fast-update doesn't install toolchains; full provision now has it (cloud-init), but the 15:56 box predates that — verify next full provision, or add an idempotent Go check to update-pipeline-box.
+3. PUSH_TOKEN final-8 migration; error-rate step root-cause (unchanged).
+4. #510: goose twice produced zero tree changes for the pilot-evaluation issue — likely a docs-shaped issue the recipe can't act on; consider docs-class routing or escalate-fast.


### PR DESCRIPTION
Delta pulse: the real verification gate executed for the first time — go build PASS, go test FAIL on goose-littered toolchain contamination in the impl commit → correct escalation. Two issues lost to a 70-second go-install race (announced precisely). Followups: stage-litter deny-list, then requeue.