### PR TITLE
feat(observation): require lead-capture + analytics on growth page issues

### DIFF
--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -233,6 +233,7 @@ def test_assessment_recipe_templates_params_as_single_line_paths() -> None:
     # Customer-acquisition steering (approved 2026-06-17): the loop proposes
     # paid-customer growth work, not housekeeping.
     assert "PAID CUSTOMERS" in recipe
+    assert "lead-capture form" in recipe  # pre-wires the nurture/Mautic handoff
     # Templating a param must not add lines (single-line path values only).
     templated = (
         recipe.replace("{{ open_board_file }}", "/tmp/board.md")

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -291,6 +291,10 @@ prompt: |
     conversion work) — these flow straight to the build pipeline; OR
     ["needs-human"] ONLY if it truly needs capital, a human decision, or an
     external account/credential (e.g. manual community outreach, ad spend).
+  - If it is a landing page, signup, or trial-flow task, REQUIRE in its
+    acceptance criteria: a lead-capture form (email at minimum) AND a web
+    analytics/tracking snippet — so every visitor becomes a trackable lead the
+    nurture system can follow up. A page that cannot capture a lead is not done.
 
   Do NOT: re-create board items; propose internal pipeline/infra busywork (only
   customer-facing, revenue-advancing work); close or escalate needs-human


### PR DESCRIPTION
Pre-wires the nurture/Mautic handoff: landing/signup/trial issues the growth loop files must require a lead-capture form + analytics snippet in their acceptance criteria, so pages the pipeline ships capture leads from day one (Mautic has something to nurture the moment it's stood up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)