### PR TITLE
fix(observation): pass open board as file path, not inline YAML (unblocks live observation)

### DIFF
--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -168,3 +168,22 @@ def test_goose_assessor_surfaces_raw_log_on_failure(
         with pytest.raises(RuntimeError):
             assessor(ObservationInputs())
     assert "GOOSE-RAW: provider config invalid" in caplog.text
+
+
+def test_assessment_recipe_stays_valid_yaml_after_param_templating() -> None:
+    # goose substitutes {{ params }} into the recipe text BEFORE parsing it, so
+    # every param must be a single-line value (a path) — a multi-line value
+    # injected into the `prompt: |` block breaks out of the literal scalar and
+    # goose rejects the recipe ("Invalid recipe: did not find expected key").
+    # Regression for the live observation flip producing zero work.
+    import yaml
+
+    from wgmesh_pipeline.observation_gather import _assessment_recipe
+
+    recipe = _assessment_recipe()
+    assert "{{ open_board_file }}" in recipe
+    assert "{{ open_board }}" not in recipe  # never inline the multi-line board
+    templated = recipe.replace("{{ open_board_file }}", "/tmp/board.md").replace(
+        "{{ assessment_file }}", "/tmp/assessment.json"
+    )
+    yaml.safe_load(templated)  # raises if a param injection breaks the YAML

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -163,12 +163,19 @@ class GooseObservationAssessor:
             output = tmp_path / "assessment.json"
             recipe = tmp_path / "observation-assessment.yaml"
             recipe.write_text(_assessment_recipe(), encoding="utf-8")
+            # Pass the board as a FILE PATH, never inline content: goose
+            # substitutes {{ params }} into the recipe YAML before parsing, so a
+            # multi-line value injected into the `prompt: |` block breaks out of
+            # the literal scalar ("Invalid recipe: did not find expected key").
+            # The committed recipes pass paths (spec_file/diff_file) for this.
+            board_file = tmp_path / "open_board.md"
+            board_file.write_text(_inputs_board(inputs), encoding="utf-8")
             result = GooseRunner(self.config).run_recipe(
                 recipe=recipe,
                 workdir=self.repo_root,
                 params={
                     "assessment_file": str(output),
-                    "open_board": _inputs_board(inputs),
+                    "open_board_file": str(board_file),
                 },
                 expected_output=output,
                 stage="observation",
@@ -226,16 +233,16 @@ parameters:
     input_type: string
     requirement: required
     description: "Absolute path where strict JSON assessment must be written."
-  - key: open_board
+  - key: open_board_file
     input_type: string
     requirement: required
-    description: "Open issue board snapshot."
+    description: "Path to the open issue board snapshot (markdown)."
 prompt: |
   You are the observation loop for wgmesh, a decentralized WireGuard mesh
   networking product with managed ingress.
 
-  Current open board:
-  {{ open_board }}
+  Read the current open issue board (markdown) at this path:
+  {{ open_board_file }}
 
   Write ONLY strict JSON to this exact file path:
   {{ assessment_file }}


### PR DESCRIPTION
## Root cause (diagnosed end-to-end this session)
Live observation produced zero work: `goose exited 1` → (after surfacing raw_log, #1775) `Error: Invalid recipe: did not find expected key`. goose substitutes `{{ params }}` into the recipe YAML **before parsing**, and `open_board` was the multi-line markdown board injected into the `prompt: |` literal block → replacement lines at column 0 break the scalar → invalid YAML. Reproduced locally with `yaml.safe_load`.

## Fix
Write the board to a temp file; pass `open_board_file` (single-line path) as the param. Matches the committed recipes (`spec_file`/`diff_file` are paths, never inline content). Regression test parses the recipe after param templating.

- [x] Local repro: templated recipe now valid YAML. 6 tests pass; ruff/black/mypy clean.

Last link in the chain to a self-driving box: ZAI key valid → gate live → recipe valid → observation can assess and generate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)