### PR TITLE
fix(observation-loop): guard issue closes — no autonomous COMPLETED on non-merge signal

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -728,8 +728,12 @@ jobs:
 
             # Guard 1: never autonomously close a human escalation. The loop
             # closed needs-human #652 on its own judgment (2026-06-11).
-            labels=$(gh issue view "$number" --repo "$TARGET_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
-            if echo "$labels" | grep -q "needs-human"; then
+            # Fail-closed: if the label fetch fails we refuse to close blind.
+            if ! labels=$(gh issue view "$number" --repo "$TARGET_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null); then
+              echo "SKIP close #${number}: label fetch failed — refusing to close blind (reason was: $reason)"
+              continue
+            fi
+            if echo ",$labels," | grep -q ",needs-human,"; then
               echo "SKIP close #${number}: needs-human label — human-lane only (reason was: $reason)"
               continue
             fi

--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -725,7 +725,27 @@ jobs:
           jq -c '.issues_to_close // [] | .[]' /tmp/assessment.json | while read -r item; do
             number=$(echo "$item" | jq -r '.number')
             reason=$(echo "$item" | jq -r '.reason')
-            gh issue close "$number" --repo "$TARGET_REPO" --comment "Closed by observation loop: $reason" || true
+
+            # Guard 1: never autonomously close a human escalation. The loop
+            # closed needs-human #652 on its own judgment (2026-06-11).
+            labels=$(gh issue view "$number" --repo "$TARGET_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+            if echo "$labels" | grep -q "needs-human"; then
+              echo "SKIP close #${number}: needs-human label — human-lane only (reason was: $reason)"
+              continue
+            fi
+
+            # Guard 2: if the assessment's own reason says relabel/reopen,
+            # the disposition is not a close — #652's close comment literally
+            # read 'Relabel rather than close' while the step closed it.
+            if echo "$reason" | grep -qiE "relabel|reopen|rather than clos"; then
+              echo "SKIP close #${number}: reason contradicts close action: $reason"
+              continue
+            fi
+
+            # Guard 3 (R5): an LLM assessment is a non-merge signal — close
+            # as 'not planned', never COMPLETED. COMPLETED is reserved for
+            # the merged-impl-PR closer.
+            gh issue close "$number" --repo "$TARGET_REPO" --reason "not planned" --comment "Closed by observation loop: $reason" || true
           done
 
       - name: Create needs-human issue if requested


### PR DESCRIPTION
## Summary

Trace of wgmesh#652's close (2026-06-11 18:40Z) found the observation loop's `Close issues from assessment` step blind-closing whatever the LLM assessment lists in `issues_to_close[]`. It closed #652 **COMPLETED** while its own reason text read *'Relabel rather than close'* — and the issue carried `needs-human` (spec #667 needs workflow-file pushes no bot token can make). R5 of the [issue-lifecycle-guards plan](docs/plans/2026-06-11-002-fix-issue-lifecycle-guards-plan.md): no autonomous path closes COMPLETED on a non-merge signal.

## Guards added (observation-loop.yml, close step)

1. **needs-human → skip.** Human escalations are never autonomously closed.
2. **Reason↔action check.** Reason mentioning relabel/reopen contradicts a close → skip + loud log.
3. **R5: `--reason "not planned"`.** LLM assessment = non-merge signal; COMPLETED stays reserved for the merged-impl-PR closer.

#652 itself reopened + relabeled fn:ops per the loop's stated intent.

## Test plan

- [x] Guards are plain gh/grep shell — exercised paths identical to existing step style
- [ ] Next observation-loop run: skips logged for any needs-human/contradictory dispositions; closes (if any) land as not-planned