### PR TITLE
feat(control-loop): U4 gather adapters — observation + strategy_audit (shadow-safe)

### DIFF
--- a/pipeline/tests/test_control_loop.py
+++ b/pipeline/tests/test_control_loop.py
@@ -24,21 +24,34 @@ from wgmesh_pipeline import control_loop as cl
 from wgmesh_pipeline.config import Config, load_config
 from wgmesh_pipeline.control_loop import (
     SELFHEAL_STATE_KEY,
+    STRATEGY_AUDIT_STATE_KEY,
     SUPERVISOR_STATE_KEY,
     ControlLoopScheduler,
+)
+from wgmesh_pipeline.observation import (
+    ObservationAction,
+    ObservationInputs,
+    ObservationPlan,
 )
 from wgmesh_pipeline.selfheal import SelfHealInputs, SelfHealRun
 from wgmesh_pipeline.selfheal.models import HealAction
 from wgmesh_pipeline.state.store import StateStore
 from wgmesh_pipeline.supervisor import RankResult, SupervisorRankRun
 
-
 # --- frozen fakes -----------------------------------------------------------
 
-_WRITE_METHODS = frozenset({
-    "add_label", "remove_label", "comment", "create_pr", "update_pr_body",
-    "merge_pr", "push_branch", "approve_pr",
-})
+_WRITE_METHODS = frozenset(
+    {
+        "add_label",
+        "remove_label",
+        "comment",
+        "create_pr",
+        "update_pr_body",
+        "merge_pr",
+        "push_branch",
+        "approve_pr",
+    }
+)
 
 
 class SpyForge:
@@ -57,6 +70,7 @@ class SpyForge:
             if name == "list_open_issues":
                 return []
             return None
+
         return method
 
 
@@ -70,17 +84,26 @@ class SpyStore:
         def method(*args, **kwargs):
             self.calls.append(name)
             return None
+
         return method
 
 
 def _empty_rank_run() -> SupervisorRankRun:
-    result = RankResult(generated_at="2026-06-13T00:00:00Z", top=(), stage_summary={}, unknown=())
-    return SupervisorRankRun(result=result, state={}, material_changed=False, rank_changed=False)
+    result = RankResult(
+        generated_at="2026-06-13T00:00:00Z", top=(), stage_summary={}, unknown=()
+    )
+    return SupervisorRankRun(
+        result=result, state={}, material_changed=False, rank_changed=False
+    )
 
 
 def _empty_selfheal_run() -> SelfHealRun:
     return SelfHealRun(
-        state={}, actions=(), audit=(), circuit_breaker_tripped=False, mutation_asserted=True,
+        state={},
+        actions=(),
+        audit=(),
+        circuit_breaker_tripped=False,
+        mutation_asserted=True,
     )
 
 
@@ -116,28 +139,37 @@ def _config(**overrides) -> Config:
     return Config(**base)
 
 
-async def _run_briefly(scheduler: ControlLoopScheduler, *, seconds: float = 0.05) -> None:
+async def _run_briefly(
+    scheduler: ControlLoopScheduler, *, seconds: float = 0.05
+) -> None:
     stop = asyncio.Event()
 
     async def stopper() -> None:
         await asyncio.sleep(seconds)
         stop.set()
 
-    await asyncio.wait_for(
-        asyncio.gather(scheduler.run(stop), stopper()), timeout=5.0
-    )
+    await asyncio.wait_for(asyncio.gather(scheduler.run(stop), stopper()), timeout=5.0)
 
 
 # --- tests ------------------------------------------------------------------
+
 
 def test_each_enabled_planner_fires_at_least_once() -> None:
     sup = Spy(_empty_rank_run())
     heal = Spy(_empty_selfheal_run())
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01,
-                       observation_interval_seconds=0.01, strategy_audit_interval_seconds=0.01),
-        forge=SpyForge(), store=SpyStore(),
-        supervisor_planner=sup, selfheal_planner=heal,
+        config=_config(
+            selfheal_interval_seconds=0.01,
+            supervisor_interval_seconds=0.01,
+            observation_interval_seconds=0.01,
+            strategy_audit_interval_seconds=0.01,
+        ),
+        forge=SpyForge(),
+        store=SpyStore(),
+        supervisor_planner=sup,
+        selfheal_planner=heal,
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     assert sup.calls >= 1, "supervisor planner never fired"
@@ -151,26 +183,38 @@ def test_shadow_performs_no_forge_writes_and_no_state_save_when_immaterial() -> 
     forge = SpyForge()
     store = SpyStore()
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01),
-        forge=forge, store=store,
-        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+        config=_config(
+            selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01
+        ),
+        forge=forge,
+        store=store,
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     assert forge.write_calls == [], f"shadow wrote to forge: {forge.write_calls}"
-    assert "save_control_state" not in store.calls, (
-        f"immaterial cycle persisted state: {store.calls}"
-    )
+    assert (
+        "save_control_state" not in store.calls
+    ), f"immaterial cycle persisted state: {store.calls}"
     # Reading prior state is expected (closes the previous_state gap).
     assert set(store.calls) <= {"load_control_state"}
 
 
 def test_one_planner_raising_does_not_stop_siblings_or_scheduler() -> None:
-    boom = Spy(_empty_rank_run(), raises=True)   # supervisor crashes every cycle
-    heal = Spy(_empty_selfheal_run())            # sibling must keep firing
+    boom = Spy(_empty_rank_run(), raises=True)  # supervisor crashes every cycle
+    heal = Spy(_empty_selfheal_run())  # sibling must keep firing
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01),
-        forge=SpyForge(), store=SpyStore(),
-        supervisor_planner=boom, selfheal_planner=heal,
+        config=_config(
+            selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01
+        ),
+        forge=SpyForge(),
+        store=SpyStore(),
+        supervisor_planner=boom,
+        selfheal_planner=heal,
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched, seconds=0.08))
     assert boom.calls >= 2, "crashing planner stopped retrying — task died"
@@ -179,10 +223,18 @@ def test_one_planner_raising_does_not_stop_siblings_or_scheduler() -> None:
 
 def test_stop_event_cancels_all_tasks_promptly() -> None:
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=100, supervisor_interval_seconds=100,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=SpyForge(), store=SpyStore(),
-        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+        config=_config(
+            selfheal_interval_seconds=100,
+            supervisor_interval_seconds=100,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=SpyForge(),
+        store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     # Long intervals: run() must still return promptly once stop is set, proving
     # the wait is interruptible (not blocked on the 100s timeout).
@@ -190,26 +242,136 @@ def test_stop_event_cancels_all_tasks_promptly() -> None:
 
 
 def test_observation_and_strategy_audit_slots_log_skip_reason(caplog) -> None:
+    class TolerantForge(SpyForge):
+        def __getattr__(self, name):
+            def method(*args, **kwargs):
+                self.calls.append(name)
+                if name == "list_open_issues":
+                    return []
+                if name == "create_issue":
+                    self.write_calls.append(name)
+                    return {"dry_run": True}
+                return None
+
+            return method
+
+    def assessor(inputs: ObservationInputs):
+        return {"issues_to_create": [{"title": "Control-loop smoke", "body": "b"}]}
+
+    def planner(assessment, inputs):
+        return ObservationPlan(
+            actions=(
+                ObservationAction(
+                    kind="create_issue", title="Control-loop smoke", body="b"
+                ),
+            ),
+            skips=(),
+        )
+
     sched = ControlLoopScheduler(
-        config=_config(observation_interval_seconds=0.01, strategy_audit_interval_seconds=0.01),
-        forge=SpyForge(), store=SpyStore(),
-        supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+        config=_config(
+            observation_interval_seconds=0.01, strategy_audit_interval_seconds=100
+        ),
+        forge=TolerantForge(),
+        store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=assessor,
+        observation_planner=planner,
     )
     with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.control_loop"):
         asyncio.run(_run_briefly(sched))
     text = caplog.text
-    assert "module=observation" in text and "LLM assessment input not yet wired" in text
-    assert "module=strategy_audit" in text and "live metrics gather not yet wired" in text
+    assert "module=observation" in text
+    assert "planned_actions=1" in text
+    assert "executed=1" in text
+
+
+def test_strategy_audit_cycle_persists_material_change_and_executes_drift_action(
+    tmp_path, caplog
+) -> None:
+    class DriftForge(SpyForge):
+        def __getattr__(self, name):
+            def method(*args, **kwargs):
+                self.calls.append(name)
+                if name == "list_open_issues":
+                    return []
+                if name == "create_issue":
+                    self.write_calls.append(name)
+                    return {"dry_run": True}
+                return None
+
+            return method
+
+    db = StateStore(tmp_path / "state.db")
+    db.save_control_state(
+        STRATEGY_AUDIT_STATE_KEY,
+        {
+            "audits": [
+                {
+                    "ran_at": "2026-06-14T00:00:00Z",
+                    "metrics": {
+                        "paid_customers": 10,
+                        "autonomous_ship_rate": 1.0,
+                        "lead_time_hours": 1,
+                        "self_heal_rate": 1.0,
+                        "active_stuck_issues": 0,
+                        "cycle_time_to_revenue": None,
+                        "fetch_status": {
+                            "paid_customers": "ok",
+                            "cycle_time_to_revenue": "no_customers",
+                        },
+                    },
+                    "milestones_status": [],
+                }
+            ],
+            "last_reported_drift_fingerprint": "old",
+        },
+        fingerprint="old",
+    )
+    sched = ControlLoopScheduler(
+        config=_config(
+            strategy_audit_interval_seconds=0.01, observation_interval_seconds=100
+        ),
+        forge=DriftForge(),
+        store=db,
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        strategy_text_reader=lambda: "last_updated: 2026-06-15\n\n## Milestones\n",
+        strategy_http_get=lambda url, timeout: type(
+            "R",
+            (),
+            {
+                "text": "Paid subscriber\n1",
+                "raise_for_status": lambda self: None,
+            },
+        )(),
+        now_provider=lambda: "2026-06-15T00:00:00Z",
+    )
+    with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.control_loop"):
+        asyncio.run(_run_briefly(sched))
+    saved = db.load_control_state(STRATEGY_AUDIT_STATE_KEY)
+    assert saved is not None
+    assert saved["last_reported_drift_fingerprint"] != "old"
+    assert "module=strategy_audit" in caplog.text
+    assert "decision=open_pr" in caplog.text
 
 
 def test_live_mode_forced_to_shadow_with_warning_no_writes(caplog) -> None:
     forge = SpyForge()
     with caplog.at_level(logging.WARNING, logger="wgmesh_pipeline.control_loop"):
         sched = ControlLoopScheduler(
-            config=_config(control_loop_mode="live", selfheal_interval_seconds=0.01,
-                           supervisor_interval_seconds=0.01),
-            forge=forge, store=SpyStore(),
-            supervisor_planner=Spy(_empty_rank_run()), selfheal_planner=Spy(_empty_selfheal_run()),
+            config=_config(
+                control_loop_mode="live",
+                selfheal_interval_seconds=0.01,
+                supervisor_interval_seconds=0.01,
+            ),
+            forge=forge,
+            store=SpyStore(),
+            supervisor_planner=Spy(_empty_rank_run()),
+            selfheal_planner=Spy(_empty_selfheal_run()),
+            observation_assessor=lambda inputs: {},
+            strategy_text_reader=lambda: None,
         )
         asyncio.run(_run_briefly(sched))
     assert "FORCING shadow" in caplog.text
@@ -231,9 +393,16 @@ def test_real_planners_run_against_forge_without_writing() -> None:
     # zero-write contract end-to-end, not just with spies).
     forge = SpyForge()
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=0.01,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=forge, store=SpyStore(),
+        config=_config(
+            selfheal_interval_seconds=0.01,
+            supervisor_interval_seconds=0.01,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=forge,
+        store=SpyStore(),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     assert forge.write_calls == []
@@ -241,6 +410,7 @@ def test_real_planners_run_against_forge_without_writing() -> None:
 
 
 # --- config env parsing -----------------------------------------------------
+
 
 def _base_env(**extra) -> dict[str, str]:
     env = {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "DATABASE_MODE": "local"}
@@ -259,14 +429,16 @@ def test_config_defaults_control_loop_disabled_shadow() -> None:
 
 
 def test_config_parses_control_loop_env() -> None:
-    cfg = load_config(_base_env(
-        CONTROL_LOOP_ENABLED="true",
-        CONTROL_LOOP_MODE="live",
-        SELFHEAL_INTERVAL_SECONDS="60",
-        SUPERVISOR_INTERVAL_SECONDS="120",
-        OBSERVATION_INTERVAL_SECONDS="180",
-        STRATEGY_AUDIT_INTERVAL_SECONDS="240",
-    ))
+    cfg = load_config(
+        _base_env(
+            CONTROL_LOOP_ENABLED="true",
+            CONTROL_LOOP_MODE="live",
+            SELFHEAL_INTERVAL_SECONDS="60",
+            SUPERVISOR_INTERVAL_SECONDS="120",
+            OBSERVATION_INTERVAL_SECONDS="180",
+            STRATEGY_AUDIT_INTERVAL_SECONDS="240",
+        )
+    )
     assert cfg.control_loop_enabled is True
     assert cfg.control_loop_mode == "live"  # honored in config; scheduler forces shadow
     assert cfg.selfheal_interval_seconds == 60
@@ -282,18 +454,28 @@ def test_config_rejects_bad_control_loop_mode() -> None:
 
 def test_config_truthy_variants() -> None:
     for raw in ("1", "true", "YES", "On"):
-        assert load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled is True
+        assert (
+            load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled
+            is True
+        )
     for raw in ("0", "false", "", "no"):
-        assert load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled is False
+        assert (
+            load_config(_base_env(CONTROL_LOOP_ENABLED=raw)).control_loop_enabled
+            is False
+        )
 
 
 # --- U3: state persistence (material-change-gated, round-trip) ---------------
 
 
 def _material_rank_run(fingerprint: str = "fp-1") -> SupervisorRankRun:
-    result = RankResult(generated_at="2026-06-13T00:00:00Z", top=(), stage_summary={}, unknown=())
+    result = RankResult(
+        generated_at="2026-06-13T00:00:00Z", top=(), stage_summary={}, unknown=()
+    )
     state = {"material_fingerprint": fingerprint, "top3": ["wgmesh#727"]}
-    return SupervisorRankRun(result=result, state=state, material_changed=True, rank_changed=True)
+    return SupervisorRankRun(
+        result=result, state=state, material_changed=True, rank_changed=True
+    )
 
 
 class CapturingSupervisorSpy:
@@ -312,10 +494,18 @@ def test_supervisor_material_change_persists_and_round_trips(tmp_path) -> None:
     db = StateStore(tmp_path / "state.db")
     sup = CapturingSupervisorSpy(_material_rank_run())
     sched = ControlLoopScheduler(
-        config=_config(supervisor_interval_seconds=0.01, selfheal_interval_seconds=100,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=SpyForge(), store=db,
-        supervisor_planner=sup, selfheal_planner=Spy(_empty_selfheal_run()),
+        config=_config(
+            supervisor_interval_seconds=0.01,
+            selfheal_interval_seconds=100,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=SpyForge(),
+        store=db,
+        supervisor_planner=sup,
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched, seconds=0.08))
 
@@ -325,34 +515,50 @@ def test_supervisor_material_change_persists_and_round_trips(tmp_path) -> None:
     # First cycle saw no prior state; a later cycle loaded the persisted copy
     # (closes the previous_state-not-loaded gap).
     assert sup.previous_states[0] is None
-    assert any(ps is not None for ps in sup.previous_states[1:]), \
-        "later cycle did not load persisted previous_state"
+    assert any(
+        ps is not None for ps in sup.previous_states[1:]
+    ), "later cycle did not load persisted previous_state"
 
 
 def test_supervisor_immaterial_run_does_not_persist(tmp_path) -> None:
     db = StateStore(tmp_path / "state.db")
     sched = ControlLoopScheduler(
-        config=_config(supervisor_interval_seconds=0.01, selfheal_interval_seconds=100,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=SpyForge(), store=db,
+        config=_config(
+            supervisor_interval_seconds=0.01,
+            selfheal_interval_seconds=100,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=SpyForge(),
+        store=db,
         supervisor_planner=Spy(_empty_rank_run()),  # material_changed=False
         selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     assert db.load_control_state(SUPERVISOR_STATE_KEY) is None
 
 
 def _selfheal_run_with_action() -> SelfHealRun:
-    action = HealAction(kind="retrigger_triage", number=5,
-                        remove_label="needs-triage", add_label="needs-triage")
+    action = HealAction(
+        kind="retrigger_triage",
+        number=5,
+        remove_label="needs-triage",
+        add_label="needs-triage",
+    )
     return SelfHealRun(
         state={"issues_healed_total": 1, "last_check": "2026-06-13T00:00:00Z"},
-        actions=(action,), audit=(), circuit_breaker_tripped=False, mutation_asserted=True,
+        actions=(action,),
+        audit=(),
+        circuit_breaker_tripped=False,
+        mutation_asserted=True,
     )
 
 
 def test_selfheal_material_activity_persists(tmp_path) -> None:
     db = StateStore(tmp_path / "state.db")
+
     # SpyForge isn't used for writes here: retrigger calls remove_label/add_label
     # which the SpyForge RAISES on — so use a tolerant recording forge instead.
     class TolerantForge(SpyForge):
@@ -362,14 +568,22 @@ def test_selfheal_material_activity_persists(tmp_path) -> None:
                 if name == "list_open_issues":
                     return []
                 return None
+
             return method
 
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=100,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=TolerantForge(), store=db,
+        config=_config(
+            selfheal_interval_seconds=0.01,
+            supervisor_interval_seconds=100,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=TolerantForge(),
+        store=db,
         supervisor_planner=Spy(_empty_rank_run()),
         selfheal_planner=Spy(_selfheal_run_with_action()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     saved = db.load_control_state(SELFHEAL_STATE_KEY)
@@ -379,11 +593,18 @@ def test_selfheal_material_activity_persists(tmp_path) -> None:
 def test_selfheal_idle_cycle_does_not_persist(tmp_path) -> None:
     db = StateStore(tmp_path / "state.db")
     sched = ControlLoopScheduler(
-        config=_config(selfheal_interval_seconds=0.01, supervisor_interval_seconds=100,
-                       observation_interval_seconds=100, strategy_audit_interval_seconds=100),
-        forge=SpyForge(), store=db,
+        config=_config(
+            selfheal_interval_seconds=0.01,
+            supervisor_interval_seconds=100,
+            observation_interval_seconds=100,
+            strategy_audit_interval_seconds=100,
+        ),
+        forge=SpyForge(),
+        store=db,
         supervisor_planner=Spy(_empty_rank_run()),
         selfheal_planner=Spy(_empty_selfheal_run()),  # no actions, no breaker
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
     )
     asyncio.run(_run_briefly(sched))
     assert db.load_control_state(SELFHEAL_STATE_KEY) is None

--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import pytest
+
+from wgmesh_pipeline.observation import (
+    ObservationAction,
+    ObservationInputs,
+    ObservationPlan,
+)
+from wgmesh_pipeline.observation_gather import (
+    build_observation_inputs,
+    run_observation_cycle,
+)
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    labels: tuple[str, ...]
+    state: str = "open"
+    pull_request: dict[str, Any] | None = None
+
+
+class ShadowForge:
+    def __init__(self) -> None:
+        self.write_calls: list[tuple[str, Any]] = []
+
+    def list_open_issues(self) -> list[Issue]:
+        return [
+            Issue(1, "Ship CLI onboarding", ("fn:dev", "needs-triage")),
+            Issue(2, "Blocked deploy", ("needs-human",)),
+        ]
+
+    def create_issue(self, **kwargs: Any) -> dict[str, Any]:
+        self.write_calls.append(("create_issue", kwargs))
+        return {"dry_run": True, "operation": "create_issue"}
+
+
+class RaisingWriteForge(ShadowForge):
+    def create_issue(self, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("real forge write reached")
+
+
+class Store:
+    pass
+
+
+def test_build_observation_inputs_from_open_issue_snapshot() -> None:
+    inputs = build_observation_inputs(ShadowForge())
+
+    assert inputs == ObservationInputs(
+        open_issue_titles=("Ship CLI onboarding", "Blocked deploy"),
+        closed_issue_titles=(),
+        issue_labels={1: ("fn:dev", "needs-triage"), 2: ("needs-human",)},
+    )
+
+
+def test_valid_llm_assessment_plans_and_executes_shadow_dry_run(caplog) -> None:
+    forge = ShadowForge()
+    planned_inputs: list[ObservationInputs] = []
+
+    def assessor(inputs: ObservationInputs) -> Mapping[str, Any]:
+        assert inputs.open_issue_titles == ("Ship CLI onboarding", "Blocked deploy")
+        return {
+            "issues_to_create": [{"title": "Add smoke test", "body": "b", "labels": []}]
+        }
+
+    def planner(
+        assessment: Mapping[str, Any], inputs: ObservationInputs
+    ) -> ObservationPlan:
+        planned_inputs.append(inputs)
+        assert assessment["issues_to_create"][0]["title"] == "Add smoke test"
+        return ObservationPlan(
+            actions=(
+                ObservationAction(
+                    kind="create_issue", title="Add smoke test", body="b"
+                ),
+            ),
+            skips=(),
+        )
+
+    with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.observation_gather"):
+        result = run_observation_cycle(
+            forge, Store(), assessor=assessor, planner=planner
+        )
+
+    assert planned_inputs
+    assert result.skipped is False
+    assert result.assessment["issues_to_create"][0]["title"] == "Add smoke test"
+    assert [r.status for r in result.execution_results] == ["executed"]
+    assert forge.write_calls == [
+        ("create_issue", {"title": "Add smoke test", "body": "b", "labels": ()})
+    ]
+    assert "module=observation" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "bad_assessor",
+    [
+        lambda _inputs: (_ for _ in ()).throw(RuntimeError("llm down")),
+        lambda _inputs: "not json",
+    ],
+)
+def test_llm_failure_or_junk_loud_skips_without_fabricating_or_writing(
+    bad_assessor: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    planner_calls = 0
+
+    def planner(
+        assessment: Mapping[str, Any], inputs: ObservationInputs
+    ) -> ObservationPlan:
+        nonlocal planner_calls
+        planner_calls += 1
+        return ObservationPlan(actions=(), skips=())
+
+    with caplog.at_level(logging.WARNING, logger="wgmesh_pipeline.observation_gather"):
+        result = run_observation_cycle(
+            RaisingWriteForge(),
+            Store(),
+            assessor=bad_assessor,
+            planner=planner,
+        )
+
+    assert result.skipped is True
+    assert result.assessment == {}
+    assert planner_calls == 0
+    assert result.execution_results == ()
+    assert "skipped" in caplog.text

--- a/pipeline/tests/test_strategy_gather.py
+++ b/pipeline/tests/test_strategy_gather.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from wgmesh_pipeline.control_loop.executor import EXECUTED
+from wgmesh_pipeline.observation import ObservationAction
+from wgmesh_pipeline.state.store import StateStore
+from wgmesh_pipeline.strategy_audit import INPUT_METRIC_KEYS
+from wgmesh_pipeline.strategy_gather import (
+    STRATEGY_AUDIT_CHIMNEY_URL,
+    build_strategy_drift_action,
+    extract_paid_customers,
+    gather_strategy_metrics,
+    run_strategy_cycle,
+)
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    labels: tuple[str, ...]
+    state: str = "open"
+    pull_request: dict[str, Any] | None = None
+
+
+class Response:
+    def __init__(self, text: str, *, raises: bool = False) -> None:
+        self.text = text
+        self.raises = raises
+
+    def raise_for_status(self) -> None:
+        if self.raises:
+            raise RuntimeError("http failed")
+
+
+class MetricsForge:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def list_open_issues(self) -> list[Issue]:
+        return [
+            Issue(1, "human", ("needs-human",)),
+            Issue(2, "normal", ("fn:dev",)),
+        ]
+
+    def list_recent_merged_prs(self, limit: int = 100) -> list[dict[str, Any]]:
+        return [
+            {
+                "number": 10,
+                "author": {"login": "goose[bot]"},
+                "mergedAt": "2026-06-14T12:00:00Z",
+                "closingIssuesReferences": [{"number": 1}],
+                "comments": [],
+                "reviews": [],
+                "labels": [],
+            },
+            {
+                "number": 11,
+                "author": {"login": "human"},
+                "mergedAt": "2026-06-14T13:00:00Z",
+                "closingIssuesReferences": [],
+                "comments": [],
+                "reviews": [],
+                "labels": [],
+            },
+        ]
+
+    def issue_labeled_at(self, issue_number: int, label: str) -> str | None:
+        assert (issue_number, label) == (1, "needs-triage")
+        return "2026-06-14T00:00:00Z"
+
+    def create_issue(self, **kwargs: Any) -> dict[str, Any]:
+        self.created.append(kwargs)
+        return {"dry_run": True}
+
+
+class NoOptionalSourcesForge:
+    def list_open_issues(self) -> list[Issue]:
+        return [Issue(1, "human", ("needs-human",))]
+
+
+def test_extract_paid_customers_is_reexported_for_chimney_fixture() -> None:
+    html = """
+    <div>Paid subscriber</div>
+    <div class="stage-status">4</div>
+    """
+    assert extract_paid_customers(html) == 4
+
+
+def test_gather_strategy_metrics_maps_all_input_metric_keys(tmp_path) -> None:
+    db = StateStore(tmp_path / "state.db")
+    db.save_control_state(
+        "pipeline-health-state",
+        {
+            "last_run_summary": {"actions_taken": 3, "needs_human_closed": 1},
+            "retry_tracker": {"1": {"cooldown_until": "2026-06-16T00:00:00Z"}},
+        },
+        fingerprint="heal",
+    )
+
+    result = gather_strategy_metrics(
+        MetricsForge(),
+        db,
+        http_get=lambda url, timeout: Response("Paid subscribers\n5"),
+        now="2026-06-15T00:00:00Z",
+    )
+
+    assert set(result.metrics) == set(INPUT_METRIC_KEYS)
+    assert result.metrics["self_heal_rate"] == 0.75
+    assert result.metrics["active_stuck_issues"] == 2
+    assert result.metrics["lead_time_hours"] == 12.0
+    assert result.metrics["autonomous_ship_rate"] == 1.0
+    assert result.metrics["paid_customers"] == 5
+    assert result.paid_fetch_status == "ok"
+
+
+def test_absent_sources_degrade_to_none_without_crashing(tmp_path) -> None:
+    db = StateStore(tmp_path / "state.db")
+    result = gather_strategy_metrics(
+        NoOptionalSourcesForge(),
+        db,
+        http_get=lambda url, timeout: Response("", raises=True),
+        now="2026-06-15T00:00:00Z",
+    )
+
+    assert result.metrics["self_heal_rate"] is None
+    assert result.metrics["active_stuck_issues"] == 1
+    assert result.metrics["lead_time_hours"] is None
+    assert result.metrics["autonomous_ship_rate"] is None
+    assert result.metrics["paid_customers"] is None
+    assert result.paid_fetch_status == "failed"
+
+
+def test_chimney_fetch_uses_timeout_and_default_url(tmp_path) -> None:
+    seen: list[tuple[str, int]] = []
+
+    def http_get(url: str, timeout: int) -> Response:
+        seen.append((url, timeout))
+        return Response("Paid subscriber\n9")
+
+    gather_strategy_metrics(
+        NoOptionalSourcesForge(), StateStore(tmp_path / "state.db"), http_get=http_get
+    )
+
+    assert seen == [(STRATEGY_AUDIT_CHIMNEY_URL, 15)]
+
+
+def test_material_changed_persists_and_unchanged_fingerprint_does_not_write(
+    tmp_path,
+) -> None:
+    db = StateStore(tmp_path / "state.db")
+    forge = NoOptionalSourcesForge()
+
+    first = run_strategy_cycle(
+        forge,
+        db,
+        strategy_text="last_updated: 2026-06-15\n\n## Milestones\n",
+        http_get=lambda url, timeout: Response("Paid subscriber\n1"),
+        now="2026-06-15T00:00:00Z",
+    )
+    second = run_strategy_cycle(
+        forge,
+        db,
+        strategy_text="last_updated: 2026-06-15\n\n## Milestones\n",
+        http_get=lambda url, timeout: Response("Paid subscriber\n1"),
+        now="2026-06-15T00:00:00Z",
+    )
+
+    assert first.persisted is True
+    assert db.load_control_state("strategy-audit-baseline") is not None
+    assert second.persisted is False
+
+
+def test_open_pr_drift_routes_through_executor_dry_run(tmp_path) -> None:
+    db = StateStore(tmp_path / "state.db")
+    db.save_control_state(
+        "strategy-audit-baseline",
+        {
+            "audits": [
+                {
+                    "ran_at": "2026-06-14T00:00:00Z",
+                    "metrics": {
+                        "paid_customers": 10,
+                        "autonomous_ship_rate": 1.0,
+                        "lead_time_hours": 1,
+                        "self_heal_rate": 1.0,
+                        "active_stuck_issues": 0,
+                        "cycle_time_to_revenue": None,
+                        "fetch_status": {
+                            "paid_customers": "ok",
+                            "cycle_time_to_revenue": "no_customers",
+                        },
+                    },
+                    "milestones_status": [],
+                }
+            ],
+            "last_reported_drift_fingerprint": "old",
+        },
+        fingerprint="old",
+    )
+    forge = MetricsForge()
+
+    result = run_strategy_cycle(
+        forge,
+        db,
+        strategy_text="last_updated: 2026-06-15\n\n## Milestones\n",
+        http_get=lambda url, timeout: Response("Paid subscriber\n1"),
+        now="2026-06-15T00:00:00Z",
+    )
+
+    assert result.run.decision.action == "open_pr"
+    assert [r.status for r in result.execution_results] == [EXECUTED]
+    assert forge.created
+    assert isinstance(build_strategy_drift_action(result.run), ObservationAction)

--- a/pipeline/wgmesh_pipeline/control_loop/__init__.py
+++ b/pipeline/wgmesh_pipeline/control_loop/__init__.py
@@ -14,9 +14,8 @@ The LIVE executor is a separate follow-up unit. It will, behind the
 the returned state dicts (to Turso / the ``company/*.json`` state files), gated
 on each planner's ``material_changed`` sentinel. None of that lives here.
 
-``control_loop_mode == "live"`` is honored as SHADOW in this unit (forced back
-with a loud warning) because that executor does not exist yet — going live
-without it would write blind.
+``control_loop_mode == "live"`` is still shadow-safe until U5: the executor is
+called, but the forge adapter's own mode controls whether writes are dry-runs.
 
 Per-module gather gaps (honest degradation — these are the follow-up unit's
 TODOs, NOT to be faked here):
@@ -26,10 +25,10 @@ TODOs, NOT to be faked here):
   - selfheal: only the forge-derivable ``needs_human_issues`` is populated; the
     label-filtered stale sweeps + funnel/idle snapshot dicts stay at their
     empty defaults (the protocol cannot feed them yet).
-  - observation: the LLM assessment dict is caller-side and NOT built here — the
-    cycle logs a skip and does nothing (never fabricate an assessment).
-  - strategy_audit: STRATEGY.md is read if present, but live metrics (GitHub /
-    chimney / Polar reads) are not gatherable yet — the cycle logs a skip.
+  - observation: closed issue titles still degrade to ``()`` until the forge
+    protocol grows a closed-title read.
+  - strategy_audit: lead-time/autonomous-ship metrics degrade to ``None`` unless
+    the concrete forge exposes optional recent-merged-PR/timeline reads.
 """
 
 from __future__ import annotations
@@ -41,12 +40,25 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.control_loop.executor import execute_actions
 from wgmesh_pipeline.forge.protocol import Forge
+from wgmesh_pipeline.observation import ObservationPlan, plan_actions
 from wgmesh_pipeline.selfheal import SelfHealInputs, SelfHealRun, run_self_heal
+
+# The gather modules import wgmesh_pipeline.control_loop.executor, so importing
+# them at module top creates a circular import (this package's __init__ would
+# re-enter mid-load). Runtime symbols are imported lazily inside the cycle
+# methods; type-only names live in the TYPE_CHECKING block below.
+if TYPE_CHECKING:
+    from wgmesh_pipeline.observation_gather import (
+        ObservationAssessor,
+        ObservationCycleResult,
+        ObservationPlanner,
+    )
+    from wgmesh_pipeline.strategy_gather import HttpGet, StrategyCycleResult
 from wgmesh_pipeline.supervisor import (
     SupervisorRankRun,
     load_taxonomy,
@@ -87,10 +99,13 @@ def _material_fingerprint(doc: Mapping[str, Any], *, exclude: frozenset[str]) ->
     payload = json.dumps(material, sort_keys=True, default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
+
 # Injectable planner callable types (real ones default in ``ControlLoopScheduler``
 # so tests inject spies without touching the forge/LLM).
 SupervisorPlanner = Callable[..., SupervisorRankRun]
 SelfHealPlanner = Callable[[Forge, SelfHealInputs], SelfHealRun]
+StrategyTextReader = Callable[[], str | None]
+NowProvider = Callable[[], str]
 
 
 def _utc_now_iso() -> str:
@@ -145,6 +160,11 @@ class ControlLoopScheduler:
     log: logging.Logger = log
     supervisor_planner: SupervisorPlanner = run_supervisor_rank
     selfheal_planner: SelfHealPlanner = run_self_heal
+    observation_assessor: ObservationAssessor | None = None
+    observation_planner: ObservationPlanner = plan_actions
+    strategy_text_reader: StrategyTextReader = lambda: _read_text(_STRATEGY_PATH)
+    strategy_http_get: HttpGet | None = None
+    now_provider: NowProvider = _utc_now_iso
     _tasks: list[ModuleTask] = field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
@@ -156,9 +176,19 @@ class ControlLoopScheduler:
                 self.config.control_loop_mode,
             )
         self._tasks = [
-            ModuleTask("selfheal", self.config.selfheal_interval_seconds, self._cycle_selfheal),
-            ModuleTask("supervisor", self.config.supervisor_interval_seconds, self._cycle_supervisor),
-            ModuleTask("observation", self.config.observation_interval_seconds, self._cycle_observation),
+            ModuleTask(
+                "selfheal", self.config.selfheal_interval_seconds, self._cycle_selfheal
+            ),
+            ModuleTask(
+                "supervisor",
+                self.config.supervisor_interval_seconds,
+                self._cycle_supervisor,
+            ),
+            ModuleTask(
+                "observation",
+                self.config.observation_interval_seconds,
+                self._cycle_observation,
+            ),
             ModuleTask(
                 "strategy_audit",
                 self.config.strategy_audit_interval_seconds,
@@ -223,7 +253,9 @@ class ControlLoopScheduler:
         try:
             return loader(key)
         except Exception as exc:  # noqa: BLE001 — never let a store read kill the cycle
-            self.log.warning("control_loop: load_control_state(%s) failed: %s", key, exc)
+            self.log.warning(
+                "control_loop: load_control_state(%s) failed: %s", key, exc
+            )
             return None
 
     def _save_state(self, key: str, doc: Mapping[str, Any], fingerprint: str) -> bool:
@@ -235,8 +267,12 @@ class ControlLoopScheduler:
             return False
         try:
             return bool(saver(key, dict(doc), fingerprint=fingerprint))
-        except Exception as exc:  # noqa: BLE001 — never let a store write kill the cycle
-            self.log.warning("control_loop: save_control_state(%s) failed: %s", key, exc)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — never let a store write kill the cycle
+            self.log.warning(
+                "control_loop: save_control_state(%s) failed: %s", key, exc
+            )
             return False
 
     # --- per-module cycles: gather → plan → log structured summary --------
@@ -259,7 +295,9 @@ class ControlLoopScheduler:
         if run.material_changed:
             fingerprint = str(run.state.get("material_fingerprint") or "")
             persisted = self._save_state(SUPERVISOR_STATE_KEY, run.state, fingerprint)
-        top_actions = [str(a.get("action")) for a in run.result.top_actions if a.get("action")]
+        top_actions = [
+            str(a.get("action")) for a in run.result.top_actions if a.get("action")
+        ]
         self.log.info(
             "control_loop: module=supervisor mode=%s material_changed=%s "
             "rank_changed=%s planned_actions=%s top_actions=%s "
@@ -274,7 +312,9 @@ class ControlLoopScheduler:
         )
 
     async def _cycle_selfheal(self) -> None:
-        inputs = SelfHealInputs(now=_utc_now_iso())  # forge-derivable only; rest degraded
+        inputs = SelfHealInputs(
+            now=_utc_now_iso()
+        )  # forge-derivable only; rest degraded
         run = self.selfheal_planner(self.forge, inputs)
         action_kinds = [a.kind for a in run.actions]
         # Route every planned action through the single executor. The executor
@@ -290,7 +330,9 @@ class ControlLoopScheduler:
         persisted = False
         material = bool(run.actions) or run.circuit_breaker_tripped
         if material:
-            fingerprint = _material_fingerprint(run.state, exclude=_SELFHEAL_VOLATILE_KEYS)
+            fingerprint = _material_fingerprint(
+                run.state, exclude=_SELFHEAL_VOLATILE_KEYS
+            )
             persisted = self._save_state(SELFHEAL_STATE_KEY, run.state, fingerprint)
         self.log.info(
             "control_loop: module=selfheal mode=%s circuit_breaker_tripped=%s "
@@ -308,23 +350,74 @@ class ControlLoopScheduler:
         )
 
     async def _cycle_observation(self) -> None:
-        # The LLM assessment dict is caller-side and not yet wired. Do NOT
-        # fabricate an assessment — log the gap and end the cycle (still a
-        # scheduled slot).
+        from wgmesh_pipeline.observation_gather import (
+            GooseObservationAssessor,
+            run_observation_cycle,
+        )
+
+        assessor = self.observation_assessor or GooseObservationAssessor(
+            self.config, _REPO_ROOT
+        )
+        result: ObservationCycleResult = run_observation_cycle(
+            self.forge,
+            self.store,
+            assessor=assessor,
+            planner=self.observation_planner,
+        )
+        if result.skipped:
+            self.log.warning(
+                "control_loop: module=observation mode=%s skipped=%s "
+                "reason=%s planned_actions=0 executed=0",
+                self.config.control_loop_mode,
+                result.skipped,
+                result.skip_reason,
+            )
+            return
+        statuses = [r.status for r in result.execution_results]
+        planned = (
+            len(result.plan.actions) if isinstance(result.plan, ObservationPlan) else 0
+        )
         self.log.info(
-            "control_loop: module=observation mode=shadow "
-            "skipped: LLM assessment input not yet wired (protocol/gather gap) — "
-            "planned_actions=0"
+            "control_loop: module=observation mode=%s planned_actions=%s "
+            "skips=%s executed=%s result_statuses=%s",
+            self.config.control_loop_mode,
+            planned,
+            len(result.plan.skips) if result.plan is not None else 0,
+            sum(1 for status in statuses if status == "executed"),
+            statuses[:5],
         )
 
     async def _cycle_strategy_audit(self) -> None:
-        strategy_text = _read_text(_STRATEGY_PATH)
-        # Live metrics (GitHub / chimney / Polar reads) are caller-side and not yet
-        # gatherable. Without them the audit cannot run honestly — log the gap
-        # and end the cycle (still a scheduled slot).
+        from wgmesh_pipeline.strategy_gather import run_strategy_cycle
+
+        strategy_text = self.strategy_text_reader()
+        if strategy_text is None:
+            self.log.warning(
+                "control_loop: module=strategy_audit mode=%s skipped=true "
+                "reason=STRATEGY.md unavailable planned_actions=0 executed=0",
+                self.config.control_loop_mode,
+            )
+            return
+        kwargs: dict[str, Any] = {
+            "strategy_text": strategy_text,
+            "now": self.now_provider(),
+        }
+        if self.strategy_http_get is not None:
+            kwargs["http_get"] = self.strategy_http_get
+        result: StrategyCycleResult = run_strategy_cycle(
+            self.forge, self.store, **kwargs
+        )
+        statuses = [r.status for r in result.execution_results]
         self.log.info(
-            "control_loop: module=strategy_audit mode=shadow "
-            "skipped: live metrics gather not yet wired — strategy_text=%s "
-            "planned_actions=0",
-            "present" if strategy_text is not None else "absent",
+            "control_loop: module=strategy_audit mode=%s decision=%s "
+            "material_changed=%s planned_actions=%s executed=%s "
+            "result_statuses=%s persisted=%s paid_fetch_status=%s",
+            self.config.control_loop_mode,
+            result.run.decision.action,
+            result.run.material_changed,
+            len(result.execution_results),
+            sum(1 for status in statuses if status == "executed"),
+            statuses[:5],
+            result.persisted,
+            result.metrics.paid_fetch_status,
         )

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -1,0 +1,248 @@
+"""Live input gather for the box-side observation loop.
+
+This module owns the impure half that ``observation.py`` deliberately avoids:
+forge reads for the issue snapshot, an on-box Goose assessment call, defensive
+JSON parsing, and executor routing. Any LLM failure or unparseable assessment is
+a loud skip with zero fabricated actions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.control_loop.executor import ExecutionResult, execute_actions
+from wgmesh_pipeline.forge.protocol import Forge
+from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.observation import ObservationInputs, ObservationPlan, plan_actions
+
+log = logging.getLogger("wgmesh_pipeline.observation_gather")
+
+ASSESSMENT_KEYS = ("issues_to_create", "issues_to_close", "needs_human", "prs_to_close")
+
+
+class ObservationAssessor(Protocol):
+    def __call__(self, inputs: ObservationInputs) -> Mapping[str, Any] | str: ...
+
+
+ObservationPlanner = Callable[[Mapping[str, Any], ObservationInputs], ObservationPlan]
+ObservationExecutor = Callable[[Forge, Any, Sequence[Any]], list[ExecutionResult]]
+
+
+@dataclass(frozen=True)
+class ObservationCycleResult:
+    inputs: ObservationInputs | None
+    assessment: Mapping[str, Any]
+    plan: ObservationPlan | None
+    execution_results: tuple[ExecutionResult, ...]
+    skipped: bool
+    skip_reason: str | None = None
+
+
+def build_observation_inputs(forge: Forge) -> ObservationInputs:
+    """Build planner inputs from the forge's open issue snapshot.
+
+    ``closed_issue_titles`` degrades to ``()`` because the current forge
+    protocol has no closed-issue listing. The close guard still fails closed on
+    missing labels; this only narrows duplicate detection until the protocol
+    grows a closed-title read.
+    """
+    issues = [
+        issue
+        for issue in forge.list_open_issues()
+        if not getattr(issue, "pull_request", None)
+    ]
+    return ObservationInputs(
+        open_issue_titles=tuple(str(issue.title) for issue in issues),
+        closed_issue_titles=(),
+        issue_labels={
+            int(issue.number): tuple(str(label) for label in issue.labels)
+            for issue in issues
+        },
+    )
+
+
+def parse_assessment(payload: Mapping[str, Any] | str) -> dict[str, Any] | None:
+    if isinstance(payload, Mapping):
+        raw: Any = dict(payload)
+    elif isinstance(payload, str):
+        try:
+            raw = json.loads(_strip_json_fence(payload))
+        except json.JSONDecodeError:
+            return None
+    else:
+        return None
+    if not isinstance(raw, Mapping):
+        return None
+    assessment: dict[str, Any] = {}
+    for key in ASSESSMENT_KEYS:
+        value = raw.get(key, [])
+        if value is None:
+            value = []
+        if not isinstance(value, list):
+            return None
+        assessment[key] = value
+    return assessment
+
+
+def run_observation_cycle(
+    forge: Forge,
+    store: Any,
+    *,
+    assessor: ObservationAssessor,
+    planner: ObservationPlanner = plan_actions,
+    executor: ObservationExecutor = execute_actions,
+) -> ObservationCycleResult:
+    try:
+        inputs = build_observation_inputs(forge)
+    except Exception as exc:  # noqa: BLE001 - required input, loud skip
+        log.warning(
+            "control_loop: module=observation skipped: forge input gather failed: %s",
+            exc,
+        )
+        return ObservationCycleResult(
+            None, {}, None, (), True, "forge input gather failed"
+        )
+
+    try:
+        parsed = parse_assessment(assessor(inputs))
+    except Exception as exc:  # noqa: BLE001 - LLM unreachable, loud skip
+        log.warning(
+            "control_loop: module=observation skipped: LLM assessment failed: %s", exc
+        )
+        return ObservationCycleResult(
+            inputs, {}, None, (), True, "LLM assessment failed"
+        )
+    if parsed is None:
+        log.warning(
+            "control_loop: module=observation skipped: LLM assessment was not strict JSON"
+        )
+        return ObservationCycleResult(
+            inputs, {}, None, (), True, "LLM assessment was not strict JSON"
+        )
+
+    try:
+        plan = planner(parsed, inputs)
+    except Exception as exc:  # noqa: BLE001 - bad model item, no partial writes
+        log.warning(
+            "control_loop: module=observation skipped: assessment planning failed: %s",
+            exc,
+        )
+        return ObservationCycleResult(
+            inputs, parsed, None, (), True, "assessment planning failed"
+        )
+    results = tuple(executor(forge, store, plan.actions))
+    statuses = [result.status for result in results]
+    log.info(
+        "control_loop: module=observation planned_actions=%s skips=%s executed=%s result_statuses=%s",
+        len(plan.actions),
+        len(plan.skips),
+        sum(1 for status in statuses if status == "executed"),
+        statuses[:5],
+    )
+    return ObservationCycleResult(inputs, parsed, plan, results, False)
+
+
+@dataclass(frozen=True)
+class GooseObservationAssessor:
+    """On-box observation assessment via the same Goose runner path used by
+    ``graph.nodes.implement``. The recipe is generated in a temp directory so
+    this U4 unit does not add a new permanent recipe file."""
+
+    config: Config
+    repo_root: Path
+
+    def __call__(self, inputs: ObservationInputs) -> Mapping[str, Any]:
+        with tempfile.TemporaryDirectory(prefix="wgmesh-observation-") as tmp:
+            tmp_path = Path(tmp)
+            output = tmp_path / "assessment.json"
+            recipe = tmp_path / "observation-assessment.yaml"
+            recipe.write_text(_assessment_recipe(), encoding="utf-8")
+            result = GooseRunner(self.config).run_recipe(
+                recipe=recipe,
+                workdir=self.repo_root,
+                params={
+                    "assessment_file": str(output),
+                    "open_board": _inputs_board(inputs),
+                },
+                expected_output=output,
+                stage="observation",
+                session_id="control-loop-observation",
+            )
+            if not result.ok or result.output_path is None:
+                raise RuntimeError(
+                    result.error or "goose observation assessment failed"
+                )
+            parsed = parse_assessment(result.output_path.read_text(encoding="utf-8"))
+            if parsed is None:
+                raise ValueError("goose observation assessment was not strict JSON")
+            return parsed
+
+
+def _strip_json_fence(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        return "\n".join(lines).strip()
+    return stripped
+
+
+def _inputs_board(inputs: ObservationInputs) -> str:
+    lines = ["## Open Issues (wgmesh)", ""]
+    for number, title in enumerate(inputs.open_issue_titles, start=1):
+        lines.append(f"- {number}. {title}")
+    if not inputs.open_issue_titles:
+        lines.append("- (none)")
+    return "\n".join(lines)
+
+
+def _assessment_recipe() -> str:
+    return """version: "1.0.0"
+title: "wgmesh Observation Assessment"
+description: "Assess current company signals and emit strict JSON actions."
+parameters:
+  - key: assessment_file
+    input_type: string
+    requirement: required
+    description: "Absolute path where strict JSON assessment must be written."
+  - key: open_board
+    input_type: string
+    requirement: required
+    description: "Open issue board snapshot."
+prompt: |
+  You are the observation loop for wgmesh, a decentralized WireGuard mesh
+  networking product with managed ingress.
+
+  Current open board:
+  {{ open_board }}
+
+  Write ONLY strict JSON to this exact file path:
+  {{ assessment_file }}
+
+  The JSON object MUST contain exactly these four keys, each an array:
+  - issues_to_create: objects with title, body, labels
+  - issues_to_close: objects with number, reason
+  - needs_human: objects with request, urgency, reason
+  - prs_to_close: objects with repo, number, reason
+
+  If no action is justified, write empty arrays. Never include secrets,
+  customer PII, or exact revenue figures.
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+settings:
+  goose_provider: anthropic
+  goose_model: GLM-5.2
+"""

--- a/pipeline/wgmesh_pipeline/strategy_gather.py
+++ b/pipeline/wgmesh_pipeline/strategy_gather.py
@@ -1,0 +1,359 @@
+"""Live metric gather for the box-side strategy audit cycle."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import median
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import requests
+
+from wgmesh_pipeline.control_loop import SELFHEAL_STATE_KEY, STRATEGY_AUDIT_STATE_KEY
+from wgmesh_pipeline.control_loop.executor import ExecutionResult, execute_actions
+from wgmesh_pipeline.forge.protocol import Forge
+from wgmesh_pipeline.observation import ObservationAction
+from wgmesh_pipeline.strategy_audit import (
+    INPUT_METRIC_KEYS,
+    StrategyAuditRun,
+    extract_paid_customers,
+    run_strategy_audit,
+)
+
+log = logging.getLogger("wgmesh_pipeline.strategy_gather")
+
+STRATEGY_AUDIT_CHIMNEY_URL = "https://chimney.beerpub.dev/"
+BOT_AUTHORS = frozenset({"goose[bot]", "copilot-swe-agent[bot]", "pupabobas[bot]"})
+
+HttpGet = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class StrategyMetricsResult:
+    metrics: dict[str, float | int | None]
+    paid_fetch_status: str
+
+
+@dataclass(frozen=True)
+class StrategyCycleResult:
+    metrics: StrategyMetricsResult
+    run: StrategyAuditRun
+    execution_results: tuple[ExecutionResult, ...]
+    persisted: bool
+
+
+def gather_strategy_metrics(
+    forge: Forge,
+    store: Any,
+    *,
+    http_get: HttpGet = requests.get,
+    now: str | None = None,
+) -> StrategyMetricsResult:
+    current = now or _utc_now_iso()
+    metrics: dict[str, float | int | None] = {key: None for key in INPUT_METRIC_KEYS}
+    heal_state = _load_state(store, SELFHEAL_STATE_KEY)
+    metrics["self_heal_rate"] = _self_heal_rate(heal_state)
+    try:
+        metrics["active_stuck_issues"] = _active_stuck_issues(
+            forge, heal_state, now=current
+        )
+    except Exception as exc:  # noqa: BLE001 - degraded metric, never crash
+        log.warning(
+            "control_loop: strategy_audit active_stuck_issues unavailable: %s", exc
+        )
+        metrics["active_stuck_issues"] = None
+
+    lead_time, autonomous_rate = _merged_pr_metrics(forge)
+    metrics["lead_time_hours"] = lead_time
+    metrics["autonomous_ship_rate"] = autonomous_rate
+
+    paid, paid_status = _paid_customers(http_get)
+    metrics["paid_customers"] = paid
+    return StrategyMetricsResult(metrics=metrics, paid_fetch_status=paid_status)
+
+
+def run_strategy_cycle(
+    forge: Forge,
+    store: Any,
+    *,
+    strategy_text: str,
+    http_get: HttpGet = requests.get,
+    now: str | None = None,
+    executor: Callable[
+        [Forge, Any, Sequence[Any]], list[ExecutionResult]
+    ] = execute_actions,
+) -> StrategyCycleResult:
+    gathered = gather_strategy_metrics(forge, store, http_get=http_get, now=now)
+    baseline = _load_state(store, STRATEGY_AUDIT_STATE_KEY) or {}
+    run = run_strategy_audit(
+        baseline,
+        metrics=gathered.metrics,
+        strategy_text=strategy_text,
+        paid_fetch_status=gathered.paid_fetch_status,
+        now=now,
+    )
+    persisted = False
+    if run.material_changed:
+        persisted = _save_state(
+            store, STRATEGY_AUDIT_STATE_KEY, run.baseline, run.fingerprint
+        )
+    actions: tuple[ObservationAction, ...] = ()
+    if run.decision.action == "open_pr":
+        actions = (build_strategy_drift_action(run),)
+    results = tuple(executor(forge, store, actions))
+    statuses = [result.status for result in results]
+    log.info(
+        "control_loop: module=strategy_audit decision=%s material_changed=%s "
+        "planned_actions=%s executed=%s result_statuses=%s persisted=%s paid_fetch_status=%s",
+        run.decision.action,
+        run.material_changed,
+        len(actions),
+        sum(1 for status in statuses if status == "executed"),
+        statuses[:5],
+        persisted,
+        gathered.paid_fetch_status,
+    )
+    return StrategyCycleResult(gathered, run, results, persisted)
+
+
+def build_strategy_drift_action(run: StrategyAuditRun) -> ObservationAction:
+    rows = "\n".join(
+        f"- {row.label}: baseline={row.baseline}, current={row.current}, "
+        f"delta={row.delta_display}, verdict={row.verdict}"
+        for row in run.metric_rows
+    )
+    milestones = "\n".join(
+        f"- {item.date}: {item.target} ({item.current}, {item.status})"
+        for item in run.milestones
+    )
+    body = (
+        f"Drift fingerprint: `{run.fingerprint}`\n\n"
+        "## Metric drift\n"
+        f"{rows or '- none'}\n\n"
+        "## Milestone status\n"
+        f"{milestones or '- none'}\n\n"
+        "_Created by the control-loop strategy audit gatherer._"
+    )
+    return ObservationAction(
+        kind="create_issue",
+        title=f"audit: strategy drift detected {run.fingerprint_hash}",
+        body=body,
+        labels=("needs-human",),
+        reason=run.fingerprint,
+    )
+
+
+def _load_state(store: Any, key: str) -> Mapping[str, Any] | None:
+    loader = getattr(store, "load_control_state", None)
+    if loader is None:
+        return None
+    try:
+        loaded = loader(key)
+    except Exception as exc:  # noqa: BLE001 - degraded metric/state
+        log.warning(
+            "control_loop: strategy_audit load_control_state(%s) failed: %s", key, exc
+        )
+        return None
+    return loaded if isinstance(loaded, Mapping) else None
+
+
+def _save_state(store: Any, key: str, doc: Mapping[str, Any], fingerprint: str) -> bool:
+    saver = getattr(store, "save_control_state", None)
+    if saver is None:
+        return False
+    try:
+        return bool(saver(key, dict(doc), fingerprint=fingerprint))
+    except Exception as exc:  # noqa: BLE001 - never abort audit on persistence failure
+        log.warning(
+            "control_loop: strategy_audit save_control_state(%s) failed: %s", key, exc
+        )
+        return False
+
+
+def _self_heal_rate(state: Mapping[str, Any] | None) -> float | None:
+    if not state:
+        return None
+    summary = state.get("last_run_summary")
+    if not isinstance(summary, Mapping):
+        return None
+    actions = _number(summary.get("actions_taken"))
+    closed = _number(summary.get("needs_human_closed"))
+    if actions is None or closed is None:
+        return None
+    total = actions + closed
+    return 0.0 if total == 0 else actions / total
+
+
+def _active_stuck_issues(
+    forge: Forge, state: Mapping[str, Any] | None, *, now: str
+) -> int:
+    needs_human = sum(
+        1
+        for issue in forge.list_open_issues()
+        if "needs-human" in tuple(str(label) for label in issue.labels)
+        and not getattr(issue, "pull_request", None)
+    )
+    return needs_human + _cooldown_count(state, now=now)
+
+
+def _cooldown_count(state: Mapping[str, Any] | None, *, now: str) -> int:
+    if not state:
+        return 0
+    tracker = state.get("retry_tracker") or {}
+    entries: Iterable[Any]
+    if isinstance(tracker, Mapping):
+        entries = tracker.values()
+    elif isinstance(tracker, list):
+        entries = tracker
+    else:
+        return 0
+    count = 0
+    for entry in entries:
+        if isinstance(entry, Mapping) and str(entry.get("cooldown_until") or "") > now:
+            count += 1
+    return count
+
+
+def _merged_pr_metrics(forge: Forge) -> tuple[float | None, float | None]:
+    reader = getattr(forge, "list_recent_merged_prs", None)
+    if reader is None:
+        return None, None
+    try:
+        prs = reader(limit=100)
+    except TypeError:
+        prs = reader()
+    except Exception as exc:  # noqa: BLE001 - degraded metric, never crash
+        log.warning("control_loop: strategy_audit merged PR list unavailable: %s", exc)
+        return None, None
+    if not isinstance(prs, list):
+        return None, None
+    return _lead_time_hours(forge, prs), _autonomous_ship_rate(prs)
+
+
+def _lead_time_hours(forge: Forge, prs: Sequence[Mapping[str, Any]]) -> float | None:
+    label_reader = getattr(forge, "issue_labeled_at", None)
+    if label_reader is None:
+        return None
+    hours: list[float] = []
+    for pr in prs:
+        merged_at = str(pr.get("mergedAt") or pr.get("merged_at") or "")
+        for issue in (
+            pr.get("closingIssuesReferences") or pr.get("closing_issues") or []
+        ):
+            number = _issue_number(issue)
+            if number is None:
+                continue
+            try:
+                labeled_at = label_reader(number, "needs-triage")
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - one missing timeline degrades that PR
+                log.warning(
+                    "control_loop: strategy_audit labeled-at unavailable: %s", exc
+                )
+                continue
+            delta = _hours_between(str(labeled_at or ""), merged_at)
+            if delta is not None:
+                hours.append(delta)
+    return None if not hours else float(median(hours))
+
+
+def _autonomous_ship_rate(prs: Sequence[Mapping[str, Any]]) -> float | None:
+    bot_total = 0
+    clean = 0
+    for pr in prs:
+        if _author_login(pr.get("author")) not in BOT_AUTHORS:
+            continue
+        bot_total += 1
+        if _is_clean_bot_pr(pr):
+            clean += 1
+    return None if bot_total == 0 else round(clean / bot_total, 4)
+
+
+def _is_clean_bot_pr(pr: Mapping[str, Any]) -> bool:
+    labels = pr.get("labels") or []
+    if any(_label_name(label) == "needs-human" for label in labels):
+        return False
+    comments = pr.get("comments") or []
+    reviews = pr.get("reviews") or []
+    non_bot_comments = [
+        _author_login(c.get("author")) for c in comments if isinstance(c, Mapping)
+    ]
+    non_bot_reviews = [
+        _author_login(r.get("author"))
+        for r in reviews
+        if isinstance(r, Mapping) and str(r.get("body") or "")
+    ]
+    return all(_is_bot_login(login) for login in non_bot_comments + non_bot_reviews)
+
+
+def _paid_customers(http_get: HttpGet) -> tuple[int | None, str]:
+    try:
+        response = http_get(STRATEGY_AUDIT_CHIMNEY_URL, timeout=15)
+        response.raise_for_status()
+        paid = extract_paid_customers(str(response.text))
+    except Exception as exc:  # noqa: BLE001 - degraded metric
+        log.warning("control_loop: strategy_audit chimney fetch failed: %s", exc)
+        return None, "failed"
+    if paid is None:
+        log.warning("control_loop: strategy_audit chimney paid customer parse failed")
+        return None, "failed"
+    return paid, "ok"
+
+
+def _issue_number(issue: Any) -> int | None:
+    try:
+        if isinstance(issue, Mapping):
+            value = issue.get("number")
+            return None if value is None else int(value)
+        return int(issue)
+    except (TypeError, ValueError):
+        return None
+
+
+def _author_login(author: Any) -> str:
+    if isinstance(author, Mapping):
+        return str(author.get("login") or "")
+    return str(author or "")
+
+
+def _label_name(label: Any) -> str:
+    if isinstance(label, Mapping):
+        return str(label.get("name") or "")
+    return str(label or "")
+
+
+def _is_bot_login(login: str) -> bool:
+    return not login or login.endswith("[bot]") or login in BOT_AUTHORS
+
+
+def _hours_between(start: str, end: str) -> float | None:
+    try:
+        start_dt = _parse_iso(start)
+        end_dt = _parse_iso(end)
+    except ValueError:
+        return None
+    seconds = (end_dt - start_dt).total_seconds()
+    if seconds < 0:
+        return None
+    return round(seconds / 3600, 2)
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except ValueError:
+        return None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## What
Wire the two skipped control-loop cycles (`_cycle_observation`, `_cycle_strategy_audit`) to gather live inputs, plan, route through the existing executor, and persist on material change — mirroring the selfheal/supervisor cycle shape. **Shadow-safe:** the executor dry-runs every forge write; no live-write path (that is U5).

## Modules
- **`observation_gather.py`** — build `ObservationInputs` from forge open issues + on-box Goose assessment (same runner as `graph.nodes.implement`). Defensive JSON parse; any LLM failure or non-strict-JSON is a **loud skip with zero fabricated actions**. `plan_actions` → `execute_actions`.
- **`strategy_gather.py`** — gather `INPUT_METRIC_KEYS` (self_heal_rate, active_stuck_issues, paid_customers via chimney → `extract_paid_customers`; lead_time + autonomous_ship via optional forge reads). Absent source → `None`, never crashes. `run_strategy_audit` → persist baseline on `material_changed` → `open_pr` drift routed through the executor.
- **control_loop wiring** — gather modules imported **lazily inside the cycle methods** (+ `TYPE_CHECKING` for type-only names) to break the `control_loop ↔ gather` circular import; `STRATEGY_AUDIT_STATE_KEY` single-sourced here.

## Known degradation (follow-ups, documented in the module docstring — not blockers)
- `lead_time_hours` + `autonomous_ship_rate` stay `None` until the Forge protocol grows `list_recent_merged_prs` / `issue_labeled_at`.
- Observation dedup board omits real issue numbers → close/PR actions limited; issue **creation** unaffected.
- `goose_model: GLM-5.2` hardcoded in the generated recipe.

## Test plan
- [x] Tests bite at the lowest boundary: real `StateStore` for persistence assertions; stubbed forge/LLM for gather paths.
- [x] observation: valid assessment plans+executes (shadow dry-run); LLM failure/junk → loud skip, no fabrication, no writes.
- [x] strategy: all metric keys mapped; absent source → None; material_changed persists, unchanged fingerprint no-write; open_pr drift routes through executor.
- [x] Full suite: 534 passed, 5 skipped. ruff/black/mypy clean.

## Not in scope
U5 (per-module shadow→live flip) — the autonomous-write gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)