### PR TITLE
feat(observation): real issue numbers in LLM board + skip-reason logging

### DIFF
--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -55,9 +55,56 @@ def test_build_observation_inputs_from_open_issue_snapshot() -> None:
 
     assert inputs == ObservationInputs(
         open_issue_titles=("Ship CLI onboarding", "Blocked deploy"),
+        open_issue_numbers=(1, 2),
         closed_issue_titles=(),
         issue_labels={1: ("fn:dev", "needs-triage"), 2: ("needs-human",)},
     )
+
+
+def test_inputs_board_shows_real_issue_numbers() -> None:
+    # The board the LLM sees must carry REAL numbers (#726), not sequence
+    # indices — its close/needs-human proposals reference these, and a sequence
+    # index fails the close guard (issue_labels is keyed by real number).
+    from wgmesh_pipeline.observation_gather import _inputs_board
+
+    board = _inputs_board(
+        ObservationInputs(
+            open_issue_titles=("Stuck deploy", "VPN start/stop"),
+            open_issue_numbers=(727, 539),
+        )
+    )
+    assert "- #727: Stuck deploy" in board
+    assert "- #539: VPN start/stop" in board
+
+
+def test_observation_cycle_logs_skip_detail_codes(caplog) -> None:
+    # A vetoed cycle must surface WHY (code#number), so a 0-action cycle is not
+    # mistaken for the LLM declining.
+    from wgmesh_pipeline.observation import ObservationSkip
+
+    def planner(
+        assessment: Mapping[str, Any], inputs: ObservationInputs
+    ) -> ObservationPlan:
+        return ObservationPlan(
+            actions=(),
+            skips=(
+                ObservationSkip(
+                    action="close_issue",
+                    code="label_fetch_failed",
+                    message="x",
+                    number=42,
+                ),
+            ),
+        )
+
+    with caplog.at_level(logging.INFO, logger="wgmesh_pipeline.observation_gather"):
+        run_observation_cycle(
+            ShadowForge(),
+            Store(),
+            assessor=lambda _inputs: {"issues_to_close": [{"number": 42}]},
+            planner=planner,
+        )
+    assert "label_fetch_failed#42" in caplog.text
 
 
 def test_valid_llm_assessment_plans_and_executes_shadow_dry_run(caplog) -> None:

--- a/pipeline/wgmesh_pipeline/observation.py
+++ b/pipeline/wgmesh_pipeline/observation.py
@@ -102,6 +102,10 @@ class ObservationInputs:
     open_issue_titles: tuple[str, ...] = ()
     closed_issue_titles: tuple[str, ...] = ()
     issue_labels: Mapping[int, Sequence[str] | None] = field(default_factory=dict)
+    # Real issue numbers parallel to ``open_issue_titles`` (same order). The
+    # board shown to the LLM must carry REAL numbers, or its close/needs-human
+    # proposals reference unmatchable sequence indices and fail the close guard.
+    open_issue_numbers: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -59,6 +59,7 @@ def build_observation_inputs(forge: Forge) -> ObservationInputs:
     ]
     return ObservationInputs(
         open_issue_titles=tuple(str(issue.title) for issue in issues),
+        open_issue_numbers=tuple(int(issue.number) for issue in issues),
         closed_issue_titles=(),
         issue_labels={
             int(issue.number): tuple(str(label) for label in issue.labels)
@@ -138,10 +139,16 @@ def run_observation_cycle(
         )
     results = tuple(executor(forge, store, plan.actions))
     statuses = [result.status for result in results]
+    # Surface WHY proposals were vetoed (code#number) — otherwise a cycle that
+    # plans 0 actions is indistinguishable from one the LLM declined, hiding
+    # close-guard/dedup gaps.
+    skip_detail = [f"{s.code}#{s.number}" for s in plan.skips[:8]]
     log.info(
-        "control_loop: module=observation planned_actions=%s skips=%s executed=%s result_statuses=%s",
+        "control_loop: module=observation planned_actions=%s skips=%s "
+        "skip_detail=%s executed=%s result_statuses=%s",
         len(plan.actions),
         len(plan.skips),
+        skip_detail,
         sum(1 for status in statuses if status == "executed"),
         statuses[:5],
     )
@@ -216,10 +223,18 @@ def _strip_json_fence(text: str) -> str:
 
 
 def _inputs_board(inputs: ObservationInputs) -> str:
+    # Show REAL issue numbers (#N) so the LLM's close/needs-human proposals
+    # reference matchable numbers — sequence indices fail the close guard.
     lines = ["## Open Issues (wgmesh)", ""]
-    for number, title in enumerate(inputs.open_issue_titles, start=1):
-        lines.append(f"- {number}. {title}")
-    if not inputs.open_issue_titles:
+    titles = inputs.open_issue_titles
+    numbers = inputs.open_issue_numbers
+    if numbers and len(numbers) == len(titles):
+        for number, title in zip(numbers, titles):
+            lines.append(f"- #{number}: {title}")
+    else:
+        for title in titles:
+            lines.append(f"- {title}")
+    if not titles:
         lines.append("- (none)")
     return "\n".join(lines)
 


### PR DESCRIPTION
Observation ran live but created 0 issues — the board used sequence indices, so the LLM's close/needs-human proposals referenced unmatchable numbers and the close guard fail-closed-skipped them (`skips=3`). Now the board shows real `#N`, and `run_observation_cycle` logs `skip_detail=[code#number]` so a vetoed cycle is diagnosable.

- [x] 561+ passed. Clean 3-file diff (+70/-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)