### PR TITLE
fix(observation): route created issues to exactly one lane (fn:dev xor needs-human)

### DIFF
--- a/pipeline/tests/test_observation.py
+++ b/pipeline/tests/test_observation.py
@@ -176,6 +176,27 @@ def test_duplicate_create_is_skipped():
     assert plan.skips[0].message == "Skipping duplicate: Update burn rate alerts thresholds"
 
 
+def test_create_with_both_labels_routes_to_fn_dev_only():
+    # An LLM that hedges fn:dev + needs-human must NOT strand implementable work
+    # in the human queue: fn:dev wins so it flows to the build pipeline.
+    plan = plan_actions(
+        {"issues_to_create": [
+            {"title": "DevOps VPN SEO landing page", "body": "b",
+             "labels": ["fn:dev", "needs-human"]}]},
+        INPUTS)
+    assert len(plan.actions) == 1
+    assert plan.actions[0].labels == ("fn:dev",)
+
+
+def test_create_with_needs_human_only_is_unchanged():
+    plan = plan_actions(
+        {"issues_to_create": [
+            {"title": "Manual outreach to 50 DevOps communities", "body": "b",
+             "labels": ["needs-human"]}]},
+        INPUTS)
+    assert plan.actions[0].labels == ("needs-human",)
+
+
 def test_fresh_create_is_planned():
     plan = plan_actions(
         {"issues_to_create": [

--- a/pipeline/wgmesh_pipeline/observation.py
+++ b/pipeline/wgmesh_pipeline/observation.py
@@ -45,6 +45,7 @@ from typing import Any, Mapping, Sequence
 ORG = "atvirokodosprendimai"
 TARGET_REPO = f"{ORG}/wgmesh"
 NEEDS_HUMAN_LABEL = "needs-human"
+FN_DEV_LABEL = "fn:dev"  # pipeline-implementable lane (triage->spec->implement)
 CLOSE_REASON_NOT_PLANNED = "not planned"
 MAX_KEYWORDS = 5
 DUPLICATE_MIN_HITS = 2
@@ -189,6 +190,16 @@ def build_open_board(
     return "\n".join(lines) + "\n"
 
 
+def _route_one_lane(labels: tuple[str, ...]) -> tuple[str, ...]:
+    """A proposed create routes to exactly ONE lane. ``fn:dev`` (the pipeline
+    implements it) wins over ``needs-human``, which would gate the issue OUT of
+    the autonomous build lane — so an LLM hedging BOTH labels does not strand
+    implementable work in the human queue."""
+    if FN_DEV_LABEL in labels and NEEDS_HUMAN_LABEL in labels:
+        return tuple(label for label in labels if label != NEEDS_HUMAN_LABEL)
+    return labels
+
+
 def _vet_create(item: Mapping[str, Any], corpus: list[str], *, kind: str,
                 title: str, body: str, labels: tuple[str, ...],
                 skip_message: str) -> tuple[ObservationAction | None, ObservationSkip | None]:
@@ -200,7 +211,9 @@ def _vet_create(item: Mapping[str, Any], corpus: list[str], *, kind: str,
         return None, ObservationSkip(action=kind, code="duplicate",
                                      message=skip_message, title=title)
     corpus.append(title)
-    return ObservationAction(kind=kind, title=title, body=body, labels=labels), None
+    return ObservationAction(
+        kind=kind, title=title, body=body, labels=_route_one_lane(labels)
+    ), None
 
 
 def vet_issue_close(item: Mapping[str, Any],

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -286,9 +286,11 @@ prompt: |
     tool can execute end-to-end — never a vague theme.
   - Name the goal link in one line: how it moves trials to paid.
   - Include an acceptance check: what "done" is + the metric it should move.
-  - Carry labels: ["fn:dev"] if the pipeline can implement it as code/product;
+  - Carry EXACTLY ONE label, NEVER both: ["fn:dev"] if a coding agent can
+    implement it as code/product (most landing-page, onboarding, signup, and
+    conversion work) — these flow straight to the build pipeline; OR
     ["needs-human"] ONLY if it truly needs capital, a human decision, or an
-    external account/credential.
+    external account/credential (e.g. manual community outreach, ad spend).
 
   Do NOT: re-create board items; propose internal pipeline/infra busywork (only
   customer-facing, revenue-advancing work); close or escalate needs-human


### PR DESCRIPTION
Growth-loop issues hedged both `fn:dev` + `needs-human`; needs-human gates them out of the autonomous build lane, stranding implementable work (e.g. the SEO landing page). `_route_one_lane` makes fn:dev win on creates; prompt now mandates exactly one label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)