### PR TITLE
fix(tests): skip real-STRATEGY.md smoke test when absent (unblocks image build)

### DIFF
--- a/pipeline/tests/test_strategy_audit.py
+++ b/pipeline/tests/test_strategy_audit.py
@@ -338,6 +338,11 @@ def test_metrics_input_validation() -> None:
 
 
 def test_parse_milestones_reads_real_strategy_md() -> None:
+    # Real-file smoke test. STRATEGY.md is repo-root and NOT copied into the
+    # deploy image (image carries pipeline/ + company/ only); the box reads it
+    # gracefully-or-skips at runtime, so absence is not a failure here.
+    if not STRATEGY_FILE.exists():
+        pytest.skip("STRATEGY.md not present (e.g. inside the deploy image)")
     parsed = parse_milestones(STRATEGY_FILE.read_text(encoding="utf-8"))
     assert len(parsed) >= 1
     for date_part, target in parsed:


### PR DESCRIPTION
build-pipeline-image red since #1704: the in-image pytest hits `FileNotFoundError: /app/STRATEGY.md` — STRATEGY.md is repo-root, not in the image (pipeline/ + company/ only). Runtime handles its absence (scheduler skips strategy_audit when STRATEGY.md missing), so this real-file smoke test now skips-if-absent instead of failing. Same image-surface class as the company/ copy fix #1687. Action-success KPI: clears the standing Build Pipeline Image red.