### PR TITLE
feat(loop): control-loop scheduler — wire Phase B modules into the box (shadow)

### DIFF
--- a/pipeline/tests/test_control_loop.py
+++ b/pipeline/tests/test_control_loop.py
@@ -1,0 +1,274 @@
+"""Control-Loop scheduler tests (cutover Phase B/C, shadow-only).
+
+These pin the zero-blast-radius contract: each enabled module fires on its
+cadence, NO forge writes or store persistence happen in shadow, one planner
+crashing does not stop its siblings or the scheduler, stop cancels promptly,
+the observation/strategy_audit slots log their skip reason, and live mode is
+forced to shadow with a warning.
+
+Planners are injected as spies so tests never hit the real forge/LLM. The
+forge spy records every method call and raises if any *write* method is
+touched (the lowest-boundary check that shadow truly writes nothing). No
+mutable tree-state file is read (frozen inputs only — PR #1691 lesson).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from wgmesh_pipeline import control_loop as cl
+from wgmesh_pipeline.config import Config, load_config
+from wgmesh_pipeline.control_loop import ControlLoopScheduler
+from wgmesh_pipeline.selfheal import SelfHealInputs, SelfHealRun
+from wgmesh_pipeline.supervisor import RankResult, SupervisorRankRun
+
+
+# --- frozen fakes -----------------------------------------------------------
+
+_WRITE_METHODS = frozenset({
+    "add_label", "remove_label", "comment", "create_pr", "update_pr_body",
+    "merge_pr", "push_branch", "approve_pr",
+})
+
+
+class SpyForge:
+    """Records read calls; raises on ANY write method (shadow must not write)."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.write_calls: list[str] = []
+
+    def __getattr__(self, name: str):
+        def method(*args, **kwargs):
+            self.calls.append(name)
+            if name in _WRITE_METHODS:
+                self.write_calls.append(name)
+                raise AssertionError(f"shadow scheduler called forge write {name!r}")
+            if name == "list_open_issues":
+                return []
+            return None
+        return method
+
+
+class SpyStore:
+    """Records any method call; the scheduler must touch none in shadow."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __getattr__(self, name: str):
+        def method(*args, **kwargs):
+            self.calls.append(name)
+            return None
+        return method
+
+
+def _empty_rank_run() -> SupervisorRankRun:
+    result = RankResult(generated_at="2026-06-13T00:00:00Z", top=(), stage_summary={}, unknown=())
+    return SupervisorRankRun(result=result, state={}, material_changed=False, rank_changed=False)
+
+
+def _empty_selfheal_run() -> SelfHealRun:
+    return SelfHealRun(
+        state={}, actions=(), audit=(), circuit_breaker_tripped=False, mutation_asserted=True,
+    )
+
+
+@dataclass
+class Spy:
+    """A counting spy for an injected planner; returns a fixed result."""
+
+    result: object
+    raises: bool = False
+    calls: int = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.raises:
+            raise RuntimeError("planner boom")
+        return self.result
+
+
+def _config(**overrides) -> Config:
+    base = dict(
+        target_repo="atvirokodosprendimai/wgmesh",
+        mode="shadow",
+        database_mode="local",
+        control_loop_enabled=True,
+        control_loop_mode="shadow",
+        # tiny cadences so tests fire fast
+        selfheal_interval_seconds=1,
+        supervisor_interval_seconds=1,
+        observation_interval_seconds=1,
+        strategy_audit_interval_seconds=1,
+    )
+    base.update(overrides)
+    return Config(**base)
+
+
+async def _run_briefly(scheduler: ControlLoopScheduler, *, seconds: float = 0.05) -> None:
+    stop = asyncio.Event()
+
+    async def stopper() -> None:
+        await asyncio.sleep(seconds)
+        stop.set()
+
+    await asyncio.wait_for(
+        asyncio.gather(scheduler.run(stop), stopper()), timeout=5.0
+    )
+
+
+# --- tests ------------------------------------------------------------------
+
+def test_each_enabled_planner_fires_at_least_once() -> None:
+    sup = Spy(_empty_rank_run())
+    heal = Spy(_empty_selfheal_run())
+    sched = ControlLoopScheduler(
+        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01,
+                       observation_interval_seconds=0.01, strategy_audit_interval_seconds=0.01),
+        forge=SpyForge(), store=SpyStore(),
+        supervisor_planner=sup, selfheal_planner=heal,
+    )
+    asyncio.run(_run_briefly(sched))
+    assert sup.calls >= 1, "supervisor planner never fired"
+    assert heal.calls >= 1, "selfheal planner never fired"
+
+
+def test_shadow_performs_no_forge_writes_or_store_writes() -> None:
+    forge = SpyForge()
+    store = SpyStore()
+    sched = ControlLoopScheduler(
+        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01),
+        forge=forge, store=store,
+        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+    )
+    asyncio.run(_run_briefly(sched))
+    assert forge.write_calls == [], f"shadow wrote to forge: {forge.write_calls}"
+    assert store.calls == [], f"shadow persisted to store: {store.calls}"
+
+
+def test_one_planner_raising_does_not_stop_siblings_or_scheduler() -> None:
+    boom = Spy(_empty_rank_run(), raises=True)   # supervisor crashes every cycle
+    heal = Spy(_empty_selfheal_run())            # sibling must keep firing
+    sched = ControlLoopScheduler(
+        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01),
+        forge=SpyForge(), store=SpyStore(),
+        supervisor_planner=boom, selfheal_planner=heal,
+    )
+    asyncio.run(_run_briefly(sched, seconds=0.08))
+    assert boom.calls >= 2, "crashing planner stopped retrying — task died"
+    assert heal.calls >= 2, "sibling stopped firing when supervisor crashed"
+
+
+def test_stop_event_cancels_all_tasks_promptly() -> None:
+    sched = ControlLoopScheduler(
+        config=_config(selfheal_interval_seconds=100, supervisor_interval_seconds=100,
+                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
+        forge=SpyForge(), store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+    )
+    # Long intervals: run() must still return promptly once stop is set, proving
+    # the wait is interruptible (not blocked on the 100s timeout).
+    asyncio.run(_run_briefly(sched, seconds=0.02))
+
+
+def test_observation_and_strategy_audit_slots_log_skip_reason(caplog) -> None:
+    sched = ControlLoopScheduler(
+        config=_config(observation_interval_seconds=0.01, strategy_audit_interval_seconds=0.01),
+        forge=SpyForge(), store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+    )
+    with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.control_loop"):
+        asyncio.run(_run_briefly(sched))
+    text = caplog.text
+    assert "module=observation" in text and "LLM assessment input not yet wired" in text
+    assert "module=strategy_audit" in text and "live metrics gather not yet wired" in text
+
+
+def test_live_mode_forced_to_shadow_with_warning_no_writes(caplog) -> None:
+    forge = SpyForge()
+    with caplog.at_level(logging.WARNING, logger="wgmesh_pipeline.control_loop"):
+        sched = ControlLoopScheduler(
+            config=_config(control_loop_mode="live", selfheal_interval_seconds=0.01,
+                           supervisor_interval_seconds=0.01),
+            forge=forge, store=SpyStore(),
+            supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+        )
+        asyncio.run(_run_briefly(sched))
+    assert "FORCING shadow" in caplog.text
+    assert forge.write_calls == []
+
+
+def test_real_planners_are_the_defaults() -> None:
+    from wgmesh_pipeline.selfheal import run_self_heal
+    from wgmesh_pipeline.supervisor import run_supervisor_rank
+
+    sched = ControlLoopScheduler(config=_config(), forge=SpyForge(), store=SpyStore())
+    assert sched.supervisor_planner is run_supervisor_rank
+    assert sched.selfheal_planner is run_self_heal
+
+
+def test_real_planners_run_against_forge_without_writing() -> None:
+    # Smoke: with the real (un-injected) planners over a SpyForge, a shadow run
+    # gathers via list_open_issues and writes nothing (proves degraded gather +
+    # zero-write contract end-to-end, not just with spies).
+    forge = SpyForge()
+    sched = ControlLoopScheduler(
+        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01,
+                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
+        forge=forge, store=SpyStore(),
+    )
+    asyncio.run(_run_briefly(sched))
+    assert forge.write_calls == []
+    assert "list_open_issues" in forge.calls
+
+
+# --- config env parsing -----------------------------------------------------
+
+def _base_env(**extra) -> dict[str, str]:
+    env = {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "DATABASE_MODE": "local"}
+    env.update(extra)
+    return env
+
+
+def test_config_defaults_control_loop_disabled_shadow() -> None:
+    cfg = load_config(_base_env())
+    assert cfg.control_loop_enabled is False
+    assert cfg.control_loop_mode == "shadow"
+    assert cfg.selfheal_interval_seconds == 1800
+    assert cfg.supervisor_interval_seconds == 14400
+    assert cfg.observation_interval_seconds == 28800
+    assert cfg.strategy_audit_interval_seconds == 86400
+
+
+def test_config_parses_control_loop_env() -> None:
+    cfg = load_config(_base_env(
+        CONTROL_LOOP_ENABLED="true",
+        CONTROL_LOOP_MODE="live",
+        SELFHEAL_INTERVAL_SECONDS="60",
+        SUPERVISOR_INTERVAL_SECONDS="120",
+        OBSERVATION_INTERVAL_SECONDS="180",
+        STRATEGY_AUDIT_INTERVAL_SECONDS="240",
+    ))
+    assert cfg.control_loop_enabled is True
+    assert cfg.control_loop_mode == "live"  # honored in config; scheduler forces shadow
+    assert cfg.selfheal_interval_seconds == 60
+    assert cfg.supervisor_interval_seconds == 120
+    assert cfg.observation_interval_seconds == 180
+    assert cfg.strategy_audit_interval_seconds == 240
+
+
+def test_config_rejects_bad_control_loop_mode() -> None:
+    with pytest.raises(ValueError, match="CONTROL_LOOP_MODE"):
+        load_config(_base_env(CONTROL_LOOP_MODE="bogus"))
+
+
+def test_config_truthy_variants() -> None:
+    for raw in ("1", "true", "YES", "On"):
+        assert load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled is True
+    for raw in ("0", "false", "", "no"):
+        assert load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled is False

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -24,6 +24,16 @@ DEFAULT_GOOSE_PROVIDER = "anthropic"
 DEFAULT_GOOSE_MODEL = "GLM-4.7"
 DEFAULT_MAX_ESCALATION_ATTEMPTS = 2
 
+# Control-loop scheduler (cutover Phase B/C, shadow-first). Per-module cadences
+# mirror the Actions cron rhythms: self-heal every 30m, supervisor-rank every
+# 4h, observation every 8h, strategy-audit daily.
+VALID_CONTROL_LOOP_MODES = frozenset({"shadow", "live"})
+DEFAULT_CONTROL_LOOP_MODE = "shadow"
+DEFAULT_SELFHEAL_INTERVAL_SECONDS = 1800
+DEFAULT_SUPERVISOR_INTERVAL_SECONDS = 14400
+DEFAULT_OBSERVATION_INTERVAL_SECONDS = 28800
+DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS = 86400
+
 
 @dataclass(frozen=True)
 class Config:
@@ -54,6 +64,15 @@ class Config:
     model_registry: Mapping[str, ModelProfile] = field(default_factory=dict)
     stage_routing: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
     max_escalation_attempts: int = DEFAULT_MAX_ESCALATION_ATTEMPTS
+    # Control-loop scheduler (shadow-first; only "shadow" is honored in this
+    # unit — "live" is forced back to shadow with a loud warning since the
+    # executor that performs forge writes + state persistence is a follow-up).
+    control_loop_enabled: bool = False
+    control_loop_mode: str = DEFAULT_CONTROL_LOOP_MODE
+    selfheal_interval_seconds: int = DEFAULT_SELFHEAL_INTERVAL_SECONDS
+    supervisor_interval_seconds: int = DEFAULT_SUPERVISOR_INTERVAL_SECONDS
+    observation_interval_seconds: int = DEFAULT_OBSERVATION_INTERVAL_SECONDS
+    strategy_audit_interval_seconds: int = DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS
 
     @property
     def owner(self) -> str:
@@ -90,6 +109,15 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
     turso_token = _get_nonempty(source, "TURSO_AUTH_TOKEN")
     if db_mode == "turso" and not turso_url:
         raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
+
+    control_loop_mode = (
+        _get_nonempty(source, "CONTROL_LOOP_MODE") or DEFAULT_CONTROL_LOOP_MODE
+    ).lower()
+    if control_loop_mode not in VALID_CONTROL_LOOP_MODES:
+        valid = ", ".join(sorted(VALID_CONTROL_LOOP_MODES))
+        raise ValueError(
+            f"CONTROL_LOOP_MODE must be one of: {valid}; got {control_loop_mode!r}"
+        )
 
     goose_provider = _get_nonempty(source, "GOOSE_PROVIDER") or DEFAULT_GOOSE_PROVIDER
     goose_model = _get_nonempty(source, "GOOSE_MODEL") or DEFAULT_GOOSE_MODEL
@@ -131,6 +159,22 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
             "MAX_ESCALATION_ATTEMPTS",
             DEFAULT_MAX_ESCALATION_ATTEMPTS,
         ),
+        control_loop_enabled=_truthy(_get_nonempty(source, "CONTROL_LOOP_ENABLED")),
+        control_loop_mode=control_loop_mode,
+        selfheal_interval_seconds=_get_int(
+            source, "SELFHEAL_INTERVAL_SECONDS", DEFAULT_SELFHEAL_INTERVAL_SECONDS
+        ),
+        supervisor_interval_seconds=_get_int(
+            source, "SUPERVISOR_INTERVAL_SECONDS", DEFAULT_SUPERVISOR_INTERVAL_SECONDS
+        ),
+        observation_interval_seconds=_get_int(
+            source, "OBSERVATION_INTERVAL_SECONDS", DEFAULT_OBSERVATION_INTERVAL_SECONDS
+        ),
+        strategy_audit_interval_seconds=_get_int(
+            source,
+            "STRATEGY_AUDIT_INTERVAL_SECONDS",
+            DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS,
+        ),
     )
 
 
@@ -166,6 +210,10 @@ def _build_routing(
             )
         }
     return registry, routing
+
+
+def _truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _required(env: Mapping[str, str], name: str) -> str:

--- a/pipeline/wgmesh_pipeline/control_loop.py
+++ b/pipeline/wgmesh_pipeline/control_loop.py
@@ -1,0 +1,242 @@
+"""Box-side Control-Loop scheduler — SHADOW-ONLY (cutover Phase B/C bake).
+
+The four control-loop planners (``supervisor.run_supervisor_rank``,
+``selfheal.run_self_heal``, ``observation.plan_actions``,
+``strategy_audit.run_strategy_audit``) are parity-passive: they gather/return
+state + planned actions but never write. This scheduler wires them into the box
+loop on per-module cadences and, for each cycle, does exactly three things:
+gather inputs, call the planner, and LOG a structured one-line summary. It
+performs ZERO forge writes and ZERO state persistence — the zero-blast-radius
+bake before a later live flip.
+
+The LIVE executor is a separate follow-up unit. It will, behind the
+``company/scripts/sanitise.sh`` wall, publish the planned actions and persist
+the returned state dicts (to Turso / the ``company/*.json`` state files), gated
+on each planner's ``material_changed`` sentinel. None of that lives here.
+
+``control_loop_mode == "live"`` is honored as SHADOW in this unit (forced back
+with a loud warning) because that executor does not exist yet — going live
+without it would write blind.
+
+Per-module gather gaps (honest degradation — these are the follow-up unit's
+TODOs, NOT to be faked here):
+  - supervisor: ``previous_state`` is not loaded in shadow (passed None), so
+    rank-change/run-counter deltas reset each cycle; the forge snapshot is the
+    degraded ``snapshot_from_forge`` (no timestamps → dwell 0, single repo).
+  - selfheal: only the forge-derivable ``needs_human_issues`` is populated; the
+    label-filtered stale sweeps + funnel/idle snapshot dicts stay at their
+    empty defaults (the protocol cannot feed them yet).
+  - observation: the LLM assessment dict is caller-side and NOT built here — the
+    cycle logs a skip and does nothing (never fabricate an assessment).
+  - strategy_audit: STRATEGY.md is read if present, but live metrics (GitHub /
+    chimney / Polar reads) are not gatherable yet — the cycle logs a skip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.forge.protocol import Forge
+from wgmesh_pipeline.selfheal import SelfHealInputs, SelfHealRun, run_self_heal
+from wgmesh_pipeline.supervisor import (
+    SupervisorRankRun,
+    load_taxonomy,
+    run_supervisor_rank,
+)
+
+log = logging.getLogger("wgmesh_pipeline.control_loop")
+
+# Repo root holds company/ (taxonomy) and STRATEGY.md; config.py lives at
+# <root>/pipeline/wgmesh_pipeline/config.py, so parents[2] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TAXONOMY_PATH = _REPO_ROOT / "company" / "pipeline-stages.json"
+_STRATEGY_PATH = _REPO_ROOT / "STRATEGY.md"
+
+SHADOW = "shadow"
+
+# Injectable planner callable types (real ones default in ``ControlLoopScheduler``
+# so tests inject spies without touching the forge/LLM).
+SupervisorPlanner = Callable[..., SupervisorRankRun]
+SelfHealPlanner = Callable[[Forge, SelfHealInputs], SelfHealRun]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _load_taxonomy_or_empty() -> Mapping[str, Any]:
+    """Taxonomy for supervisor-rank; degrade to ``{}`` (documented gap) when the
+    file is absent so a missing config never crashes the scheduler."""
+    try:
+        return load_taxonomy(_TAXONOMY_PATH)
+    except (OSError, ValueError) as exc:
+        log.warning(
+            "control_loop: taxonomy unavailable (%s) — supervisor runs degraded "
+            "with an empty taxonomy",
+            exc,
+        )
+        return {}
+
+
+@dataclass(frozen=True)
+class ModuleTask:
+    """One scheduled control-loop slot: a name, its cadence, and the cycle
+    coroutine factory. ``interval_seconds`` is read off the config per module."""
+
+    name: str
+    interval_seconds: int
+    run_cycle: Callable[[], Any]  # async callable: one gather→plan→log cycle
+
+
+@dataclass
+class ControlLoopScheduler:
+    """Runs each enabled control-loop planner on its own cadence, shadow-only.
+
+    Every cycle is wrapped in try/except: one module raising is logged
+    (``log.exception``) and the task continues to its next interval — a single
+    crashing planner never kills the loop or its siblings (poller posture: loud
+    log, never silent swallow). Stop is interruptible mid-interval, mirroring
+    ``Poller.run_forever``'s ``asyncio.wait_for(stop.wait(), timeout=...)``.
+    """
+
+    config: Config
+    forge: Forge
+    store: object  # StateStore — never written in shadow; held for the live unit
+    log: logging.Logger = log
+    supervisor_planner: SupervisorPlanner = run_supervisor_rank
+    selfheal_planner: SelfHealPlanner = run_self_heal
+    _tasks: list[ModuleTask] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        if self.config.control_loop_mode != SHADOW:
+            self.log.warning(
+                "control_loop: CONTROL_LOOP_MODE=%r is not honored in this unit — "
+                "the live executor (forge writes + state persistence) is a "
+                "follow-up; FORCING shadow (zero writes).",
+                self.config.control_loop_mode,
+            )
+        self._tasks = [
+            ModuleTask("selfheal", self.config.selfheal_interval_seconds, self._cycle_selfheal),
+            ModuleTask("supervisor", self.config.supervisor_interval_seconds, self._cycle_supervisor),
+            ModuleTask("observation", self.config.observation_interval_seconds, self._cycle_observation),
+            ModuleTask(
+                "strategy_audit",
+                self.config.strategy_audit_interval_seconds,
+                self._cycle_strategy_audit,
+            ),
+        ]
+
+    @property
+    def tasks(self) -> tuple[ModuleTask, ...]:
+        return tuple(self._tasks)
+
+    async def run(self, stop: asyncio.Event | None = None) -> None:
+        """Start every module task and run until ``stop`` is set, then cancel
+        them cleanly. Shadow-only: no writes, no persistence."""
+        stop = stop or asyncio.Event()
+        self.log.info(
+            "control_loop: starting shadow scheduler tasks=%s "
+            "(selfheal=%ss supervisor=%ss observation=%ss strategy_audit=%ss)",
+            [t.name for t in self._tasks],
+            self.config.selfheal_interval_seconds,
+            self.config.supervisor_interval_seconds,
+            self.config.observation_interval_seconds,
+            self.config.strategy_audit_interval_seconds,
+        )
+        coros = [self._run_task(task, stop) for task in self._tasks]
+        runners = [asyncio.ensure_future(c) for c in coros]
+        try:
+            await asyncio.gather(*runners)
+        finally:
+            for runner in runners:
+                runner.cancel()
+            await asyncio.gather(*runners, return_exceptions=True)
+
+    async def _run_task(self, task: ModuleTask, stop: asyncio.Event) -> None:
+        """Periodic loop for one module: run a cycle, then wait the interval
+        (interruptible by ``stop``). A cycle exception is logged and the loop
+        continues — siblings and the scheduler are unaffected."""
+        while not stop.is_set():
+            try:
+                await task.run_cycle()
+            except Exception as exc:  # noqa: BLE001 — loud log, never swallow
+                self.log.exception(
+                    "control_loop: %s cycle failed: %s — continuing to next interval",
+                    task.name,
+                    exc,
+                )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=task.interval_seconds)
+            except (TimeoutError, asyncio.TimeoutError):
+                continue
+
+    # --- per-module cycles: gather → plan → log structured summary --------
+
+    async def _cycle_supervisor(self) -> None:
+        taxonomy = _load_taxonomy_or_empty()
+        run = self.supervisor_planner(
+            self.forge,
+            taxonomy=taxonomy,
+            repo=self.config.target_repo,
+            previous_state=None,  # gap: prior state not loaded in shadow
+            now=None,
+        )
+        top_actions = [str(a.get("action")) for a in run.result.top_actions if a.get("action")]
+        self.log.info(
+            "control_loop: module=supervisor mode=shadow material_changed=%s "
+            "rank_changed=%s planned_actions=%s top_actions=%s "
+            "(gap: previous_state not loaded; forge snapshot degraded)",
+            run.material_changed,
+            run.rank_changed,
+            len(run.result.top),
+            top_actions[:3],
+        )
+
+    async def _cycle_selfheal(self) -> None:
+        inputs = SelfHealInputs(now=_utc_now_iso())  # forge-derivable only; rest degraded
+        run = self.selfheal_planner(self.forge, inputs)
+        action_kinds = [a.kind for a in run.actions]
+        self.log.info(
+            "control_loop: module=selfheal mode=shadow circuit_breaker_tripped=%s "
+            "mutation_asserted=%s planned_actions=%s top_actions=%s "
+            "(gap: stale-sweep + funnel/idle snapshots empty)",
+            run.circuit_breaker_tripped,
+            run.mutation_asserted,
+            len(run.actions),
+            action_kinds[:3],
+        )
+
+    async def _cycle_observation(self) -> None:
+        # The LLM assessment dict is caller-side and not yet wired. Do NOT
+        # fabricate an assessment — log the gap and end the cycle (still a
+        # scheduled slot).
+        self.log.info(
+            "control_loop: module=observation mode=shadow "
+            "skipped: LLM assessment input not yet wired (protocol/gather gap) — "
+            "planned_actions=0"
+        )
+
+    async def _cycle_strategy_audit(self) -> None:
+        strategy_text = _read_text(_STRATEGY_PATH)
+        # Live metrics (GitHub / chimney / Polar reads) are caller-side and not yet
+        # gatherable. Without them the audit cannot run honestly — log the gap
+        # and end the cycle (still a scheduled slot).
+        self.log.info(
+            "control_loop: module=strategy_audit mode=shadow "
+            "skipped: live metrics gather not yet wired — strategy_text=%s "
+            "planned_actions=0",
+            "present" if strategy_text is not None else "absent",
+        )

--- a/pipeline/wgmesh_pipeline/control_loop.py
+++ b/pipeline/wgmesh_pipeline/control_loop.py
@@ -190,7 +190,7 @@ class ControlLoopScheduler:
         run = self.supervisor_planner(
             self.forge,
             taxonomy=taxonomy,
-            repo=self.config.target_repo,
+            repo=self.config.repo,  # short name ("wgmesh") — supervisor IDs are "repo#N" (parity)
             previous_state=None,  # gap: prior state not loaded in shadow
             now=None,
         )

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from wgmesh_pipeline.config import load_config
+from wgmesh_pipeline.control_loop import ControlLoopScheduler
 from wgmesh_pipeline.forge.factory import make_forge
 from wgmesh_pipeline.forge.gitfacts import make_resolution_lookup
 from wgmesh_pipeline.goose.runner import GooseRunner
@@ -61,7 +62,16 @@ async def async_main(*, reset_queue: bool = False) -> None:
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop.set)
-    await poller.run_forever(stop)
+
+    if config.control_loop_enabled:
+        scheduler = ControlLoopScheduler(config=config, forge=client, store=store)
+        logging.getLogger("wgmesh_pipeline").info(
+            "control loop enabled (mode=%s, shadow-only) — running concurrently with poller",
+            config.control_loop_mode,
+        )
+        await asyncio.gather(poller.run_forever(stop), scheduler.run(stop))
+    else:
+        await poller.run_forever(stop)
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary

The **execution half** of #1599 Phase B/C: `ControlLoopScheduler` wires the four parity-passive planner modules (supervisor #1682, selfheal #1692, strategy-audit #1690, observation #1693) into the box loop as per-module periodic asyncio tasks alongside the convergence tick — cadences matching the old crons (heal 30m / supervisor 4h / observation 8h / strategy 24h).

**Shadow-first, opt-in, zero blast radius.** `control_loop_enabled` defaults False (poller-only behavior unchanged when off). Each cycle: gather → plan → log structured summary; **never** writes to the forge, **never** persists state. `control_loop_mode=live` is force-downgraded to shadow with a loud WARNING — the live executor (forge writes behind the sanitise wall + Turso/JSON persistence) is the next unit.

- supervisor + selfheal gather live-degraded via the forge (no timestamps → dwell 0, single repo; documented gaps)
- observation + strategy_audit log honest skips ('LLM assessment not yet wired' / 'live metrics not yet wired') — scheduled slots, gather adapters follow
- per-cycle try/except (log.exception, continue): one module crashing never kills the loop or siblings; stop cancels all tasks cleanly

## Test plan
- [x] 12 scheduler tests: cadence firing, shadow-no-writes (spy forge raises on all 8 write methods), real-planners-over-spy-forge smoke (zero-write contract end-to-end not just with stubs), crash isolation, stop cancellation, live→shadow downgrade warning, config env parsing
- [x] Full suite **466 passed, 5 skipped**
- [x] gh-free gate green (caught + fixed 2 docstring `gh` mentions — wall works)
- Frozen fakes only (lesson #1691)