### PR TITLE
fix(observation): surface goose raw_log on assessment failure

### DIFF
--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -132,3 +132,39 @@ def test_llm_failure_or_junk_loud_skips_without_fabricating_or_writing(
     assert planner_calls == 0
     assert result.execution_results == ()
     assert "skipped" in caplog.text
+
+
+def test_goose_assessor_surfaces_raw_log_on_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A goose startup/config failure must surface its raw stdout/stderr, not
+    # just "goose exited N" — otherwise the box's observation loop goes dark
+    # with no diagnosable reason (the bug that hid why the live flip produced
+    # zero work). Reverting the raw_log log makes this RED.
+    from pathlib import Path
+
+    from wgmesh_pipeline import observation_gather as og
+    from wgmesh_pipeline.config import Config
+
+    class _FailResult:
+        ok = False
+        output_path = None
+        raw_log = "GOOSE-RAW: provider config invalid; could not start"
+        error = "goose exited 1"
+
+    class _FakeRunner:
+        def __init__(self, config: Config) -> None:
+            self.config = config
+
+        def run_recipe(self, **kwargs: Any) -> _FailResult:
+            return _FailResult()
+
+    monkeypatch.setattr(og, "GooseRunner", _FakeRunner)
+    assessor = og.GooseObservationAssessor(
+        config=Config(target_repo="atvirokodosprendimai/wgmesh"),
+        repo_root=Path("."),
+    )
+    with caplog.at_level(logging.WARNING, logger="wgmesh_pipeline.observation_gather"):
+        with pytest.raises(RuntimeError):
+            assessor(ObservationInputs())
+    assert "GOOSE-RAW: provider config invalid" in caplog.text

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -175,6 +175,18 @@ class GooseObservationAssessor:
                 session_id="control-loop-observation",
             )
             if not result.ok or result.output_path is None:
+                # Surface the raw goose output (head+tail) — otherwise a goose
+                # startup/config failure is invisible (only "goose exited N"
+                # reaches the log), which left the box's observation loop dark
+                # with no way to tell why. (observability-cracks lesson.)
+                raw = result.raw_log or ""
+                log.warning(
+                    "control_loop: observation goose failed (%s) — raw_log "
+                    "head:\n%s\n--- tail:\n%s",
+                    result.error,
+                    raw[:1500],
+                    raw[-1500:],
+                )
                 raise RuntimeError(
                     result.error or "goose observation assessment failed"
                 )


### PR DESCRIPTION
The on-box observation cycle went live but produced zero work: `goose exited 1` in ~45ms (config-fail, not API — the `ZAI_API_KEY` is valid). The reason was invisible because `GooseObservationAssessor` raised only `result.error` and **discarded `result.raw_log`** (goose's captured stdout/stderr).

This logs `raw_log` head+tail before raising, so the next observation cycle reveals *why* goose dies (recipe/config/workdir). Diagnostic unblock.

- [x] Test asserts raw_log surfaces on failure (revert → RED). ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)