### PR TITLE
feat(deploy): land containerized box-deploy path (cutover U14 foundation)

### DIFF
--- a/.github/workflows/build-pipeline-image.yml
+++ b/.github/workflows/build-pipeline-image.yml
@@ -50,7 +50,9 @@ jobs:
         run: docker run --rm "$IMAGE_NAME:test" python -m pytest pipeline/tests/ -q
 
       - name: Run eval gate inside image
-        run: docker run --rm "$IMAGE_NAME:test" python -m evals.run_evals --check
+        # evals/ is repo-level code, not in the installed package — needs
+        # PYTHONPATH inside the container (mirrors release.yml + ci.yml).
+        run: docker run --rm -e PYTHONPATH=/app/pipeline "$IMAGE_NAME:test" python -m evals.run_evals --check
 
       - name: Push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build-pipeline-image.yml
+++ b/.github/workflows/build-pipeline-image.yml
@@ -1,0 +1,65 @@
+name: Build Pipeline Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pipeline/**'
+      - 'pipeline/deploy/Dockerfile'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image name
+        run: |
+          set -euo pipefail
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "OWNER_LC=$OWNER_LC" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=ghcr.io/$OWNER_LC/wgmesh-pipeline" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image for test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pipeline/deploy/Dockerfile
+          load: true
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run pytest inside image
+        run: docker run --rm "$IMAGE_NAME:test" python -m pytest pipeline/tests/ -q
+
+      - name: Run eval gate inside image
+        run: docker run --rm "$IMAGE_NAME:test" python -m evals.run_evals --check
+
+      - name: Push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pipeline/deploy/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -64,20 +64,32 @@ jobs:
 
           docker pull "${IMAGE}:${SHA}"
 
-          previous_sha=$(cat /etc/wgmesh-pipeline/deployed_sha)
+          # First containerized deploy has no prior SHA — empty means "no
+          # rollback target", not a hard failure.
+          previous_sha=$(cat /etc/wgmesh-pipeline/deployed_sha 2>/dev/null || echo "")
           echo "${SHA}" > /etc/wgmesh-pipeline/deployed_sha
+          # Record the exact image ref for run-container.sh so the unit and
+          # the deploy workflow can never diverge on owner/name.
+          echo "${IMAGE}:${SHA}" > /etc/wgmesh-pipeline/image_ref
 
+          # Health window starts AT the restart — "1 minute ago" could match
+          # a tick from the pre-restart process.
+          restart_ts=$(date "+%Y-%m-%d %H:%M:%S")
           if systemctl restart wgmesh-pipeline \
             && sleep 10 \
             && systemctl is-active wgmesh-pipeline \
-            && journalctl -u wgmesh-pipeline --since "1 minute ago" --no-pager | grep -q "tick"; then
+            && journalctl -u wgmesh-pipeline --since "$restart_ts" --no-pager | grep -q "tick"; then
             echo "Deploy healthy: ${previous_sha} -> ${SHA}"
             exit 0
           fi
 
-          echo "${previous_sha}" > /etc/wgmesh-pipeline/deployed_sha
-          systemctl restart wgmesh-pipeline
-          echo "ROLLBACK complete"
+          if [ -n "${previous_sha}" ]; then
+            echo "${previous_sha}" > /etc/wgmesh-pipeline/deployed_sha
+            systemctl restart wgmesh-pipeline
+            echo "ROLLBACK complete to ${previous_sha}"
+          else
+            echo "ROLLBACK impossible: no previous SHA recorded (first deploy)"
+          fi
           exit 1
           REMOTE
 

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -1,0 +1,85 @@
+name: Deploy Pipeline Box
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+      sha:
+        description: 'Image tag to deploy'
+        default: 'latest'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
+          : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Resolve image owner
+        run: |
+          set -euo pipefail
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE=ghcr.io/$OWNER_LC/wgmesh-pipeline" >> "$GITHUB_ENV"
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Resolve box IP
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          echo "BOX_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Deploy image
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SHA: ${{ github.event.inputs.sha }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          SSH_SHA=$(printf '%q' "$SHA")
+          SSH_IMAGE=$(printf '%q' "$IMAGE")
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+              "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -se" <<'REMOTE'
+          set -euo pipefail
+
+          docker pull "${IMAGE}:${SHA}"
+
+          previous_sha=$(cat /etc/wgmesh-pipeline/deployed_sha)
+          echo "${SHA}" > /etc/wgmesh-pipeline/deployed_sha
+
+          if systemctl restart wgmesh-pipeline \
+            && sleep 10 \
+            && systemctl is-active wgmesh-pipeline \
+            && journalctl -u wgmesh-pipeline --since "1 minute ago" --no-pager | grep -q "tick"; then
+            echo "Deploy healthy: ${previous_sha} -> ${SHA}"
+            exit 0
+          fi
+
+          echo "${previous_sha}" > /etc/wgmesh-pipeline/deployed_sha
+          systemctl restart wgmesh-pipeline
+          echo "ROLLBACK complete"
+          exit 1
+          REMOTE
+
+      - name: Report
+        run: echo "Box $BOX_IP deployed image tag '${{ github.event.inputs.sha }}'."

--- a/docs/brainstorms/2026-06-11-containerized-box-deploy-requirements.md
+++ b/docs/brainstorms/2026-06-11-containerized-box-deploy-requirements.md
@@ -1,0 +1,106 @@
+# Containerized Box Deploy — Requirements
+
+**Date:** 2026-06-11
+**Status:** Ready for planning
+**Scope:** Deep — feature (infra/architectural change to how the wgmesh-pipeline box is updated)
+
+## Problem
+
+Updating the LangGraph pipeline box conflates two lifecycles. `provision-pipeline-box.yml`
+recreates the Hetzner VM (delete + create + cloud-init, ~13 min) to change anything beyond
+code — env, secrets, `MODEL_REGISTRY`, mode. `update-pipeline-box.yml` ships code in-place
+(~75 s) but installs the toolchain live (goose, Go, ggshield), which has broken in practice
+(the ~70 s Go-install race that cost two gate decisions; the ggshield/urllib3 conflict).
+
+The deployed artifact is not provably the artifact CI tested: deploy is `git reset --hard` +
+`pip install -e` live, which can resolve or behave differently than CI. There is no atomic
+rollback — reverting a bad deploy means another git-pull, and a half-run provision (a cancel
+landed after server-delete tonight) leaves a destroyed box.
+
+## Primary goal
+
+**Atomicity and rollback.** A deploy installs an artifact that CI already built and tested,
+swaps to it atomically, and can be reverted to the exact prior artifact in one action. Server
+recreation is never the path for an app or config update.
+
+Secondary pains this same mechanism removes: toolchain install races (baked at build), and
+server-lifecycle coupling (the VM is never recreated to ship the app).
+
+## Approach (selected)
+
+Docker image, built and tested in CI, deployed by pulling a commit-SHA tag and swapping the
+container. Chosen over a VM-side versioned-release-dir scheme because only the image bakes the
+toolchain (killing the install races) and decouples server lifecycle, collapsing the primary
+ask and two secondary pains into one mechanism.
+
+## Requirements
+
+- **R1 — Baked toolchain image.** `pipeline/deploy/Dockerfile` builds an image containing the
+  pipeline plus its full runtime toolchain: python, goose, Go 1.25.5, ggshield — all version-
+  pinned. No tool is installed at deploy time.
+- **R2 — CI build-test-push.** On merge to main, CI builds the image, runs the pipeline test
+  suite **inside the image**, and pushes it to `ghcr.io` tagged by commit SHA (and a moving
+  `latest`). A failed in-image test fails the build and blocks the push.
+- **R3 — Atomic deploy.** A deploy action pulls a specified SHA tag on the box and swaps the
+  running container to it, then health-checks the service. No server recreation. Target under
+  ~2 minutes.
+- **R4 — One-action rollback.** Re-deploying a prior SHA tag restores that exact prior
+  artifact. The previous good tag is recoverable without a rebuild.
+- **R5 — Persistent local state.** The wgmesh working tree and the Go module cache live on a
+  persistent host volume mounted into the container, surviving container swaps so deploys do
+  not re-clone or re-download. (Per session 2026-06-10, the model-litter dirs `go/`, `go-cache/`,
+  `pipeline-output/` are managed by the implement node, not the image — the volume holds the
+  legitimate checkout + module cache only.)
+- **R6 — Secrets stay on the host.** Runtime secrets are injected from the host env file
+  (`/etc/wgmesh-pipeline/env`) via `--env-file`, never baked into the image and never in
+  registry layers. A config/secret change is a host-file edit + container restart — not a
+  provision.
+- **R7 — Provision shrinks, doesn't vanish.** `provision-pipeline-box.yml` remains for
+  first-time infra standup only: create the VM, install docker, create the volume, write the
+  env file, pull and start the first container. It is no longer the path for app or config
+  updates.
+- **R8 — Keep the git-pull fast path as a dev escape hatch.** `update-pipeline-box.yml` (the
+  ~75 s in-place git-pull deploy) is retained for ad-hoc development iteration, not retired.
+  The image deploy is the production path; the git-pull path is the break-glass alternative.
+
+## Success criteria
+
+- A merge to main yields a SHA-tagged image whose push is gated on the suite passing inside it.
+- A deploy is pull + container swap with no server recreate, env and persistent state intact.
+- Rollback to the immediately prior SHA is a single dispatch and restores the exact artifact.
+- A Go or ggshield install cannot occur at deploy time — the toolchain is present by image build.
+
+## Scope boundaries
+
+**Deferred for later**
+- Per-goose-run sandbox containers (running each goose invocation in its own throwaway
+  container — already noted as a follow-up in the current Dockerfile).
+- Zero-downtime / blue-green deploy. Single box; a brief restart between container swaps is
+  acceptable.
+
+**Outside this change**
+- Turso state store and Langfuse remain as-is (already remote/decoupled).
+- Multi-box or horizontal scaling.
+
+## Dependencies / assumptions
+
+- Registry is `ghcr.io` (the org is already on GitHub). The image is assumed **private** →
+  the box needs a pull credential (deploy token or read-scoped PAT); CI pushes with its
+  workflow token. *Decision deferred to planning.*
+- The box gains a docker runtime (added in the shrunk provision, R7).
+- Assumption: goose session data does not need to persist across container swaps (sessions are
+  not reused across issues). If planning finds a reuse case, add it to the R5 volume.
+
+## Outstanding questions (for planning)
+
+1. **Build trigger granularity** — rebuild on every main merge, or only when `pipeline/`
+   (or the Dockerfile) changes, to skip docs-only/state-commit merges.
+2. **Registry auth on the box** — deploy token vs read PAT vs making the image public; how the
+   pull credential is written and rotated.
+3. **Deploy/rollback surface** — a new `deploy-pipeline-box.yml` workflow_dispatch taking a SHA
+   (default `latest`), or extend `update-pipeline-box.yml`. Rollback = same workflow with a
+   prior SHA.
+4. **Image size / build cache** — the Go toolchain layer (~600 MB) wants aggressive layer
+   caching so per-merge builds stay in the low-minutes range.
+5. **First-container ordering in provision** — volume init + env write must precede the first
+   `docker run`; define the provision step order.

--- a/pipeline/deploy/run-container.sh
+++ b/pipeline/deploy/run-container.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHA=$(cat /etc/wgmesh-pipeline/deployed_sha)
+IMAGE_OWNER=${GHCR_IMAGE_OWNER:-atvirokodosprendimai}
+
+exec docker run --rm \
+  --env-file /etc/wgmesh-pipeline/env \
+  -v /opt/wgmesh-checkout:/opt/wgmesh-checkout \
+  -v /var/cache/go-mod:/go/pkg/mod \
+  --name wgmesh-pipeline \
+  "ghcr.io/${IMAGE_OWNER}/wgmesh-pipeline:${SHA}"

--- a/pipeline/deploy/run-container.sh
+++ b/pipeline/deploy/run-container.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SHA=$(cat /etc/wgmesh-pipeline/deployed_sha)
-IMAGE_OWNER=${GHCR_IMAGE_OWNER:-atvirokodosprendimai}
+# Exact image ref is written by deploy-pipeline-box.yml at deploy time so the
+# unit and the workflow can never diverge on owner/name; the SHA-file path is
+# the fallback for hand-rolled deploys.
+STATE_DIR=/etc/wgmesh-pipeline
+if [ -f "$STATE_DIR/image_ref" ]; then
+  IMAGE_REF=$(cat "$STATE_DIR/image_ref")
+else
+  SHA=$(cat "$STATE_DIR/deployed_sha")
+  IMAGE_OWNER=${GHCR_IMAGE_OWNER:-atvirokodosprendimai}
+  IMAGE_REF="ghcr.io/${IMAGE_OWNER}/wgmesh-pipeline:${SHA}"
+fi
 
 exec docker run --rm \
-  --env-file /etc/wgmesh-pipeline/env \
+  --env-file "$STATE_DIR/env" \
   -v /opt/wgmesh-checkout:/opt/wgmesh-checkout \
   -v /var/cache/go-mod:/go/pkg/mod \
   --name wgmesh-pipeline \
-  "ghcr.io/${IMAGE_OWNER}/wgmesh-pipeline:${SHA}"
+  "$IMAGE_REF"

--- a/pipeline/docs/CONTAINER-CUTOVER.md
+++ b/pipeline/docs/CONTAINER-CUTOVER.md
@@ -1,0 +1,59 @@
+# Container Cutover Runbook
+
+Use this runbook to cut the pipeline box over to the GHCR-backed container
+deployment path. Do not run live box, SSH, Hetzner, or Docker commands until an
+operator is ready to perform the cutover.
+
+1. Set the `GHCR_PULL_TOKEN` secret in this repository.
+
+   Use the GitHub UI, or:
+
+   ```bash
+   gh secret set GHCR_PULL_TOKEN
+   ```
+
+2. Confirm `build-pipeline-image.yml` ran green on `main` and the image exists:
+
+   ```text
+   ghcr.io/<owner>/wgmesh-pipeline:latest
+   ```
+
+3. Run `provision-pipeline-box.yml` with `reset_queue=false`.
+
+   This is the shrunk provision path: Docker install, persistent volume dirs,
+   `/etc/wgmesh-pipeline/env` update, GHCR login, and systemd container startup.
+   Do not use the legacy full-box app/toolchain install path.
+
+4. Verify the box is ticking.
+
+   SSH in and watch the service journal:
+
+   ```bash
+   journalctl -u wgmesh-pipeline -f
+   ```
+
+   Confirm fresh `tick` log lines appear.
+
+5. Gate decision.
+
+   If the service is ticking, proceed to step 6. If not, investigate
+   `journalctl -u wgmesh-pipeline` before continuing.
+
+6. Test deploy and rollback.
+
+   Trigger `deploy-pipeline-box.yml` with `sha=latest` and confirm the health
+   check passes. Then trigger it with a bad SHA such as `notareal-sha` and verify
+   the workflow fails before swapping the running service, or auto-rolls back if
+   a swapped container fails health.
+
+Durable Turso state survives container recreates because it is external to the
+container.
+
+## Two image lanes (by design)
+
+- `build-pipeline-image.yml` — every `pipeline/**` push to main builds
+  `ghcr.io/<owner>/wgmesh-pipeline:<sha>` + `:latest`. This is the box
+  self-deploy cadence (#1599 U14: the box merges its own code and deploys
+  the exact merged SHA).
+- `release.yml` — operator-cut `v*` tags build versioned images from the
+  TESTED bytes (see #1673). Human-meaningful milestones, not every merge.

--- a/pipeline/docs/CONTAINER-CUTOVER.md
+++ b/pipeline/docs/CONTAINER-CUTOVER.md
@@ -57,3 +57,17 @@ container.
   the exact merged SHA).
 - `release.yml` — operator-cut `v*` tags build versioned images from the
   TESTED bytes (see #1673). Human-meaningful milestones, not every merge.
+
+## Pre-cutover requirements (review findings, 2026-06-12)
+
+- **systemd unit**: the in-repo `pipeline/deploy/wgmesh-pipeline.service` still
+  starts the venv Python directly. At cutover, point `ExecStart` at
+  `pipeline/deploy/run-container.sh` (and `ExecStop` at `docker stop
+  wgmesh-pipeline`) — the deploy workflow assumes the containerized unit.
+- **State durability**: the pipeline defaults to `database_mode="local"`
+  (SQLite inside the container — lost on swap). Before cutover either set
+  `DATABASE_MODE=turso` (the box's current production mode) or mount the DB
+  path as a host volume in `run-container.sh`.
+- **Provision drift**: step 3's "shrunk provision path" lands with #1599 U12;
+  until then the legacy provision workflow still builds the venv stack —
+  containerized boxes are cut over manually per this runbook.


### PR DESCRIPTION
## Summary

Commits the validated in-flight containerized-deploy work (plan 2026-06-11-001) that was sitting untracked: per-main-push SHA-tagged image builds, dispatch-deploy workflow, SHA-pinned `run-container.sh`, runbook + plan docs.

This is the foundation for #1599 **U14 guarded self-deploy** (KTD7) — the standing safety gap behind the 06-10 live flip. Coexists with release.yml: that lane builds versioned images from tested bytes on operator tags; this lane gives the box per-merge SHA images. Actual cutover stays operator-gated per CONTAINER-CUTOVER.md (needs GHCR_PULL_TOKEN secret + box-side switch).

## Test plan
- [x] Both workflow YAMLs valid
- [ ] First main push touching pipeline/** builds ghcr image (post-merge)
- [ ] Operator runs the cutover runbook when ready