### PR TITLE
feat(supervisor): box-side supervisor-rank module (cutover U5)

### DIFF
--- a/pipeline/tests/test_supervisor.py
+++ b/pipeline/tests/test_supervisor.py
@@ -1,0 +1,305 @@
+"""Supervisor-Rank parity + edge-case tests (cutover U5).
+
+The parity fixture reconstructs a snapshot that classifies/ranks to exactly
+the values recorded in ``company/supervisor-rank-state.json`` on main, then
+asserts the Python ranker reproduces the recorded ordering, stage summary,
+top actions, AND the byte-exact sha256 material fingerprint the Actions
+ranker (jq -Sc + sha256sum) committed. A matching fingerprint proves the
+material payload — top ids, stage summary, unknown count, top actions — is
+byte-identical to what the workflow produced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wgmesh_pipeline.forge.protocol import ForgeIssue
+from wgmesh_pipeline.supervisor import (
+    RankResult,
+    SupervisorInputs,
+    build_state,
+    classify_stage,
+    load_taxonomy,
+    material_fingerprint,
+    rank_clogs,
+    run_supervisor_rank,
+    snapshot_from_forge,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_FILE = REPO_ROOT / "company" / "supervisor-rank-state.json"
+TAXONOMY_FILE = REPO_ROOT / "company" / "pipeline-stages.json"
+
+AIT = "atvirokodosprendimai/ai-pipeline-template"
+WG = "atvirokodosprendimai/wgmesh"
+NOW = "2026-06-12T00:00:00Z"
+
+
+@pytest.fixture(scope="module")
+def taxonomy() -> dict:
+    return load_taxonomy(TAXONOMY_FILE)
+
+
+@pytest.fixture(scope="module")
+def recorded_state() -> dict:
+    return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+
+
+def _item(repo: str, type_: str, number: int, title: str, created: str, labels=()) -> dict:
+    return {
+        "repo": repo,
+        "type": type_,
+        "number": number,
+        "title": title,
+        "labels": [{"name": name} for name in labels],
+        "created_at": created,
+        "updated_at": created,
+        "is_draft": False,
+        "url": f"https://github.com/{repo}/{'pull' if type_ == 'pr' else 'issues'}/{number}",
+    }
+
+
+def parity_snapshot() -> list[dict]:
+    """Snapshot reproducing the recorded state on main (run #24).
+
+    1 triage + 4 spec + 5 review + 1 unknown = the recorded stage_summary;
+    dwell ordering reproduces the recorded top-5 and top-3.
+    """
+    return [
+        # triage: bare issue, no labels (issue_without_type_label rule)
+        _item(AIT, "issue", 934, "supervisor-rank: top pipeline clogs", "2026-05-01T00:00:00Z"),
+        # review: needs-human override
+        _item(WG, "issue", 652, "wgmesh release blocked", "2026-05-20T00:00:00Z", ["needs-human"]),
+        # spec x4: title-prefix override
+        _item(WG, "pr", 667, "spec: Issue #650", "2026-06-01T00:00:00Z"),
+        _item(WG, "pr", 689, "spec: Issue #670", "2026-06-05T00:00:00Z"),
+        _item(WG, "pr", 691, "spec: Issue #672", "2026-06-07T00:00:00Z"),
+        _item(WG, "pr", 700, "spec: Issue #680", "2026-06-11T12:00:00Z"),
+        # review x4 (below top-5 dwell)
+        _item(WG, "pr", 701, "fix: mesh route flap", "2026-06-11T18:00:00Z", ["needs-review"]),
+        _item(WG, "pr", 702, "fix: peer key rotation", "2026-06-11T18:00:00Z", ["needs-review"]),
+        _item(WG, "pr", 703, "feat: metrics endpoint", "2026-06-11T18:00:00Z", ["needs-review"]),
+        _item(WG, "pr", 704, "docs: peering guide", "2026-06-11T18:00:00Z", ["needs-review"]),
+        # unknown: labelled issue matching no rule
+        _item(AIT, "issue", 900, "ATP autobuyer ledger drift", "2026-06-10T00:00:00Z", ["question"]),
+    ]
+
+
+def parity_result(taxonomy: dict) -> RankResult:
+    return rank_clogs(
+        SupervisorInputs(items=tuple(parity_snapshot()), taxonomy=taxonomy, now=NOW)
+    )
+
+
+class TestParityWithRecordedState:
+    """The ranker reproduces the Actions ranker's recorded run on main."""
+
+    def test_top3_ids_match_recorded(self, taxonomy, recorded_state):
+        result = parity_result(taxonomy)
+        assert result.top_ids == recorded_state["last_run_top_ids"]
+
+    def test_top_actions_match_recorded(self, taxonomy, recorded_state):
+        result = parity_result(taxonomy)
+        assert result.top_actions == recorded_state["top_actions"]
+
+    def test_stage_summary_matches_recorded(self, taxonomy, recorded_state):
+        result = parity_result(taxonomy)
+        assert dict(result.stage_summary) == recorded_state["stage_summary"]
+
+    def test_unknown_count_matches_recorded(self, taxonomy, recorded_state):
+        result = parity_result(taxonomy)
+        assert len(result.unknown) == recorded_state["unknown_count"]
+
+    def test_material_fingerprint_byte_exact(self, taxonomy, recorded_state):
+        """sha256(jq -Sc payload) committed by Actions == Python fingerprint."""
+        result = parity_result(taxonomy)
+        assert material_fingerprint(result) == recorded_state["material_fingerprint"]
+
+    def test_state_dict_matches_recorded_shape_and_gates(self, taxonomy, recorded_state):
+        run = build_state(parity_result(taxonomy), recorded_state)
+        assert list(run.state.keys()) == list(recorded_state.keys())
+        # Same material → fingerprint gate closed, no rank change, run +1.
+        assert run.material_changed is False
+        assert run.rank_changed is False
+        assert run.state["run_number"] == recorded_state["run_number"] + 1
+        assert run.state["issue_number"] == recorded_state["issue_number"]
+        assert run.state["issue_url"] == recorded_state["issue_url"]
+        assert run.state["material_fingerprint"] == recorded_state["material_fingerprint"]
+
+    def test_rank_order_and_scores(self, taxonomy):
+        result = parity_result(taxonomy)
+        assert [c.rank for c in result.top] == [1, 2, 3, 4, 5]
+        assert [c.number for c in result.top] == [934, 652, 667, 689, 691]
+        # score = dwell_hours x downstream_blocked_count (all multipliers 1 here)
+        assert [c.score for c in result.top] == [1008, 552, 264, 168, 120]
+        assert all(c.score == c.dwell_hours * c.downstream_blocked_count for c in result.top)
+
+
+class TestClassification:
+    def test_needs_human_overrides_everything(self, taxonomy):
+        item = _item(WG, "pr", 1, "spec: also a spec title", NOW, ["needs-human"])
+        assert classify_stage(item, taxonomy) == "review"
+
+    def test_spec_title_prefix_case_insensitive(self, taxonomy):
+        assert classify_stage(_item(WG, "issue", 2, "Spec: thing", NOW), taxonomy) == "spec"
+
+    def test_approved_clean_pr_is_merge(self, taxonomy):
+        item = {**_item(WG, "pr", 3, "feat: ready", NOW),
+                "review_decision": "APPROVED", "merge_state_status": "CLEAN"}
+        assert classify_stage(item, taxonomy) == "merge"
+
+    def test_approved_dirty_pr_is_not_merge(self, taxonomy):
+        item = {**_item(WG, "pr", 4, "feat: conflicted", NOW),
+                "review_decision": "APPROVED", "merge_state_status": "DIRTY"}
+        assert classify_stage(item, taxonomy) != "merge"
+
+    def test_labelled_issue_matching_nothing_is_unknown(self, taxonomy):
+        item = _item(WG, "issue", 5, "mystery", NOW, ["question"])
+        assert classify_stage(item, taxonomy) == "unknown"
+
+    def test_bare_issue_is_triage(self, taxonomy):
+        assert classify_stage(_item(WG, "issue", 6, "mystery", NOW), taxonomy) == "triage"
+
+    def test_copilot_triaging_dwell_starts_at_updated_at(self, taxonomy):
+        item = {**_item(WG, "issue", 7, "stuck", "2026-06-01T00:00:00Z", ["copilot-triaging"]),
+                "updated_at": "2026-06-11T00:00:00Z"}
+        result = rank_clogs(SupervisorInputs(items=(item,), taxonomy=taxonomy, now=NOW))
+        assert result.top[0].stage == "triage"
+        assert result.top[0].dwell_hours == 24  # from updated_at, not created_at
+
+
+class TestRankingMechanics:
+    def test_empty_inputs(self, taxonomy):
+        result = rank_clogs(SupervisorInputs(items=(), taxonomy=taxonomy, now=NOW))
+        assert result.top == ()
+        assert result.unknown == ()
+        assert dict(result.stage_summary) == {
+            "triage": 0, "spec": 0, "build": 0, "review": 0,
+            "merge": 0, "verify": 0, "revenue": 0, "unknown": 0,
+        }
+        run = build_state(result, None)
+        assert run.material_changed is True  # no prior fingerprint → gate open
+        assert run.rank_changed is False  # empty prior top never flags
+        assert run.state["run_number"] == 1
+        assert run.state["last_run_top_ids"] == []
+
+    def test_ties_break_by_created_at_then_repo_then_number(self, taxonomy):
+        items = (
+            _item(WG, "pr", 20, "fix: b", "2026-06-11T00:00:00Z", ["needs-review"]),
+            _item(WG, "pr", 10, "fix: a", "2026-06-11T00:00:00Z", ["needs-review"]),
+            _item(AIT, "pr", 30, "fix: c", "2026-06-11T00:00:00Z", ["needs-review"]),
+            _item(WG, "pr", 40, "fix: older", "2026-06-10T00:00:00Z", ["needs-review"]),
+        )
+        # 40 wins on score (higher dwell); the 24h tie sorts created, repo, number.
+        result = rank_clogs(SupervisorInputs(items=items, taxonomy=taxonomy, now=NOW))
+        assert [c.number for c in result.top] == [40, 30, 10, 20]
+
+    def test_all_healthy_zero_dwell_scores_zero(self, taxonomy):
+        items = (
+            _item(WG, "pr", 50, "spec: fresh", NOW),
+            _item(WG, "pr", 51, "fix: fresh", NOW, ["needs-review"]),
+        )
+        result = rank_clogs(SupervisorInputs(items=items, taxonomy=taxonomy, now=NOW))
+        assert [c.score for c in result.top] == [0, 0]
+        assert [c.number for c in result.top] == [50, 51]  # repo+number tiebreak
+
+    def test_spec_blocked_count_multiplies_by_builds_in_repo(self, taxonomy):
+        items = (
+            _item(WG, "pr", 60, "spec: clogged", "2026-06-11T00:00:00Z"),
+            _item(WG, "pr", 61, "impl: one", NOW, ["approved-for-build"]),
+            _item(WG, "pr", 62, "impl: two", NOW, ["goose-implementation"]),
+        )
+        result = rank_clogs(SupervisorInputs(items=items, taxonomy=taxonomy, now=NOW))
+        spec = next(c for c in result.top if c.number == 60)
+        assert spec.downstream_blocked_count == 2
+        assert spec.score == 24 * 2
+
+    def test_unknown_excluded_from_top_listed_sorted(self, taxonomy):
+        items = (
+            _item(WG, "issue", 71, "mystery b", NOW, ["question"]),
+            _item(AIT, "issue", 70, "mystery a", NOW, ["question"]),
+        )
+        result = rank_clogs(SupervisorInputs(items=items, taxonomy=taxonomy, now=NOW))
+        assert result.top == ()
+        assert [u["id"] for u in result.unknown] == [f"{AIT}#70", f"{WG}#71"]
+
+    def test_top_n_truncates(self, taxonomy):
+        items = tuple(
+            _item(WG, "pr", 80 + i, f"fix: {i}", "2026-06-11T00:00:00Z", ["needs-review"])
+            for i in range(7)
+        )
+        result = rank_clogs(SupervisorInputs(items=items, taxonomy=taxonomy, now=NOW, top_n=5))
+        assert len(result.top) == 5
+
+    def test_rank_changed_when_top3_differs(self, taxonomy):
+        result = parity_result(taxonomy)
+        prev = {"last_run_top_ids": ["x#1", "y#2", "z#3"], "run_number": 3,
+                "material_fingerprint": "stale"}
+        run = build_state(result, prev)
+        assert run.rank_changed is True
+        assert run.material_changed is True
+        assert run.state["run_number"] == 4
+
+    def test_fingerprint_gate_idempotent_across_runs(self, taxonomy):
+        first = build_state(parity_result(taxonomy), None)
+        assert first.material_changed is True
+        second = build_state(parity_result(taxonomy), first.state)
+        assert second.material_changed is False
+        assert second.state["material_fingerprint"] == first.state["material_fingerprint"]
+
+
+class _ReadOnlyForge:
+    """Fake exposing ONLY the read method the runner may use; any write blows up."""
+
+    def __init__(self, issues: list[ForgeIssue]) -> None:
+        self._issues = issues
+        self.write_calls: list[str] = []
+
+    def list_open_issues(self) -> list[ForgeIssue]:
+        return self._issues
+
+    def __getattr__(self, name: str):
+        raise AssertionError(f"runner must not call forge.{name} in parity phase")
+
+
+class TestRunner:
+    def test_runner_returns_state_without_forge_writes(self, taxonomy):
+        forge = _ReadOnlyForge([
+            ForgeIssue(number=1, title="bare issue", labels=(), state="open"),
+            ForgeIssue(number=2, title="spec: thing", labels=(), state="open",
+                       pull_request={"url": "x"}),
+        ])
+        run = run_supervisor_rank(forge, taxonomy=taxonomy, repo=WG, now=NOW)
+        assert run.state["last_run_at"] == NOW
+        assert run.state["run_number"] == 1
+        assert run.state["stage_summary"]["triage"] == 1
+        assert run.state["stage_summary"]["spec"] == 1
+        # No timestamps via the Forge protocol → degraded dwell (gap documented)
+        assert all(c.dwell_hours == 0 for c in run.result.top)
+        assert forge.write_calls == []
+
+    def test_runner_prefers_explicit_snapshot(self, taxonomy, recorded_state):
+        forge = _ReadOnlyForge([])
+        run = run_supervisor_rank(
+            forge,
+            taxonomy=taxonomy,
+            repo=WG,
+            previous_state=recorded_state,
+            snapshot=parity_snapshot(),
+            now=NOW,
+        )
+        assert run.state["material_fingerprint"] == recorded_state["material_fingerprint"]
+        assert run.material_changed is False
+
+    def test_snapshot_from_forge_marks_prs(self, taxonomy):
+        forge = _ReadOnlyForge([
+            ForgeIssue(number=3, title="t", labels=("bug",), state="open",
+                       pull_request={"url": "x"}),
+        ])
+        snapshot = snapshot_from_forge(forge, WG)
+        assert snapshot[0]["type"] == "pr"
+        assert snapshot[0]["repo"] == WG
+        assert snapshot[0]["labels"] == ["bug"]

--- a/pipeline/wgmesh_pipeline/supervisor.py
+++ b/pipeline/wgmesh_pipeline/supervisor.py
@@ -1,0 +1,398 @@
+"""Box-side Supervisor-Rank: clog classification, ranking, and state building.
+
+Port of the Actions ``supervisor-rank`` workflow (cutover plan U5): the
+``classify-clogs.sh`` → ``rank-clogs.sh`` → ``recommend-actions.sh`` chain
+collapses into the pure function ``rank_clogs``; the state half of
+``publish-rank.sh`` (top-3 delta, run counter, material fingerprint) becomes
+``build_state``. Semantics are ported, not redesigned — dwell x
+downstream-blocked scoring, taxonomy stage rules, jq sort order, and the
+sha256 fingerprint are byte/ordering-compatible with the Actions ranker
+(parity-tested against the recorded ``company/supervisor-rank-state.json``).
+
+Read-only surface: recommends, does not act. ``build_state`` RETURNS the
+state dict; persisting it and publishing the anchor issue (#934) stay with
+the caller.
+
+TODO(protocol gaps) — the Forge protocol cannot yet feed a full snapshot, so
+``run_supervisor_rank`` accepts plain-dict snapshot items gathered elsewhere.
+Missing methods (do NOT extend the protocol in this unit):
+  - ``Forge.list_open_prs()`` returning review_decision, merge_state_status,
+    is_draft, created_at, updated_at — needed for PR clogs + merge stage.
+  - ``ForgeIssue`` lacks created_at / updated_at / url — needed for
+    dwell_hours; forge-sourced issues therefore classify with dwell 0.
+  - No cross-repo listing — TARGET_REPOS spans two repos, a Forge instance
+    is bound to one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from wgmesh_pipeline.forge.protocol import Forge
+
+STAGE_ORDER: tuple[str, ...] = (
+    "triage", "spec", "build", "review", "merge", "verify", "revenue", "unknown",
+)
+
+# Taxonomy match order after the hard-coded overrides (mirrors jq stage()).
+_MATCH_ORDER: tuple[str, ...] = ("revenue", "verify", "review", "build", "spec", "triage")
+
+DEFAULT_TOP_N = 5
+
+
+@dataclass(frozen=True)
+class RankedClog:
+    """One ranked item, mirroring the fields ``rank-clogs.sh`` emits per entry."""
+
+    rank: int
+    id: str
+    repo: str
+    type: str
+    number: int
+    title: str
+    stage: str
+    dwell_hours: int
+    downstream_blocked_count: int
+    score: int
+    recommended_action: str | None  # None when stage has no allowlisted action
+
+
+@dataclass(frozen=True)
+class RankResult:
+    """Ranked output, mirroring the shape of ``/tmp/ranked.json`` in Actions."""
+
+    generated_at: str
+    top: tuple[RankedClog, ...]
+    stage_summary: Mapping[str, int]
+    unknown: tuple[Mapping[str, Any], ...]
+
+    @property
+    def top_ids(self) -> list[str]:
+        """Top-3 ids — the rank-change fingerprint unit in publish-rank.sh."""
+        return [clog.id for clog in self.top[:3]]
+
+    @property
+    def top_actions(self) -> list[dict[str, Any]]:
+        """Top-5 ``{id, action}`` pairs as recorded in the state file."""
+        return [{"id": c.id, "action": c.recommended_action} for c in self.top[:DEFAULT_TOP_N]]
+
+
+@dataclass(frozen=True)
+class SupervisorInputs:
+    """Inputs to ``rank_clogs``. ``items`` use the snapshot-clogs.sh dict shape:
+    repo, type ("pr"|"issue"), number, title, labels (names or ``{"name":…}``),
+    created_at, updated_at, is_draft, review_decision, merge_state_status, url."""
+
+    items: tuple[Mapping[str, Any], ...]
+    taxonomy: Mapping[str, Any]
+    now: str
+    top_n: int = DEFAULT_TOP_N
+
+
+@dataclass(frozen=True)
+class SupervisorRankRun:
+    """Runner outcome: ranked result + the state dict the caller may persist.
+    ``material_changed`` is the commit-gate sentinel from publish-rank.sh: when
+    False the caller must NOT persist ``state`` (anti PR-per-run pile-up)."""
+
+    result: RankResult
+    state: dict[str, Any]
+    material_changed: bool
+    rank_changed: bool = False
+
+
+def load_taxonomy(path: str | Path) -> dict[str, Any]:
+    """Load and validate ``company/pipeline-stages.json`` (classify-clogs.sh guard)."""
+    taxonomy = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(taxonomy.get("stages"), list):
+        raise ValueError(f"bad taxonomy {path}: stages must be an array")
+    rules = taxonomy.get("classification_rules")
+    if not isinstance(rules, dict):
+        raise ValueError(f"bad taxonomy {path}: classification_rules must be an object")
+    for stage in taxonomy["stages"]:
+        if not isinstance(rules.get(stage), dict):
+            raise ValueError(f"bad taxonomy {path}: missing classification rule for {stage}")
+    if not isinstance(taxonomy.get("recommended_actions"), dict):
+        raise ValueError(f"bad taxonomy {path}: recommended_actions must be an object")
+    return taxonomy
+
+
+def _label_names(item: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for label in item.get("labels") or []:
+        if isinstance(label, Mapping):
+            name = label.get("name")
+            if name is not None:
+                names.append(str(name))
+        elif label is not None:
+            names.append(str(label))
+    return names
+
+
+def _has_label(item: Mapping[str, Any], name: str) -> bool:
+    return name in _label_names(item)
+
+
+def _title_starts(item: Mapping[str, Any], prefixes: Sequence[str]) -> bool:
+    title = str(item.get("title") or "").lower()
+    return any(title.startswith(str(prefix).lower()) for prefix in prefixes)
+
+
+def _matches(item: Mapping[str, Any], stage: str, taxonomy: Mapping[str, Any]) -> bool:
+    rule: Mapping[str, Any] = (taxonomy.get("classification_rules") or {}).get(stage) or {}
+    if any(_has_label(item, name) for name in rule.get("label_any") or []):
+        return True
+    if _title_starts(item, rule.get("title_prefix_any") or []):
+        return True
+    decisions = rule.get("review_decision_any") or []
+    if decisions and str(item.get("review_decision") or "") in decisions:
+        statuses = rule.get("merge_state_status_any") or []
+        if not statuses or str(item.get("merge_state_status") or "") in statuses:
+            return True
+    if (
+        stage == "triage"
+        and item.get("type") == "issue"
+        and rule.get("issue_without_type_label", False) is True
+    ):
+        names = _label_names(item)
+        if not any(name.startswith("type:") for name in names) and len(names) == 0:
+            return True
+    return False
+
+
+def classify_stage(item: Mapping[str, Any], taxonomy: Mapping[str, Any]) -> str:
+    """Stage for one item — exact port of jq ``stage()`` in classify-clogs.sh."""
+    if _has_label(item, "needs-human"):
+        return "review"
+    if str(item.get("title") or "").lower().startswith("spec:"):
+        return "spec"
+    if (
+        item.get("type") == "pr"
+        and str(item.get("review_decision") or "") == "APPROVED"
+        and str(item.get("merge_state_status") or "") in ("CLEAN", "HAS_HOOKS")
+    ):
+        return "merge"
+    for stage in _MATCH_ORDER:
+        if _matches(item, stage, taxonomy):
+            return stage
+    return "unknown"
+
+
+def _first_present(item: Mapping[str, Any], keys: Sequence[str]) -> str | None:
+    for key in keys:
+        value = item.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _parse_iso8601(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _dwell_hours(item: Mapping[str, Any], stage: str, now: str) -> int:
+    if stage == "triage" and _has_label(item, "copilot-triaging"):
+        start = _first_present(item, ("updated_at", "updatedAt", "created_at", "createdAt"))
+    else:
+        start = _first_present(item, ("created_at", "createdAt", "updated_at", "updatedAt"))
+    if not start:
+        return 0
+    delta = (_parse_iso8601(now) - _parse_iso8601(start)).total_seconds() / 3600
+    return max(int(delta // 1), 0)  # jq floor, clamped at 0
+
+
+def classify_items(
+    items: Sequence[Mapping[str, Any]], taxonomy: Mapping[str, Any], now: str
+) -> list[dict[str, Any]]:
+    """Annotate snapshot items with ``stage`` + ``dwell_hours`` (new dicts)."""
+    classified: list[dict[str, Any]] = []
+    for item in items:
+        stage = classify_stage(item, taxonomy)
+        classified.append({**item, "stage": stage, "dwell_hours": _dwell_hours(item, stage, now)})
+    return classified
+
+
+def _blocked_count(item: Mapping[str, Any], items: Sequence[Mapping[str, Any]]) -> int:
+    """Downstream-blocked multiplier — exact port of rank-clogs.sh."""
+    stage = item.get("stage") or "unknown"
+    repo = item.get("repo")
+
+    def count(stages: tuple[str, ...]) -> int:
+        n = sum(1 for it in items if it.get("repo") == repo and (it.get("stage") or "") in stages)
+        return max(n, 1)
+
+    if stage == "spec":
+        return count(("build",))
+    if stage == "triage":
+        return count(("spec", "build", "review"))
+    if stage == "merge":
+        return count(("merge",))
+    if stage == "unknown":
+        return 0
+    return 1
+
+
+def _recommended_action(stage: str, taxonomy: Mapping[str, Any]) -> str | None:
+    """Action for a stage — port of recommend-actions.sh (allowlist-gated)."""
+    action = (taxonomy.get("recommended_actions") or {}).get(stage)
+    if action is not None and action in (taxonomy.get("allowed_actions") or []):
+        return str(action)
+    return None
+
+
+def rank_clogs(inputs: SupervisorInputs) -> RankResult:
+    """Classify, score, and rank clogs — port of the Actions ranker chain.
+
+    score = dwell_hours x downstream_blocked_count; top-N excludes unknown,
+    sorted by (-score, created_at, repo, number); stage_summary spans all
+    items; unknown listed separately sorted by (repo, number).
+    """
+    classified = classify_items(inputs.items, inputs.taxonomy, inputs.now)
+
+    scored: list[dict[str, Any]] = []
+    for item in classified:
+        blocked = _blocked_count(item, classified)
+        scored.append({
+            **item,
+            "id": f"{item.get('repo')}#{item.get('number')}",
+            "downstream_blocked_count": blocked,
+            "score": (item.get("dwell_hours") or 0) * blocked,
+        })
+
+    rankable = [it for it in scored if (it.get("stage") or "unknown") != "unknown"]
+    rankable.sort(key=lambda it: (
+        -(it.get("score") or 0),
+        _first_present(it, ("created_at", "createdAt")) or "",
+        it.get("repo") or "",
+        it.get("number") or 0,
+    ))
+
+    top = tuple(
+        RankedClog(
+            rank=position + 1,
+            id=it["id"],
+            repo=it.get("repo") or "",
+            type=it.get("type") or "",
+            number=int(it.get("number") or 0),
+            title=it.get("title") or "",
+            stage=it["stage"],
+            dwell_hours=int(it.get("dwell_hours") or 0),
+            downstream_blocked_count=int(it["downstream_blocked_count"]),
+            score=int(it["score"]),
+            recommended_action=_recommended_action(it["stage"], inputs.taxonomy),
+        )
+        for position, it in enumerate(rankable[: inputs.top_n])
+    )
+
+    stage_summary = {
+        stage: sum(1 for it in classified if (it.get("stage") or "unknown") == stage)
+        for stage in STAGE_ORDER
+    }
+
+    unknown = sorted(
+        (
+            {key: it.get(key) for key in ("id", "repo", "type", "number", "title", "stage")}
+            for it in scored
+            if (it.get("stage") or "unknown") == "unknown"
+        ),
+        key=lambda it: (it.get("repo") or "", it.get("number") or 0),
+    )
+
+    return RankResult(
+        generated_at=inputs.now, top=top, stage_summary=stage_summary, unknown=tuple(unknown)
+    )
+
+
+def material_fingerprint(result: RankResult) -> str:
+    """sha256 over the material fields — byte-compatible with publish-rank.sh.
+    The shell uses ``jq -Sc`` (recursively sorted keys, compact separators);
+    ``json.dumps(sort_keys=True, separators=(",", ":"))`` produces identical
+    bytes, verified against the recorded fingerprint on main."""
+    payload = {
+        "top_ids": result.top_ids,
+        "stage_summary": dict(result.stage_summary),
+        "unknown_count": len(result.unknown),
+        "top_actions": result.top_actions,
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_state(
+    result: RankResult, previous_state: Mapping[str, Any] | None = None
+) -> SupervisorRankRun:
+    """Build the supervisor-rank state dict — port of publish-rank.sh state logic.
+    Returns the would-be ``company/supervisor-rank-state.json`` content plus the
+    ``material_changed`` sentinel: ``rank_changed`` compares top-3 ids against
+    the prior run (empty prior never flags), ``run_number`` increments, and
+    ``issue_number``/``issue_url`` carry over (publishing is the caller's job)."""
+    prev = previous_state or {}
+    previous_top = list(prev.get("last_run_top_ids") or [])
+    previous_fingerprint = str(prev.get("material_fingerprint") or "")
+    current_top = result.top_ids
+    rank_changed = bool(previous_top) and previous_top != current_top
+    fingerprint = material_fingerprint(result)
+    material_changed = not (previous_fingerprint and previous_fingerprint == fingerprint)
+    state: dict[str, Any] = {
+        "last_run_at": result.generated_at,
+        "last_run_top_ids": current_top,
+        "rank_changed": rank_changed,
+        "run_number": int(prev.get("run_number") or 0) + 1,
+        "issue_number": prev.get("issue_number"),
+        "issue_url": prev.get("issue_url"),
+        "stage_summary": dict(result.stage_summary),
+        "unknown_count": len(result.unknown),
+        "top_actions": result.top_actions,
+        "material_fingerprint": fingerprint,
+    }
+    return SupervisorRankRun(
+        result=result, state=state, material_changed=material_changed, rank_changed=rank_changed
+    )
+
+
+def snapshot_from_forge(forge: Forge, repo: str) -> list[dict[str, Any]]:
+    """Best-effort snapshot via existing Forge methods only.
+    Degraded relative to snapshot-clogs.sh (see protocol gaps at module top):
+    no timestamps (dwell 0), no review_decision / merge_state_status (no
+    merge-stage detection), single repo. Items whose ``pull_request`` payload
+    is present become ``type: "pr"`` (GitHub /issues returns PRs too)."""
+    return [
+        {
+            "repo": repo,
+            "type": "pr" if issue.pull_request else "issue",
+            "number": issue.number,
+            "title": issue.title,
+            "labels": list(issue.labels),
+            "created_at": None,
+            "updated_at": None,
+            "is_draft": False,
+            "url": None,
+        }
+        for issue in forge.list_open_issues()
+    ]
+
+
+def run_supervisor_rank(
+    forge: Forge,
+    *,
+    taxonomy: Mapping[str, Any],
+    repo: str,
+    previous_state: Mapping[str, Any] | None = None,
+    snapshot: Sequence[Mapping[str, Any]] | None = None,
+    now: str | None = None,
+    top_n: int = DEFAULT_TOP_N,
+) -> SupervisorRankRun:
+    """Gather inputs, rank, and return the state dict. No forge writes.
+    ``snapshot`` (plain dicts, snapshot-clogs.sh shape) overrides the degraded
+    forge-derived snapshot until the protocol grows the listed gap methods.
+    Persisting the returned ``state`` (only when ``material_changed``) and
+    publishing the anchor issue remain the caller's responsibility."""
+    items = list(snapshot) if snapshot is not None else snapshot_from_forge(forge, repo)
+    timestamp = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    inputs = SupervisorInputs(items=tuple(items), taxonomy=taxonomy, now=timestamp, top_n=top_n)
+    return build_state(rank_clogs(inputs), previous_state)


### PR DESCRIPTION
## Summary

#1599 **U5 / Phase B**: ports the Actions supervisor-rank chain (snapshot→classify→rank→recommend→publish jq scripts) to a box module `pipeline/wgmesh_pipeline/supervisor.py` — pure `rank_clogs()` + `build_state()` + thin `run_supervisor_rank(forge, …)` runner. Zero GitHub writes in this phase: the runner returns the state dict; publishing stays with the caller until parity bakes.

## Parity evidence (the U5 verification bar)

1. **Byte-exact fingerprint**: Python `json.dumps(sort_keys)`+sha256 reproduces the workflow's `jq -Sc | sha256sum` material fingerprint from run #24's recorded state.
2. Recorded-state tests: top-3 ids, top-5 actions, stage summary, unknown count, key order, commit-gate sentinel all match `company/supervisor-rank-state.json`.
3. Live cross-check: the actual classify/rank/recommend bash scripts run on the same pinned fixture produce field-identical output.

## Protocol gaps (documented, deliberately NOT extended here)

`Forge.list_open_prs()` w/ review metadata; `ForgeIssue` timestamps; cross-repo listing. Runner accepts a snapshot dict until those land.

## Test plan
- [x] 25 new tests (parity + classification edges + ties/empty/top-N/multipliers)
- [x] Full suite 350 passed, 5 skipped