### PR TITLE
chore(box-config): flip observation live (OBSERVATION_LIVE=true)

### DIFF
--- a/company/box-config.json
+++ b/company/box-config.json
@@ -8,6 +8,6 @@
   "STRATEGY_AUDIT_INTERVAL_SECONDS": "86400",
   "SUPERVISOR_LIVE": "false",
   "SELFHEAL_LIVE": "false",
-  "OBSERVATION_LIVE": "false",
+  "OBSERVATION_LIVE": "true",
   "STRATEGY_AUDIT_LIVE": "false"
 }


### PR DESCRIPTION
First deliberate per-module live flip behind the gate (#1773). Observation's control-loop cycle will publish planned actions through the executor's sanitise wall instead of dry-running — generating goal-advancing work when the queue is idle. All other modules stay shadow.

**Reversible:** set back to `"false"` + redeploy.

**Deploy ordering (important):** takes effect only after the gate image (control-loop per-module gate + U4 gather) is deployed via `update-pipeline-box`. Deploy ONLY after the `build-pipeline-image` run for the gate commit (`b838056`) is green — else the box would run U4 *without* the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)