### PR TITLE
feat: move eval-judges + release-notes summary to GLM-5.2

### DIFF
--- a/.github/workflows/daily-release-notes.yml
+++ b/.github/workflows/daily-release-notes.yml
@@ -72,7 +72,7 @@ jobs:
           pr_list=$(cat /tmp/pr_list.txt)
           # Build the request with jq so the PR text is safely JSON-encoded.
           jq -n --arg prs "$pr_list" '{
-            model: "anthropic/claude-sonnet-4",
+            model: "z-ai/glm-5.2",
             messages: [
               {role: "system", content: "You write a short daily release-notes email for a small founding team. Plain English. Explain WHAT shipped and WHY it matters, grouping related PRs into themes, most impactful first. 4-10 sentences or tight bullets. No preamble, no signature."},
               {role: "user", content: ("Merged pull requests today:\n\n" + $prs)}

--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -52,6 +52,11 @@ _BOOLEAN = {
     "reasoning": {"description": "One sentence reasoning; name what leaked if any."},
 }
 
+# Judge model: GLM-5.2 via the project's "zai" LLM connection (z.ai, anthropic
+# adapter). `provider` must match a connection from GET /api/public/llm-connections;
+# the connection must offer this `model` (see langfuse-llm-connection workflow).
+_JUDGE_MODEL = {"provider": "zai", "model": "GLM-5.2"}
+
 EVALUATORS = [
     {
         "name": "growth_issue_quality",
@@ -69,7 +74,7 @@ EVALUATORS = [
         ),
         "variables": ["output"],
         "outputDefinition": _NUMERIC,
-        "modelConfig": None,
+        "modelConfig": _JUDGE_MODEL,
     },
     {
         "name": "impl_faithfulness",
@@ -84,7 +89,7 @@ EVALUATORS = [
         ),
         "variables": ["input", "output"],
         "outputDefinition": _NUMERIC,
-        "modelConfig": None,
+        "modelConfig": _JUDGE_MODEL,
     },
     {
         "name": "public_safety_pass",
@@ -97,7 +102,7 @@ EVALUATORS = [
         ),
         "variables": ["output"],
         "outputDefinition": _BOOLEAN,
-        "modelConfig": None,
+        "modelConfig": _JUDGE_MODEL,
     },
 ]
 


### PR DESCRIPTION
GLM-5.2 is now top-ranked for coding (box already uses it). Pin eval-judge modelConfig to zai/GLM-5.2 + switch release-notes summary to z-ai/glm-5.2. 🤖 Generated with [Claude Code](https://claude.com/claude-code)