### PR TITLE
feat(ci): box-side bot-PR CI gate (cutover U9)

### DIFF
--- a/.github/workflows/pii-policy-check.yml
+++ b/.github/workflows/pii-policy-check.yml
@@ -37,6 +37,13 @@ permissions:
 
 jobs:
   pii-policy-check:
+    # Cutover #1599 U9: bot PRs run this same path-scoped rule on the box
+    # (wgmesh_pipeline.forge.box_ci.pii_path_violations, per-commit over the
+    # PR range) as a merge-gate stage; retire this Actions run for that PR
+    # class. The guard never lapses for ANY class: ci.yml (U10) carries the
+    # absorbed pii-policy-check job on every PR — fork PRs, the highest
+    # PII-risk authors, stay on the Actions sandbox.
+    if: github.event_name != 'pull_request' || !startsWith(github.event.pull_request.head.ref, 'bot/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -19,6 +19,12 @@ permissions:
 
 jobs:
   pytest:
+    # Cutover #1599 U9: bot PRs (bot/* head branches) are CI'd on the box
+    # itself (wgmesh_pipeline.forge.box_ci feeds the merge gate); this
+    # Actions run is retired for that PR class. External/host PRs keep
+    # Actions CI via ci.yml (U10), which runs unconditionally — so a
+    # branch named to dodge this filter still gets the full ci.yml suite.
+    if: github.event_name != 'pull_request' || !startsWith(github.event.pull_request.head.ref, 'bot/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sanitise-wall.yml
+++ b/.github/workflows/sanitise-wall.yml
@@ -9,6 +9,11 @@ permissions:
 
 jobs:
   check-sanitise-gate:
+    # Cutover #1599 U9: bot PRs are sanitise-gated on the box (box_ci runs
+    # company/scripts/sanitise.sh over the PR diff before merge); retire
+    # this Actions run for that PR class. The leak guard never lapses for
+    # ANY class: ci.yml (U10) runs its sanitise job on every PR and push.
+    if: github.event_name != 'pull_request' || !startsWith(github.event.pull_request.head.ref, 'bot/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/pipeline/tests/test_box_ci.py
+++ b/pipeline/tests/test_box_ci.py
@@ -1,0 +1,359 @@
+"""Box-side pre-merge CI for bot PRs (cutover U9).
+
+The box runs the verification suite + sanitise + the path-scoped PII rules
+itself instead of waiting on Actions check-runs. All subprocess work is
+stubbed at the subprocess boundary (fake `runner`); the composition logic —
+verdict, fail-closed behavior, message hygiene — stays in the tested path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wgmesh_pipeline.forge.box_ci import (
+    BoxCiResult,
+    make_box_ci_runner,
+    pii_path_violations,
+    run_box_ci,
+)
+
+
+class FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeGit:
+    """Subprocess-shaped stub: maps git argv tuples to canned results."""
+
+    def __init__(self, responses: dict[tuple[str, ...], FakeCompleted]):
+        self.responses = responses
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, cmd: list[str], **kwargs: Any) -> FakeCompleted:
+        key = tuple(cmd)
+        self.calls.append(key)
+        if key in self.responses:
+            return self.responses[key]
+        # Unmapped fetches are benign (best-effort); anything else fails.
+        if cmd[:2] == ["git", "fetch"]:
+            return FakeCompleted(0)
+        return FakeCompleted(returncode=128, stderr=f"unmapped: {cmd}")
+
+
+REPO = Path("/repo")
+BASE = "base000"
+HEAD = "head999"
+
+
+def _rev_list(*commits: str) -> dict[tuple[str, ...], FakeCompleted]:
+    return {
+        ("git", "rev-list", f"{BASE}..{HEAD}"): FakeCompleted(0, stdout="\n".join(commits) + ("\n" if commits else "")),
+    }
+
+
+def _diff_tree(commit: str, *files: str) -> dict[tuple[str, ...], FakeCompleted]:
+    return {
+        (
+            "git",
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "-M",
+            "-m",
+            "--diff-filter=ACMRT",
+            commit,
+        ): FakeCompleted(0, stdout="\n".join(files) + ("\n" if files else ""))
+    }
+
+
+def test_pii_clean_range_has_no_violations() -> None:
+    git = FakeGit({**_rev_list("c1"), **_diff_tree("c1", "pipeline/x.py", "docs/plans/a.md")})
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert violations == ()
+
+
+def test_pii_empty_commit_range_passes() -> None:
+    git = FakeGit(_rev_list())
+
+    assert pii_path_violations(REPO, BASE, HEAD, runner=git) == ()
+
+
+def test_pii_customers_namespace_is_banned() -> None:
+    git = FakeGit(
+        {
+            **_rev_list("c1"),
+            **_diff_tree("c1", "docs/customers/acme.md"),
+            ("git", "cat-file", "-e", "c1:docs/customers/acme.md"): FakeCompleted(0),
+        }
+    )
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert len(violations) == 1
+    assert "docs/customers/" in violations[0]
+
+
+def test_pii_email_in_outreach_is_blocked_and_value_never_leaks() -> None:
+    content = "Dear stargazer,\ncontact: real.person@gmail.com\nthanks"
+    git = FakeGit(
+        {
+            **_rev_list("c1"),
+            **_diff_tree("c1", "docs/outreach/campaign.md"),
+            ("git", "cat-file", "-p", "c1:docs/outreach/campaign.md"): FakeCompleted(0, stdout=content),
+        }
+    )
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert len(violations) == 1
+    assert "docs/outreach/campaign.md" in violations[0]
+    assert "line 2" in violations[0]
+    # Never echo the matched address: the failure text lands in public
+    # surfaces (PR comments, logs).
+    assert "real.person@gmail.com" not in violations[0]
+    assert "gmail" not in violations[0]
+
+
+def test_pii_allow_listed_domains_pass() -> None:
+    content = "a@example.com b@noreply.github.com c@users.noreply.github.com"
+    git = FakeGit(
+        {
+            **_rev_list("c1"),
+            **_diff_tree("c1", "docs/outreach/campaign.md"),
+            ("git", "cat-file", "-p", "c1:docs/outreach/campaign.md"): FakeCompleted(0, stdout=content),
+        }
+    )
+
+    assert pii_path_violations(REPO, BASE, HEAD, runner=git) == ()
+
+
+def test_pii_scans_intermediate_commit_even_if_moved_out_before_head() -> None:
+    """The commit-then-move-out bypass: PII added in c1 under a restricted
+    path then renamed out in c2 must still be caught (per-commit scan)."""
+    git = FakeGit(
+        {
+            **_rev_list("c2", "c1"),
+            **_diff_tree("c1", "docs/outreach/leak.md"),
+            **_diff_tree("c2", "docs/notes/leak.md"),
+            ("git", "cat-file", "-p", "c1:docs/outreach/leak.md"): FakeCompleted(
+                0, stdout="hidden@victim.org"
+            ),
+        }
+    )
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert len(violations) == 1
+    assert "docs/outreach/leak.md" in violations[0]
+
+
+def test_pii_fails_closed_when_git_cannot_enumerate_commits() -> None:
+    git = FakeGit({("git", "rev-list", f"{BASE}..{HEAD}"): FakeCompleted(128, stderr="bad revision")})
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert violations
+    assert "could not" in violations[0]
+
+
+def test_pii_fails_closed_when_diff_tree_fails() -> None:
+    git = FakeGit({**_rev_list("c1")})  # diff-tree for c1 unmapped -> rc 128
+
+    violations = pii_path_violations(REPO, BASE, HEAD, runner=git)
+
+    assert violations
+    assert "could not" in violations[0]
+
+
+# ---- run_box_ci composition ----
+
+
+class FakeForge:
+    def __init__(self, *, pr: dict | None = None, diff: str = "+ok\n"):
+        self.pr = pr if pr is not None else {
+            "number": 7,
+            "head": {"ref": "bot/impl-7", "sha": HEAD},
+            "base": {"sha": BASE},
+        }
+        self.diff = diff
+        self.diff_calls = 0
+
+    def get_pr(self, number: int) -> dict:
+        return self.pr
+
+    def get_diff(self, pr_number: int) -> str:
+        self.diff_calls += 1
+        return self.diff
+
+
+def _green_verifier(repo_path: Path, branch: str) -> dict:
+    return {"tests_passed": True, "steps": [], "failed_step": None, "output_tail": ""}
+
+
+def _red_verifier(repo_path: Path, branch: str) -> dict:
+    return {
+        "tests_passed": False,
+        "steps": [],
+        "failed_step": "go test",
+        "output_tail": "FAIL",
+        "reason": "go test failed",
+    }
+
+
+def _clean_git() -> FakeGit:
+    return FakeGit(_rev_list())
+
+
+def test_box_ci_green_when_all_stages_pass() -> None:
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=_green_verifier,
+        sanitiser=lambda text: True,
+        runner=_clean_git(),
+    )
+
+    assert result == BoxCiResult(green=True, failures=())
+
+
+def test_box_ci_red_when_verification_fails() -> None:
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=_red_verifier,
+        sanitiser=lambda text: True,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+    assert any("go test failed" in f for f in result.failures)
+
+
+def test_box_ci_red_when_sanitise_fails() -> None:
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=_green_verifier,
+        sanitiser=lambda text: False,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+    assert any("sanitise" in f for f in result.failures)
+
+
+def test_box_ci_red_when_pii_violation_found() -> None:
+    git = FakeGit(
+        {
+            **_rev_list("c1"),
+            **_diff_tree("c1", "docs/customers/x.md"),
+            ("git", "cat-file", "-e", "c1:docs/customers/x.md"): FakeCompleted(0),
+        }
+    )
+
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=_green_verifier,
+        sanitiser=lambda text: True,
+        runner=git,
+    )
+
+    assert result.green is False
+    assert any("pii" in f for f in result.failures)
+
+
+def test_box_ci_fails_closed_when_pr_shape_is_missing_refs() -> None:
+    forge = FakeForge(pr={"number": 7})
+
+    result = run_box_ci(
+        forge,
+        7,
+        repo_path=REPO,
+        verifier=_green_verifier,
+        sanitiser=lambda text: True,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+
+
+def test_box_ci_fails_closed_when_diff_fetch_raises() -> None:
+    class BrokenDiff(FakeForge):
+        def get_diff(self, pr_number: int) -> str:
+            raise RuntimeError("503 from forge")
+
+    result = run_box_ci(
+        BrokenDiff(),
+        7,
+        repo_path=REPO,
+        verifier=_green_verifier,
+        sanitiser=lambda text: True,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+    assert any("diff" in f for f in result.failures)
+
+
+def test_box_ci_fails_closed_when_verifier_raises() -> None:
+    """A missing clone / dead git must become a red verdict with the cause
+    in the failures — never an exception that strands the issue mid-merge."""
+
+    def broken_verifier(repo_path: Path, branch: str) -> dict:
+        raise FileNotFoundError("/opt/wgmesh-checkout")
+
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=broken_verifier,
+        sanitiser=lambda text: True,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+    assert any("could not run" in f for f in result.failures)
+
+
+def test_box_ci_accumulates_failures_across_stages() -> None:
+    result = run_box_ci(
+        FakeForge(),
+        7,
+        repo_path=REPO,
+        verifier=_red_verifier,
+        sanitiser=lambda text: False,
+        runner=_clean_git(),
+    )
+
+    assert result.green is False
+    assert len(result.failures) == 2
+
+
+def test_make_box_ci_runner_binds_repo_path_and_overrides() -> None:
+    seen: dict[str, Any] = {}
+
+    def verifier(repo_path: Path, branch: str) -> dict:
+        seen["repo_path"] = repo_path
+        seen["branch"] = branch
+        return _green_verifier(repo_path, branch)
+
+    runner = make_box_ci_runner(
+        "/some/clone", verifier=verifier, sanitiser=lambda text: True, runner=_clean_git()
+    )
+    result = runner(FakeForge(), 7)
+
+    assert result.green is True
+    assert seen["repo_path"] == Path("/some/clone")
+    assert seen["branch"] == "bot/impl-7"

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -480,3 +480,63 @@ def test_gate_self_serves_reviewer_approval_then_merges() -> None:
     )
     assert approve["kwargs"]["headers"]["Authorization"] == "Bearer reviewer-pat"
     assert any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
+
+
+# ---- cutover U9: box-run CI feeds the gate for bot PRs; no Actions
+# check-run poll happens when a box CI verdict is in the state ----
+
+
+def _u9_state(client, *, box_ci):
+    return {
+        "issue": GitHubIssue(number=9, title="Fix relay", labels=(), state="open"),
+        "github": client,
+        "diff": "+docs\n",
+        "changed_files": ["docs/readme.md"],
+        "impl_pr": 456,
+        "tests_passed": True,
+        "sanitise_ok": True,
+        "review_findings": [],
+        "box_ci": box_ci,
+    }
+
+
+def test_gate_red_box_ci_blocks_merge_without_any_actions_run() -> None:
+    """U9 verification scenario: a failing test on a box PR blocks its merge
+    without any Actions run — the gate consumes the box verdict and never
+    touches the check-runs API."""
+    from wgmesh_pipeline.forge.box_ci import BoxCiResult
+
+    client = GitHubClient(
+        cfg(mode="live"), session=SessionForPr({"number": 456}), sanitiser=lambda text: True
+    )
+    ci_calls: list[int] = []
+
+    def box_ci(forge, pr_number: int) -> BoxCiResult:
+        ci_calls.append(pr_number)
+        return BoxCiResult(green=False, failures=("box ci: go test failed",))
+
+    result = gate_node(_u9_state(client, box_ci=box_ci), max_files=3)
+
+    assert ci_calls == [456]
+    assert result["decision"] == "escalate"
+    assert any("go test failed" in r for r in result["risk_reasons"])
+    assert not any("/check-runs" in c["url"] for c in client.session.calls)
+    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
+    assert any(c["url"].endswith("/issues/9/labels") for c in client.session.calls)
+
+
+def test_gate_green_box_ci_merges_without_actions_check_runs() -> None:
+    from wgmesh_pipeline.forge.box_ci import BoxCiResult
+
+    client = GitHubClient(
+        cfg(mode="live"), session=SessionForPr({"number": 456}), sanitiser=lambda text: True
+    )
+
+    result = gate_node(
+        _u9_state(client, box_ci=lambda forge, pr: BoxCiResult(green=True, failures=())),
+        max_files=3,
+    )
+
+    assert result["decision"] == "merge"
+    assert not any("/check-runs" in c["url"] for c in client.session.calls)
+    assert any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)

--- a/pipeline/tests/test_live_e2e.py
+++ b/pipeline/tests/test_live_e2e.py
@@ -13,6 +13,7 @@ import asyncio
 import pytest
 
 from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.forge.box_ci import BoxCiResult
 from wgmesh_pipeline.github.client import GitHubClient
 from wgmesh_pipeline.poller import Poller
 from wgmesh_pipeline.scoring import init_scoring
@@ -113,7 +114,15 @@ def _live_poller(tmp_path, graph, session):
     cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="live", max_files=3)
     store = StateStore(tmp_path / "state.db")
     client = _RecordingClient(cfg, session=session)
-    return Poller(config=cfg, store=store, client=client, graph=graph)
+    # Box CI (U9) green: these scenarios exercise the flow downstream of the
+    # box's own pre-merge CI; box_ci internals are covered in test_box_ci.py.
+    return Poller(
+        config=cfg,
+        store=store,
+        client=client,
+        graph=graph,
+        box_ci=lambda forge, pr: BoxCiResult(green=True, failures=()),
+    )
 
 
 def test_live_low_risk_issue_merges_and_scores(tmp_path) -> None:

--- a/pipeline/tests/test_merge_gate.py
+++ b/pipeline/tests/test_merge_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from wgmesh_pipeline.forge.box_ci import BoxCiResult
 from wgmesh_pipeline.forge.merge_gate import ensure_mergeable
 
 
@@ -19,11 +20,13 @@ class ReviewClient:
         self._approvals = list(approvals or [])
         self._reviewer_credential = reviewer_credential
         self.approve_calls: list[int] = []
+        self.checks_polls: list[int] = []
 
     def get_pr(self, number: int) -> dict[str, Any]:
         return {"user": {"login": self._author}}
 
     def pr_checks_green(self, pr_number: int) -> bool:
+        self.checks_polls.append(pr_number)
         return self._checks_green
 
     def list_pr_approvals(self, pr_number: int) -> list[str]:
@@ -111,3 +114,54 @@ def test_approve_failure_becomes_readiness_reason_not_exception() -> None:
 
     assert readiness.ready is False
     assert any("reviewer approval failed" in r for r in readiness.reasons)
+
+
+# ---- box-run CI verdict (cutover U9): bot PRs are CI'd on the box, the
+# gate consumes that verdict and never polls Actions check-runs for them ----
+
+
+def test_box_ci_verdict_replaces_actions_check_runs() -> None:
+    client = ReviewClient(checks_green=False, approvals=["reviewer-bot"])
+
+    readiness = ensure_mergeable(
+        client, 7, ci_verdict=BoxCiResult(green=True, failures=())
+    )
+
+    assert readiness.ready is True
+    assert client.checks_polls == []
+
+
+def test_red_box_ci_blocks_merge_with_its_failures_as_reasons() -> None:
+    client = ReviewClient(checks_green=True, approvals=["reviewer-bot"])
+
+    readiness = ensure_mergeable(
+        client,
+        7,
+        ci_verdict=BoxCiResult(green=False, failures=("box ci: go test failed",)),
+    )
+
+    assert readiness.ready is False
+    assert "ci not green" in readiness.reasons
+    assert any("go test failed" in r for r in readiness.reasons)
+    assert client.checks_polls == []
+
+
+def test_red_box_ci_defers_reviewer_approval() -> None:
+    """Same as the red-Actions case: don't burn an approval on a red build."""
+    client = ReviewClient(approvals=[], reviewer_credential=True)
+
+    readiness = ensure_mergeable(
+        client, 7, ci_verdict=BoxCiResult(green=False, failures=("box ci: sanitise failed",))
+    )
+
+    assert readiness.ready is False
+    assert client.approve_calls == []
+
+
+def test_no_verdict_keeps_actions_check_runs_path() -> None:
+    client = ReviewClient(checks_green=True, approvals=["reviewer-bot"])
+
+    readiness = ensure_mergeable(client, 7)
+
+    assert readiness.ready is True
+    assert client.checks_polls == [7]

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.forge.box_ci import BoxCiResult
 from wgmesh_pipeline.github.client import GitHubClient
 from wgmesh_pipeline.graph.build import build_graph
 from wgmesh_pipeline.poller import Poller
@@ -269,7 +270,14 @@ def test_reviewed_issue_not_phantom_merged_when_side_effect_fails(tmp_path, cfg:
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(2, "Ready", stage="reviewed", impl_pr=321)
     client = FailingMergeClient(live)
-    p = Poller(config=live, store=store, client=client, graph=Graph())
+    # Box CI (U9) green so the gate proceeds to the merge call under test.
+    p = Poller(
+        config=live,
+        store=store,
+        client=client,
+        graph=Graph(),
+        box_ci=lambda forge, pr: BoxCiResult(green=True, failures=()),
+    )
     p.scratch[2] = {
         "diff": "+docs\n",
         "changed_files": ["docs/readme.md"],
@@ -313,10 +321,21 @@ def test_advance_one_stage_injects_goose_runner_and_repo_path(tmp_path, cfg: Con
     graph = InspectingGraph()
     repo_path = tmp_path / "wgmesh"
     runner = object()
+
+    def box_ci(forge, pr):
+        return BoxCiResult(green=True, failures=())
+
     spec_only = Config(target_repo=cfg.target_repo, mode="spec-only", repo_path=str(repo_path))
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(17, "Already triaged", stage="triaged")
-    p = Poller(config=spec_only, store=store, client=EmptyClient(spec_only), graph=graph, goose_runner=runner)
+    p = Poller(
+        config=spec_only,
+        store=store,
+        client=EmptyClient(spec_only),
+        graph=graph,
+        goose_runner=runner,
+        box_ci=box_ci,
+    )
 
     p._advance_one_stage(store.get_issue(17))
 
@@ -324,6 +343,7 @@ def test_advance_one_stage_injects_goose_runner_and_repo_path(tmp_path, cfg: Con
     assert graph.seen_state["goose_runner"] is runner
     assert graph.seen_state["repo_path"] == repo_path
     assert graph.seen_state["config"] is spec_only
+    assert graph.seen_state["box_ci"] is box_ci
 
 
 def test_specced_issue_opens_spec_pr_then_stops_in_spec_only(tmp_path, cfg: Config) -> None:
@@ -411,9 +431,6 @@ def test_reviewed_issue_records_escalated_when_gate_flips_decision(tmp_path, cfg
 
         def request(self, method, url, **kwargs):
             self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-            if "/check-runs" in url:
-                # CI red -> gate must refuse the merge and escalate.
-                return Response({"check_runs": [{"status": "completed", "conclusion": "failure"}]})
             if method == "GET" and url.endswith("/reviews"):
                 return Response([])
             if method == "GET" and "/pulls/" in url:
@@ -425,7 +442,14 @@ def test_reviewed_issue_records_escalated_when_gate_flips_decision(tmp_path, cfg
     store.upsert_issue(3, "Ready", stage="reviewed", impl_pr=321)
     session = RoutedSession()
     client = EmptyClient(live, session=session)
-    p = Poller(config=live, store=store, client=client, graph=Graph())
+    # Box CI (U9) red -> gate must refuse the merge and escalate.
+    p = Poller(
+        config=live,
+        store=store,
+        client=client,
+        graph=Graph(),
+        box_ci=lambda forge, pr: BoxCiResult(green=False, failures=("box ci: go test failed",)),
+    )
     p.scratch[3] = {
         "diff": "+docs\n",
         "changed_files": ["docs/readme.md"],

--- a/pipeline/wgmesh_pipeline/forge/box_ci.py
+++ b/pipeline/wgmesh_pipeline/forge/box_ci.py
@@ -1,0 +1,230 @@
+"""Box-side pre-merge CI for bot-authored PRs (cutover #1599 U9).
+
+The box is the CI for its own PRs: before the merge gate it runs the
+verification suite, `company/scripts/sanitise.sh` over the PR diff, and the
+path-scoped PII rules that `pii-policy-check.yml` enforces (docs/outreach/**
+email ban + docs/customers/** banned namespace — born from the 2026-05-09
+PR #820 stargazer-email incident). The resulting verdict feeds
+`merge_gate.ensure_mergeable` instead of an Actions check-runs poll; Actions
+CI remains only for external PRs (U10's retained sandbox lane).
+
+Fail closed everywhere: a stage that cannot run is a failure, never a pass.
+PII failure messages report path + line number only — never the matched
+address — because gate reasons land on public surfaces.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from wgmesh_pipeline.verification import run_verification
+
+log = logging.getLogger(__name__)
+
+SANITISE_SCRIPT = Path(__file__).resolve().parents[3] / "company" / "scripts" / "sanitise.sh"
+SANITISE_TIMEOUT_SECONDS = 120
+GIT_TIMEOUT_SECONDS = 120
+
+# Mirrors pii-policy-check.yml: scan only policy-restricted paths.
+RESTRICTED_PATH_RE = re.compile(r"^docs/(outreach|customers)/")
+CUSTOMERS_PREFIX = "docs/customers/"
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# example.com is RFC 2606 reserved; the github.com domains are GH system mail.
+ALLOWED_EMAIL_DOMAIN_RE = re.compile(
+    r"^@(example\.com|noreply\.github\.com|users\.noreply\.github\.com)$"
+)
+
+
+class _CiSurface(Protocol):
+    def get_pr(self, number: int) -> dict[str, Any]: ...
+
+    def get_diff(self, pr_number: int) -> str: ...
+
+
+@dataclass(frozen=True)
+class BoxCiResult:
+    green: bool
+    failures: tuple[str, ...]
+
+
+def run_box_ci(
+    client: _CiSurface,
+    pr_number: int,
+    *,
+    repo_path: Path,
+    verifier: Callable[..., dict] = run_verification,
+    sanitiser: Callable[[str], bool] | None = None,
+    runner: Callable[..., Any] = subprocess.run,
+) -> BoxCiResult:
+    """Run the full box-side CI for one PR and return a single verdict.
+
+    Stages run independently and failures accumulate, so an escalation
+    carries every reason at once instead of one per retry.
+    """
+    sanitise = sanitiser if sanitiser is not None else _run_sanitise
+    failures: list[str] = []
+
+    pr = client.get_pr(pr_number)
+    branch = str(((pr.get("head") or {}).get("ref")) or "")
+    head_sha = str(((pr.get("head") or {}).get("sha")) or "")
+    base_sha = str(((pr.get("base") or {}).get("sha")) or "")
+    if not branch or not head_sha or not base_sha:
+        return BoxCiResult(
+            green=False,
+            failures=(f"box ci: PR #{pr_number} is missing head/base refs — cannot verify",),
+        )
+
+    # Fail closed, loudly: a stage that cannot run (missing clone, dead git)
+    # is a red verdict with the cause in the reasons — never an exception
+    # that strands the issue mid-merge, never a silent pass.
+    try:
+        verification = verifier(repo_path, branch)
+    except Exception as exc:
+        log.warning("box ci: verification could not run for PR #%s: %s", pr_number, exc)
+        verification = {"tests_passed": False, "reason": f"verification could not run: {exc}"}
+    if not verification.get("tests_passed", False):
+        reason = verification.get("reason") or verification.get("failed_step") or "tests failed"
+        failures.append(f"box ci: verification failed ({reason})")
+
+    try:
+        diff = client.get_diff(pr_number)
+    except Exception as exc:
+        log.warning("box ci: could not fetch diff for PR #%s: %s", pr_number, exc)
+        failures.append(f"box ci: could not fetch PR diff ({exc})")
+    else:
+        if not sanitise(diff):
+            failures.append("box ci: sanitise failed")
+
+    try:
+        pii = pii_path_violations(repo_path, base_sha, head_sha, runner=runner)
+    except Exception as exc:
+        log.warning("box ci: pii check could not run for PR #%s: %s", pr_number, exc)
+        pii = (f"pii check could not run: {exc}",)
+    failures.extend(f"box ci: pii violation: {violation}" for violation in pii)
+
+    if failures:
+        log.warning("box ci: PR #%s RED: %s", pr_number, "; ".join(failures))
+    else:
+        log.info("box ci: PR #%s green (verification + sanitise + pii)", pr_number)
+    return BoxCiResult(green=not failures, failures=tuple(failures))
+
+
+def make_box_ci_runner(
+    repo_path: str | Path, **overrides: Any
+) -> Callable[[Any, int], BoxCiResult]:
+    """Bind a repo clone path (and optional stage overrides, for tests) into
+    the `(client, pr_number) -> BoxCiResult` shape the gate consumes."""
+    path = Path(repo_path)
+
+    def _run(client: Any, pr_number: int) -> BoxCiResult:
+        return run_box_ci(client, pr_number, repo_path=path, **overrides)
+
+    return _run
+
+
+def pii_path_violations(
+    repo_path: Path,
+    base_sha: str,
+    head_sha: str,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> tuple[str, ...]:
+    """Port of pii-policy-check.yml's scan, per-commit over base..head.
+
+    Per-commit (not endpoint-diff) so content that lived under a restricted
+    path in an intermediate commit but was renamed out before HEAD is still
+    scanned — the commit-then-move-out bypass.
+    """
+    # Best-effort: make sure the base commit is reachable locally (the
+    # verification stage already fetched the head branch).
+    _git(runner, repo_path, "fetch", "--no-tags", "origin", base_sha)
+
+    listed = _git(runner, repo_path, "rev-list", f"{base_sha}..{head_sha}")
+    if listed.returncode != 0:
+        return (f"pii check could not enumerate commits {base_sha[:7]}..{head_sha[:7]}: "
+                f"{(listed.stderr or '').strip()}",)
+
+    violations: list[str] = []
+    for commit in [line for line in (listed.stdout or "").splitlines() if line.strip()]:
+        tree = _git(
+            runner,
+            repo_path,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "-M",
+            "-m",
+            "--diff-filter=ACMRT",
+            commit,
+        )
+        if tree.returncode != 0:
+            violations.append(
+                f"pii check could not inspect commit {commit[:7]}: {(tree.stderr or '').strip()}"
+            )
+            continue
+        files = sorted(
+            {line for line in (tree.stdout or "").splitlines() if RESTRICTED_PATH_RE.match(line)}
+        )
+        for path in files:
+            violations.extend(_scan_restricted_file(runner, repo_path, commit, path))
+    return tuple(violations)
+
+
+def _scan_restricted_file(
+    runner: Callable[..., Any], repo_path: Path, commit: str, path: str
+) -> list[str]:
+    if path.startswith(CUSTOMERS_PREFIX):
+        exists = _git(runner, repo_path, "cat-file", "-e", f"{commit}:{path}")
+        if exists.returncode == 0:
+            return [
+                f"{path} (commit {commit[:7]}): docs/customers/** is a policy-banned "
+                "namespace — customer/sponsor exchanges live in private operator notes"
+            ]
+        return []
+
+    shown = _git(runner, repo_path, "cat-file", "-p", f"{commit}:{path}")
+    if shown.returncode != 0:
+        # File absent at this commit (renamed-out source path) — nothing to scan.
+        return []
+    found: list[str] = []
+    for lineno, line in enumerate((shown.stdout or "").splitlines(), start=1):
+        for match in EMAIL_RE.finditer(line):
+            domain = match.group(0)[match.group(0).index("@"):]
+            if not ALLOWED_EMAIL_DOMAIN_RE.match(domain):
+                # Report position only — never the address itself.
+                found.append(
+                    f"{path}: disallowed email at line {lineno} (commit {commit[:7]})"
+                )
+    return found
+
+
+def _git(runner: Callable[..., Any], repo_path: Path, *args: str) -> Any:
+    return runner(
+        ["git", *args],
+        cwd=repo_path,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+    )
+
+
+def _run_sanitise(text: str) -> bool:
+    try:
+        completed = subprocess.run(
+            [str(SANITISE_SCRIPT)],
+            input=text,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=SANITISE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0

--- a/pipeline/wgmesh_pipeline/forge/box_ci.py
+++ b/pipeline/wgmesh_pipeline/forge/box_ci.py
@@ -69,7 +69,16 @@ def run_box_ci(
     sanitise = sanitiser if sanitiser is not None else _run_sanitise
     failures: list[str] = []
 
-    pr = client.get_pr(pr_number)
+    # Fail closed on the very first read too: a forge outage is a red
+    # verdict, never an exception stranding the gate mid-merge.
+    try:
+        pr = client.get_pr(pr_number)
+    except Exception:
+        log.exception("box ci: could not fetch PR #%s", pr_number)
+        return BoxCiResult(
+            green=False,
+            failures=(f"box ci: could not fetch PR #{pr_number} (see box logs)",),
+        )
     branch = str(((pr.get("head") or {}).get("ref")) or "")
     head_sha = str(((pr.get("head") or {}).get("sha")) or "")
     base_sha = str(((pr.get("base") or {}).get("sha")) or "")
@@ -85,8 +94,8 @@ def run_box_ci(
     try:
         verification = verifier(repo_path, branch)
     except Exception as exc:
-        log.warning("box ci: verification could not run for PR #%s: %s", pr_number, exc)
-        verification = {"tests_passed": False, "reason": f"verification could not run: {exc}"}
+        log.exception("box ci: verification could not run for PR #%s: %s", pr_number, exc)
+        verification = {"tests_passed": False, "reason": "verification could not run (see box logs)"}
     if not verification.get("tests_passed", False):
         reason = verification.get("reason") or verification.get("failed_step") or "tests failed"
         failures.append(f"box ci: verification failed ({reason})")
@@ -94,8 +103,8 @@ def run_box_ci(
     try:
         diff = client.get_diff(pr_number)
     except Exception as exc:
-        log.warning("box ci: could not fetch diff for PR #%s: %s", pr_number, exc)
-        failures.append(f"box ci: could not fetch PR diff ({exc})")
+        log.exception("box ci: could not fetch diff for PR #%s: %s", pr_number, exc)
+        failures.append("box ci: could not fetch PR diff (see box logs)")
     else:
         if not sanitise(diff):
             failures.append("box ci: sanitise failed")
@@ -103,8 +112,8 @@ def run_box_ci(
     try:
         pii = pii_path_violations(repo_path, base_sha, head_sha, runner=runner)
     except Exception as exc:
-        log.warning("box ci: pii check could not run for PR #%s: %s", pr_number, exc)
-        pii = (f"pii check could not run: {exc}",)
+        log.exception("box ci: pii check could not run for PR #%s: %s", pr_number, exc)
+        pii = ("pii check could not run (see box logs)",)
     failures.extend(f"box ci: pii violation: {violation}" for violation in pii)
 
     if failures:

--- a/pipeline/wgmesh_pipeline/forge/merge_gate.py
+++ b/pipeline/wgmesh_pipeline/forge/merge_gate.py
@@ -17,6 +17,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from wgmesh_pipeline.forge.box_ci import BoxCiResult
+
 log = logging.getLogger(__name__)
 
 
@@ -38,10 +40,23 @@ class MergeReadiness:
     reasons: tuple[str, ...]
 
 
-def ensure_mergeable(client: _ReviewSurface, pr_number: int) -> MergeReadiness:
+def ensure_mergeable(
+    client: _ReviewSurface,
+    pr_number: int,
+    *,
+    ci_verdict: BoxCiResult | None = None,
+) -> MergeReadiness:
     reasons: list[str] = []
 
-    if not client.pr_checks_green(pr_number):
+    # Cutover U9: bot PRs are CI'd on the box itself; when a box-run verdict
+    # is supplied it IS the CI signal and the Actions check-runs API is never
+    # polled. Without a verdict (external PRs / not-yet-cutover configs) the
+    # host's check-runs remain the source.
+    if ci_verdict is not None:
+        if not ci_verdict.green:
+            reasons.append("ci not green")
+            reasons.extend(ci_verdict.failures)
+    elif not client.pr_checks_green(pr_number):
         reasons.append("ci not green")
 
     pr = client.get_pr(pr_number)

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -85,7 +85,11 @@ def apply_gate_side_effects(state: GraphState) -> None:
         # Shadow mode skips the live readiness reads — the merge itself is
         # only a dry-run record there.
         if getattr(getattr(client, "config", None), "mode", None) != "shadow":
-            readiness = ensure_mergeable(client, int(impl_pr))
+            # Cutover U9: when a box-CI runner is wired, the box's own verdict
+            # IS the CI signal — the host's Actions check-runs are not polled.
+            box_ci = state.get("box_ci")
+            ci_verdict = box_ci(client, int(impl_pr)) if box_ci is not None else None
+            readiness = ensure_mergeable(client, int(impl_pr), ci_verdict=ci_verdict)
             if not readiness.ready:
                 log.warning(
                     "gate: PR #%s not mergeable (%s); escalating instead of merging",

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from wgmesh_pipeline.forge.box_ci import BoxCiResult
 from wgmesh_pipeline.forge.merge_gate import ensure_mergeable
 from wgmesh_pipeline.graph.state import Decision, GraphState
 from wgmesh_pipeline.risk import classify_risk
@@ -88,7 +89,17 @@ def apply_gate_side_effects(state: GraphState) -> None:
             # Cutover U9: when a box-CI runner is wired, the box's own verdict
             # IS the CI signal — the host's Actions check-runs are not polled.
             box_ci = state.get("box_ci")
-            ci_verdict = box_ci(client, int(impl_pr)) if box_ci is not None else None
+            ci_verdict = None
+            if box_ci is not None:
+                try:
+                    ci_verdict = box_ci(client, int(impl_pr))
+                except Exception:
+                    # A crashing runner is a red verdict (fail closed), never
+                    # an exception that strands the issue mid-merge.
+                    log.exception("gate: box CI runner crashed for PR #%s", impl_pr)
+                    ci_verdict = BoxCiResult(
+                        green=False, failures=("box ci: runner crashed (see box logs)",)
+                    )
             readiness = ensure_mergeable(client, int(impl_pr), ci_verdict=ci_verdict)
             if not readiness.ready:
                 log.warning(

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -34,5 +34,8 @@ class GraphState(TypedDict, total=False):
     github: GitHubClient
     repo_path: str | Path
     goose_runner: Any
+    # Box-side pre-merge CI for bot PRs (cutover U9):
+    # (client, pr_number) -> wgmesh_pipeline.forge.box_ci.BoxCiResult
+    box_ci: Any
     impl_pr: int
     config: Config

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.forge.box_ci import make_box_ci_runner
 from wgmesh_pipeline.forge.protocol import Forge, ForgeIssue as GitHubIssue
 from wgmesh_pipeline.github.reconcile import reconcile_issues
 from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
@@ -24,6 +25,8 @@ class Poller:
     graph: object
     resolution_lookup: object | None = None
     goose_runner: object | None = None
+    # (client, pr_number) -> BoxCiResult; None wires the real box CI runner.
+    box_ci: object | None = None
     scratch: dict[int, dict] = field(default_factory=dict)
     last_reconcile_error: str | None = None
 
@@ -82,6 +85,10 @@ class Poller:
             "github": self.client,
             "config": self.config,
             "repo_path": Path(self.config.repo_path),
+            # Cutover U9: the box CIs its own bot PRs (verification +
+            # sanitise + path-scoped PII) — the gate consumes this verdict
+            # instead of polling the host's Actions check-runs.
+            "box_ci": self.box_ci or make_box_ci_runner(self.config.repo_path),
         }
         if self.goose_runner is not None:
             state["goose_runner"] = self.goose_runner


### PR DESCRIPTION
## Summary

#1599 **U9 / Phase D**: the box CIs its own bot PRs. `forge/box_ci.py` runs the verification suite, `sanitise.sh` over the PR diff, and the path-scoped PII rules (per-commit over the PR range, mirroring pii-policy-check.yml incl. the commit-then-move-out bypass guard) — fail-closed at every stage; PII failures report path+line only, never the matched address. The verdict feeds `ensure_mergeable(ci_verdict=…)`; with a verdict present the Actions check-runs API is never polled. Poller wires the real runner by default.

Legacy pipeline-ci/sanitise-wall/pii-policy-check gain `bot/*`-head skip conditions (the box owns that class); ci.yml (U10) still runs unconditionally on every PR, so nothing lapses for any author class — fork PRs stay on the Actions sandbox.

Provenance: built by a session-limited agent (86 tool calls), salvaged, gate wiring completed, all tests verified post-salvage.

## Test plan
- [x] test_box_ci.py (new) + U9 gate tests: red box-CI blocks merge with no Actions calls; green box-CI merges without check-runs polling
- [x] Full suite 373 passed, 5 skipped