### PR TITLE
fix(deploy): run goose installer non-interactively in image build

### DIFF
--- a/pipeline/deploy/Dockerfile
+++ b/pipeline/deploy/Dockerfile
@@ -7,7 +7,7 @@ FROM python:3.11-slim
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git curl ca-certificates bzip2 unzip xz-utils \
  && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | bash
+ && curl -fsSL https://github.com/block/goose/releases/latest/download/download_cli.sh | CONFIGURE=false bash
 
 WORKDIR /app
 COPY pipeline/ /app/pipeline/


### PR DESCRIPTION
Image-lane failure #2 (after #1684's bzip2 fix): installer reaches 'Configuring goose' and dies on /dev/tty (no TTY in docker build). `CONFIGURE=false bash` skips the interactive step per the installer's own docs (line 24); runtime config comes from the env-file. Lane's post-merge run is the test.