### PR TITLE
feat(gate): ggshield secret scan replaces keyword diff-content check

### DIFF
--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -16,6 +16,7 @@ name: Provision Pipeline Box
 #   DEEPSEEK_API_KEY / OPENAI_API_KEY / MINIMAX_API_KEY  — native provider keys
 #   MODEL_REGISTRY               — JSON: {key: {provider,model,billing,credential_env,host?}}
 #   STAGE_ROUTING                — JSON: {stage: registry_key}
+#   GITGUARDIAN_API_KEY          — optional; secret gate fails closed to keyword scan without it
 # wgmesh is PUBLIC, so shadow needs no GitHub token (reads only). Live (later)
 # needs WGMESH_BOT_PAT.
 
@@ -121,6 +122,12 @@ jobs:
             # service user) — the default ~/.local/bin lands in root's home and
             # is unreachable by the service + the non-interactive SSH PATH.
             - curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | HOME=/root GOOSE_BIN_DIR=/usr/local/bin CONFIGURE=false bash
+            # ggshield in an isolated venv: pip3 --break-system-packages
+            # collides with debian's urllib3 (RECORD-file uninstall error,
+            # 2026-06-11). Symlink onto PATH for the service user.
+            - python3 -m venv /opt/ggshield-venv
+            - /opt/ggshield-venv/bin/pip install -q ggshield
+            - ln -sf /opt/ggshield-venv/bin/ggshield /usr/local/bin/ggshield
             # Go toolchain: review_node runs the REAL go build/test/vet gate on
             # bot/impl-N branches (the tests_passed signal). Pinned to the
             # wgmesh go.mod toolchain line.
@@ -177,6 +184,9 @@ jobs:
           MODEL_REGISTRY: ${{ secrets.MODEL_REGISTRY }}
           STAGE_ROUTING: ${{ secrets.STAGE_ROUTING }}
           MAX_ESCALATION_ATTEMPTS: ${{ vars.MAX_ESCALATION_ATTEMPTS }}
+          # Optional; without it ggshield is unavailable and the gate fails closed
+          # to the existing keyword scan.
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           MODE: ${{ github.event.inputs.pipeline_mode }}
           DBMODE: ${{ github.event.inputs.database_mode }}
           RESET_QUEUE_INPUT: ${{ github.event.inputs.reset_queue }}
@@ -203,6 +213,7 @@ jobs:
           MODEL_REGISTRY='$MODEL_REGISTRY'
           STAGE_ROUTING='$STAGE_ROUTING'
           MAX_ESCALATION_ATTEMPTS=$MAX_ESCALATION_ATTEMPTS
+          GITGUARDIAN_API_KEY=$GITGUARDIAN_API_KEY
           WGMESH_CHECKOUT_PATH=/opt/wgmesh-checkout
           DATABASE_MODE=$DBMODE
           PIPELINE_DB_PATH=/opt/wgmesh-pipeline/state.db

--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -68,6 +68,9 @@ jobs:
                tar -C /usr/local -xzf /tmp/go.tgz && rm -f /tmp/go.tgz
              fi
              ln -sf /usr/local/go/bin/go /usr/local/bin/go
+             # GITGUARDIAN_API_KEY is optional; without it ggshield is unavailable
+             # and the gate fails closed to the existing keyword scan.
+             command -v ggshield >/dev/null || { python3 -m venv /opt/ggshield-venv && /opt/ggshield-venv/bin/pip install -q ggshield && ln -sf /opt/ggshield-venv/bin/ggshield /usr/local/bin/ggshield; }
              git config --global --add safe.directory /opt/wgmesh-pipeline
              cd /opt/wgmesh-pipeline
              git fetch origin main

--- a/pipeline/tests/test_risk.py
+++ b/pipeline/tests/test_risk.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from wgmesh_pipeline.secret_scan import SecretScanResult
 from wgmesh_pipeline.risk import classify_risk
 
 
@@ -23,7 +24,16 @@ def test_secret_key_added_in_benign_path_is_high_risk() -> None:
 +SECRET_KEY=abc123
 """
 
-    result = classify_risk(["config/example.env"], diff, max_files=3)
+    result = classify_risk(
+        ["config/example.env"],
+        diff,
+        max_files=3,
+        secret_scanner=lambda diff_text: SecretScanResult(
+            available=False,
+            found=False,
+            detail="ggshield not installed",
+        ),
+    )
 
     assert result.tier == "high"
     assert "high-risk diff content" in result.reasons[0]
@@ -51,3 +61,52 @@ def test_exactly_max_files_boundary_is_low_risk() -> None:
     result = classify_risk(["a", "b", "c"], "+small\n", max_files=3)
 
     assert result.tier == "low"
+
+
+def test_clean_diff_with_secret_keyword_not_flagged_when_ggshield_clean() -> None:
+    diff = """diff --git a/tests/example.sh b/tests/example.sh
++ b/tests/example.sh
++ ./tool --secret testSecret
+"""
+
+    result = classify_risk(
+        ["tests/example.sh"],
+        diff,
+        max_files=3,
+        secret_scanner=lambda diff_text: SecretScanResult(available=True, found=False, detail=None),
+    )
+
+    assert result.tier == "low"
+    assert not any("high-risk diff content" in reason for reason in result.reasons)
+
+
+def test_verified_secret_flagged() -> None:
+    result = classify_risk(
+        ["config/example.env"],
+        "+PASSWORD=abc123\n",
+        max_files=3,
+        secret_scanner=lambda diff_text: SecretScanResult(
+            available=True,
+            found=True,
+            detail="ggshield: 1 incident(s) [HardcodedPassword]",
+        ),
+    )
+
+    assert result.tier == "high"
+    assert any("verified secret in diff" in reason for reason in result.reasons)
+
+
+def test_ggshield_unavailable_falls_back_to_keyword() -> None:
+    result = classify_risk(
+        ["tests/example.sh"],
+        "+./tool --secret testSecret\n",
+        max_files=3,
+        secret_scanner=lambda diff_text: SecretScanResult(
+            available=False,
+            found=False,
+            detail="ggshield not installed",
+        ),
+    )
+
+    assert result.tier == "high"
+    assert any("keyword fallback" in reason for reason in result.reasons)

--- a/pipeline/tests/test_risk.py
+++ b/pipeline/tests/test_risk.py
@@ -1,7 +1,24 @@
 from __future__ import annotations
 
+import pytest
+
+from wgmesh_pipeline import secret_scan as secret_scan_mod
 from wgmesh_pipeline.secret_scan import SecretScanResult
 from wgmesh_pipeline.risk import classify_risk
+
+
+@pytest.fixture(autouse=True)
+def _no_real_ggshield(monkeypatch):
+    # Tests that don't inject a scanner must not spawn a real ggshield
+    # subprocess. risk.classify_risk does a call-time import from
+    # wgmesh_pipeline.secret_scan, so patch the source attribute. Default to
+    # "clean scan available"; tests exercising keyword fallback or a found
+    # secret inject their own scanner explicitly.
+    monkeypatch.setattr(
+        secret_scan_mod,
+        "scan_diff_for_secrets",
+        lambda diff_text: SecretScanResult(available=True, found=False, detail="ggshield: 0 incident(s)"),
+    )
 
 
 def test_docs_only_diff_is_low_risk() -> None:

--- a/pipeline/tests/test_secret_scan.py
+++ b/pipeline/tests/test_secret_scan.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from wgmesh_pipeline.secret_scan import scan_diff_for_secrets
+
+
+def test_found_true_when_json_has_incidents() -> None:
+    def runner(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=(
+                '{"entities_with_incidents": ['
+                '{"incidents": [{"type": "HardcodedPassword"}]}'
+                "]}"
+            ),
+            stderr="",
+        )
+
+    result = scan_diff_for_secrets("+password = 'abc'\n", runner=runner, ggshield_bin="ggshield")
+
+    assert result.available is True
+    assert result.found is True
+    assert result.detail == "ggshield: 1 incident(s) [HardcodedPassword]"
+
+
+def test_found_false_when_json_has_empty_entities() -> None:
+    def runner(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout='{"entities_with_incidents": []}',
+            stderr="",
+        )
+
+    result = scan_diff_for_secrets("+testSecret flag\n", runner=runner, ggshield_bin="ggshield")
+
+    assert result.available is True
+    assert result.found is False
+    assert result.detail == "ggshield: 0 incident(s)"
+
+
+def test_available_false_when_binary_missing(monkeypatch) -> None:
+    monkeypatch.setattr("wgmesh_pipeline.secret_scan.shutil.which", lambda name: None)
+
+    result = scan_diff_for_secrets("+SECRET_KEY=abc\n", ggshield_bin=None)
+
+    assert result.available is False
+    assert result.found is False
+    assert result.detail == "ggshield not installed"
+
+
+def test_available_false_on_unparseable_stdout_and_nonzero_returncode() -> None:
+    def runner(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout="authentication required",
+            stderr="missing GITGUARDIAN_API_KEY",
+        )
+
+    result = scan_diff_for_secrets("+secret\n", runner=runner, ggshield_bin="ggshield")
+
+    assert result.available is False
+    assert result.found is False
+    assert result.detail == "ggshield invalid json"
+
+
+def test_timeout_path() -> None:
+    def runner(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    result = scan_diff_for_secrets("+secret\n", runner=runner, ggshield_bin="ggshield")
+
+    assert result.available is False
+    assert result.found is False
+    assert result.detail == "ggshield timeout"
+
+
+def test_temp_file_is_removed_after_call() -> None:
+    temp_paths: list[str] = []
+
+    def runner(args, **kwargs) -> subprocess.CompletedProcess[str]:
+        temp_paths.append(args[4])
+        assert Path(args[4]).exists()
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout='{"entities_with_incidents": []}',
+            stderr="",
+        )
+
+    result = scan_diff_for_secrets("+small\n", runner=runner, ggshield_bin="ggshield")
+
+    assert result.available is True
+    assert temp_paths
+    assert not Path(temp_paths[0]).exists()

--- a/pipeline/wgmesh_pipeline/risk.py
+++ b/pipeline/wgmesh_pipeline/risk.py
@@ -25,7 +25,13 @@ class RiskResult:
         return self.tier == "high"
 
 
-def classify_risk(changed_files: Iterable[str], diff_text: str, *, max_files: int) -> RiskResult:
+def classify_risk(
+    changed_files: Iterable[str],
+    diff_text: str,
+    *,
+    max_files: int,
+    secret_scanner=None,
+) -> RiskResult:
     """Classify implementation risk.
 
     `max_files` is inclusive: exactly MAX_FILES changed files is allowed;
@@ -38,9 +44,20 @@ def classify_risk(changed_files: Iterable[str], diff_text: str, *, max_files: in
     if risky_paths:
         reasons.append(f"high-risk path: {risky_paths[0]}")
 
-    risky_added_line = _high_risk_added_line(diff_text)
-    if risky_added_line:
-        reasons.append(f"high-risk diff content: {risky_added_line}")
+    if secret_scanner is None:
+        from wgmesh_pipeline.secret_scan import scan_diff_for_secrets
+
+        secret_scanner = scan_diff_for_secrets
+
+    scan = secret_scanner(diff_text)
+    if scan.available is False:
+        risky_added_line = _high_risk_added_line(diff_text)
+        if risky_added_line:
+            reasons.append(
+                f"high-risk diff content (keyword fallback, ggshield unavailable): {risky_added_line}"
+            )
+    elif scan.found:
+        reasons.append(f"verified secret in diff: {scan.detail}")
 
     if len(files) > max_files:
         reasons.append(f"changed file count {len(files)} exceeds MAX_FILES={max_files}")

--- a/pipeline/wgmesh_pipeline/risk.py
+++ b/pipeline/wgmesh_pipeline/risk.py
@@ -44,26 +44,30 @@ def classify_risk(
     if risky_paths:
         reasons.append(f"high-risk path: {risky_paths[0]}")
 
-    if secret_scanner is None:
-        from wgmesh_pipeline.secret_scan import scan_diff_for_secrets
-
-        secret_scanner = scan_diff_for_secrets
-
-    scan = secret_scanner(diff_text)
-    if scan.available is False:
-        risky_added_line = _high_risk_added_line(diff_text)
-        if risky_added_line:
-            reasons.append(
-                f"high-risk diff content (keyword fallback, ggshield unavailable): {risky_added_line}"
-            )
-    elif scan.found:
-        reasons.append(f"verified secret in diff: {scan.detail}")
-
     if len(files) > max_files:
         reasons.append(f"changed file count {len(files)} exceeds MAX_FILES={max_files}")
 
     if _adds_network_call(diff_text):
         reasons.append("net-new outbound network call")
+
+    # Secret scan runs LAST and only when the cheap checks left the change
+    # otherwise-mergeable: that's the only state where its result changes the
+    # decision. An already-high change escalates regardless, so spending a
+    # ggshield API call / subprocess on it would be pure cost.
+    if not reasons:
+        if secret_scanner is None:
+            from wgmesh_pipeline.secret_scan import scan_diff_for_secrets
+
+            secret_scanner = scan_diff_for_secrets
+        scan = secret_scanner(diff_text)
+        if scan.available is False:
+            risky_added_line = _high_risk_added_line(diff_text)
+            if risky_added_line:
+                reasons.append(
+                    f"high-risk diff content (keyword fallback, ggshield unavailable): {risky_added_line}"
+                )
+        elif scan.found:
+            reasons.append(f"verified secret in diff: {scan.detail}")
 
     if reasons:
         return RiskResult(tier="high", reasons=tuple(reasons))

--- a/pipeline/wgmesh_pipeline/secret_scan.py
+++ b/pipeline/wgmesh_pipeline/secret_scan.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SecretScanResult:
+    available: bool
+    found: bool
+    detail: str | None
+
+
+def scan_diff_for_secrets(
+    diff_text: str,
+    *,
+    runner=subprocess.run,
+    ggshield_bin: str | None = None,
+    timeout: int = 120,
+) -> SecretScanResult:
+    ggshield = ggshield_bin or shutil.which("ggshield")
+    if ggshield is None:
+        log.info("ggshield not installed; using keyword fallback")
+        return SecretScanResult(available=False, found=False, detail="ggshield not installed")
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".diff", delete=False) as tmp:
+            tmp.write(diff_text)
+            tmp_path = tmp.name
+
+        completed = runner(
+            [ggshield, "secret", "scan", "path", tmp_path, "--json", "--exit-zero"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        log.warning("ggshield secret scan timed out")
+        return SecretScanResult(available=False, found=False, detail="ggshield timeout")
+    finally:
+        if tmp_path is not None:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        if completed.returncode != 0:
+            log.warning("ggshield secret scan failed: %s", (completed.stderr or "")[:200])
+        else:
+            log.warning("ggshield secret scan returned invalid json")
+        return SecretScanResult(available=False, found=False, detail="ggshield invalid json")
+
+    incident_count = 0
+    detector_types: list[str] = []
+    entities = payload.get("entities_with_incidents", []) if isinstance(payload, dict) else []
+    if isinstance(entities, list):
+        for entity in entities:
+            if not isinstance(entity, dict):
+                continue
+            incidents = entity.get("incidents", [])
+            if not isinstance(incidents, list):
+                continue
+            incident_count += len(incidents)
+            for incident in incidents:
+                if not isinstance(incident, dict):
+                    continue
+                detector_type = incident.get("type") or incident.get("detector_name")
+                if detector_type:
+                    detector_types.append(str(detector_type))
+
+    detail = f"ggshield: {incident_count} incident(s)"
+    if detector_types:
+        detail = f"{detail} [{', '.join(detector_types)}]"
+
+    return SecretScanResult(available=True, found=incident_count > 0, detail=detail)

--- a/pipeline/wgmesh_pipeline/secret_scan.py
+++ b/pipeline/wgmesh_pipeline/secret_scan.py
@@ -31,10 +31,20 @@ def scan_diff_for_secrets(
         log.info("ggshield not installed; using keyword fallback")
         return SecretScanResult(available=False, found=False, detail="ggshield not installed")
 
+    # Scan only ADDED content: a secret being removed (or sitting in an
+    # unchanged context line / the diff header) must not block the merge.
+    added = "\n".join(
+        line[1:]
+        for line in diff_text.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+    if not added.strip():
+        return SecretScanResult(available=True, found=False, detail="ggshield: 0 incident(s)")
+
     tmp_path: str | None = None
     try:
         with tempfile.NamedTemporaryFile("w", suffix=".diff", delete=False) as tmp:
-            tmp.write(diff_text)
+            tmp.write(added)
             tmp_path = tmp.name
 
         completed = runner(


### PR DESCRIPTION
## Why
The risk gate's content-secret check keyword-matched `secrets?|token|credential` on added diff lines and could not tell a test fixture from a leak. #510 (clean `status --json`, green tests, no real secret) escalated only because a test file added `testSecret := "..."` and a `--secret` CLI flag — blocking the first autonomous merge for a non-reason.

## What
- New `secret_scan.py`: runs `ggshield secret scan path --json --exit-zero`, returns `(available, found, detail)`. Found-ness from parsed json; unparseable+nonzero (e.g. bad/absent key) → `available=False`.
- `classify_risk`: ggshield clean → no content reason (the #510 fix); real secret → `verified secret in diff`; ggshield unavailable → **fail closed** to the keyword scan, announced.
- **Unchanged**: path-based domain risk (crypto/payments/auth FILES escalate to human), max_files, network-call check.
- Provision + fast-update install ggshield (isolated venv — `--break-system-packages` collides with debian urllib3); `GITGUARDIAN_API_KEY` optional, gate fails closed without it.

## Live validation (box)
- key healthy (workspace 507381, 8.7k quota)
- #510 diff → **0 incidents** (false positive gone)
- planted `ghp_…` → 1 incident "GitHub Personal Access Token"

## Verification
240 passed, 2 skipped; revert→RED on the #510 regression guard + scanner tests.

## Deploy
Box already has ggshield + key in live env; fast-update pulls this code → #510 should clear the content gate next review tick.