### PR TITLE
fix(pipeline): model-litter deny-list + Go self-heal in fast update

### DIFF
--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -60,6 +60,14 @@ jobs:
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
             "set -euo pipefail
+             # Toolchain self-heal: a box recreated from an older provision may
+             # lack Go (2026-06-10: a 70s install race cost two gate decisions
+             # 'go binary not found'). Idempotent — skips when present.
+             if [ ! -x /usr/local/go/bin/go ]; then
+               curl -fsSL https://go.dev/dl/go1.25.5.linux-amd64.tar.gz -o /tmp/go.tgz
+               tar -C /usr/local -xzf /tmp/go.tgz && rm -f /tmp/go.tgz
+             fi
+             ln -sf /usr/local/go/bin/go /usr/local/bin/go
              git config --global --add safe.directory /opt/wgmesh-pipeline
              cd /opt/wgmesh-pipeline
              git fetch origin main

--- a/pipeline/tests/test_implement_retry_pr.py
+++ b/pipeline/tests/test_implement_retry_pr.py
@@ -194,6 +194,49 @@ def test_implement_starts_from_clean_workspace(tmp_path: Path) -> None:
     assert result["impl_pr"] == 4242
     assert client.calls[:2] == [("push_branch", "bot/impl-77"), ("create_pr", "bot/impl-77")]
     assert _git(clone, "diff", "--name-only", "origin/main..HEAD").stdout.splitlines() == ["README.md"]
+
+
+class _LitteringRunner(_FakeRunner):
+    """Mimics 2026-06-10: the model materialized a go/ toolchain tree and a
+    go-cache/ module cache in the checkout alongside its real edit."""
+
+    def run_recipe(self, **kwargs):
+        workdir = Path(kwargs["workdir"])
+        (workdir / "go" / "src" / "cmd" / "dist").mkdir(parents=True, exist_ok=True)
+        (workdir / "go" / "src" / "cmd" / "dist" / "build_test.go").write_text("package dist\n")
+        (workdir / "go-cache" / "some" / "mod@v1").mkdir(parents=True, exist_ok=True)
+        (workdir / "go-cache" / "some" / "mod@v1" / "a.go").write_text("package a\n")
+        return super().run_recipe(**kwargs)
+
+
+def test_stage_excludes_model_litter(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    clone = tmp_path / "clone"
+    _init_origin_with_spec_branch(origin)
+    _clone(origin, clone)
+
+    client = _RecordingClient()
+    runner = _LitteringRunner(
+        "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-wgmesh\n+wgmesh fixed\n",
+        edit_file="README.md",
+        edit_content="wgmesh fixed\n",
+    )
+
+    result = implement_node(
+        {
+            "issue": GitHubIssue(number=77, title="Fix relay", labels=("needs-triage",), state="open"),
+            "github": client,
+            "goose_runner": runner,
+            "repo_path": clone,
+            "spec_path": "specs/issue-77-spec.md",
+        }
+    )
+
+    assert result["impl_pr"] == 4242
+    committed = _git(clone, "diff", "--name-only", "origin/main..HEAD").stdout.splitlines()
+    assert committed == ["README.md"]
+    assert not any(p.startswith(("go/", "go-cache/")) for p in committed)
+    assert not any(p.startswith(("go/", "go-cache/")) for p in result["changed_files"])
     assert _git(clone, "show", "HEAD:README.md").stdout == "wgmesh fixed\n"
     assert _git(clone, "show", "HEAD:main.go").stdout == "package main\n\nfunc main() {}\n"
     assert result["diff"].startswith("diff --git a/README.md b/README.md")

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -146,21 +146,27 @@ def _materialize_spec(repo_path: Path, state: dict, spec_rel: Path) -> None:
     spec_path.write_text(content)
 
 
+# Model litter: goose's LLM materializes toolchain/cache dirs inside the
+# checkout (observed: GOMODCACHE=go-cache 18:29Z; a full go/ toolchain source
+# tree that git add -A committed and go test then rejected, 19:56Z — both
+# 2026-06-10). Cache dirs contain write-protected files git clean can't
+# remove, and none of it may ever reach an impl commit.
+MODEL_LITTER_DIRS = ("pipeline-output", "go", "go-cache", ".cache")
+
+
 def _prepare_impl_workspace(repo_path: Path, branch: str) -> None:
     _git(repo_path, "fetch", "origin", "main", check=False)
     checkout = _git(repo_path, "checkout", "-B", branch, "origin/main", check=False)
     if checkout.returncode != 0:
         _git(repo_path, "checkout", "-B", branch)
     _git(repo_path, "checkout", "--", ".")
-    # go-cache: goose's model has improvised GOMODCACHE=go-cache inside the
-    # checkout; Go module caches are write-protected, so git clean dies on
-    # them (live incident 2026-06-10 18:29Z). Exclude rather than fight.
-    _git(repo_path, "clean", "-fd", "--exclude=pipeline-output", "--exclude=go-cache")
+    excludes = [f"--exclude={d}" for d in MODEL_LITTER_DIRS]
+    _git(repo_path, "clean", "-fd", *excludes)
 
 
 def _stage_impl_tree(repo_path: Path) -> None:
     _git(repo_path, "add", "-A")
-    _git(repo_path, "reset", "-q", "--", "pipeline-output")
+    _git(repo_path, "reset", "-q", "--", *MODEL_LITTER_DIRS)
 
 
 def _ensure_impl_pr(state: dict) -> None:


### PR DESCRIPTION
## Why
First real verification run (#540, 19:56Z) correctly FAILed `go test`: goose's model had materialized a full `go/` toolchain source tree in the checkout and `_stage_impl_tree`'s `git add -A` committed it. Second member of the model-litter class after #1639's `go-cache`. Separately, the 15:56 box recreation (pre-#1633 cloud-init) lost the Go toolchain; reinstall raced two review ticks by ~70s (`reason: go binary not found`, announced precisely).

## What
- `MODEL_LITTER_DIRS = (pipeline-output, go, go-cache, .cache)` — excluded from workspace `git clean` AND reset out of staging before the impl commit.
- Wall test `test_stage_excludes_model_litter`: littering fake runner; commit must contain only the real edit. Revert→RED proven.
- `update-pipeline-box`: idempotent Go 1.25.5 install (skips when present) — fast path self-heals toolchain loss.

## Verification
231 passed, 2 skipped.

## After merge
Fast-deploy, strip needs-human from code-class issues, full provision reset_queue=true → clean cycle toward the first autonomous merge.