### PR TITLE
feat(model): adopt GLM-5.2 (verified serving) — unify template model

### DIFF
--- a/pipeline/recipes/wgmesh-implementation.yaml
+++ b/pipeline/recipes/wgmesh-implementation.yaml
@@ -51,8 +51,8 @@ extensions:
 
 # Pin provider/model like wgmesh-triage-spec.yaml: goose honors recipe settings
 # even when env GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session
-# runs. z.ai is Anthropic-compatible via ANTHROPIC_HOST; glm-4.6 is the current
+# runs. z.ai is Anthropic-compatible via ANTHROPIC_HOST. GLM-5.1 is the current flagship
 # valid model id.
 settings:
   goose_provider: anthropic
-  goose_model: glm-4.6
+  goose_model: GLM-5.1

--- a/pipeline/recipes/wgmesh-implementation.yaml
+++ b/pipeline/recipes/wgmesh-implementation.yaml
@@ -51,8 +51,8 @@ extensions:
 
 # Pin provider/model like wgmesh-triage-spec.yaml: goose honors recipe settings
 # even when env GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session
-# runs. z.ai is Anthropic-compatible via ANTHROPIC_HOST. GLM-5.1 is the current flagship
+# runs. z.ai is Anthropic-compatible via ANTHROPIC_HOST. GLM-5.2 is the current flagship (verified serving 2026-06-14)
 # valid model id.
 settings:
   goose_provider: anthropic
-  goose_model: GLM-5.1
+  goose_model: GLM-5.2

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -52,8 +52,10 @@ extensions:
 
 # Pin provider/model in the recipe (goose honors recipe settings even when env
 # GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session runs). z.ai is
-# Anthropic-compatible via ANTHROPIC_HOST; glm-4.6 is the current valid model id
-# (GLM-4.7 did not exist — goose loaded the recipe then no-opped).
+# Anthropic-compatible via ANTHROPIC_HOST. GLM-5.1 is the current flagship
+# (per z.ai docs 2026-06-14; marketing announced "GLM-5.2" but it is NOT in
+# the API model list — using an unlisted id silently no-ops, as GLM-4.7 once
+# did). Matches the seed recipes, already on GLM-5.1.
 settings:
   goose_provider: anthropic
-  goose_model: glm-4.6
+  goose_model: GLM-5.1

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -52,10 +52,10 @@ extensions:
 
 # Pin provider/model in the recipe (goose honors recipe settings even when env
 # GOOSE_PROVIDER/GOOSE_MODEL don't take in headless --no-session runs). z.ai is
-# Anthropic-compatible via ANTHROPIC_HOST. GLM-5.1 is the current flagship
+# Anthropic-compatible via ANTHROPIC_HOST. GLM-5.2 is the current flagship (verified serving 2026-06-14)
 # (per z.ai docs 2026-06-14; marketing announced "GLM-5.2" but it is NOT in
 # the API model list — using an unlisted id silently no-ops, as GLM-4.7 once
 # did). Matches the seed recipes, already on GLM-5.1.
 settings:
   goose_provider: anthropic
-  goose_model: GLM-5.1
+  goose_model: GLM-5.2

--- a/pipeline/tests/test_recipes_exist.py
+++ b/pipeline/tests/test_recipes_exist.py
@@ -36,12 +36,14 @@ def test_implementation_recipe_declares_node_params() -> None:
 
 
 def test_implementation_recipe_pins_known_good_model() -> None:
-    import yaml
-    recipe = yaml.safe_load((RECIPES_DIR / "wgmesh-implementation.yaml").read_text())
-    settings = recipe.get("settings", {})
-    assert settings.get("goose_provider") == "anthropic"
-    # The ACTUAL pinned model (not file text / comments) must EXIST on z.ai —
-    # an unlisted id silently no-ops (GLM-4.7 once did). Current listed flagships
-    # per z.ai docs 2026-06-14.
-    KNOWN_GOOD = {"GLM-5.1", "GLM-5", "glm-4.6"}
-    assert settings.get("goose_model") in KNOWN_GOOD
+    # Parse the ACTUAL setting lines (skip comments) — no yaml dep (CI is bare).
+    lines = [
+        l.strip() for l in (RECIPES_DIR / "wgmesh-implementation.yaml").read_text().splitlines()
+        if l.strip() and not l.lstrip().startswith("#")
+    ]
+    provider = next((l.split(":", 1)[1].strip().strip(chr(34)) for l in lines if l.startswith("goose_provider:")), None)
+    model = next((l.split(":", 1)[1].strip().strip(chr(34)) for l in lines if l.startswith("goose_model:")), None)
+    assert provider == "anthropic"
+    # Pinned model must be one z.ai actually serves — an unserved id silently
+    # routes/no-ops. Verified 2026-06-14: requesting GLM-5.x serves glm-5.2.
+    assert model in {"GLM-5.2", "GLM-5.1", "GLM-5", "glm-4.6"}

--- a/pipeline/tests/test_recipes_exist.py
+++ b/pipeline/tests/test_recipes_exist.py
@@ -36,9 +36,12 @@ def test_implementation_recipe_declares_node_params() -> None:
 
 
 def test_implementation_recipe_pins_known_good_model() -> None:
-    text = (RECIPES_DIR / "wgmesh-implementation.yaml").read_text()
-    assert "goose_provider: anthropic" in text
-    # Must pin a model that EXISTS on z.ai (an unlisted id silently no-ops —
-    # GLM-4.7 once did). Known-good set per z.ai docs 2026-06-14.
-    KNOWN_GOOD = ("GLM-5.1", "GLM-5", "glm-4.6", "GLM-4.7")
-    assert any(f"goose_model: {m}" in text for m in KNOWN_GOOD)
+    import yaml
+    recipe = yaml.safe_load((RECIPES_DIR / "wgmesh-implementation.yaml").read_text())
+    settings = recipe.get("settings", {})
+    assert settings.get("goose_provider") == "anthropic"
+    # The ACTUAL pinned model (not file text / comments) must EXIST on z.ai —
+    # an unlisted id silently no-ops (GLM-4.7 once did). Current listed flagships
+    # per z.ai docs 2026-06-14.
+    KNOWN_GOOD = {"GLM-5.1", "GLM-5", "glm-4.6"}
+    assert settings.get("goose_model") in KNOWN_GOOD

--- a/pipeline/tests/test_recipes_exist.py
+++ b/pipeline/tests/test_recipes_exist.py
@@ -38,4 +38,7 @@ def test_implementation_recipe_declares_node_params() -> None:
 def test_implementation_recipe_pins_known_good_model() -> None:
     text = (RECIPES_DIR / "wgmesh-implementation.yaml").read_text()
     assert "goose_provider: anthropic" in text
-    assert "goose_model: glm-4.6" in text
+    # Must pin a model that EXISTS on z.ai (an unlisted id silently no-ops —
+    # GLM-4.7 once did). Known-good set per z.ai docs 2026-06-14.
+    KNOWN_GOOD = ("GLM-5.1", "GLM-5", "glm-4.6", "GLM-4.7")
+    assert any(f"goose_model: {m}" in text for m in KNOWN_GOOD)

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -66,7 +66,7 @@ DEFAULT_MAX_FILES = 20
 DEFAULT_REPO_PATH = "/opt/wgmesh-checkout"
 DEFAULT_RECIPES_DIR = str(Path(__file__).resolve().parents[1] / "recipes")
 DEFAULT_GOOSE_PROVIDER = "anthropic"
-DEFAULT_GOOSE_MODEL = "GLM-4.7"
+DEFAULT_GOOSE_MODEL = "GLM-5.1"
 DEFAULT_MAX_ESCALATION_ATTEMPTS = 2
 
 # Control-loop scheduler (cutover Phase B/C, shadow-first). Per-module cadences

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -66,7 +66,7 @@ DEFAULT_MAX_FILES = 20
 DEFAULT_REPO_PATH = "/opt/wgmesh-checkout"
 DEFAULT_RECIPES_DIR = str(Path(__file__).resolve().parents[1] / "recipes")
 DEFAULT_GOOSE_PROVIDER = "anthropic"
-DEFAULT_GOOSE_MODEL = "GLM-5.1"
+DEFAULT_GOOSE_MODEL = "GLM-5.2"
 DEFAULT_MAX_ESCALATION_ATTEMPTS = 2
 
 # Control-loop scheduler (cutover Phase B/C, shadow-first). Per-module cadences


### PR DESCRIPTION
## Summary

Operator: take GLM-5.2. **Live-verified** against z.ai's anthropic endpoint (2026-06-14): requesting GLM-5.2 returns 200 and serves model `glm-5.2` — it IS live (the marketing email was right; the API docs *page* lagged, listing only up to GLM-5.1). Requesting GLM-5.1 also serves `glm-5.2` (z.ai routes the 5.x family forward).

Important gotcha learned: z.ai's endpoint does **not** 404 on unknown model ids — it 200s and routes — so HTTP code can't validate an id; the response `model` field is the real signal. (This is the actual mechanism behind the old GLM-4.7 'no-op'.)

- config.DEFAULT_GOOSE_MODEL + template recipes: → **GLM-5.2** (verified serving; matches operator intent)
- recipe-pin test: parses the actual `goose_model` line **without PyYAML** (CI is a bare interpreter; `import yaml` broke pipeline-tests), skips comments, asserts membership in the served-model set

## Operator-only (separate)
ZAI_API_KEY refresh (secret in both repos + box env) — verified working with the provided key.

## Test plan
- [x] recipe-pin (no-yaml) + config + routing green
- [x] live z.ai verification: GLM-5.2 → 200, serves glm-5.2