### PR TITLE
feat(evals): open_source_default Langfuse judge (PikaPods-grounded)

### DIFF
--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -57,6 +57,21 @@ _BOOLEAN = {
 # the connection must offer this `model` (see langfuse-llm-connection workflow).
 _JUDGE_MODEL = {"provider": "zai", "model": "GLM-5.2"}
 
+_PIKAPODS_SNAPSHOT = """PikaPods self-hosts these open-source apps (non-exhaustive):
+- Zapier / IFTTT -> Activepieces, Automatisch
+- Airtable -> Baserow, NocoDB
+- Sentry -> Bugsink, GlitchTip
+- Google Analytics -> Umami, Matomo
+- Slack / Teams -> Mattermost
+- Mailchimp / marketing automation -> Mautic, Listmonk
+- Salesforce / HubSpot -> Twenty CRM
+- Confluence / Notion -> Docmost, BookStack
+- Intercom / community support -> Answer
+- status / uptime monitoring -> Uptime Kuma
+- 1Password / Bitwarden -> Vaultwarden
+- Firebase -> Pocketbase, Directus
+"""
+
 EVALUATORS = [
     {
         "name": "growth_issue_quality",
@@ -104,6 +119,29 @@ EVALUATORS = [
         "outputDefinition": _BOOLEAN,
         "modelConfig": _JUDGE_MODEL,
     },
+    {
+        "name": "open_source_default",
+        "type": "llm_as_judge",
+        "prompt": (
+            "You are scoring a box-PROPOSED ISSUE on whether it defaults to "
+            "open-source / self-hostable tooling instead of proprietary SaaS.\n\n"
+            f"{_PIKAPODS_SNAPSHOT}\n"
+            "Proposed issue:\n{{output}}\n\n"
+            "Rule of thumb: if PikaPods has it, we can use it.\n\n"
+            "Score 0.0-1.0 with these anchors: 1.0 = proposal adopts NO "
+            "third-party tool/service (NOT APPLICABLE), OR proposes an open-"
+            "source/self-hostable tool, OR names a PikaPods app; ~0.5 = "
+            "proposes a proprietary SaaS but with explicit justification that "
+            "the OSS/PikaPods equivalent cannot meet the need; 0.0 = proposes "
+            "a proprietary SaaS where a PikaPods/OSS equivalent plainly exists "
+            "(e.g. Intercom->Answer, Zapier->Activepieces), with no "
+            "justification. Reasoning: one sentence naming the proprietary "
+            "tool and the OSS alternative."
+        ),
+        "variables": ["output"],
+        "outputDefinition": _NUMERIC,
+        "modelConfig": _JUDGE_MODEL,
+    },
 ]
 
 # --- evaluation rules (WHAT to score) ---------------------------------------
@@ -148,6 +186,14 @@ RULES = [
     {
         "name": "rule_public_safety_pass",
         "evaluatorName": "public_safety_pass",
+        "target": "observation",
+        "sampling": 1.0,
+        "filter": _GEN_FILTER,
+        "mapping": [{"variable": "output", "source": "output"}],
+    },
+    {
+        "name": "rule_open_source_default",
+        "evaluatorName": "open_source_default",
         "target": "observation",
         "sampling": 1.0,
         "filter": _GEN_FILTER,

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+if str(PIPELINE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_ROOT))
+
+from evals.setup_langfuse_evaluators import (  # noqa: E402
+    EVALUATORS,
+    RULES,
+    _GEN_FILTER,
+    _JUDGE_MODEL,
+    _NUMERIC,
+    _PIKAPODS_SNAPSHOT,
+    main,
+)
+
+
+@pytest.mark.unit
+def test_open_source_default_evaluator_shape_and_prompt() -> None:
+    matches = [ev for ev in EVALUATORS if ev["name"] == "open_source_default"]
+
+    assert len(matches) == 1
+    evaluator = matches[0]
+    assert evaluator["type"] == "llm_as_judge"
+    assert evaluator["variables"] == ["output"]
+    assert evaluator["outputDefinition"] is _NUMERIC
+    assert evaluator["modelConfig"] is _JUDGE_MODEL
+    assert "{{output}}" in evaluator["prompt"]
+    assert "Intercom" in evaluator["prompt"]
+    assert "Answer" in evaluator["prompt"]
+    assert "Zapier" in evaluator["prompt"]
+    assert "Activepieces" in evaluator["prompt"]
+    assert "not applicable" in evaluator["prompt"].lower()
+    assert "PikaPods self-hosts these open-source apps" in _PIKAPODS_SNAPSHOT
+
+
+@pytest.mark.unit
+def test_open_source_default_rule_shape() -> None:
+    matches = [rule for rule in RULES if rule["name"] == "rule_open_source_default"]
+
+    assert len(matches) == 1
+    rule = matches[0]
+    assert rule["evaluatorName"] == "open_source_default"
+    assert rule["target"] == "observation"
+    assert rule["filter"] is _GEN_FILTER
+    assert rule["mapping"] == [{"variable": "output", "source": "output"}]
+
+
+@pytest.mark.unit
+def test_rules_reference_existing_evaluators() -> None:
+    evaluator_names = {ev["name"] for ev in EVALUATORS}
+
+    assert all(rule["evaluatorName"] in evaluator_names for rule in RULES)
+
+
+@pytest.mark.unit
+def test_setup_langfuse_evaluator_counts() -> None:
+    assert len(EVALUATORS) == 4
+    assert len(RULES) == 4
+
+
+@pytest.mark.unit
+def test_dry_run_prints_open_source_default(capsys) -> None:
+    assert main(["--dry-run"]) == 0
+
+    captured = capsys.readouterr()
+    assert "open_source_default" in captured.out
+    assert "rule_open_source_default" in captured.out


### PR DESCRIPTION
## What

Adds a 4th Langfuse LLM-as-judge evaluator `open_source_default` (+ sibling rule `rule_open_source_default`) to `pipeline/evals/setup_langfuse_evaluators.py`.

Advisory NUMERIC score on box-**proposed issues**: does the proposal default to open-source / self-hostable tooling instead of proprietary SaaS? Grounded by a static embedded **PikaPods catalog snapshot** as ground truth for "if PikaPods has it, we can use it" (e.g. Intercom→Answer, Zapier→Activepieces, Airtable→Baserow, Sentry→Bugsink).

- **Advisory only** — no gate, no sanitise wall, `eval_gate`/`run_evals` untouched.
- **N/A → 1.0** — proposals adopting no third-party tool are not penalised.
- Scores the same `{{output}}` generations + `_GEN_FILTER` as `growth_issue_quality`.
- Reuses `_NUMERIC` + `_JUDGE_MODEL` (GLM-5.2/`zai`), idempotent, stdlib-only.

Also adds the **first unit test** for `setup_langfuse_evaluators.py` (none existed): shape, embedded-snapshot, N/A clause, cross-list integrity, `--dry-run` render.

## Plan

`docs/plans/2026-06-17-001-feat-open-source-default-evaluator-plan.md`

## Test plan

- [x] `pytest pipeline/tests/test_setup_langfuse_evaluators.py` → 5 passed
- [x] `python pipeline/evals/setup_langfuse_evaluators.py --dry-run` → 4 evaluators + 4 rules, exit 0, no network
- [x] full `pytest pipeline` → 570 passed / 5 skipped
- [x] black + ruff clean
- [ ] post-merge: dispatch `register-langfuse-evaluators.yml` mode=probe, then mode=apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)