### PR TITLE
fix(selfheal): merged spec PR is not issue resolution (false-completion)

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -559,9 +559,13 @@ jobs:
             reason=""
 
             # Signal 1: Check for linked merged PRs
+            # FALSE-COMPLETION GUARD (2026-06-13): only a merged impl/fix PR resolves
+            # an issue. A merged spec: PR is NOT resolution — counting it closed #539
+            # and #573 on merged specs #576/#574 (issues reopened). Filter the
+            # cross-referenced PR title to ^(impl|fix): before counting.
             merged_prs=$(gh api "repos/$TARGET_REPO/issues/${number}/timeline" \
-              --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request.merged_at != null)] | length' \
-              2>/dev/null || echo "0")
+              --jq "[.[] | select(.event == \"cross-referenced\" and .source.issue.pull_request.merged_at != null and (.source.issue.title | test(\"^(impl|fix):\"; \"i\")))] | length" \
+                2>/dev/null || echo "0")
             if [ "$merged_prs" -gt 0 ] 2>/dev/null; then
               resolved="true"
               reason="Linked PR merged ($merged_prs merged PR(s) found)"

--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -563,9 +563,13 @@ jobs:
             # an issue. A merged spec: PR is NOT resolution — counting it closed #539
             # and #573 on merged specs #576/#574 (issues reopened). Filter the
             # cross-referenced PR title to ^(impl|fix): before counting.
-            merged_prs=$(gh api "repos/$TARGET_REPO/issues/${number}/timeline" \
-              --jq "[.[] | select(.event == \"cross-referenced\" and .source.issue.pull_request.merged_at != null and (.source.issue.title | test(\"^(impl|fix):\"; \"i\")))] | length" \
-                2>/dev/null || echo "0")
+            # --paginate: older issues have >30 timeline events; the merged
+            # impl/fix cross-ref can be on a later page. Emit matching PR
+            # numbers across all pages and count with wc -l (`--jq ...| length`
+            # would emit one length per page, not a total).
+            merged_prs=$(gh api --paginate "repos/$TARGET_REPO/issues/${number}/timeline" \
+              --jq ".[] | select(.event == \"cross-referenced\" and .source.issue.pull_request.merged_at != null and (.source.issue.title | test(\"^(impl|fix):\"; \"i\"))) | .source.issue.number" \
+              2>/dev/null | wc -l | tr -d " " || echo "0")
             if [ "$merged_prs" -gt 0 ] 2>/dev/null; then
               resolved="true"
               reason="Linked PR merged ($merged_prs merged PR(s) found)"

--- a/pipeline/wgmesh_pipeline/selfheal/models.py
+++ b/pipeline/wgmesh_pipeline/selfheal/models.py
@@ -72,6 +72,11 @@ class SelfHealInputs:
     merged_resolution_issues: frozenset[int] = frozenset()
     open_spec_pr_issues: frozenset[int] = frozenset()
     open_impl_pr_issues: frozenset[int] = frozenset()
+    # Count of merged IMPL/FIX resolution PRs linked to each issue. FALSE-
+    # COMPLETION GUARD: the gather MUST filter cross-referenced PR titles to
+    # ^(impl|fix): — a merged spec:/heal:/loop: PR is NOT resolution. Counting
+    # spec merges falsely closed #539/#573 (legacy pipeline-health bug fixed
+    # 2026-06-13); this contract keeps the on-box gather correct by design.
     linked_merged_pr_counts: Mapping[int, int] = field(default_factory=dict)
     loop_state: Mapping[str, Any] = field(default_factory=dict)
     costs: Mapping[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Self-heal was closing issues COMPLETED on merged **spec** PRs. #539 (Android VPN fd) and #573 (triage reopen gap) both auto-closed 2026-06-11 — *'Resolved by self-healing: Linked PR merged'* — when their merged PR was a **spec** (#576/#574), not an impl. #539's real implementation (#718, +1322 lines) was never on main. Found while hand-draining the wgmesh pile: 5 of 6 stuck PRs were for issues this bug had falsely completed.

## Root cause

The timeline query counted **any** cross-referenced merged PR:
```
select(.event==cross-referenced and .source.issue.pull_request.merged_at != null)
```
A merged spec satisfies that. Only a merged **impl/fix** is resolution.

## Fix

- **`pipeline-health.yml`** (the live closer): timeline jq now filters `.source.issue.title | test("^(impl|fix):"; "i")` before counting. Verified locally: spec-merged → 0 (not resolved), impl-merged → 1 (resolved).
- **`selfheal/models.py`** (the box port #1692 preserved the bug via byte-parity): `linked_merged_pr_counts` documented as impl/fix-only so the on-box gather inherits the guard when wired (box is shadow / not gathering yet, so it can't mis-close today).

Same exact-title discipline as the reconcile resolved-guard (#1656). #539/#573 reopened; #718 parked as genuine WIP.

## Test plan
- [x] jq filter logic verified both directions
- [x] box selfheal suite 40 passed
- [ ] next pipeline-health run: a needs-human issue with only a merged spec is NOT closed