### PR TITLE
fix(heartbeat): retry empty PR file list — async diff race left heal PR dwelling

### DIFF
--- a/.github/workflows/heartbeat-pr-automerge.yml
+++ b/.github/workflows/heartbeat-pr-automerge.yml
@@ -79,13 +79,24 @@ jobs:
               ;;
           esac
 
+          # GitHub computes the PR file list asynchronously after creation;
+          # an immediate query on the `opened` event can return an empty list
+          # for a PR that does have changes. With no retrigger (heartbeat PRs
+          # never get new commits), one lost race left the PR dwelling
+          # forever (#1634). Retry before treating empty as a real violation.
           changed_files=()
-          while IFS= read -r path; do
-            [ -n "$path" ] && changed_files+=("$path")
-          done < <(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json files --jq '.files[].path')
+          for attempt in 1 2 3 4 5; do
+            changed_files=()
+            while IFS= read -r path; do
+              [ -n "$path" ] && changed_files+=("$path")
+            done < <(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json files --jq '.files[].path')
+            [ "${#changed_files[@]}" -gt 0 ] && break
+            echo "PR file list empty (attempt $attempt/5); waiting for GitHub to compute the diff"
+            sleep 10
+          done
 
           if [ "${#changed_files[@]}" -eq 0 ]; then
-            echo "::error::Heartbeat PR has no changed files"
+            echo "::error::Heartbeat PR has no changed files after 5 attempts"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

PR #1634 (heal state PR) dwelled a full day: the fast-lane fired on `opened` 6s after PR creation, queried `gh pr view --json files` 13s in, and got an **empty list** — GitHub computes PR file lists asynchronously, so an immediate query races the diff computation. `heartbeat-pr-automerge.yml` treated empty as a hard scope failure (`Heartbeat PR has no changed files`, run 27289930712), and since heartbeat PRs never receive new commits there was no `synchronize` retrigger — one lost race = permanent dwell. Same trigger-gap shape as the bot-merge `synchronize` gap.

## Fix

Retry the file-list query up to 5× with 10s backoff before declaring the PR empty. Genuinely empty PRs still fail, 50s later. Scope/branch/author gates unchanged.

## Test plan

- [x] #1634 retriggered via close→reopen — lane re-ran with populated file list (validation path exercised live)
- [ ] Next heal/loop/supervisor-rank state PR auto-merges without manual touch