### PR TITLE
fix(deploy): goose installer needs bzip2/unzip/xz in the image

### DIFF
--- a/pipeline/deploy/Dockerfile
+++ b/pipeline/deploy/Dockerfile
@@ -5,7 +5,7 @@
 FROM python:3.11-slim
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git curl ca-certificates \
+ && apt-get install -y --no-install-recommends git curl ca-certificates bzip2 unzip xz-utils \
  && rm -rf /var/lib/apt/lists/* \
  && curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash
 


### PR DESCRIPTION
Pulse followup #1 (2026-06-12): the new image lane's first runs failed in the Dockerfile goose-install step — `download_cli.sh` requires tar/unzip/bzip2 (verified from the installer source). Adds the three packages to the apt layer.

Test plan: merge triggers build-pipeline-image.yml on main (pipeline/** path) — the lane itself is the test.