### PR TITLE
fix(tests): freeze supervisor parity fixture — live state file mutates

### DIFF
--- a/pipeline/tests/fixtures/supervisor_rank_state.json
+++ b/pipeline/tests/fixtures/supervisor_rank_state.json
@@ -1,0 +1,46 @@
+{
+  "last_run_at": "2026-06-12T03:56:05Z",
+  "last_run_top_ids": [
+    "atvirokodosprendimai/ai-pipeline-template#934",
+    "atvirokodosprendimai/wgmesh#652",
+    "atvirokodosprendimai/wgmesh#667"
+  ],
+  "rank_changed": false,
+  "run_number": 24,
+  "issue_number": 934,
+  "issue_url": "https://github.com/atvirokodosprendimai/ai-pipeline-template/issues/934",
+  "stage_summary": {
+    "triage": 1,
+    "spec": 4,
+    "build": 0,
+    "review": 5,
+    "merge": 0,
+    "verify": 0,
+    "revenue": 0,
+    "unknown": 1
+  },
+  "unknown_count": 1,
+  "top_actions": [
+    {
+      "id": "atvirokodosprendimai/ai-pipeline-template#934",
+      "action": "bounce-label"
+    },
+    {
+      "id": "atvirokodosprendimai/wgmesh#652",
+      "action": "escalate-needs-human"
+    },
+    {
+      "id": "atvirokodosprendimai/wgmesh#667",
+      "action": "manual-merge"
+    },
+    {
+      "id": "atvirokodosprendimai/wgmesh#689",
+      "action": "manual-merge"
+    },
+    {
+      "id": "atvirokodosprendimai/wgmesh#691",
+      "action": "manual-merge"
+    }
+  ],
+  "material_fingerprint": "35a1ac2c907b0de539804afd60039417ede2bf0185d78b17f73f842806cea2e4"
+}

--- a/pipeline/tests/test_supervisor.py
+++ b/pipeline/tests/test_supervisor.py
@@ -30,7 +30,11 @@ from wgmesh_pipeline.supervisor import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-STATE_FILE = REPO_ROOT / "company" / "supervisor-rank-state.json"
+# FROZEN fixture — a copy of company/supervisor-rank-state.json at the time
+# the parity values were recorded. The live file mutates every 4h cron run;
+# parity must pin the recorded inputs, not chase a moving file (broke CI on
+# the first post-merge cron commit, 2026-06-12).
+STATE_FILE = Path(__file__).parent / "fixtures" / "supervisor_rank_state.json"
 TAXONOMY_FILE = REPO_ROOT / "company" / "pipeline-stages.json"
 
 AIT = "atvirokodosprendimai/ai-pipeline-template"


### PR DESCRIPTION
CI-blocking: U5 parity tests read the live `company/supervisor-rank-state.json`, which the 4-hourly supervisor cron rewrites — first post-merge cron commit broke pipeline-tests for every subsequent PR (seen on #1690). Fixture frozen under `pipeline/tests/fixtures/`. 25/25 green.