### PR TITLE
feat(selfheal): box-side self-heal module (cutover U4)

### DIFF
--- a/pipeline/tests/fixtures/pipeline_health_state.json
+++ b/pipeline/tests/fixtures/pipeline_health_state.json
@@ -1,0 +1,94 @@
+{
+  "last_check": "2026-06-12T17:21:49Z",
+  "check_interval_hours": 0.5,
+  "checks_run": 838,
+  "issues_healed_total": 29,
+  "consecutive_no_mutation_runs": 0,
+  "retry_tracker": {
+    "651": {
+      "retries": 2,
+      "last_retry": "2026-06-06T10:04:04Z",
+      "action": "retrigger_triage",
+      "cooldown_until": "2026-06-08T13:02:23Z"
+    },
+    "584": {
+      "retries": 2,
+      "last_retry": "2026-06-06T10:04:08Z",
+      "action": "retrigger_triage",
+      "cooldown_until": "2026-06-07T11:53:01Z"
+    },
+    "573": {
+      "retries": 2,
+      "last_retry": "2026-06-06T10:04:13Z",
+      "action": "retrigger_triage",
+      "cooldown_until": "2026-06-07T11:53:02Z"
+    },
+    "540": {
+      "retries": 2,
+      "last_retry": "2026-06-06T10:04:17Z",
+      "action": "retrigger_triage",
+      "cooldown_until": "2026-06-07T11:53:03Z"
+    },
+    "539": {
+      "retries": 2,
+      "last_retry": "2026-06-06T10:04:22Z",
+      "action": "retrigger_triage",
+      "cooldown_until": "2026-06-07T11:53:04Z"
+    },
+    "652": {
+      "retries": 1,
+      "last_retry": "2026-06-07T11:08:51Z",
+      "action": "retrigger_triage"
+    },
+    "pr-667": {
+      "retries": 2,
+      "last_retry": "2026-06-12T01:56:38Z",
+      "action": "retrigger_goose"
+    },
+    "pr-691": {
+      "retries": 2,
+      "last_retry": "2026-06-12T06:45:56Z",
+      "action": "retrigger_goose"
+    },
+    "pr-702": {
+      "retries": 1,
+      "last_retry": "2026-06-11T19:18:14Z",
+      "action": "retrigger_goose"
+    },
+    "pr-720": {
+      "retries": 1,
+      "last_retry": "2026-06-11T21:34:29Z",
+      "action": "retrigger_goose"
+    },
+    "pr-689": {
+      "retries": 1,
+      "last_retry": "2026-06-12T06:46:02Z",
+      "action": "retrigger_goose"
+    }
+  },
+  "funnel_signals": {
+    "dogfood": true,
+    "presence": true,
+    "endpoint_details": "chimney:ok,cloudroof:ok,coroot:ok,tvcentras:ok",
+    "checked_at": "2026-06-12T17:21:48Z"
+  },
+  "idle_signal": {
+    "idle": false,
+    "open_prs": 6,
+    "active_pipeline_issues": 0,
+    "checked_at": "2026-06-12T17:21:48Z"
+  },
+  "last_run_summary": {
+    "stale_triage_found": 0,
+    "stale_copilot_found": 0,
+    "stale_approved_found": 0,
+    "needs_human_closed": 0,
+    "actions_taken": 0,
+    "errors": 0
+  },
+  "last_mutation_asserted_at": "2026-06-12T17:21:49Z",
+  "last_mutation_assertion": {
+    "status": "passed",
+    "checked_at": "2026-06-12T17:21:49Z"
+  }
+}

--- a/pipeline/tests/selfheal_fixtures.py
+++ b/pipeline/tests/selfheal_fixtures.py
@@ -1,0 +1,56 @@
+"""Shared fixtures/helpers for the Self-Heal test files (cutover U4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wgmesh_pipeline.selfheal import SelfHealInputs
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_FILE = REPO_ROOT / "company" / "pipeline-health-state.json"
+
+NOW = "2026-06-12T17:21:49Z"
+SIGNALS_NOW = "2026-06-12T17:21:48Z"
+STALE = "2026-06-10T00:00:00Z"  # > 48h before NOW: stale for every sweep
+FRESH = "2026-06-12T17:00:00Z"
+
+ENDPOINTS_OK = tuple(
+    {"name": name, "url": f"https://{name}.example", "status": 200}
+    for name in ("chimney", "cloudroof", "coroot", "tvcentras")
+)
+CLAUDE_MD = "# wgmesh\n## Architecture\nmesh\n## Build\nmake\n"
+
+
+class NoCallForge:
+    """The runner must not touch the forge when inputs are complete."""
+
+    def __getattr__(self, name: str):
+        raise AssertionError(f"runner must not call forge.{name}")
+
+
+def issue(number: int, title: str = "t", created: str = STALE, labels=()) -> dict:
+    return {
+        "number": number, "title": title, "createdAt": created,
+        "labels": [{"name": name} for name in labels],
+    }
+
+
+def pr(number: int, title: str, updated: str = STALE, labels=()) -> dict:
+    return {
+        "number": number, "title": title, "updatedAt": updated,
+        "labels": [{"name": name} for name in labels],
+    }
+
+
+def make_inputs(**overrides) -> SelfHealInputs:
+    base = dict(
+        now=NOW, run_id="run-1", needs_human_issues=(),
+        endpoints=ENDPOINTS_OK, claude_md_text=CLAUDE_MD,
+        signals_now=SIGNALS_NOW,
+    )
+    base.update(overrides)
+    return SelfHealInputs(**base)
+
+
+def kinds(run) -> list[str]:
+    return [action.kind for action in run.actions]

--- a/pipeline/tests/selfheal_fixtures.py
+++ b/pipeline/tests/selfheal_fixtures.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from wgmesh_pipeline.selfheal import SelfHealInputs
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-STATE_FILE = REPO_ROOT / "company" / "pipeline-health-state.json"
+# FROZEN fixture (lesson #1691): the live state file mutates every 30min
+# heal cron; parity pins the recorded copy.
+STATE_FILE = Path(__file__).parent / "fixtures" / "pipeline_health_state.json"
 
 NOW = "2026-06-12T17:21:49Z"
 SIGNALS_NOW = "2026-06-12T17:21:48Z"

--- a/pipeline/tests/test_selfheal.py
+++ b/pipeline/tests/test_selfheal.py
@@ -1,0 +1,215 @@
+"""Self-Heal parity + runner tests (cutover U4).
+
+The parity fixture replays the run recorded in
+``company/pipeline-health-state.json`` on main (a healthy nothing-to-heal
+check) and asserts the Python runner reproduces the WHOLE state file
+byte-exact — counters, retry tracker, funnel/idle signals, summary, and the
+mutation assertion, in the workflow's jq key order. Detector-level edges
+live in ``test_selfheal_detectors.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from selfheal_fixtures import (
+    NOW,
+    STATE_FILE,
+    NoCallForge,
+    issue,
+    kinds,
+    make_inputs,
+    pr,
+)
+from wgmesh_pipeline.forge.protocol import ForgeIssue
+from wgmesh_pipeline.selfheal import (
+    HealAction,
+    assert_state_mutation,
+    run_self_heal,
+)
+
+
+@pytest.fixture(scope="module")
+def recorded_state() -> dict:
+    return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture()
+def parity_run(recorded_state):
+    previous = {
+        **recorded_state,
+        "last_check": "2026-06-12T16:51:43Z",
+        "checks_run": recorded_state["checks_run"] - 1,
+    }
+    return run_self_heal(
+        NoCallForge(),
+        make_inputs(previous_state=previous, open_prs=6),
+    )
+
+
+class TestParityWithRecordedState:
+    """A healthy nothing-to-heal run reproduces the recorded state on main."""
+
+    def test_state_byte_exact(self, parity_run):
+        rendered = json.dumps(parity_run.state, indent=2) + "\n"
+        assert rendered == STATE_FILE.read_text(encoding="utf-8")
+
+    def test_counters_match_recorded(self, parity_run, recorded_state):
+        assert parity_run.state["checks_run"] == recorded_state["checks_run"]
+        assert (
+            parity_run.state["issues_healed_total"]
+            == recorded_state["issues_healed_total"]
+        )
+        assert parity_run.state["last_run_summary"] == recorded_state["last_run_summary"]
+
+    def test_retry_tracker_carried_unchanged(self, parity_run, recorded_state):
+        assert parity_run.state["retry_tracker"] == recorded_state["retry_tracker"]
+
+    def test_healthy_run_asserts_mutation(self, parity_run):
+        assert parity_run.mutation_asserted is True
+        assert parity_run.state["consecutive_no_mutation_runs"] == 0
+        assert parity_run.state["last_mutation_assertion"]["status"] == "passed"
+
+    def test_no_heal_actions_planned(self, parity_run):
+        assert parity_run.actions == ()
+        assert parity_run.circuit_breaker_tripped is False
+
+    def test_previous_state_not_mutated(self, recorded_state):
+        previous = {**recorded_state, "last_check": "2026-06-12T16:51:43Z"}
+        frozen = json.dumps(previous, sort_keys=True)
+        run_self_heal(NoCallForge(), make_inputs(previous_state=previous, open_prs=6))
+        assert json.dumps(previous, sort_keys=True) == frozen
+
+
+class TestCircuitBreaker:
+    def test_ten_escalations_trip_breaker_and_gate_later_sweeps(self, recorded_state):
+        issues = tuple(issue(100 + i) for i in range(10))
+        tracker = {str(100 + i): {"retries": 2} for i in range(10)}
+        previous = {**recorded_state, "retry_tracker": tracker, "checks_run": 1}
+        run = run_self_heal(
+            NoCallForge(),
+            make_inputs(
+                previous_state=previous,
+                stale_triage_issues=issues,
+                stale_copilot_issues=(issue(660),),  # must be gated off
+                needs_human_issues=(issue(700, title="budget gone"),),
+            ),
+        )
+        assert run.circuit_breaker_tripped is True
+        assert kinds(run).count("escalate") == 10
+        assert "circuit_breaker" in kinds(run)
+        assert "retrigger_copilot" not in kinds(run)
+        assert run.state["last_run_summary"]["stale_copilot_found"] == 0
+        # funnel step gated → previous funnel_signals preserved verbatim
+        assert run.state["funnel_signals"] == recorded_state["funnel_signals"]
+        # idle signal still computed (unconditional step)
+        assert run.state["idle_signal"]["idle"] is False
+
+    def test_breaker_issue_body_counts(self, recorded_state):
+        issues = tuple(issue(100 + i) for i in range(10))
+        tracker = {str(100 + i): {"retries": 2} for i in range(10)}
+        run = run_self_heal(
+            NoCallForge(),
+            make_inputs(
+                previous_state={**recorded_state, "retry_tracker": tracker},
+                stale_triage_issues=issues,
+            ),
+        )
+        breaker = next(a for a in run.actions if a.kind == "circuit_breaker")
+        assert "10 issues created, 0 errors" in (breaker.body or "")
+
+
+class TestAssertStateMutation:
+    def test_frozen_clock_fails_assertion(self, recorded_state):
+        previous = {**recorded_state, "last_check": NOW}  # last_check cannot advance
+        run = run_self_heal(NoCallForge(), make_inputs(previous_state=previous, open_prs=6))
+        assert run.mutation_asserted is False
+        assert run.state["consecutive_no_mutation_runs"] == 1
+        assert run.state["last_mutation_assertion"]["reason"] == "last_check-not-advanced"
+
+    def test_second_consecutive_failure_escalates_supervisor_dead(self):
+        state = {"last_check": NOW, "consecutive_no_mutation_runs": 1}
+        updated, passed, action = assert_state_mutation(NOW, state, NOW)
+        assert passed is False
+        assert updated["consecutive_no_mutation_runs"] == 2
+        assert isinstance(action, HealAction)
+        assert action.title == "supervisor-dead: pipeline-health frozen"
+        assert "consecutive_no_mutation_runs=2." in (action.body or "")
+
+    def test_advance_resets_counter(self):
+        state = {"last_check": NOW, "consecutive_no_mutation_runs": 5}
+        updated, passed, action = assert_state_mutation("2026-06-12T16:00:00Z", state, NOW)
+        assert passed is True and action is None
+        assert updated["consecutive_no_mutation_runs"] == 0
+
+
+class TestEveryDetectorFires:
+    def test_all_sweeps_act_in_one_run(self, recorded_state):
+        previous = {**recorded_state, "retry_tracker": {}, "checks_run": 10,
+                    "issues_healed_total": 5, "last_check": "2026-06-12T16:00:00Z"}
+        run = run_self_heal(
+            NoCallForge(),
+            make_inputs(
+                previous_state=previous,
+                stale_triage_issues=(issue(651),),
+                stale_copilot_issues=(issue(660),),
+                stale_approved_prs=(pr(667, "spec: Issue #650"),),
+                needs_human_issues=(issue(700, title="x"),),
+                linked_merged_pr_counts={700: 1},
+                open_prs=3,
+            ),
+        )
+        assert kinds(run) == [
+            "retrigger_triage", "retrigger_copilot", "retrigger_goose",
+            "close_needs_human",
+        ]
+        summary = run.state["last_run_summary"]
+        assert summary == {
+            "stale_triage_found": 1, "stale_copilot_found": 1, "stale_approved_found": 1,
+            "needs_human_closed": 1, "actions_taken": 4, "errors": 0,
+        }
+        assert run.state["issues_healed_total"] == 9  # 5 + 4
+        assert run.state["checks_run"] == 11
+        assert set(run.state["retry_tracker"]) == {"651", "660", "pr-667"}
+        assert run.mutation_asserted is True
+
+
+class _ReadOnlyForge:
+    """Exposes ONLY the read the runner may use; any write blows up."""
+
+    def __init__(self, issues: list[ForgeIssue]) -> None:
+        self._issues = issues
+
+    def list_open_issues(self) -> list[ForgeIssue]:
+        return self._issues
+
+    def __getattr__(self, name: str):
+        raise AssertionError(f"runner must not call forge.{name} in parity phase")
+
+
+class TestForgeFallback:
+    def test_needs_human_derived_from_forge_when_input_missing(self):
+        forge = _ReadOnlyForge([
+            ForgeIssue(number=700, title="x", labels=("needs-human",), state="open"),
+            ForgeIssue(number=701, title="y", labels=("needs-human",), state="open",
+                       pull_request={"url": "z"}),  # PRs filtered out
+            ForgeIssue(number=702, title="z", labels=("bug",), state="open"),
+        ])
+        run = run_self_heal(
+            forge,
+            make_inputs(
+                needs_human_issues=None, linked_merged_pr_counts={700: 1}, open_prs=1
+            ),
+        )
+        assert kinds(run) == ["close_needs_human"]
+        assert run.actions[0].number == 700
+
+    def test_idle_run_with_empty_previous_state(self):
+        run = run_self_heal(NoCallForge(), make_inputs(open_prs=0))
+        assert run.state["checks_run"] == 1
+        assert run.state["issues_healed_total"] == 0
+        assert run.state["idle_signal"]["idle"] is True
+        assert kinds(run) == ["dispatch_observation_loop"]
+        assert run.mutation_asserted is True  # empty prev → first check still advances

--- a/pipeline/tests/test_selfheal_detectors.py
+++ b/pipeline/tests/test_selfheal_detectors.py
@@ -1,0 +1,260 @@
+"""Self-Heal detector edge cases (cutover U4): the three stale sweeps, the
+needs-human resolution signals, and the funnel/idle signal functions.
+Runner-level + parity tests live in ``test_selfheal.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from selfheal_fixtures import (
+    ENDPOINTS_OK,
+    FRESH,
+    NOW,
+    STALE,
+    NoCallForge,
+    issue,
+    kinds,
+    make_inputs,
+    pr,
+)
+from wgmesh_pipeline.selfheal import (
+    check_funnel_signals,
+    decide_idle_dispatch,
+    run_self_heal,
+    sweep_needs_human,
+    sweep_stale_approved,
+    sweep_stale_copilot,
+    sweep_stale_triage,
+)
+
+
+class TestStaleTriageSweep:
+    def test_first_failure_retriggers_labels(self):
+        inputs = make_inputs(stale_triage_issues=(issue(651),))
+        outcome = sweep_stale_triage(inputs, {})
+        action = outcome.actions[0]
+        assert (action.kind, action.remove_label, action.add_label) == (
+            "retrigger_triage", "needs-triage", "needs-triage"
+        )
+        assert outcome.retry_tracker["651"] == {
+            "retries": 1, "last_retry": NOW, "action": "retrigger_triage",
+        }
+        assert (outcome.stale_found, outcome.actions_taken, outcome.issues_created) == (1, 1, 0)
+
+    def test_two_failures_escalates_needs_human_with_cooldown(self):
+        tracker = {"651": {"retries": 2, "last_retry": STALE, "action": "retrigger_triage"}}
+        outcome = sweep_stale_triage(make_inputs(stale_triage_issues=(issue(651),)), tracker)
+        action = outcome.actions[0]
+        assert action.kind == "escalate"
+        assert action.title == "[needs-human] Stuck at triage: #651"
+        assert action.body == (
+            "Self-healing failed to resolve stale triage for #651 after 2 attempts."
+        )
+        # escalate only ADDS cooldown_until (retries/last_retry preserved)
+        assert outcome.retry_tracker["651"] == {
+            "retries": 2, "last_retry": STALE, "action": "retrigger_triage",
+            "cooldown_until": "2026-06-13T17:21:49Z",
+        }
+        assert outcome.issues_created == 1
+
+    def test_cooldown_skips_but_counts_stale(self):
+        tracker = {"651": {"retries": 2, "cooldown_until": "2026-06-13T00:00:00Z"}}
+        outcome = sweep_stale_triage(make_inputs(stale_triage_issues=(issue(651),)), tracker)
+        assert outcome.actions == ()
+        assert outcome.stale_found == 1
+
+    def test_expired_cooldown_heal_replaces_entry_dropping_cooldown(self):
+        tracker = {"651": {"retries": 1, "cooldown_until": "2026-06-01T00:00:00Z"}}
+        outcome = sweep_stale_triage(make_inputs(stale_triage_issues=(issue(651),)), tracker)
+        assert outcome.actions[0].kind == "retrigger_triage"
+        assert "cooldown_until" not in outcome.retry_tracker["651"]
+        assert outcome.retry_tracker["651"]["retries"] == 2
+
+    def test_skips_before_stale_count(self):
+        inputs = make_inputs(
+            stale_triage_issues=(
+                issue(1, labels=("manual-only",)),
+                issue(2, labels=("wont-do",)),
+                issue(3, labels=("needs-info", "bug")),
+                issue(4),  # completed: merged resolution PR exists
+                issue(5, created=FRESH),  # not past cutoff
+            ),
+            merged_resolution_issues=frozenset({4}),
+        )
+        outcome = sweep_stale_triage(inputs, {})
+        assert outcome.stale_found == 0
+        assert outcome.actions == ()
+
+    def test_malformed_tracker_raises_loudly(self):
+        with pytest.raises(ValueError, match="malformed retry_tracker"):
+            sweep_stale_triage(
+                make_inputs(stale_triage_issues=(issue(651),)), {"651": "garbage"}
+            )
+
+    def test_audit_lines_byte_compatible_with_jq(self):
+        outcome = sweep_stale_triage(make_inputs(stale_triage_issues=(issue(651),)), {})
+        line = json.dumps(outcome.audit[0], separators=(",", ":"))
+        assert line == (
+            '{"timestamp":"2026-06-12T17:21:49Z","run_id":"run-1",'
+            '"action":"retrigger_triage","issue_number":651,"target_repo":"wgmesh",'
+            '"reason":"stale >24h at needs-triage","outcome":"success","retry_count":1}'
+        )
+
+
+class TestStaleCopilotSweep:
+    def test_heal_swaps_copilot_label_for_needs_triage(self):
+        outcome = sweep_stale_copilot(make_inputs(stale_copilot_issues=(issue(660),)), {})
+        action = outcome.actions[0]
+        assert (action.kind, action.remove_label, action.add_label) == (
+            "retrigger_copilot", "copilot-triaging", "needs-triage"
+        )
+
+    def test_open_spec_pr_skips_after_stale_count(self):
+        inputs = make_inputs(
+            stale_copilot_issues=(issue(660),), open_spec_pr_issues=frozenset({660})
+        )
+        outcome = sweep_stale_copilot(inputs, {})
+        assert outcome.stale_found == 1  # counted, then skipped
+        assert outcome.actions == ()
+
+    def test_48h_cutoff_excludes_two_day_old_issue(self):
+        outcome = sweep_stale_copilot(
+            make_inputs(stale_copilot_issues=(issue(661, created="2026-06-11T00:00:00Z"),)),
+            {},
+        )
+        assert outcome.stale_found == 0
+
+
+class TestStaleApprovedSweep:
+    def test_tracker_keyed_pr_prefix_and_goose_retrigger(self):
+        outcome = sweep_stale_approved(
+            make_inputs(stale_approved_prs=(pr(667, "spec: Issue #650 - mesh"),)), {}
+        )
+        assert outcome.actions[0].kind == "retrigger_goose"
+        assert outcome.actions[0].target == "pr"
+        assert "pr-667" in outcome.retry_tracker
+
+    def test_open_impl_pr_skips_after_count(self):
+        inputs = make_inputs(
+            stale_approved_prs=(pr(667, "spec: Issue #650 - mesh"),),
+            open_impl_pr_issues=frozenset({650}),
+        )
+        outcome = sweep_stale_approved(inputs, {})
+        assert outcome.stale_found == 1
+        assert outcome.actions == ()
+
+    def test_escalation_title_and_reason(self):
+        tracker = {"pr-667": {"retries": 2}}
+        outcome = sweep_stale_approved(
+            make_inputs(stale_approved_prs=(pr(667, "spec: Issue #650"),)), tracker
+        )
+        assert outcome.actions[0].title == "[needs-human] Stuck at build: PR #667"
+        assert outcome.audit[0]["reason"] == "2 consecutive build trigger failures"
+
+
+class TestNeedsHumanSweep:
+    def test_linked_merged_pr_closes(self):
+        inputs = make_inputs(
+            needs_human_issues=(issue(700, title="anything"),),
+            linked_merged_pr_counts={700: 2},
+        )
+        outcome = sweep_needs_human(inputs)
+        assert outcome.actions[0].comment == (
+            "Resolved by self-healing: Linked PR merged (2 merged PR(s) found)"
+        )
+        assert outcome.closed == 1
+
+    def test_api_key_title_resolved_by_running_loop(self):
+        inputs = make_inputs(
+            needs_human_issues=(issue(701, title="Missing API key for loop"),),
+            loop_state={"last_run": "2026-06-12T00:00:00Z", "run_count": 41},
+        )
+        outcome = sweep_needs_human(inputs)
+        assert "run_count=41" in outcome.actions[0].reason
+
+    def test_health_title_resolved_when_all_endpoints_ok(self):
+        inputs = make_inputs(needs_human_issues=(issue(702, title="Health endpoint down"),))
+        assert sweep_needs_human(inputs).actions[0].reason == (
+            "All health endpoints responding OK"
+        )
+
+    def test_health_title_unresolved_when_endpoint_fails(self):
+        bad = ENDPOINTS_OK[:3] + ({"name": "tvcentras", "status": 503},)
+        inputs = make_inputs(
+            needs_human_issues=(issue(702, title="Health endpoint down"),), endpoints=bad
+        )
+        assert sweep_needs_human(inputs).actions == ()
+
+    def test_budget_title_resolved_by_integer_capital_only(self):
+        item = issue(703, title="burn rate exceeds budget")
+        ok = make_inputs(
+            needs_human_issues=(item,), costs={"runway": {"available_capital": 9000}}
+        )
+        assert "available_capital=9000" in sweep_needs_human(ok).actions[0].reason
+        floaty = make_inputs(
+            needs_human_issues=(item,), costs={"runway": {"available_capital": 9000.5}}
+        )
+        assert sweep_needs_human(floaty).actions == ()  # shell -gt is integer-only
+
+    def test_no_signal_and_manual_only_skip(self):
+        inputs = make_inputs(
+            needs_human_issues=(
+                issue(704, title="mystery failure"),
+                issue(705, title="health alarm", labels=("manual-only",)),
+            ),
+        )
+        assert sweep_needs_human(inputs).actions == ()
+
+
+class TestSignals:
+    def test_dogfood_requires_architecture_and_build(self):
+        signals, _ = check_funnel_signals(make_inputs(claude_md_text="## Architecture only"))
+        assert signals["dogfood"] is False
+        signals, _ = check_funnel_signals(make_inputs())
+        assert signals["dogfood"] is True
+
+    def test_presence_false_and_details_on_failing_endpoint(self):
+        bad = ENDPOINTS_OK[:1] + ({"name": "cloudroof", "status": 500},)
+        signals, entry = check_funnel_signals(make_inputs(endpoints=bad))
+        assert signals["presence"] is False
+        assert signals["endpoint_details"] == "chimney:ok,cloudroof:fail"
+        assert entry["signals"] == {"dogfood": True, "presence": False}
+
+    def test_no_endpoints_means_no_presence(self):
+        signals, _ = check_funnel_signals(make_inputs(endpoints=()))
+        assert signals["presence"] is False
+        assert signals["endpoint_details"] == ""
+
+    def test_idle_dispatch_fires_once_then_cools_down_6h(self):
+        idle = {"idle": True, "open_prs": 0, "active_pipeline_issues": 0, "checked_at": NOW}
+        action, updated = decide_idle_dispatch(idle, NOW)
+        assert action is not None and action.kind == "dispatch_observation_loop"
+        assert updated["last_dispatch_at"] == NOW
+        again, kept = decide_idle_dispatch(updated, "2026-06-12T19:21:49Z")  # 2h later
+        assert again is None
+        assert kept["last_dispatch_at"] == NOW
+        later, bumped = decide_idle_dispatch(updated, "2026-06-13T00:21:49Z")  # 7h later
+        assert later is not None
+        assert bumped["last_dispatch_at"] == "2026-06-13T00:21:49Z"
+
+    def test_not_idle_never_dispatches(self):
+        action, _ = decide_idle_dispatch({"idle": False}, NOW)
+        assert action is None
+
+    def test_runner_idle_run_plans_dispatch(self):
+        run = run_self_heal(NoCallForge(), make_inputs(open_prs=0))
+        assert run.state["idle_signal"]["idle"] is True
+        assert kinds(run) == ["dispatch_observation_loop"]
+        assert run.state["idle_signal"]["last_dispatch_at"] == NOW
+
+    def test_active_pipeline_label_is_exact_match(self):
+        issues = (
+            issue(1, labels=("needs-triage-extra",)),  # NOT active (exact match)
+            issue(2, labels=("goose-implementation",)),
+        )
+        run = run_self_heal(NoCallForge(), make_inputs(open_prs=0, open_issues=issues))
+        assert run.state["idle_signal"]["active_pipeline_issues"] == 1
+        assert run.state["idle_signal"]["idle"] is False

--- a/pipeline/wgmesh_pipeline/selfheal/__init__.py
+++ b/pipeline/wgmesh_pipeline/selfheal/__init__.py
@@ -1,0 +1,90 @@
+"""Box-side Self-Heal: stalled-stage detection, escalation, and state building.
+
+Port of the Actions ``pipeline-health`` workflow (cutover plan U4): the three
+stale sweeps (needs-triage / copilot-triaging / approved-for-build), the
+circuit breaker, the fulfilled-needs-human close, the funnel + idle signals,
+the idle observation-loop dispatch, the state summary, and the
+state-mutation assertion (``assert-state-mutation.sh``) all become pure
+decision functions; ``run_self_heal`` is the thin runner. Semantics are
+ported, not redesigned — skip ordering, substring label matching, retry /
+cooldown / escalate-after-2, audit-entry shapes, and the state-file key
+order are parity-tested byte-exact against the recorded
+``company/pipeline-health-state.json`` on main.
+
+Planning surface only (this phase): the runner RETURNS the state dict plus
+the planned heal actions — it performs NO forge writes. Every action body /
+comment must pass ``company/scripts/sanitise.sh`` before the executor
+publishes it (the workflow gates every create/close on it). Failing
+detections raise loudly — nothing is swallowed (institutional learning).
+
+TODO(protocol gaps) — the Forge protocol cannot feed these sweeps, so
+``SelfHealInputs`` carries plain-dict snapshots gathered elsewhere. Missing
+surface (do NOT extend the protocol in this unit):
+  - label-filtered issue/PR listing WITH createdAt/updatedAt — needed for
+    every stale cutoff; ``list_open_issues`` has no timestamps or filters.
+  - open-PR title search ("spec: Issue #N" / "impl: Issue #N") — in-progress
+    skips; ``has_merged_resolution_pr`` covers only the merged-PR skip.
+  - issue timeline (cross-referenced merged PRs) — needs-human signal 1.
+  - cross-repo file fetch (wgmesh CLAUDE.md) — dogfood signal.
+  - repository_dispatch — the idle observation-loop trigger.
+  - HTTP probe of health endpoints — presence signal (boundary I/O).
+"""
+
+from wgmesh_pipeline.selfheal.models import (
+    ACTIVE_PIPELINE_LABELS,
+    CHECK_INTERVAL_HOURS,
+    CIRCUIT_MAX_CREATES,
+    CIRCUIT_MAX_ERRORS,
+    ESCALATE_COOLDOWN_HOURS,
+    IDLE_DISPATCH_COOLDOWN_SECONDS,
+    MAX_RETRIES_BEFORE_ESCALATE,
+    SUPERVISOR_DEAD_TITLE,
+    HealAction,
+    SelfHealInputs,
+    SelfHealRun,
+    SweepOutcome,
+)
+from wgmesh_pipeline.selfheal.runner import needs_human_from_forge, run_self_heal
+from wgmesh_pipeline.selfheal.signals import (
+    assert_state_mutation,
+    build_state,
+    check_funnel_signals,
+    check_idle_signal,
+    decide_idle_dispatch,
+)
+from wgmesh_pipeline.selfheal.sweeps import (
+    circuit_breaker_action,
+    circuit_breaker_tripped,
+    sweep_needs_human,
+    sweep_stale_approved,
+    sweep_stale_copilot,
+    sweep_stale_triage,
+)
+
+__all__ = [
+    "ACTIVE_PIPELINE_LABELS",
+    "CHECK_INTERVAL_HOURS",
+    "CIRCUIT_MAX_CREATES",
+    "CIRCUIT_MAX_ERRORS",
+    "ESCALATE_COOLDOWN_HOURS",
+    "IDLE_DISPATCH_COOLDOWN_SECONDS",
+    "MAX_RETRIES_BEFORE_ESCALATE",
+    "SUPERVISOR_DEAD_TITLE",
+    "HealAction",
+    "SelfHealInputs",
+    "SelfHealRun",
+    "SweepOutcome",
+    "assert_state_mutation",
+    "build_state",
+    "check_funnel_signals",
+    "check_idle_signal",
+    "circuit_breaker_action",
+    "circuit_breaker_tripped",
+    "decide_idle_dispatch",
+    "needs_human_from_forge",
+    "run_self_heal",
+    "sweep_needs_human",
+    "sweep_stale_approved",
+    "sweep_stale_copilot",
+    "sweep_stale_triage",
+]

--- a/pipeline/wgmesh_pipeline/selfheal/models.py
+++ b/pipeline/wgmesh_pipeline/selfheal/models.py
@@ -1,0 +1,141 @@
+"""Self-Heal dataclasses, constants, and shared pure helpers (cutover U4).
+
+Constants mirror the ``pipeline-health`` workflow's hard-coded values; the
+dataclasses are the planning surface — no forge writes happen here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+TARGET_REPO_NAME = "wgmesh"
+MAX_RETRIES_BEFORE_ESCALATE = 2
+CIRCUIT_MAX_CREATES = 10
+CIRCUIT_MAX_ERRORS = 5
+ESCALATE_COOLDOWN_HOURS = 24
+IDLE_DISPATCH_COOLDOWN_SECONDS = 6 * 60 * 60
+CHECK_INTERVAL_HOURS = 0.5
+ACTIVE_PIPELINE_LABELS = (
+    "needs-triage", "copilot-triaging", "copilot-revising",
+    "approved-for-build", "goose-implementation",
+)
+SUPERVISOR_DEAD_TITLE = "supervisor-dead: pipeline-health frozen"
+
+
+@dataclass(frozen=True)
+class HealAction:
+    """One planned heal write. ``body``/``comment`` MUST pass the sanitise
+    gate before the executor publishes them (workflow parity)."""
+
+    kind: str  # audit action name: retrigger_* / escalate / close_needs_human / ...
+    number: int | None = None
+    target: str = "issue"  # "issue" | "pr" | "repo"
+    remove_label: str | None = None
+    add_label: str | None = None
+    title: str | None = None
+    body: str | None = None
+    comment: str | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SweepOutcome:
+    """Counters + planned actions from one detector (mirrors the per-step
+    ``local_*`` counters the workflow accumulates into GITHUB_ENV)."""
+
+    actions: tuple[HealAction, ...] = ()
+    audit: tuple[dict[str, Any], ...] = ()
+    retry_tracker: Mapping[str, Any] = field(default_factory=dict)
+    stale_found: int = 0
+    actions_taken: int = 0
+    errors: int = 0
+    issues_created: int = 0
+    closed: int = 0
+
+
+@dataclass(frozen=True)
+class SelfHealInputs:
+    """Plain-dict inputs replacing the workflow's label-filtered queries
+    (see protocol gaps in the package docstring). Items carry the query JSON
+    shapes: number, title, createdAt/updatedAt, labels (names or
+    ``{"name": …}``)."""
+
+    now: str
+    run_id: str = "local"
+    previous_state: Mapping[str, Any] = field(default_factory=dict)
+    stale_triage_issues: tuple[Mapping[str, Any], ...] = ()
+    stale_copilot_issues: tuple[Mapping[str, Any], ...] = ()
+    stale_approved_prs: tuple[Mapping[str, Any], ...] = ()
+    needs_human_issues: tuple[Mapping[str, Any], ...] | None = None
+    merged_resolution_issues: frozenset[int] = frozenset()
+    open_spec_pr_issues: frozenset[int] = frozenset()
+    open_impl_pr_issues: frozenset[int] = frozenset()
+    linked_merged_pr_counts: Mapping[int, int] = field(default_factory=dict)
+    loop_state: Mapping[str, Any] = field(default_factory=dict)
+    costs: Mapping[str, Any] = field(default_factory=dict)
+    endpoints: tuple[Mapping[str, Any], ...] = ()  # {name, url, status}
+    claude_md_text: str | None = None
+    open_prs: int = 0
+    open_issues: tuple[Mapping[str, Any], ...] = ()
+    cutoff_override_minutes: int | None = None
+    signals_now: str | None = None  # separate step clock; defaults to ``now``
+
+
+@dataclass(frozen=True)
+class SelfHealRun:
+    """Runner outcome: planned actions + the state dict the caller may
+    persist (after the sanitise gate), plus the mutation-assertion verdict."""
+
+    state: dict[str, Any]
+    actions: tuple[HealAction, ...]
+    audit: tuple[dict[str, Any], ...]
+    circuit_breaker_tripped: bool
+    mutation_asserted: bool
+
+
+def parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def iso(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def shift(now: str, *, hours: float = 0, minutes: float = 0) -> str:
+    return iso(parse_iso(now) + timedelta(hours=hours, minutes=minutes))
+
+
+def labels_joined(item: Mapping[str, Any]) -> str:
+    """Comma-joined label names — the workflow greps this string, so all
+    label checks downstream are SUBSTRING matches (ported as-is)."""
+    names = []
+    for label in item.get("labels") or []:
+        names.append(str(label.get("name")) if isinstance(label, Mapping) else str(label))
+    return ",".join(names)
+
+
+def first_timestamp(item: Mapping[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        if item.get(key):
+            return str(item[key])
+    return ""
+
+
+def audit_entry(now: str, run_id: str, action: str, number: int | None, reason: str,
+                retry_count: int | None, **extra: Any) -> dict[str, Any]:
+    """Audit-log entry, key order byte-compatible with the workflow's jq -nc."""
+    return {
+        "timestamp": now, "run_id": run_id, "action": action,
+        "issue_number": number, "target_repo": TARGET_REPO_NAME,
+        "reason": reason, "outcome": "success", "retry_count": retry_count,
+        **extra,
+    }
+
+
+def tracker_entry(tracker: Mapping[str, Any], key: str) -> dict[str, Any]:
+    entry = tracker.get(key) or {}
+    if not isinstance(entry, Mapping):  # fail loudly, never swallow
+        raise ValueError(f"malformed retry_tracker entry for {key!r}: {entry!r}")
+    return dict(entry)

--- a/pipeline/wgmesh_pipeline/selfheal/runner.py
+++ b/pipeline/wgmesh_pipeline/selfheal/runner.py
@@ -80,6 +80,7 @@ def run_self_heal(forge: Forge, inputs: SelfHealInputs) -> SelfHealRun:
         actions += copilot.actions
         audit += copilot.audit
         taken += copilot.actions_taken
+        errors += copilot.errors
         created += copilot.issues_created
         found["copilot"] = copilot.stale_found
         tripped = circuit_breaker_tripped(created, errors)
@@ -90,6 +91,7 @@ def run_self_heal(forge: Forge, inputs: SelfHealInputs) -> SelfHealRun:
         actions += approved.actions
         audit += approved.audit
         taken += approved.actions_taken
+        errors += approved.errors
         created += approved.issues_created
         found["approved"] = approved.stale_found
         tripped = circuit_breaker_tripped(created, errors)
@@ -105,6 +107,7 @@ def run_self_heal(forge: Forge, inputs: SelfHealInputs) -> SelfHealRun:
         actions += humans.actions
         audit += humans.audit
         taken += humans.actions_taken
+        errors += humans.errors
         closed += humans.closed
         funnel_signals, funnel_audit = check_funnel_signals(inputs)
         audit.append(funnel_audit)

--- a/pipeline/wgmesh_pipeline/selfheal/runner.py
+++ b/pipeline/wgmesh_pipeline/selfheal/runner.py
@@ -1,0 +1,133 @@
+"""Self-Heal thin runner (cutover U4): diagnose → plan heals → build state.
+
+NO forge writes this phase — the runner returns the state dict plus the
+planned actions; persisting state, the sanitise gate, and publishing the
+actions stay with the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+from wgmesh_pipeline.forge.protocol import Forge
+from wgmesh_pipeline.selfheal.models import (
+    HealAction,
+    SelfHealInputs,
+    SelfHealRun,
+    audit_entry,
+)
+from wgmesh_pipeline.selfheal.signals import (
+    assert_state_mutation,
+    build_state,
+    check_funnel_signals,
+    check_idle_signal,
+    decide_idle_dispatch,
+)
+from wgmesh_pipeline.selfheal.sweeps import (
+    circuit_breaker_action,
+    circuit_breaker_tripped,
+    sweep_needs_human,
+    sweep_stale_approved,
+    sweep_stale_copilot,
+    sweep_stale_triage,
+)
+
+
+def needs_human_from_forge(forge: Forge) -> tuple[dict[str, Any], ...]:
+    """Best-effort needs-human snapshot via existing Forge methods only
+    (no timestamps needed for this sweep, so it is NOT degraded)."""
+    return tuple(
+        {"number": issue.number, "title": issue.title, "labels": list(issue.labels)}
+        for issue in forge.list_open_issues()
+        if "needs-human" in issue.labels and not issue.pull_request
+    )
+
+
+def run_self_heal(forge: Forge, inputs: SelfHealInputs) -> SelfHealRun:
+    """Step order and circuit gating mirror the workflow exactly: triage
+    sweep, breaker check (creates the breaker issue), copilot / approved /
+    needs-human sweeps and funnel signals all gated on the breaker; the idle
+    signal is computed unconditionally; the idle dispatch is gated; the state
+    summary always lands; the mutation assertion runs last."""
+    prev = inputs.previous_state
+    tracker: Mapping[str, Any] = dict(prev.get("retry_tracker") or {})
+    actions: list[HealAction] = []
+    audit: list[dict[str, Any]] = []
+    taken = errors = created = closed = 0
+    found = {"triage": 0, "copilot": 0, "approved": 0}
+
+    triage = sweep_stale_triage(inputs, tracker)
+    tracker = triage.retry_tracker
+    actions += triage.actions
+    audit += triage.audit
+    taken += triage.actions_taken
+    errors += triage.errors
+    created += triage.issues_created
+    found["triage"] = triage.stale_found
+
+    tripped = circuit_breaker_tripped(created, errors)
+    if tripped:
+        actions.append(circuit_breaker_action(created, errors))
+        audit.append(audit_entry(
+            inputs.now, inputs.run_id, "circuit_breaker", None,
+            "per-run limit exceeded", None,
+        ))
+
+    if not tripped:
+        copilot = sweep_stale_copilot(inputs, tracker)
+        tracker = copilot.retry_tracker
+        actions += copilot.actions
+        audit += copilot.audit
+        taken += copilot.actions_taken
+        created += copilot.issues_created
+        found["copilot"] = copilot.stale_found
+        tripped = circuit_breaker_tripped(created, errors)
+
+    if not tripped:
+        approved = sweep_stale_approved(inputs, tracker)
+        tracker = approved.retry_tracker
+        actions += approved.actions
+        audit += approved.audit
+        taken += approved.actions_taken
+        created += approved.issues_created
+        found["approved"] = approved.stale_found
+        tripped = circuit_breaker_tripped(created, errors)
+
+    funnel_signals = dict(prev.get("funnel_signals") or {})
+    if not tripped:
+        needs_human_inputs = inputs
+        if inputs.needs_human_issues is None:
+            needs_human_inputs = replace(
+                inputs, needs_human_issues=needs_human_from_forge(forge)
+            )
+        humans = sweep_needs_human(needs_human_inputs)
+        actions += humans.actions
+        audit += humans.audit
+        taken += humans.actions_taken
+        closed += humans.closed
+        funnel_signals, funnel_audit = check_funnel_signals(inputs)
+        audit.append(funnel_audit)
+
+    idle_signal = check_idle_signal(inputs, taken, errors)
+    if not tripped:
+        dispatch, idle_signal = decide_idle_dispatch(idle_signal, inputs.now)
+        if dispatch is not None:
+            actions.append(dispatch)
+
+    state = build_state(
+        prev, now=inputs.now, retry_tracker=tracker,
+        funnel_signals=funnel_signals, idle_signal=idle_signal,
+        stale_triage_found=found["triage"], stale_copilot_found=found["copilot"],
+        stale_approved_found=found["approved"], needs_human_closed=closed,
+        actions_taken=taken, errors=errors,
+    )
+    state, passed, dead = assert_state_mutation(
+        str(prev.get("last_check") or ""), state, inputs.now
+    )
+    if dead is not None:
+        actions.append(dead)
+    return SelfHealRun(
+        state=state, actions=tuple(actions), audit=tuple(audit),
+        circuit_breaker_tripped=tripped, mutation_asserted=passed,
+    )

--- a/pipeline/wgmesh_pipeline/selfheal/signals.py
+++ b/pipeline/wgmesh_pipeline/selfheal/signals.py
@@ -1,0 +1,167 @@
+"""Self-Heal signals + state: funnel/dogfood/presence, idle detection, the
+idle observation-loop dispatch, the state summary, and the state-mutation
+assertion (cutover U4). Pure decisions — no forge writes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from wgmesh_pipeline.selfheal.models import (
+    ACTIVE_PIPELINE_LABELS,
+    CHECK_INTERVAL_HOURS,
+    IDLE_DISPATCH_COOLDOWN_SECONDS,
+    SUPERVISOR_DEAD_TITLE,
+    HealAction,
+    SelfHealInputs,
+    audit_entry,
+    labels_joined,
+    parse_iso,
+)
+
+
+def check_funnel_signals(inputs: SelfHealInputs) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Dogfood + presence signals → (funnel_signals state value, audit entry)."""
+    text = inputs.claude_md_text or ""
+    dogfood = bool(text) and ("architecture" in text.lower()) and ("build" in text.lower())
+    details: list[str] = []
+    presence = bool(inputs.endpoints)
+    for endpoint in inputs.endpoints:
+        ok = 200 <= int(endpoint.get("status") or 0) < 400
+        details.append(f"{endpoint.get('name')}:{'ok' if ok else 'fail'}")
+        presence = presence and ok
+    checked_at = inputs.signals_now or inputs.now
+    signals = {
+        "dogfood": dogfood, "presence": presence,
+        "endpoint_details": ",".join(details), "checked_at": checked_at,
+    }
+    entry = audit_entry(
+        checked_at, inputs.run_id, "check_funnel_signals", None,
+        "periodic signal check", None, signals={"dogfood": dogfood, "presence": presence},
+    )
+    return signals, entry
+
+
+def check_idle_signal(
+    inputs: SelfHealInputs, actions_taken: int, errors: int
+) -> dict[str, Any]:
+    """Idle detector — open PRs + active-pipeline-labelled issues + this run.
+    Label match here is EXACT (jq ``any(.labels[].name; . == …)``), unlike
+    the grep-substring checks in the sweeps."""
+    active = sum(
+        1 for issue in inputs.open_issues
+        if any(name in ACTIVE_PIPELINE_LABELS for name in labels_joined(issue).split(","))
+    )
+    idle = inputs.open_prs == 0 and active == 0 and actions_taken == 0 and errors == 0
+    signal: dict[str, Any] = {
+        "idle": idle, "open_prs": inputs.open_prs, "active_pipeline_issues": active,
+        "checked_at": inputs.signals_now or inputs.now,
+    }
+    last_dispatch = str(
+        (inputs.previous_state.get("idle_signal") or {}).get("last_dispatch_at") or ""
+    )
+    if last_dispatch:
+        signal["last_dispatch_at"] = last_dispatch
+    return signal
+
+
+def decide_idle_dispatch(
+    idle_signal: Mapping[str, Any], now: str
+) -> tuple[HealAction | None, dict[str, Any]]:
+    """Observation-loop dispatch on idle, behind the 6h cooldown."""
+    signal = dict(idle_signal)
+    if not signal.get("idle"):
+        return None, signal
+    last = str(signal.get("last_dispatch_at") or "")
+    if last:
+        try:
+            elapsed = (parse_iso(now) - parse_iso(last)).total_seconds()
+        except ValueError:
+            elapsed = None  # unparseable → shell fell back to epoch 0 (dispatch)
+        if elapsed is not None and elapsed < IDLE_DISPATCH_COOLDOWN_SECONDS:
+            return None, signal
+    action = HealAction(
+        kind="dispatch_observation_loop", target="repo",
+        body=f"signal=idle-pipeline source=pipeline-health idle_checked_at={now}",
+        reason="idle pipeline",
+    )
+    return action, {**signal, "last_dispatch_at": now}
+
+
+def build_state(
+    previous_state: Mapping[str, Any],
+    *,
+    now: str,
+    retry_tracker: Mapping[str, Any],
+    funnel_signals: Mapping[str, Any],
+    idle_signal: Mapping[str, Any],
+    stale_triage_found: int,
+    stale_copilot_found: int,
+    stale_approved_found: int,
+    needs_human_closed: int,
+    actions_taken: int,
+    errors: int,
+) -> dict[str, Any]:
+    """State summary — key order byte-compatible with the workflow's jq -n."""
+    return {
+        "last_check": now,
+        "check_interval_hours": CHECK_INTERVAL_HOURS,
+        "checks_run": int(previous_state.get("checks_run") or 0) + 1,
+        "issues_healed_total": int(previous_state.get("issues_healed_total") or 0)
+        + actions_taken,
+        "consecutive_no_mutation_runs": int(
+            previous_state.get("consecutive_no_mutation_runs") or 0
+        ),
+        "retry_tracker": dict(retry_tracker),
+        "funnel_signals": dict(funnel_signals),
+        "idle_signal": dict(idle_signal),
+        "last_run_summary": {
+            "stale_triage_found": stale_triage_found,
+            "stale_copilot_found": stale_copilot_found,
+            "stale_approved_found": stale_approved_found,
+            "needs_human_closed": needs_human_closed,
+            "actions_taken": actions_taken,
+            "errors": errors,
+        },
+    }
+
+
+def assert_state_mutation(
+    pre_run_last_check: str, state: Mapping[str, Any], now: str
+) -> tuple[dict[str, Any], bool, HealAction | None]:
+    """Port of assert-state-mutation.sh: returns (state', passed, escalation).
+
+    Pass: ``last_check`` advanced → counter resets, assertion recorded.
+    Fail: counter increments; at >=2 consecutive failures the supervisor-dead
+    needs-human escalation is planned (create-or-comment is the executor's
+    concern). Never silent — the runner surfaces the verdict either way.
+    """
+    post = str(state.get("last_check") or "")
+    if post and post != pre_run_last_check:
+        passed_state = {
+            **state,
+            "consecutive_no_mutation_runs": 0,
+            "last_mutation_asserted_at": now,
+            "last_mutation_assertion": {"status": "passed", "checked_at": now},
+        }
+        return passed_state, True, None
+    count = int(state.get("consecutive_no_mutation_runs") or 0) + 1
+    failed_state = {
+        **state,
+        "consecutive_no_mutation_runs": count,
+        "last_mutation_asserted_at": now,
+        "last_mutation_assertion": {
+            "status": "failed", "reason": "last_check-not-advanced", "checked_at": now,
+        },
+    }
+    action: HealAction | None = None
+    if count >= 2:
+        action = HealAction(
+            kind="supervisor_dead", target="issue", title=SUPERVISOR_DEAD_TITLE,
+            body=(
+                "pipeline-health did not prove state mutation. "
+                f"Reason: last_check-not-advanced. consecutive_no_mutation_runs={count}."
+            ),
+            add_label="needs-human", reason="last_check-not-advanced",
+        )
+    return failed_state, False, action

--- a/pipeline/wgmesh_pipeline/selfheal/sweeps.py
+++ b/pipeline/wgmesh_pipeline/selfheal/sweeps.py
@@ -1,0 +1,247 @@
+"""Self-Heal detectors: the three stale sweeps, the circuit breaker, and the
+fulfilled-needs-human close (cutover U4). Pure decisions — no forge writes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.selfheal.models import (
+    CIRCUIT_MAX_CREATES,
+    CIRCUIT_MAX_ERRORS,
+    ESCALATE_COOLDOWN_HOURS,
+    MAX_RETRIES_BEFORE_ESCALATE,
+    HealAction,
+    SelfHealInputs,
+    SweepOutcome,
+    audit_entry,
+    first_timestamp,
+    labels_joined,
+    shift,
+    tracker_entry,
+)
+
+
+@dataclass(frozen=True)
+class _StaleSpec:
+    """Per-sweep constants for the shared stale engine."""
+
+    timestamp_keys: tuple[str, ...]
+    cutoff_hours: int
+    tracker_prefix: str
+    heal_kind: str
+    heal_reason: str
+    remove_label: str
+    add_label: str
+    target: str
+    escalate_title: str  # format with {n}
+    escalate_body: str  # format with {n} and {r}
+    escalate_reason: str
+
+
+_TRIAGE = _StaleSpec(
+    timestamp_keys=("createdAt", "created_at"), cutoff_hours=24, tracker_prefix="",
+    heal_kind="retrigger_triage", heal_reason="stale >24h at needs-triage",
+    remove_label="needs-triage", add_label="needs-triage", target="issue",
+    escalate_title="[needs-human] Stuck at triage: #{n}",
+    escalate_body="Self-healing failed to resolve stale triage for #{n} after {r} attempts.",
+    escalate_reason="2 consecutive triage failures",
+)
+_COPILOT = _StaleSpec(
+    timestamp_keys=("createdAt", "created_at"), cutoff_hours=48, tracker_prefix="",
+    heal_kind="retrigger_copilot", heal_reason="stale >48h at copilot-triaging",
+    remove_label="copilot-triaging", add_label="needs-triage", target="issue",
+    escalate_title="[needs-human] Stuck at copilot-triaging: #{n}",
+    escalate_body=(
+        "Self-healing failed to resolve stale copilot-triaging for #{n} after {r} attempts."
+    ),
+    escalate_reason="2 consecutive copilot-triaging failures",
+)
+_APPROVED = _StaleSpec(
+    timestamp_keys=("updatedAt", "updated_at"), cutoff_hours=24, tracker_prefix="pr-",
+    heal_kind="retrigger_goose", heal_reason="stale >24h at approved-for-build",
+    remove_label="approved-for-build", add_label="approved-for-build", target="pr",
+    escalate_title="[needs-human] Stuck at build: PR #{n}",
+    escalate_body=(
+        "Self-healing failed to resolve stale approved-for-build PR #{n} after {r} attempts."
+    ),
+    escalate_reason="2 consecutive build trigger failures",
+)
+
+_Skip = Callable[[Mapping[str, Any]], bool]
+
+
+def _sweep_stale(
+    items: tuple[Mapping[str, Any], ...],
+    spec: _StaleSpec,
+    retry_tracker: Mapping[str, Any],
+    inputs: SelfHealInputs,
+    pre_count_skip: _Skip,
+    post_count_skip: _Skip,
+) -> SweepOutcome:
+    """Shared stale engine — exact port of one workflow sweep step.
+
+    Ordering parity: manual-only (+ ``pre_count_skip``) before the stale
+    count; ``post_count_skip`` (in-progress spec/impl PR) after it; then
+    cooldown (ISO string compare, as the shell ``\\<``), then
+    escalate-after-2, else heal (label toggle). Heal REPLACES the tracker
+    entry (dropping any cooldown_until); escalate only sets cooldown_until.
+    """
+    now, run_id = inputs.now, inputs.run_id
+    if inputs.cutoff_override_minutes is not None:
+        cutoff = shift(now, minutes=-inputs.cutoff_override_minutes)
+    else:
+        cutoff = shift(now, hours=-spec.cutoff_hours)
+    tracker = dict(retry_tracker)
+    actions: list[HealAction] = []
+    audit: list[dict[str, Any]] = []
+    stale = taken = created = 0
+
+    for item in items:
+        if first_timestamp(item, spec.timestamp_keys) >= cutoff:
+            continue  # jq: select(.created/updatedAt < cutoff)
+        number = int(item["number"])
+        labels = labels_joined(item)
+        if "manual-only" in labels or pre_count_skip(item):
+            continue
+        stale += 1
+        if post_count_skip(item):
+            continue
+        key = f"{spec.tracker_prefix}{number}"
+        entry = tracker_entry(tracker, key)
+        retries = int(entry.get("retries") or 0)
+        cooldown = str(entry.get("cooldown_until") or "")
+        if cooldown and now < cooldown:
+            continue
+        if retries >= MAX_RETRIES_BEFORE_ESCALATE:
+            actions.append(HealAction(
+                kind="escalate", number=number, target=spec.target,
+                title=spec.escalate_title.format(n=number),
+                body=spec.escalate_body.format(n=number, r=retries),
+                add_label="needs-human", reason=spec.escalate_reason,
+            ))
+            created += 1
+            taken += 1
+            tracker[key] = {**entry, "cooldown_until": shift(now, hours=ESCALATE_COOLDOWN_HOURS)}
+            audit.append(audit_entry(
+                now, run_id, "escalate", number, spec.escalate_reason, retries
+            ))
+            continue
+        actions.append(HealAction(
+            kind=spec.heal_kind, number=number, target=spec.target,
+            remove_label=spec.remove_label, add_label=spec.add_label,
+            reason=spec.heal_reason,
+        ))
+        taken += 1
+        tracker[key] = {"retries": retries + 1, "last_retry": now, "action": spec.heal_kind}
+        audit.append(audit_entry(
+            now, run_id, spec.heal_kind, number, spec.heal_reason, retries + 1
+        ))
+
+    return SweepOutcome(
+        actions=tuple(actions), audit=tuple(audit), retry_tracker=tracker,
+        stale_found=stale, actions_taken=taken, issues_created=created,
+    )
+
+
+def sweep_stale_triage(inputs: SelfHealInputs, tracker: Mapping[str, Any]) -> SweepOutcome:
+    """Stale needs-triage sweep (24h). Exclusion labels and the merged
+    spec/impl-PR completion check skip BEFORE the stale count (cf. #540)."""
+    def pre(item: Mapping[str, Any]) -> bool:
+        labels = labels_joined(item)
+        if "wont-do" in labels or "needs-info" in labels:
+            return True
+        return int(item["number"]) in inputs.merged_resolution_issues
+
+    return _sweep_stale(
+        inputs.stale_triage_issues, _TRIAGE, tracker, inputs, pre, lambda item: False
+    )
+
+
+def sweep_stale_copilot(inputs: SelfHealInputs, tracker: Mapping[str, Any]) -> SweepOutcome:
+    """Stale copilot-triaging sweep (48h); spec-PR-in-progress skips after count."""
+    return _sweep_stale(
+        inputs.stale_copilot_issues, _COPILOT, tracker, inputs,
+        lambda item: False,
+        lambda item: int(item["number"]) in inputs.open_spec_pr_issues,
+    )
+
+
+def sweep_stale_approved(inputs: SelfHealInputs, tracker: Mapping[str, Any]) -> SweepOutcome:
+    """Stale approved-for-build PR sweep (24h on updatedAt, tracker key pr-N);
+    an open impl PR for the spec's issue number skips after the count."""
+    def post(item: Mapping[str, Any]) -> bool:
+        match = re.search(r"Issue #(\d+)", str(item.get("title") or ""))
+        return bool(match) and int(match.group(1)) in inputs.open_impl_pr_issues
+
+    return _sweep_stale(
+        inputs.stale_approved_prs, _APPROVED, tracker, inputs, lambda item: False, post
+    )
+
+
+def circuit_breaker_tripped(issues_created: int, errors: int) -> bool:
+    return issues_created >= CIRCUIT_MAX_CREATES or errors >= CIRCUIT_MAX_ERRORS
+
+
+def circuit_breaker_action(issues_created: int, errors: int) -> HealAction:
+    """The needs-human breaker issue (only the post-triage check creates it)."""
+    return HealAction(
+        kind="circuit_breaker", target="issue",
+        title="[needs-human] Pipeline self-healing circuit breaker triggered",
+        body=(
+            f"Self-healing hit per-run limits: {issues_created} issues created, "
+            f"{errors} errors. Manual review required."
+        ),
+        add_label="needs-human", reason="per-run limit exceeded",
+    )
+
+
+def _needs_human_resolution(item: Mapping[str, Any], inputs: SelfHealInputs) -> str | None:
+    """Resolution reason for one needs-human issue, or None (signal order
+    and the title-pattern elif chain ported exactly)."""
+    number = int(item["number"])
+    merged = int(inputs.linked_merged_pr_counts.get(number) or 0)
+    if merged > 0:
+        return f"Linked PR merged ({merged} merged PR(s) found)"
+    title = str(item.get("title") or "").lower()
+    if re.search(r"(api key|secret)", title):
+        run_count = int(inputs.loop_state.get("run_count") or 0)
+        if str(inputs.loop_state.get("last_run") or "") and run_count > 0:
+            return f"Observation loop running successfully (run_count={run_count})"
+    elif re.search(r"(health|endpoint)", title):
+        if inputs.endpoints and all(
+            200 <= int(e.get("status") or 0) < 400 for e in inputs.endpoints
+        ):
+            return "All health endpoints responding OK"
+    elif re.search(r"(burn|capital|budget)", title):
+        capital = (inputs.costs.get("runway") or {}).get("available_capital") or 0
+        if isinstance(capital, int) and capital > 0:  # shell -gt is integer-only
+            return f"Costs data populated (available_capital={capital})"
+    return None
+
+
+def sweep_needs_human(inputs: SelfHealInputs) -> SweepOutcome:
+    """Close fulfilled needs-human issues (resolution signals 1 + 2)."""
+    actions: list[HealAction] = []
+    audit: list[dict[str, Any]] = []
+    closed = 0
+    for item in inputs.needs_human_issues or ():
+        if "manual-only" in labels_joined(item):
+            continue
+        reason = _needs_human_resolution(item, inputs)
+        if reason is None:
+            continue
+        number = int(item["number"])
+        actions.append(HealAction(
+            kind="close_needs_human", number=number, target="issue",
+            comment=f"Resolved by self-healing: {reason}", reason=reason,
+        ))
+        closed += 1
+        audit.append(audit_entry(
+            inputs.now, inputs.run_id, "close_needs_human", number, reason, None
+        ))
+    return SweepOutcome(
+        actions=tuple(actions), audit=tuple(audit), closed=closed, actions_taken=closed
+    )


### PR DESCRIPTION
## Summary

#1599 **U4 / Phase B**: ports the pipeline-health self-heal chain to a `wgmesh_pipeline.selfheal` package — stale sweeps (triage/copilot/approved + circuit breaker), funnel/idle signals with 6h dispatch cooldown, needs-human resolution, mutation-assertion port with supervisor-dead escalation. Pure decision functions + runner returning state + planned actions; zero forge writes this phase. Package split keeps every file <400 lines.

## Parity (byte-exact)

Healthy replay reproduces the recorded `pipeline-health-state.json` byte-for-byte (`json.dumps(...)+'\n' == file bytes`) — counters, retry_tracker, signals, jq key order. Proven to bite (constant mutation → RED). Audit lines exact-string match the workflow's `jq -nc` output. Subtle semantics ported exactly (substring vs exact label match, per-sweep stale-count ordering, heal-replaces vs escalate-appends tracker entries, lexicographic ISO cooldown).

Fixture frozen per the #1691 lesson (live file mutates every 30min).

## Gaps (module TODOs; protocol untouched)

Label-filtered listing w/ timestamps, PR title search, issue timeline, cross-repo fetch, repository_dispatch, HTTP probe — inputs arrive as snapshot dicts until those land. pipeline-health.yml stays active for the parity bake (KTD2/3).

## Test plan
- [x] 40 selfheal tests (parity + detector edges)
- [x] Full suite 413 passed, 5 skipped