### PR TITLE
fix(deploy): image must carry company/ — sanitise wall is runtime-critical

### DIFF
--- a/pipeline/deploy/Dockerfile
+++ b/pipeline/deploy/Dockerfile
@@ -11,6 +11,11 @@ RUN apt-get update \
 
 WORKDIR /app
 COPY pipeline/ /app/pipeline/
+# company/ is runtime-critical: the write gate resolves
+# company/scripts/sanitise.sh relative to the package (client.py
+# SANITISE_SCRIPT) — without it every gated write would fail closed at
+# runtime. Parity tests also read recorded state from company/.
+COPY company/ /app/company/
 RUN pip install --no-cache-dir -e /app/pipeline
 
 # Non-root: the container holds the bot PAT; shrink the blast radius.


### PR DESCRIPTION
Image-lane round 3: pytest-in-image failures (25 supervisor parity errors + 3 spec-only gate failures) traced to `company/` never being copied into the image. Runtime-critical, not test-only: the write gate resolves `company/scripts/sanitise.sh` relative to the installed package — a container without it fails every gated write. The #1673 review's residual-risk note called this exact gap. Lane's post-merge run is the test.