### PR TITLE
feat(strategy): box-side strategy-audit module (cutover U6)

### DIFF
--- a/pipeline/tests/fixtures/strategy_audit_baseline.json
+++ b/pipeline/tests/fixtures/strategy_audit_baseline.json
@@ -1,0 +1,345 @@
+{
+  "audits": [
+    {
+      "ran_at": "2026-05-03T14:41:59Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 4.84,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 0,
+        "fetch_status": {
+          "paid_customers": "ok"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-06-30",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-01",
+          "target": "1 paying customer (90-day target)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "4 customers (Year 1)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "42 customers, $10K ARR (Year 2)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2029-05-03",
+          "target": "420 customers, $100K ARR (Year 3, MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "ran_at": "2026-05-06T11:04:45Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 5.21,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 0,
+        "cycle_time_to_revenue": null,
+        "fetch_status": {
+          "paid_customers": "ok",
+          "cycle_time_to_revenue": "no_customers"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-05-10",
+          "target": "first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-05-17",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-05-31",
+          "target": "1 paying customer",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2026-06-14",
+          "target": "2nd seed product spec'd and entering convergence engine",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-31",
+          "target": "4 customers ($10K ARR run-rate path)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "42 customers, $10K ARR",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "420 customers, $100K ARR (MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "ran_at": "2026-05-09T10:04:17Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 5.59,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 0,
+        "cycle_time_to_revenue": null,
+        "fetch_status": {
+          "paid_customers": "ok",
+          "cycle_time_to_revenue": "no_customers"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-05-10",
+          "target": "first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-05-17",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-05-31",
+          "target": "1 paying customer",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2026-06-14",
+          "target": "2nd seed product spec'd and entering convergence engine",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-31",
+          "target": "4 customers ($10K ARR run-rate path)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "42 customers, $10K ARR",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "420 customers, $100K ARR (MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "ran_at": "2026-05-10T10:11:50Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 5.21,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 0,
+        "cycle_time_to_revenue": null,
+        "fetch_status": {
+          "paid_customers": "ok",
+          "cycle_time_to_revenue": "no_customers"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-05-10",
+          "target": "first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)",
+          "current": "not measured",
+          "status": "pending-uncertain"
+        },
+        {
+          "date": "2026-05-17",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-05-31",
+          "target": "1 paying customer",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2026-06-14",
+          "target": "2nd seed product spec'd and entering convergence engine",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-31",
+          "target": "4 customers ($10K ARR run-rate path)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "42 customers, $10K ARR",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "420 customers, $100K ARR (MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "ran_at": "2026-06-09T11:58:26Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 154.77,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 0,
+        "cycle_time_to_revenue": null,
+        "fetch_status": {
+          "paid_customers": "ok",
+          "cycle_time_to_revenue": "no_customers"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-05-10",
+          "target": "first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)",
+          "current": "not measured",
+          "status": "pending-uncertain"
+        },
+        {
+          "date": "2026-05-17",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending-uncertain"
+        },
+        {
+          "date": "2026-05-31",
+          "target": "1 paying customer",
+          "current": "0 paid customers",
+          "status": "overdue"
+        },
+        {
+          "date": "2026-06-14",
+          "target": "2nd seed product spec'd and entering convergence engine",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-31",
+          "target": "4 customers ($10K ARR run-rate path)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "42 customers, $10K ARR",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "420 customers, $100K ARR (MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    },
+    {
+      "ran_at": "2026-06-11T12:43:01Z",
+      "metrics": {
+        "paid_customers": 0,
+        "autonomous_ship_rate": null,
+        "lead_time_hours": 154.77,
+        "self_heal_rate": 0,
+        "active_stuck_issues": 1,
+        "cycle_time_to_revenue": null,
+        "fetch_status": {
+          "paid_customers": "ok",
+          "cycle_time_to_revenue": "no_customers"
+        }
+      },
+      "milestones_status": [
+        {
+          "date": "2026-05-10",
+          "target": "first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)",
+          "current": "not measured",
+          "status": "pending-uncertain"
+        },
+        {
+          "date": "2026-05-17",
+          "target": "wgmesh edge node beta (first seeded product reaches public beta)",
+          "current": "not measured",
+          "status": "pending-uncertain"
+        },
+        {
+          "date": "2026-05-31",
+          "target": "1 paying customer",
+          "current": "0 paid customers",
+          "status": "overdue"
+        },
+        {
+          "date": "2026-06-14",
+          "target": "2nd seed product spec'd and entering convergence engine",
+          "current": "not measured",
+          "status": "pending"
+        },
+        {
+          "date": "2026-08-31",
+          "target": "4 customers ($10K ARR run-rate path)",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2027-05-03",
+          "target": "42 customers, $10K ARR",
+          "current": "0 paid customers",
+          "status": "pending"
+        },
+        {
+          "date": "2028-05-03",
+          "target": "420 customers, $100K ARR (MSC)",
+          "current": "0 paid customers",
+          "status": "pending"
+        }
+      ]
+    }
+  ],
+  "last_reported_drift_fingerprint": "metrics=;overdue_milestones=2026-05-31"
+}

--- a/pipeline/tests/test_strategy_audit.py
+++ b/pipeline/tests/test_strategy_audit.py
@@ -1,0 +1,353 @@
+"""Strategy-audit parity + edge-case tests (cutover U6).
+
+Parity fixtures replay recorded Actions runs against the on-main
+``company/strategy-audit-baseline.json``:
+
+  - The latest run (2026-06-12, drift PR #1677 "audit: strategy drift
+    detected ae5123115cb0") must reproduce verdict, fingerprint, and the
+    12-char title hash byte-exact, and the updated baseline's
+    ``last_reported_drift_fingerprint`` must equal what the run's marker
+    committed to main (the value recorded in the baseline file today).
+  - The 2026-06-10 run (drift PR #1624 "audit: strategy drift detected
+    0ba6becc8c61") pins a metric-drift fingerprint hash.
+  - The 2026-06-11 commit_main run must append an audit entry byte-identical
+    (including key order) to the recorded ``audits[-1]``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wgmesh_pipeline.strategy_audit import (
+    FIRST_RUN_FINGERPRINT,
+    MAX_AUDITS,
+    MetricRow,
+    append_audit,
+    decide,
+    drift_fingerprint,
+    extract_paid_customers,
+    fingerprint_hash,
+    metric_row,
+    milestone_status,
+    parse_milestones,
+    run_strategy_audit,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASELINE_FILE = REPO_ROOT / "company" / "strategy-audit-baseline.json"
+STRATEGY_FILE = REPO_ROOT / "STRATEGY.md"
+
+# Milestones section frozen as of the recorded runs (matches the recorded
+# audits' milestone targets byte-for-byte; the real STRATEGY.md may evolve).
+STRATEGY_FIXTURE = """\
+# STRATEGY
+
+## Milestones
+
+- **2026-05-10** — first audit-loop closes cleanly (drift PR opens, founder applies, doc updates, audit re-runs green)
+- **2026-05-17** — wgmesh edge node beta (first seeded product reaches public beta)
+- **2026-05-31** — 1 paying customer
+- **2026-06-14** — 2nd seed product spec'd and entering convergence engine
+- **2026-08-31** — 4 customers ($10K ARR run-rate path)
+- **2027-05-03** — 42 customers, $10K ARR
+- **2028-05-03** — 420 customers, $100K ARR (MSC)
+
+## Next section
+"""
+
+# Fingerprint the 2026-06-10 run reported (drift PR #1624) — the value
+# last_reported held when the 06-11 and 06-12 runs executed.
+FP_STUCK = "metrics=active_stuck_issues;overdue_milestones=2026-05-31"
+# Fingerprint the latest run reported (drift PR #1677, 2026-06-12).
+FP_OVERDUE_ONLY = "metrics=;overdue_milestones=2026-05-31"
+
+METRICS_2026_06_11 = {
+    "paid_customers": 0,
+    "autonomous_ship_rate": None,
+    "lead_time_hours": 154.77,
+    "self_heal_rate": 0,
+    "active_stuck_issues": 1,
+}
+
+
+@pytest.fixture(scope="module")
+def recorded() -> dict:
+    return json.loads(BASELINE_FILE.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------- parity
+
+
+def test_parity_latest_run_verdict_and_fingerprint(recorded: dict) -> None:
+    """Replay the 2026-06-12 run that opened drift PR #1677."""
+    pre_run = {**recorded, "last_reported_drift_fingerprint": FP_STUCK}
+    run = run_strategy_audit(
+        pre_run,
+        metrics=METRICS_2026_06_11,  # 06-12 measured the same values
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-06-12T12:17:20Z",
+    )
+    assert run.fingerprint == FP_OVERDUE_ONLY
+    # PR #1677 title: "audit: strategy drift detected ae5123115cb0"
+    assert run.fingerprint_hash == "ae5123115cb0"
+    assert run.any_drift is True
+    assert run.decision.action == "open_pr"
+    assert run.material_changed is True
+    # The marker the run committed to main is what the file records today.
+    assert (
+        run.baseline["last_reported_drift_fingerprint"]
+        == recorded["last_reported_drift_fingerprint"]
+    )
+    # Metric table from the PR body: all OK / NO DATA, deltas 0% / n/a.
+    assert [(r.verdict, r.delta_display) for r in run.metric_rows] == [
+        ("OK", "0%"),
+        ("NO DATA", "n/a"),
+        ("OK", "0%"),
+        ("OK", "0%"),
+        ("OK", "0%"),
+        ("NO DATA", "n/a"),
+    ]
+    # Milestone table from the PR body.
+    assert [m.status for m in run.milestones] == [
+        "pending-uncertain",
+        "pending-uncertain",
+        "overdue",
+        "pending",
+        "pending",
+        "pending",
+        "pending",
+    ]
+
+
+def test_parity_prior_run_metric_drift_hash(recorded: dict) -> None:
+    """Replay the 2026-06-10 run that opened drift PR #1624."""
+    pre_run = {
+        "audits": recorded["audits"][:5],  # through the 2026-06-09 entry
+        "last_reported_drift_fingerprint": FP_OVERDUE_ONLY,
+    }
+    run = run_strategy_audit(
+        pre_run,
+        metrics=METRICS_2026_06_11,  # active_stuck_issues went 0 -> 1
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-06-10T12:18:50Z",
+    )
+    assert run.fingerprint == FP_STUCK
+    # PR #1624 title: "audit: strategy drift detected 0ba6becc8c61"
+    assert run.fingerprint_hash == "0ba6becc8c61"
+    assert run.decision.action == "open_pr"
+    drifted = [r.key for r in run.metric_rows if r.drift]
+    assert drifted == ["active_stuck_issues"]
+
+
+def test_parity_appended_entry_byte_exact(recorded: dict) -> None:
+    """Replay the 2026-06-11 commit_main run; the appended audit entry must
+    be byte-identical (key order included) to the recorded audits[-1]."""
+    pre_run = {
+        "audits": recorded["audits"][:5],
+        "last_reported_drift_fingerprint": FP_STUCK,
+    }
+    run = run_strategy_audit(
+        pre_run,
+        metrics=METRICS_2026_06_11,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-06-11T12:43:01Z",
+    )
+    # Drift fingerprint repeats the already-reported one -> no new PR; the
+    # metric values changed (stuck 0 -> 1) -> baseline telemetry commit.
+    assert run.decision.action == "commit_main"
+    assert run.decision.open_pr is False
+    assert run.material_changed is True
+    assert len(run.baseline["audits"]) == 6
+    expected = recorded["audits"][-1]
+    actual = run.baseline["audits"][-1]
+    assert actual == expected
+    # Byte-exact including key order (what jq persisted on main).
+    assert json.dumps(actual, indent=2) == json.dumps(expected, indent=2)
+    # last_reported carries over unchanged on commit_main.
+    assert run.baseline["last_reported_drift_fingerprint"] == FP_STUCK
+
+
+# ----------------------------------------------------------------- edges
+
+
+def _baseline_with_metrics(metrics: dict, fingerprint: str) -> dict:
+    return {
+        "audits": [{"ran_at": "2026-05-01T00:00:00Z", "metrics": dict(metrics)}],
+        "last_reported_drift_fingerprint": fingerprint,
+    }
+
+
+def test_no_drift_no_value_change_skips() -> None:
+    metrics = {**METRICS_2026_06_11, "active_stuck_issues": 0}
+    previous = {**metrics, "cycle_time_to_revenue": None}
+    baseline = _baseline_with_metrics(previous, "metrics=;overdue_milestones=")
+    run = run_strategy_audit(
+        baseline,
+        metrics=metrics,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-05-09T00:00:00Z",  # before any milestone date
+    )
+    assert run.any_drift is False
+    assert run.fingerprint == "metrics=;overdue_milestones="
+    assert run.decision.action == "skip"
+    assert run.material_changed is False
+    # Input baseline not mutated (immutability).
+    assert len(baseline["audits"]) == 1
+
+
+def test_all_null_metrics_no_data_everywhere() -> None:
+    nulls = {key: None for key in METRICS_2026_06_11}
+    previous = {**nulls, "cycle_time_to_revenue": None}
+    baseline = _baseline_with_metrics(previous, "metrics=;overdue_milestones=")
+    run = run_strategy_audit(
+        baseline,
+        metrics=nulls,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-05-09T00:00:00Z",
+        paid_fetch_status="fetch_failed",
+    )
+    assert all(r.verdict == "NO DATA" and r.drift is False for r in run.metric_rows)
+    assert run.any_drift is False
+    assert run.decision.action == "skip"
+    # Null paid count renders the workflow's literal "null paid customers".
+    customer_rows = [m for m in run.milestones if "paying customer" in m.target]
+    assert customer_rows and customer_rows[0].current == "null paid customers"
+    entry = run.baseline["audits"][-1]
+    assert entry["metrics"]["fetch_status"]["paid_customers"] == "fetch_failed"
+
+
+def test_first_run_never_flags_drift() -> None:
+    run = run_strategy_audit(
+        {"audits": []},
+        metrics=METRICS_2026_06_11,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-06-12T00:00:00Z",  # 2026-05-31 milestone is overdue
+    )
+    assert run.first_run is True
+    assert run.any_drift is False
+    assert run.fingerprint == FIRST_RUN_FINGERPRINT
+    # The seeded baseline still commits (metric values appeared).
+    assert run.decision.action == "commit_main"
+    assert run.material_changed is True
+    assert len(run.baseline["audits"]) == 1
+
+
+def test_overdue_milestone_boundary() -> None:
+    milestones = [("2026-06-12", "1 paying customer")]
+    # Due today + target unmet -> overdue (bash: today >= date).
+    assert milestone_status(milestones, "2026-06-12", 0)[0].status == "overdue"
+    # Due tomorrow -> still pending.
+    assert milestone_status(milestones, "2026-06-11", 0)[0].status == "pending"
+    # Target met -> met, even past the date.
+    assert milestone_status(milestones, "2026-07-01", 1)[0].status == "met"
+    # Non-customer milestone past due -> pending-uncertain, never overdue.
+    other = [("2026-06-12", "edge node beta ships")]
+    assert milestone_status(other, "2026-06-12", 0)[0].status == "pending-uncertain"
+
+
+def test_metric_row_threshold_boundaries() -> None:
+    # grow: delta exactly +10% drifts (>=); just under does not.
+    assert metric_row("m", "M", "grow", 10, 11).drift is True
+    assert metric_row("m", "M", "grow", 10, 10.9).drift is False
+    # drop: delta exactly -10% drifts (<=); a drop on a "grow" metric does not.
+    assert metric_row("m", "M", "drop", 10, 9).drift is True
+    assert metric_row("m", "M", "grow", 10, 9).drift is False
+    # zero baseline clamps the denominator at 0.0001 (0 -> 1 is huge drift).
+    row = metric_row("m", "M", "grow", 0, 1)
+    assert row.drift is True and row.delta == pytest.approx(10000.0)
+    # display formatting mirrors jq tostring (+ sign, integral floats bare).
+    assert metric_row("m", "M", "grow", 10, 11).delta_display == "+10%"
+    assert metric_row("m", "M", "drop", 10, 9).delta_display == "-10%"
+
+
+def test_fingerprint_stability_and_idempotent_rerun() -> None:
+    rows = (
+        metric_row("active_stuck_issues", "Active stuck issues", "grow", 0, 1),
+        metric_row("lead_time_hours", "Lead time hours", "grow", 5.0, 50.0),
+    )
+    milestones = milestone_status(
+        [("2026-05-31", "1 paying customer"), ("2026-04-30", "2 customers")],
+        "2026-06-12",
+        0,
+    )
+    fp = drift_fingerprint(rows, milestones)
+    # Sorted + unique, independent of input order.
+    assert fp == (
+        "metrics=active_stuck_issues,lead_time_hours"
+        ";overdue_milestones=2026-04-30,2026-05-31"
+    )
+    assert drift_fingerprint(tuple(reversed(rows)), tuple(reversed(milestones))) == fp
+    assert fingerprint_hash(fp) == fingerprint_hash(fp)
+    assert drift_fingerprint(rows, milestones, first_run=True) == FIRST_RUN_FINGERPRINT
+
+    # Re-running on the runner's own output with identical inputs is a no-op.
+    first = run_strategy_audit(
+        {"audits": []},
+        metrics=METRICS_2026_06_11,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-05-09T00:00:00Z",
+    )
+    second = run_strategy_audit(
+        first.baseline,
+        metrics=METRICS_2026_06_11,
+        strategy_text=STRATEGY_FIXTURE,
+        now="2026-05-09T01:00:00Z",
+    )
+    assert second.fingerprint == first.fingerprint
+    assert second.decision.action == "skip"
+    assert second.material_changed is False
+
+
+def test_decide_requires_new_fingerprint_for_pr() -> None:
+    """The dedupe contract: a repeated drift fingerprint never re-opens."""
+    baseline = {"audits": [], "last_reported_drift_fingerprint": FP_OVERDUE_ONLY}
+    candidate = append_audit(baseline, {"ran_at": "x", "metrics": {}})
+    decision, updated = decide(baseline, candidate, True, FP_OVERDUE_ONLY)
+    assert decision.action == "skip" and decision.open_pr is False
+    assert updated["last_reported_drift_fingerprint"] == FP_OVERDUE_ONLY
+    decision, updated = decide(baseline, candidate, True, FP_STUCK)
+    assert decision.action == "open_pr"
+    assert updated["last_reported_drift_fingerprint"] == FP_STUCK
+
+
+def test_append_audit_caps_and_does_not_mutate() -> None:
+    baseline = {"audits": [{"ran_at": str(i)} for i in range(MAX_AUDITS)]}
+    updated = append_audit(baseline, {"ran_at": "new"})
+    assert len(updated["audits"]) == MAX_AUDITS
+    assert updated["audits"][-1]["ran_at"] == "new"
+    assert updated["audits"][0]["ran_at"] == "1"  # oldest dropped
+    assert len(baseline["audits"]) == MAX_AUDITS  # input untouched
+
+
+def test_metrics_input_validation() -> None:
+    with pytest.raises(ValueError, match="active_stuck_issues"):
+        run_strategy_audit(
+            {"audits": []},
+            metrics={**METRICS_2026_06_11, "active_stuck_issues": "1"},
+            strategy_text=STRATEGY_FIXTURE,
+            now="2026-06-12T00:00:00Z",
+        )
+
+
+# ------------------------------------------------- sourced reads (plan §U6)
+
+
+def test_parse_milestones_reads_real_strategy_md() -> None:
+    parsed = parse_milestones(STRATEGY_FILE.read_text(encoding="utf-8"))
+    assert len(parsed) >= 1
+    for date_part, target in parsed:
+        assert len(date_part) == 10 and target
+
+
+def test_extract_paid_customers_from_chimney_html() -> None:
+    html = (
+        '<div class="stage-metric">Paid subscriber</div>\n'
+        '<div class="stage-status">3</div>\n'
+    )
+    assert extract_paid_customers(html) == 3
+    assert extract_paid_customers("<html>no signal</html>") is None
+    # Count on the same line as the label still extracts.
+    assert extract_paid_customers("Paid subscribers: 7") == 7

--- a/pipeline/tests/test_strategy_audit.py
+++ b/pipeline/tests/test_strategy_audit.py
@@ -37,7 +37,9 @@ from wgmesh_pipeline.strategy_audit import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BASELINE_FILE = REPO_ROOT / "company" / "strategy-audit-baseline.json"
+# FROZEN fixture (same lesson as #1691): the live baseline mutates on every
+# strategy-audit cron run; parity pins the recorded copy.
+BASELINE_FILE = Path(__file__).parent / "fixtures" / "strategy_audit_baseline.json"
 STRATEGY_FILE = REPO_ROOT / "STRATEGY.md"
 
 # Milestones section frozen as of the recorded runs (matches the recorded

--- a/pipeline/wgmesh_pipeline/strategy_audit.py
+++ b/pipeline/wgmesh_pipeline/strategy_audit.py
@@ -1,0 +1,399 @@
+"""Box-side Strategy-Drift Audit: metric drift, milestones, baseline, fingerprint.
+
+Port of the Actions ``strategy-audit`` workflow (cutover plan U6): the
+``metric_row`` jq function, the STRATEGY.md milestone parser/status loop, and
+``.github/scripts/strategy-audit-gate.sh`` (drift fingerprint, metric-values
+gate, decide) collapse into pure functions; ``run_strategy_audit`` is a thin
+runner over plain-dict inputs. Semantics are ported, not redesigned — the
+0.0001 denominator clamp, jq rounding, date string-compare, and the
+``metrics=...;overdue_milestones=...`` fingerprint are byte-compatible
+(parity-tested against the recorded ``company/strategy-audit-baseline.json``
+and drift PRs #1624/#1677).
+
+CRITICAL design note — dedupe, don't stack: the Actions version opened one
+drift PR per run, piling near-identical drift PRs (#1624/#1677 both closed
+reasoned as that anti-pattern). ``run_strategy_audit`` therefore performs NO
+GitHub writes: it RETURNS the updated baseline dict plus a drift verdict,
+exposing ``material_changed`` + ``fingerprint`` so the future caller dedupes
+— ``decision.action == "open_pr"`` only when the fingerprint is NEW versus
+``last_reported_drift_fingerprint``; ``material_changed`` False = do nothing.
+
+Caller-side (mirror the workflow): gathering input metrics (gh-based reads,
+chimney HTTP fetch — only the pure ``extract_paid_customers`` parse lives
+here) and the ``company/scripts/sanitise.sh`` wall before any persist.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+DRIFT_THRESHOLD = 0.10
+MAX_AUDITS = 365
+FIRST_RUN_FINGERPRINT = "metrics=;overdue_milestones="
+CYCLE_TIME_FETCH_STATUS = "no_customers"
+
+# (key, label, direction) in the exact emission order of the workflow.
+METRIC_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("paid_customers", "Paid customers", "drop"),
+    ("autonomous_ship_rate", "Autonomous-ship rate", "drop"),
+    ("lead_time_hours", "Lead time hours", "grow"),
+    ("self_heal_rate", "Self-heal rate", "drop"),
+    ("active_stuck_issues", "Active stuck issues", "grow"),
+    ("cycle_time_to_revenue", "Cycle time to revenue (hours)", "grow"),
+)
+
+# Caller-supplied keys; cycle_time_to_revenue is synthesized null (declared
+# in STRATEGY.md but not yet computable — no Polar webhook).
+INPUT_METRIC_KEYS: tuple[str, ...] = tuple(key for key, _, _ in METRIC_SPECS[:-1])
+
+
+_MILESTONE_DATE_RE = re.compile(r"^- \*\*(\d{4}-\d{2}-\d{2})\*\* .*")
+_MILESTONE_TARGET_RE = re.compile(r"^- \*\*[0-9-]+\*\* . (.*)$")
+_CUSTOMER_TARGET_RE = re.compile(r"paying customer|customers", re.IGNORECASE)
+_FIRST_INT_RE = re.compile(r"\d+")
+
+
+@dataclass(frozen=True)
+class MetricRow:
+    """One metric verdict — mirrors the fields the ``metric_row`` jq emits."""
+
+    key: str
+    label: str
+    baseline: float | int | None
+    current: float | int | None
+    delta: float | None
+    pct_abs: float | None
+    delta_display: str
+    verdict: str  # "OK" | "DRIFT" | "NO DATA"
+    drift: bool
+
+
+@dataclass(frozen=True)
+class MilestoneStatus:
+    """One STRATEGY.md milestone row, as persisted in ``milestones_status``."""
+
+    date: str
+    target: str
+    current: str
+    status: str  # "pending" | "pending-uncertain" | "overdue" | "met"
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "date": self.date,
+            "target": self.target,
+            "current": self.current,
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class AuditDecision:
+    """Outcome of ``decide`` — port of ``strategy_audit_decide``'s env file."""
+
+    action: str  # "open_pr" | "commit_main" | "skip"
+    open_pr: bool
+    commit_main: bool
+    metric_values_changed: bool
+    fingerprint: str
+    last_reported: str
+
+
+@dataclass(frozen=True)
+class StrategyAuditRun:
+    """Runner outcome: verdict + the updated baseline dict the caller may
+    persist. ``material_changed`` is the dedupe sentinel: when False the
+    caller must NOT persist ``baseline`` nor open anything (anti pile-up)."""
+
+    ran_at: str
+    first_run: bool
+    metric_rows: tuple[MetricRow, ...]
+    milestones: tuple[MilestoneStatus, ...]
+    any_drift: bool
+    fingerprint: str
+    fingerprint_hash: str
+    decision: AuditDecision
+    baseline: dict[str, Any]
+    material_changed: bool
+
+
+def _jq_round(value: float) -> float:
+    """jq ``round`` — half away from zero (C round), not banker's rounding."""
+    if value >= 0:
+        return math.floor(value + 0.5)
+    return math.ceil(value - 0.5)
+
+
+def _format_number(value: float | int) -> str:
+    """jq ``tostring`` for numbers: integral floats print without ``.0``."""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def metric_row(
+    key: str,
+    label: str,
+    direction: str,
+    baseline: float | int | None,
+    current: float | int | None,
+    threshold: float = DRIFT_THRESHOLD,
+) -> MetricRow:
+    """One metric drift verdict — exact port of the workflow's ``metric_row`` jq."""
+    if direction not in ("drop", "grow"):
+        raise ValueError(f"metric_row: direction must be drop|grow, got {direction!r}")
+    if baseline is None or current is None:
+        return MetricRow(key, label, baseline, current, None, None, "n/a", "NO DATA", False)
+    absb = abs(baseline)
+    denom = 0.0001 if absb < 0.0001 else absb
+    delta = (current - baseline) / denom
+    pct = _jq_round(delta * 1000) / 10
+    pct_abs = -pct if pct < 0 else pct
+    drift = (direction == "drop" and delta <= -threshold) or (
+        direction == "grow" and delta >= threshold
+    )
+    delta_display = ("+" if pct > 0 else "") + _format_number(pct) + "%"
+    verdict = "DRIFT" if drift else "OK"
+    return MetricRow(key, label, baseline, current, delta, pct_abs, delta_display, verdict, drift)
+
+
+def evaluate_metrics(
+    previous_metrics: Mapping[str, Any] | None,
+    current_metrics: Mapping[str, Any],
+    threshold: float = DRIFT_THRESHOLD,
+) -> tuple[MetricRow, ...]:
+    """All metric rows in the workflow's emission order (METRIC_SPECS)."""
+    previous = previous_metrics or {}
+    return tuple(
+        metric_row(key, label, direction, previous.get(key), current_metrics.get(key), threshold)
+        for key, label, direction in METRIC_SPECS
+    )
+
+
+def parse_milestones(strategy_text: str) -> tuple[tuple[str, str], ...]:
+    """(date, target) pairs from STRATEGY.md's ``## Milestones`` section —
+    port of the awk section filter + sed date/target extraction."""
+    in_section = False
+    parsed: list[tuple[str, str]] = []
+    for line in strategy_text.splitlines():
+        if line.startswith("## Milestones"):
+            in_section = True
+            continue
+        if line.startswith("## "):
+            in_section = False
+        if not (in_section and line.startswith("- ")):
+            continue
+        date_match = _MILESTONE_DATE_RE.match(line)
+        if not date_match:
+            continue
+        target_match = _MILESTONE_TARGET_RE.match(line)
+        parsed.append((date_match.group(1), target_match.group(1) if target_match else ""))
+    return tuple(parsed)
+
+
+def milestone_status(
+    milestones: Sequence[tuple[str, str]],
+    today: str,
+    paid_customers: float | int | None,
+) -> tuple[MilestoneStatus, ...]:
+    """Status per milestone — exact port of the workflow's milestone loop.
+    Customer-count milestones compare against ``paid_customers``; any other
+    milestone past its date is ``pending-uncertain`` (calendar reminder, never
+    drift). Date compare is YYYY-MM-DD string order, ``today >= date``."""
+    statuses: list[MilestoneStatus] = []
+    for date_part, target in milestones:
+        current = "not measured"
+        status = "pending"
+        if _CUSTOMER_TARGET_RE.search(target):
+            num_match = _FIRST_INT_RE.search(target)
+            target_num = int(num_match.group(0)) if num_match else None
+            paid_display = "null" if paid_customers is None else _format_number(paid_customers)
+            current = f"{paid_display} paid customers"
+            if paid_customers is not None and target_num is not None and paid_customers >= target_num:
+                status = "met"
+            elif today >= date_part:
+                status = "overdue"
+        elif today >= date_part:
+            status = "pending-uncertain"
+        statuses.append(MilestoneStatus(date_part, target, current, status))
+    return tuple(statuses)
+
+
+def drift_fingerprint(
+    rows: Sequence[MetricRow],
+    milestones: Sequence[MilestoneStatus],
+    first_run: bool = False,
+) -> str:
+    """``metrics=...;overdue_milestones=...`` — port of
+    ``strategy_audit_drift_fingerprint`` (unique+sorted keys/dates)."""
+    if first_run:
+        return FIRST_RUN_FINGERPRINT
+    metric_keys = sorted({row.key for row in rows if row.verdict == "DRIFT" or row.drift})
+    overdue_dates = sorted({m.date for m in milestones if m.status == "overdue"})
+    return "metrics=" + ",".join(metric_keys) + ";overdue_milestones=" + ",".join(overdue_dates)
+
+
+def fingerprint_hash(fingerprint: str) -> str:
+    """First 12 hex chars of sha256 — the workflow's branch/title suffix."""
+    return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()[:12]
+
+
+def extract_paid_customers(html: str) -> int | None:
+    """Paid-subscriber count from the chimney dashboard HTML — port of
+    ``grep -i -A 1 'Paid subscriber' | grep -oE '[0-9]+' | head -n 1``.
+    The fetch itself stays with the caller; this is the pure parse."""
+    lines = html.splitlines()
+    window: list[str] = []
+    for index, line in enumerate(lines):
+        if "paid subscriber" in line.lower():
+            window.append(line)
+            if index + 1 < len(lines):
+                window.append(lines[index + 1])
+    match = _FIRST_INT_RE.search("\n".join(window))
+    return int(match.group(0)) if match else None
+
+
+def build_metrics_record(
+    metrics: Mapping[str, Any], paid_fetch_status: str
+) -> dict[str, Any]:
+    """The ``metrics`` object persisted per audit entry, exact key order.
+    ``cycle_time_to_revenue`` is always null (not yet computable)."""
+    for key in INPUT_METRIC_KEYS:
+        value = metrics.get(key)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, (int, float))):
+            raise ValueError(f"metric {key} must be a number or None, got {value!r}")
+    return {
+        "paid_customers": metrics.get("paid_customers"),
+        "autonomous_ship_rate": metrics.get("autonomous_ship_rate"),
+        "lead_time_hours": metrics.get("lead_time_hours"),
+        "self_heal_rate": metrics.get("self_heal_rate"),
+        "active_stuck_issues": metrics.get("active_stuck_issues"),
+        "cycle_time_to_revenue": None,
+        "fetch_status": {
+            "paid_customers": str(paid_fetch_status),
+            "cycle_time_to_revenue": CYCLE_TIME_FETCH_STATUS,
+        },
+    }
+
+
+def append_audit(baseline: Mapping[str, Any], entry: Mapping[str, Any]) -> dict[str, Any]:
+    """New baseline dict with ``entry`` appended to ``audits`` (capped at
+    the trailing MAX_AUDITS, jq ``.[-365:]``). Inputs are not mutated."""
+    audits = list(baseline.get("audits") or [])
+    audits.append(dict(entry))
+    return {**baseline, "audits": audits[-MAX_AUDITS:]}
+
+
+def _latest_metric_values(state: Mapping[str, Any]) -> dict[str, Any]:
+    audits = state.get("audits") or []
+    last: Mapping[str, Any] = audits[-1] if audits else {}
+    metrics = dict((last or {}).get("metrics") or {})
+    metrics.pop("fetch_status", None)
+    return metrics
+
+
+def metric_values_changed(
+    baseline: Mapping[str, Any], candidate: Mapping[str, Any]
+) -> bool:
+    """Did the latest audit's metric VALUES change (fetch_status excluded)?
+    Port of ``strategy_audit_metric_values_changed``."""
+    return _latest_metric_values(baseline) != _latest_metric_values(candidate)
+
+
+def decide(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    any_drift: bool,
+    fingerprint: str,
+) -> tuple[AuditDecision, dict[str, Any]]:
+    """Port of ``strategy_audit_decide``: open_pr only on a NEW drift
+    fingerprint; commit_main on metric-value change; otherwise skip. Returns
+    decision + candidate with ``last_reported_drift_fingerprint`` updated."""
+    last_reported = str(baseline.get("last_reported_drift_fingerprint") or "")
+    values_changed = metric_values_changed(baseline, candidate)
+
+    action = "skip"
+    open_pr = False
+    commit_main = False
+    output_fingerprint = last_reported
+    if any_drift and fingerprint != last_reported:
+        action = "open_pr"
+        open_pr = True
+        output_fingerprint = fingerprint
+    elif values_changed:
+        action = "commit_main"
+        commit_main = True
+
+    updated = {**candidate, "last_reported_drift_fingerprint": output_fingerprint}
+    decision = AuditDecision(
+        action=action,
+        open_pr=open_pr,
+        commit_main=commit_main,
+        metric_values_changed=values_changed,
+        fingerprint=fingerprint,
+        last_reported=last_reported,
+    )
+    return decision, updated
+
+
+def run_strategy_audit(
+    baseline: Mapping[str, Any],
+    *,
+    metrics: Mapping[str, Any],
+    strategy_text: str,
+    paid_fetch_status: str = "ok",
+    now: str | None = None,
+    threshold: float = DRIFT_THRESHOLD,
+) -> StrategyAuditRun:
+    """Evaluate drift, build the audit entry, and return verdict + updated
+    baseline. NO GitHub writes — persisting ``baseline`` (only when
+    ``material_changed``, through the sanitise wall) and any PR/anchor
+    side effect keyed on ``decision``/``fingerprint`` stay with the caller.
+
+    ``metrics`` is a plain dict with INPUT_METRIC_KEYS (numbers or None);
+    ``strategy_text`` is the STRATEGY.md content; ``now`` is an ISO-8601 UTC
+    timestamp (``today`` for milestone checks derives from its date part).
+    """
+    ran_at = now or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    today = ran_at[:10]
+
+    audits = baseline.get("audits") or []
+    first_run = len(audits) == 0
+    previous: Mapping[str, Any] = (audits[-1] if audits else {}) or {}
+
+    record = build_metrics_record(metrics, paid_fetch_status)
+    rows = evaluate_metrics(previous.get("metrics"), record, threshold)
+    milestones = milestone_status(
+        parse_milestones(strategy_text), today, record["paid_customers"]
+    )
+
+    # First run never flags drift (workflow zeroes both counts).
+    metric_drift_count = 0 if first_run else sum(1 for row in rows if row.drift)
+    overdue_count = 0 if first_run else sum(1 for m in milestones if m.status == "overdue")
+    any_drift = metric_drift_count > 0 or overdue_count > 0
+    fingerprint = drift_fingerprint(rows, milestones, first_run)
+
+    entry = {
+        "ran_at": ran_at,
+        "metrics": record,
+        "milestones_status": [m.as_dict() for m in milestones],
+    }
+    candidate = append_audit(baseline, entry)
+    decision, updated = decide(baseline, candidate, any_drift, fingerprint)
+
+    return StrategyAuditRun(
+        ran_at=ran_at,
+        first_run=first_run,
+        metric_rows=rows,
+        milestones=milestones,
+        any_drift=any_drift,
+        fingerprint=fingerprint,
+        fingerprint_hash=fingerprint_hash(fingerprint),
+        decision=decision,
+        baseline=updated,
+        material_changed=decision.action != "skip",
+    )


### PR DESCRIPTION
## Summary

#1599 **U6 / Phase B**: ports the strategy-audit chain (metric drift eval, milestone status, baseline append, drift fingerprint, gate decision) to `pipeline/wgmesh_pipeline/strategy_audit.py` — pure functions + plain-dict runner, zero GitHub writes this phase. Exposes `material_changed`/fingerprint so the future caller dedupes drift reports instead of stacking one PR per run (the #1624/#1677 pile anti-pattern, both closed reasoned).

## Parity evidence (byte-exact vs independently recorded artifacts)

- Replays reproduce the REAL drift PRs: #1677 (`metrics=;overdue_milestones=2026-05-31` → hash `ae5123115cb0`) and #1624 (`metrics=active_stuck_issues;…` → `0ba6becc8c61`) — hashes verified against live PR titles before tests were written
- 2026-06-11 commit_main replay appends an audit entry byte-identical (key order included) to the recorded baseline
- Mutation check: breaking the fingerprint join turns the suite RED

## Out of scope (caller/U8 domain, documented)

Metric gathering (gh queries, chimney fetch), sanitise wall, PR-body markdown, MentisDB/PostHog emission. strategy-audit.yml stays active until its bake-gated disable.

## Test plan
- [x] 14 new tests (parity + no-drift/all-null/overdue-boundary/fingerprint stability)
- [x] Full suite 387 passed, 5 skipped