### PR TITLE
fix(reconcile): resolved-issue guard — merged-PR lookup with mid-flight gate

### DIFF
--- a/docs/brainstorms/2026-06-11-issue-lifecycle-guards-requirements.md
+++ b/docs/brainstorms/2026-06-11-issue-lifecycle-guards-requirements.md
@@ -1,0 +1,109 @@
+# Issue Lifecycle Guards — Requirements
+
+**Date:** 2026-06-11
+**Status:** Ready for planning
+**Scope:** Deep — feature (lifecycle/architecture change to the wgmesh autonomous pipeline)
+**Origin:** ce-debug investigation of the "false-completion" defect (session 2026-06-11)
+
+## Problem
+
+The pipeline reprocesses issues that are already resolved and mis-closes issues that aren't.
+Traced root causes:
+
+1. **No resolved-guard on claim.** `pipeline/wgmesh_pipeline/github/reconcile.py` claims every
+   open issue (`list_open_issues`) with no check for an existing merged resolution. Issues that
+   were resolved months ago and **operator-reopened** (#510 — spec #511 merged 2026-04-12,
+   reopened 04-29; #540 — impl #544 merged 2026-04-29, reopened 05-05) got re-specced and
+   re-implemented, producing dangling duplicate PRs (#688/#719, #690/#717).
+2. **Stale-merged-PR re-close.** `.github/workflows/close-resolved-issues.yml` closes an issue
+   `state_reason: completed` when it finds *any* merged `impl: Issue #N` PR, blind to whether the
+   issue was reopened *after* that merge for new work. #540's April merge re-closed it on 06-10
+   while its new impl #717 was still open.
+3. **Diffuse, unexplained close authority.** Multiple workflows close issues COMPLETED via the
+   `PUSH_TOKEN` principal (close-resolved-issues, verify-comment-close, e2e-verify-close). #584
+   closed COMPLETED on 06-10 with **no merged PR of any kind** — the responsible closer is not
+   yet identified.
+
+Net effect: convergence accounting is corrupted (issues look done that aren't, and resolved
+issues spawn dangling work), and it blocked the first clean autonomous merge by destroying
+candidate subjects.
+
+## Goal
+
+The box processes an issue at most once to resolution, and an issue closes COMPLETED only on a
+real current-cycle resolution signal — while still letting the operator deliberately request
+rework.
+
+## Decisions (resolved in brainstorm)
+
+- **Claim model: reopen + explicit rework marker.** An issue with a merged resolution is
+  re-claimable by the box **only** if it is open AND carries an explicit `needs-rework` label
+  AND has no open bot PR. A bare reopen (no marker) is invisible to the box — it will not
+  re-spec or re-implement. New work without a marker means a new issue.
+- **Close authority is consolidated and fenced.** One designated closer sets `COMPLETED`,
+  keyed on a merged impl PR for the *current* work cycle (a merge that post-dates the latest
+  reopen, or — equivalently under the marker model — a merge while no `needs-rework` is active).
+  Other autonomous closers must not set COMPLETED on stale or non-merge signals.
+- **#584 handling: fence, don't block.** The exact closer that mis-closed #584 is fenced out by
+  the close-authority consolidation even though it is not fully root-caused. Locking down who may
+  close is the fix; a full #584 forensic is not a blocker (see Outstanding Questions).
+- **`needs-rework` is operator-applied.** The box does not auto-detect "reopened for new work";
+  the operator labels the issue. Accepted as the explicit, low-magic control surface.
+
+## Requirements
+
+- **R1** Reconcile skips a resolved issue (one with a merged impl/spec resolution, or box state
+  already `merged`) unless it is open, labelled `needs-rework`, and has no open bot PR.
+- **R2** A bare reopen (no `needs-rework`) never triggers claim, spec, or implement.
+- **R3** Applying `needs-rework` to a reopened resolved issue makes it claimable for a fresh cycle;
+  the box treats it as new work (new spec/impl branch cycle) and clears the marker when the new
+  cycle resolves.
+- **R4** Exactly one workflow may close an issue `state_reason: completed`, and only on a merged
+  impl PR belonging to the current cycle. Stale-merged-PR matches (a merge predating the latest
+  reopen) do not close.
+- **R5** No autonomous path closes an issue COMPLETED on a non-merge signal (the #584 class is
+  fenced out).
+- **R6** One-time cleanup: the existing dangling duplicate PRs (#688/#719, #690/#717, #668/#722)
+  are closed with a goal-citing reason, since their issues are resolved or marker-less.
+
+## Success criteria
+
+- A resolved-then-reopened issue without `needs-rework` sits untouched: no new spec/impl PR, no
+  re-close churn.
+- Labelling such an issue `needs-rework` drives exactly one fresh cycle and the issue closes only
+  when that cycle's impl PR merges.
+- No issue closes COMPLETED without a current-cycle merged impl PR.
+- After cleanup, zero dangling bot PRs against resolved/closed issues.
+
+## Scope Boundaries
+
+**In scope:** reconcile claim guard (R1-R3), close-authority consolidation + stale-match fix
+(R4-R5), one-time dangling-PR cleanup (R6).
+
+### Deferred for later
+- Auto-detecting "reopened for new work" without a manual marker (the timestamp model was
+  considered and set aside as too silent — revisit only if the manual marker proves burdensome).
+- The first autonomous impl merge itself — needs a fresh low-risk issue, tracked separately; not
+  this lifecycle work.
+
+### Outside this change
+- The verification gate, ggshield, routing, cost capture — all working, untouched.
+- The PUSH_TOKEN→app-token migration (separate OPEN track), though close-authority consolidation
+  should prefer the durable principal where it touches the same workflows.
+
+## Dependencies / Assumptions
+
+- Assumes "resolved" is detectable from a merged impl PR (title/branch convention `bot/impl-N` /
+  `impl: Issue #N`) and/or the box's Turso state. Planning confirms the canonical signal.
+- Assumes the operator will apply `needs-rework` when they want a redo (replaces the current
+  bare-reopen behavior they used on #510/#540).
+
+## Outstanding Questions (for planning)
+
+1. **#584 closer identity.** Fenced by R5, but worth a bounded trace at plan time: which workflow
+   (suspect verify-comment-close on a stray issue_comment) set COMPLETED with no merged PR, and
+   does the consolidation actually remove its ability to?
+2. **Canonical resolved-signal.** Merged-PR search vs box Turso state vs both — which is
+   authoritative for R1/R4, and how do they reconcile when they disagree.
+3. **Marker lifecycle.** Who clears `needs-rework` and when (on new-cycle claim? on new merge?) so
+   it can't get stuck and re-trigger.

--- a/docs/plans/2026-06-11-002-fix-issue-lifecycle-guards-plan.md
+++ b/docs/plans/2026-06-11-002-fix-issue-lifecycle-guards-plan.md
@@ -1,0 +1,190 @@
+---
+title: "fix: Issue lifecycle guards — stop reprocessing resolved issues, fix false-completion"
+status: active
+date: 2026-06-11
+origin: docs/brainstorms/2026-06-11-issue-lifecycle-guards-requirements.md
+type: fix
+---
+
+# fix: Issue lifecycle guards
+
+**Target repos:** pipeline code in `ai-pipeline-template` (`pipeline/wgmesh_pipeline/...`); workflows in the **wgmesh** repo (`.github/workflows/...`). Paths below are repo-relative to whichever repo owns the file.
+
+## Summary
+
+Stop the box reprocessing already-resolved issues, and stop issues closing `COMPLETED`
+without a current-cycle merged impl PR. A resolved issue (one with a merged impl PR) is
+re-claimable only when reopened AND labelled `needs-rework` AND it has no open bot PR; a
+bare reopen is invisible to the box. One closer owns `COMPLETED`, keyed on a current-cycle
+merge; the stale-merged-PR re-close and the non-merge closers are removed. A one-time
+scripted cleanup closes the existing dangling duplicate PRs.
+
+---
+
+## Problem Frame
+
+`reconcile_issues` (`pipeline/wgmesh_pipeline/github/reconcile.py`) skips issues whose
+**Turso** stage is terminal — but `reset_queue` wipes Turso, so after any reset a
+reopened-and-previously-resolved issue (open on GitHub, no merged label) re-enters as
+`queued` and the box re-specs/re-implements it. #510 (spec #511 merged Apr-12, reopened
+Apr-29) and #540 (impl #544 merged Apr-29, reopened May-5) produced dangling dup PRs
+(#688/#719, #690/#717). Separately, `close-resolved-issues.yml` closes on *any* merged
+`impl: Issue #N` match, blind to a post-merge reopen, and other workflows close COMPLETED on
+non-merge signals (#584 closed with no merged PR). See origin for the full ce-debug trace.
+
+The Turso-wipe insight is load-bearing: the resolved-guard cannot rely on local state,
+because the exact failure path destroys it. It must read a GitHub-side signal.
+
+---
+
+## Requirements (origin traceability)
+
+- **R1** Reconcile skips a resolved issue unless open + `needs-rework` + no open bot PR (origin R1).
+- **R2** Bare reopen (no `needs-rework`) never triggers claim/spec/implement (origin R2).
+- **R3** `needs-rework` on a resolved issue drives exactly one fresh cycle; marker cleared on new-cycle claim (origin R3).
+- **R4** Exactly one workflow closes `state_reason: completed`, only on a current-cycle merged impl PR; stale-merged matches do not close (origin R4).
+- **R5** No autonomous path closes COMPLETED on a non-merge signal (origin R5).
+- **R6** One-time cleanup closes dangling dup PRs #688/#719, #690/#717, #668/#722 with goal-citing reasons (origin R6).
+
+---
+
+## Key Technical Decisions
+
+- **Resolved-signal = live merged-PR lookup, not local state.** Reconcile asks GitHub
+  "does a merged `impl: Issue #N` (or resolving spec) PR exist?" because `reset_queue`
+  wipes the Turso state the old terminal-skip relied on. One extra API call per *candidate*
+  issue (only those not already terminal in state), acceptable at the box's tick cadence.
+- **`needs-rework` is the single rework control.** Operator-applied. Its presence overrides
+  the resolved-skip; its absence means a resolved issue is left alone regardless of open/closed.
+- **One closer: `close-resolved-issues.yml`, current-cycle-gated.** It already owns the
+  merged-PR→close path; extend it to require the merged PR to post-date the issue's latest
+  reopen (or, equivalently, that the issue is not in a `needs-rework` cycle). The other
+  closers stop setting COMPLETED.
+- **Cleanup is a scripted operator step, not an autonomous sweep.** A bulk `gh pr close`
+  with reasons, run once, kept out of the loop so no autonomous path mass-closes PRs.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+  tick[reconcile tick] --> open[list_open_issues]
+  open --> term{Turso stage terminal?}
+  term -- yes --> skip1[skip]
+  term -- no/None --> res{merged impl PR exists?}
+  res -- no --> claim[normal claim/queue]
+  res -- yes --> rework{needs-rework label\n+ no open bot PR?}
+  rework -- no --> skip2[mark merged, do NOT re-claim]
+  rework -- yes --> fresh[claim fresh cycle\nclear needs-rework]
+```
+
+Close authority, after:
+
+```mermaid
+flowchart LR
+  merge[impl PR merged] --> cyc{merge newer than\nlatest reopen?}
+  cyc -- yes --> close[close COMPLETED]
+  cyc -- no --> leave[leave open]
+  vcc[verify-comment / e2e-verify] -. no longer sets COMPLETED .-> x[removed]
+```
+
+---
+
+## Implementation Units
+
+### U1. Reconcile resolved-guard (merged-PR lookup + needs-rework override)
+
+- **Goal:** Reconcile does not re-queue a resolved issue unless it is in an explicit rework cycle.
+- **Requirements:** R1, R2, R3.
+- **Dependencies:** none (U4 label can land in parallel; guard treats absent label as "no rework").
+- **Files:** `pipeline/wgmesh_pipeline/github/reconcile.py`, `pipeline/wgmesh_pipeline/github/client.py` (add a `has_merged_impl_pr(issue_number)` query if absent), `pipeline/tests/test_reconcile.py`.
+- **Approach:** in the `current_stage is None / not terminal` path, before queuing, check `has_merged_impl_pr(issue.number)`. If a merged impl PR exists AND `needs-rework` is NOT in labels → `upsert_issue(stage="merged", status=issue.state)` and skip (do not queue). If `needs-rework` IS present AND no open bot PR → queue a fresh cycle and remove the `needs-rework` label (R3 clear-on-claim). Reuse the existing `find_open_pr_number`/branch helpers for the open-bot-PR check. Keep the existing label-based MERGED_LABELS path.
+- **Patterns to follow:** existing `reconcile.py` branch structure; `client.list_open_pulls`/`find_open_pr_number` for the bot-PR check.
+- **Test scenarios:**
+  - Covers R1/R2. Issue open, no Turso state (post-reset), merged impl PR exists, no `needs-rework` → marked merged, NOT queued.
+  - Covers R3. Same but `needs-rework` present + no open bot PR → queued fresh, label removed.
+  - `needs-rework` present BUT an open bot PR exists → not re-queued (avoid duplicate in-flight).
+  - No merged impl PR (genuinely new issue) → queued as today (no regression).
+  - Existing MERGED_LABELS / needs-human / needs-triage paths unchanged (regression guard).
+- **Verification:** reconcile unit suite green; a simulated post-reset reopened-resolved issue is not re-queued.
+
+### U2. Close-authority consolidation + stale-match fix
+
+- **Goal:** Only one workflow closes COMPLETED, and only on a current-cycle merged impl PR.
+- **Requirements:** R4.
+- **Dependencies:** none.
+- **Files:** `.github/workflows/close-resolved-issues.yml` (wgmesh).
+- **Approach:** in both the PR-merge path and the sweep path, before closing, require the merged impl PR's merge time to be **newer than the issue's latest `reopened` event** (GitHub issue timeline), OR equivalently that the issue carries no active `needs-rework`. A stale merge (predating the last reopen) does not close. Keep `shouldSkip` (bug-class/gated) logic.
+- **Patterns to follow:** existing github-script close logic in the file; issue timeline API for reopen time.
+- **Test scenarios:** `Test expectation: logic-documented (YAML/github-script, no Python harness).` Manual/integration checks: (a) issue with merge newer than last reopen → closes; (b) issue reopened after its only merged impl PR → does NOT close; (c) bug-class/gated issue still skipped.
+- **Verification:** a reopened-after-merge issue survives a sweep run without closing.
+
+### U3. Fence non-merge closers (#584 class)
+
+- **Goal:** No workflow sets `state_reason: completed` on a non-merge signal.
+- **Requirements:** R5.
+- **Dependencies:** none.
+- **Files:** `.github/workflows/verify-comment-close.yml`, `.github/workflows/e2e-verify-close.yml` (wgmesh).
+- **Approach:** audit each closer. verify-comment-close (issue_comment trigger) and e2e-verify-close (workflow_run) may close only via the verified-bug lifecycle (awaiting-verification → verified), never a bare COMPLETED on an unresolved issue. Bounded trace of the #584 close (suspect verify-comment-close on a stray comment) to confirm the path that fired and close it off. If a closer has a legitimate close path, gate it on the same current-cycle-merge requirement as U2.
+- **Test scenarios:** `Test expectation: logic-documented.` Integration: a stray issue comment on an unresolved issue does not close it; an e2e-verify failure does not close COMPLETED.
+- **Verification:** the #584 reproduction (or its closest reconstruction) no longer closes the issue.
+
+### U4. `needs-rework` label lifecycle
+
+- **Goal:** The label exists, is documented, and is cleared at the right point.
+- **Requirements:** R3.
+- **Dependencies:** U1 (consumer).
+- **Files:** label creation (one-time `gh label create` or in provision), a short doc note in `pipeline/docs/` or AGENTS-adjacent guidance, `.github/workflows/` only if a workflow must clear it.
+- **Approach:** create the `needs-rework` label in wgmesh. Document the operator workflow: reopen + apply `needs-rework` to request a redo. Clearing happens in U1 on fresh-cycle claim (single clear-point to avoid a stuck marker re-triggering).
+- **Test scenarios:** `Test expectation: none — label + docs.` (Clear-on-claim behavior is tested in U1.)
+- **Verification:** label present in wgmesh; the operator runbook names the reopen+label step.
+
+### U5. One-time dangling-PR cleanup
+
+- **Goal:** Close the existing dangling duplicate PRs with reasons.
+- **Requirements:** R6.
+- **Dependencies:** U1 (so re-running reconcile won't immediately recreate them).
+- **Files:** a documented `gh` command sequence in `pipeline/docs/` (operator-run); no autonomous code.
+- **Approach:** `gh pr close` #688, #719, #690, #717, #668, #722 (wgmesh) each with a reason citing the resolved/duplicate status and the lifecycle fix. Verify the parent issues are in the correct state afterward (resolved issues stay closed; #584 reopened if it was wrongly closed and has real pending work — operator judgment).
+- **Test scenarios:** `Test expectation: none — one-time operator cleanup.`
+- **Verification:** zero open `bot/spec-*` or `bot/impl-*` PRs against resolved/closed issues after the sweep.
+
+---
+
+## Scope Boundaries
+
+**In scope:** U1-U5 above.
+
+### Deferred to Follow-Up Work
+- Auto-detecting "reopened for new work" without the manual `needs-rework` marker (timestamp model set aside in brainstorm as too silent).
+- The first autonomous impl merge itself — needs a fresh low-risk issue, tracked separately.
+
+### Outside this change
+- Verification gate, ggshield, routing, cost capture (working, untouched).
+- The PUSH_TOKEN→app-token migration — separate OPEN track; U2/U3 should prefer the durable principal where they already touch these workflows, but the migration itself is not this plan.
+
+---
+
+## Risks & Dependencies
+
+- **Per-tick API cost (U1).** The merged-PR lookup adds a call per non-terminal candidate. Mitigation: only for issues without a terminal Turso stage; cache within a tick if the candidate set is large.
+- **Timeline-based stale check (U2).** Reopen-time vs merge-time comparison is subtle; a missing timeline read defaults must fail safe to NOT closing (leave open) rather than closing wrongly.
+- **#584 not fully root-caused.** U3 fences by removing non-merge close authority even if the exact trigger stays unproven (origin decision). Residual risk: an unaudited closer remains; mitigation is the bounded trace in U3.
+- **Cross-repo.** Code in ai-pipeline-template, workflows in wgmesh — two PRs, sequence U1 (pipeline) and U2-U4 (wgmesh) can land independently; U5 cleanup after U1 deploys.
+
+---
+
+## Open Questions (resolve at implementation)
+
+1. **#584 closer identity** — bounded trace at impl time: which workflow set COMPLETED with no merged PR, and does U3 actually remove its ability to.
+2. **Resolving-PR definition** — does a merged *spec* PR count as "resolved" (it did for #510 via #511), or only a merged *impl* PR? Affects U1's `has_merged_impl_pr` predicate.
+3. **Marker clear timing** — confirmed clear-on-claim (U1); verify it can't get stuck if the fresh cycle fails before producing a PR.
+
+---
+
+## Sources & Research
+
+- Origin: `docs/brainstorms/2026-06-11-issue-lifecycle-guards-requirements.md`.
+- ce-debug trace (session 2026-06-11, memory `project_box_spec_contract_mismatch` wave 22): reset_queue wipes Turso → reopened-resolved issues re-enter; close-resolved-issues stale-merged match; #584 non-merge close.
+- Code read this session: `pipeline/wgmesh_pipeline/github/reconcile.py` (terminal-skip + MERGED_LABELS), `.github/workflows/close-resolved-issues.yml` (merged-guard + sweep), `verify-comment-close.yml` / `e2e-verify-close.yml` (PUSH_TOKEN closers).

--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -272,3 +272,40 @@ def test_list_open_issues_filters_out_pull_requests(cfg: Config) -> None:
     issues = GitHubClient(cfg, session=session).list_open_issues()
 
     assert [i.number for i in issues] == [10]
+
+
+def _search_response(*titles: str) -> Response:
+    return Response({"total_count": len(titles), "items": [{"title": t} for t in titles]})
+
+
+def test_has_merged_resolution_pr_matches_exact_prefix_title(cfg: Config) -> None:
+    session = Session(_search_response("impl: Issue #540 - Goose implementation"))
+
+    client = GitHubClient(cfg, session=session)
+
+    assert client.has_merged_resolution_pr(540) is True
+    assert len(session.calls) == 1
+    assert "/search/issues" in session.calls[0]["url"]
+
+
+def test_has_merged_resolution_pr_accepts_copilot_era_spec_suffix(cfg: Config) -> None:
+    session = Session(
+        _search_response("spec: Add `wgmesh status --json` output format (Issue #510)")
+    )
+
+    assert GitHubClient(cfg, session=session).has_merged_resolution_pr(510) is True
+
+
+def test_has_merged_resolution_pr_rejects_loose_token_match(cfg: Config) -> None:
+    """Search-API quoted phrases are token-loose: a query for "impl: Issue #540"
+    also returns PRs that merely mention the issue. A referencing PR must not
+    mark the issue resolved — that silently drops it from the pipeline."""
+    session = Session(_search_response("fix: regression caused by Issue #540 rollout"))
+
+    assert GitHubClient(cfg, session=session).has_merged_resolution_pr(540) is False
+
+
+def test_has_merged_resolution_pr_rejects_number_prefix_match(cfg: Config) -> None:
+    session = Session(_search_response("impl: Issue #5401 - other work"))
+
+    assert GitHubClient(cfg, session=session).has_merged_resolution_pr(540) is False

--- a/pipeline/tests/test_github_client.py
+++ b/pipeline/tests/test_github_client.py
@@ -309,3 +309,9 @@ def test_has_merged_resolution_pr_rejects_number_prefix_match(cfg: Config) -> No
     session = Session(_search_response("impl: Issue #5401 - other work"))
 
     assert GitHubClient(cfg, session=session).has_merged_resolution_pr(540) is False
+
+
+def test_has_merged_resolution_pr_rejects_alphanumeric_continuation(cfg: Config) -> None:
+    session = Session(_search_response("impl: Issue #540A - other work"))
+
+    assert GitHubClient(cfg, session=session).has_merged_resolution_pr(540) is False

--- a/pipeline/tests/test_reconcile.py
+++ b/pipeline/tests/test_reconcile.py
@@ -10,16 +10,42 @@ from wgmesh_pipeline.state.store import StateStore
 
 
 class Client(GitHubClient):
-    def __init__(self, issues: Iterable[GitHubIssue]):
+    def __init__(
+        self,
+        issues: Iterable[GitHubIssue],
+        *,
+        merged_resolution_prs: Iterable[int] = (),
+        open_pr_branches: Iterable[str] = (),
+        resolution_lookup_error: Exception | None = None,
+    ):
         super().__init__(Config(target_repo="atvirokodosprendimai/wgmesh"))
         self._issues = list(issues)
+        self._merged_resolution_prs = set(merged_resolution_prs)
+        self._open_pr_branches = set(open_pr_branches)
+        self._resolution_lookup_error = resolution_lookup_error
         self.removed_labels: list[tuple[int, str]] = []
+        self.removed_label_flags: list[tuple[int, str, bool]] = []
+        self.merged_resolution_lookups: list[int] = []
+        self.open_pr_lookups: list[str] = []
 
     def list_open_issues(self) -> list[GitHubIssue]:
         return self._issues
 
+    def has_merged_resolution_pr(self, issue_number: int) -> bool:
+        self.merged_resolution_lookups.append(issue_number)
+        if self._resolution_lookup_error is not None:
+            raise self._resolution_lookup_error
+        return issue_number in self._merged_resolution_prs
+
+    def find_open_pr_number(self, head_branch: str) -> int | None:
+        self.open_pr_lookups.append(head_branch)
+        if head_branch in self._open_pr_branches:
+            return 9000
+        return None
+
     def remove_label(self, issue_number: int, label: str, *, spec_pr: bool = False):
         self.removed_labels.append((issue_number, label))
+        self.removed_label_flags.append((issue_number, label, spec_pr))
         return {"ok": True}
 
 
@@ -76,6 +102,103 @@ def test_merged_upstream_issue_advances_and_is_not_requeued(tmp_path) -> None:
     assert record.stage == "merged"
     assert record.status == "closed"
     assert store.claim_next(now=datetime.now(timezone.utc)) is None
+
+
+def test_reopened_resolved_issue_without_rework_is_marked_merged_not_queued(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    client = Client([issue(510, (), title="Already fixed")], merged_resolution_prs={510})
+
+    result = reconcile_issues(client, store)
+
+    record = store.get_issue(510)
+    assert result.merged == 1
+    assert record.stage == "merged"
+    assert record.status == "open"
+    assert store.claim_next(now=datetime.now(timezone.utc)) is None
+    assert client.open_pr_lookups == []
+
+
+def test_reopened_resolved_issue_with_rework_and_no_open_bot_pr_is_requeued_and_label_cleared(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    client = Client([issue(540, ("needs-rework",), title="Redo")], merged_resolution_prs={540})
+
+    result = reconcile_issues(client, store)
+
+    claimed = store.claim_next(now=datetime.now(timezone.utc))
+    assert result.merged == 0
+    assert claimed is not None
+    assert claimed.number == 540
+    assert claimed.stage == "queued"
+    assert client.open_pr_lookups == ["bot/impl-540"]
+    assert client.removed_label_flags == [(540, "needs-rework", True)]
+
+
+def test_reopened_resolved_issue_with_rework_and_open_bot_pr_is_left_in_flight(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    client = Client(
+        [issue(540, ("needs-rework",), title="Redo")],
+        merged_resolution_prs={540},
+        open_pr_branches={"bot/impl-540"},
+    )
+
+    result = reconcile_issues(client, store)
+
+    assert result.merged == 0
+    assert result.queued == 0
+    assert store.claim_next(now=datetime.now(timezone.utc)) is None
+    assert client.open_pr_lookups == ["bot/impl-540"]
+    assert client.removed_labels == []
+
+
+def test_reopened_issue_without_merged_resolution_pr_is_queued_as_before(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    client = Client([issue(700, (), title="New work")])
+
+    reconcile_issues(client, store)
+
+    claimed = store.claim_next(now=datetime.now(timezone.utc))
+    assert claimed is not None
+    assert claimed.number == 700
+    assert claimed.stage == "queued"
+    assert client.merged_resolution_lookups == [700]
+
+
+def test_mid_flight_issue_with_merged_spec_pr_keeps_stage_and_skips_lookup(tmp_path) -> None:
+    """An issue the box is actively working on (non-None stage in store) must
+    NOT be marked merged when its spec PR merges mid-flight — the resolution
+    lookup is for issues unknown to the store (fresh or post-reset_queue).
+    Without this gate the box abandons every impl after its spec merges."""
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(609, "In flight", stage="spec_ready", status="open")
+    client = Client([issue(609, (), title="In flight")], merged_resolution_prs={609})
+
+    result = reconcile_issues(client, store)
+
+    assert client.merged_resolution_lookups == []
+    assert store.get_issue(609).stage == "spec_ready"
+    assert result.merged == 0
+
+
+def test_resolution_lookup_error_skips_issue_without_aborting_tick(tmp_path) -> None:
+    """A failed lookup (e.g. search rate-limit 403) must neither abort the whole
+    reconcile (stalls every claim) nor fail open (re-queues a resolved issue —
+    the bug the guard exists to stop). The issue is skipped for this tick."""
+    store = StateStore(tmp_path / "state.db")
+    client = Client(
+        [issue(510, (), title="Lookup fails"), issue(700, ("needs-triage",), title="Fine")],
+        resolution_lookup_error=RuntimeError("403 rate limited"),
+    )
+
+    result = reconcile_issues(client, store)
+
+    assert result.seen == 2
+    assert result.queued == 1
+    try:
+        store.get_issue(510)
+        raise AssertionError("issue 510 must not be upserted on lookup failure")
+    except KeyError:
+        pass
+    assert store.get_issue(700).stage == "queued"
 
 
 def test_needs_human_label_escalates_and_excludes_from_claim(tmp_path) -> None:

--- a/pipeline/tests/test_reconcile.py
+++ b/pipeline/tests/test_reconcile.py
@@ -126,6 +126,7 @@ def test_reopened_resolved_issue_with_rework_and_no_open_bot_pr_is_requeued_and_
 
     claimed = store.claim_next(now=datetime.now(timezone.utc))
     assert result.merged == 0
+    assert result.queued == 1
     assert claimed is not None
     assert claimed.number == 540
     assert claimed.stage == "queued"

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -89,6 +90,32 @@ class GitHubClient:
         if isinstance(resp, list) and resp and resp[0].get("number") is not None:
             return int(resp[0]["number"])
         return None
+
+    def has_merged_resolution_pr(self, issue_number: int) -> bool:
+        """True if a merged resolution PR (impl/spec/fix) exists for the issue.
+
+        Search-API quoted phrases are token-loose — a query for
+        "spec: Issue #510" also matches 'spec: Add ... (Issue #510)' and PRs
+        that merely mention the issue — so search is only a candidate
+        generator; titles are verified locally against the exact resolution
+        formats. One call total, not one per prefix: search counts against
+        the 30-requests/minute search budget, not the core API budget.
+        """
+        owner = self.config.owner
+        repo = self.config.repo
+        data = self._request(
+            "GET",
+            "/search/issues",
+            params={
+                "q": f'repo:{owner}/{repo} is:pr is:merged in:title "Issue #{issue_number}"',
+                "per_page": 30,
+            },
+        )
+        pattern = re.compile(
+            rf"^(?:impl|spec|fix): (?:Issue #{issue_number}(?!\d)|.*\(Issue #{issue_number}\)\s*$)"
+        )
+        items = data.get("items") or []
+        return any(pattern.match(str(item.get("title", ""))) for item in items)
 
     def get_diff(self, pr_number: int) -> str:
         return self._request(

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -112,7 +112,7 @@ class GitHubClient:
             },
         )
         pattern = re.compile(
-            rf"^(?:impl|spec|fix): (?:Issue #{issue_number}(?!\d)|.*\(Issue #{issue_number}\)\s*$)"
+            rf"^(?:impl|spec|fix): (?:Issue #{issue_number}(?!\w)|.*\(Issue #{issue_number}\)\s*$)"
         )
         items = data.get("items") or []
         return any(pattern.match(str(item.get("title", ""))) for item in items)

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -70,6 +70,7 @@ def reconcile_issues(client: GitHubClient, store: StateStore) -> ReconcileResult
                         continue
                     store.upsert_issue(issue.number, issue.title, stage="queued", status="open")
                     client.remove_label(issue.number, "needs-rework", spec_pr=True)
+                    queued += 1
                     continue
             store.upsert_issue(issue.number, issue.title, stage=current_stage or "queued", status="open")
     return ReconcileResult(seen=seen, queued=queued, escalated=escalated, merged=merged)

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 from wgmesh_pipeline.state.store import StateStore
+
+log = logging.getLogger(__name__)
 
 
 TERMINAL_STAGES = {"merged", "escalated", "failed"}
@@ -44,6 +47,30 @@ def reconcile_issues(client: GitHubClient, store: StateStore) -> ReconcileResult
                 # reconcile every tick and stalled the whole loop.
                 client.remove_label(issue.number, "needs-triage", spec_pr=True)
         else:
+            # Resolved-guard: only for issues the store has never seen (fresh
+            # or post-reset_queue — the path that wipes Turso state). An issue
+            # with a live stage is mid-flight; its merged *spec* PR must not
+            # mark it resolved, or every impl is abandoned after spec merge.
+            if current_stage is None:
+                try:
+                    resolved = client.has_merged_resolution_pr(issue.number)
+                except Exception as exc:
+                    # Skip this issue for the tick: aborting the whole
+                    # reconcile on a search rate-limit stalls every claim,
+                    # and failing open re-queues a resolved issue — the bug
+                    # this guard exists to stop.
+                    log.warning("reconcile: resolution lookup failed for #%s: %s", issue.number, exc)
+                    continue
+                if resolved:
+                    if "needs-rework" not in labels:
+                        store.upsert_issue(issue.number, issue.title, stage="merged", status=issue.state)
+                        merged += 1
+                        continue
+                    if client.find_open_pr_number(f"bot/impl-{issue.number}") is not None:
+                        continue
+                    store.upsert_issue(issue.number, issue.title, stage="queued", status="open")
+                    client.remove_label(issue.number, "needs-rework", spec_pr=True)
+                    continue
             store.upsert_issue(issue.number, issue.title, stage=current_stage or "queued", status="open")
     return ReconcileResult(seen=seen, queued=queued, escalated=escalated, merged=merged)
 


### PR DESCRIPTION
## Summary

Implements **U1** of [the issue-lifecycle-guards plan](docs/plans/2026-06-11-002-fix-issue-lifecycle-guards-plan.md) (R1–R3): reconcile no longer re-queues an already-resolved issue after `reset_queue` wipes Turso state (the #510/#540 dangling-dup-PR failure). A resolved issue re-enters only when open + `needs-rework` + no open bot PR; the label is cleared on requeue. Bare reopen stays invisible.

The resolved-signal is a **live GitHub merged-PR lookup**, not local state — the failure path destroys local state by definition.

## Defects caught in ce-debug review of the first draft (all fixed here)

1. **Mid-flight false-merge (critical).** The draft ran the lookup for every non-terminal issue, so any issue whose *spec* PR merged mid-flight was marked `merged` next tick and its impl abandoned — reintroducing the false-completion defect (#1653) this branch exists to stop. Now the lookup is gated on `current_stage is None` (issue unknown to the store = fresh or post-reset, exactly the target scenario).
2. **Token-loose Search matching.** GitHub Search quoted phrases are not exact-phrase (verified live: `"spec: Issue #510"` matches `spec: Add ... (Issue #510)`), so a merely-referencing merged PR would falsely resolve an issue. Search is now only a candidate generator; titles are verified locally against the exact resolution formats (`impl|spec|fix: Issue #N …` and the Copilot-era `… (Issue #N)` suffix).
3. **Search rate-budget stall.** Draft spent 3 search calls per candidate per tick against a 30/min budget, and a 403 aborted the whole reconcile+claim. Now 1 call per never-seen issue, and a lookup failure skips just that issue for the tick (fail-safe: neither stalls the loop nor fails open).

## Test plan

- [x] 6 new tests: mid-flight gate keeps stage + skips lookup; lookup error skips issue without aborting tick; HTTP-boundary (`Session`-stub) title-matching tests covering exact-prefix accept, Copilot-era suffix accept, loose-token reject, number-prefix (`#5401` vs `#540`) reject — gate stays in path per the test-fakes-override-the-gate lesson
- [x] Full suite: **250 passed, 2 skipped**
- [x] Regex verified against real merged wgmesh PR titles (#544, #511, #651-fix, #714-spec)
- [ ] Post-deploy: box tick log shows `reconcile seen=N` with no resolution-lookup warnings; #510/#540-class issues stay un-queued after a reset

Plan + origin brainstorm committed so doc references resolve in-tree. U2 (single closer gate), U4 (label), U6 (cleanup script) are separate units in the wgmesh repo.