### PR TITLE
fix(evals): idempotent Langfuse rule registration (PATCH on 409)

### DIFF
--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -254,6 +254,25 @@ def _existing_names(path: str, key: str = "data") -> set[str]:
     return {str(i.get("name")) for i in items if isinstance(i, dict) and i.get("name")}
 
 
+def _existing_rule_ids() -> dict[str, str]:
+    status, payload = _request("GET", f"{_UNSTABLE}/evaluation-rules")
+    if status != 200 or not isinstance(payload, dict):
+        return {}
+    items = (
+        payload.get("data")
+        or payload.get("evaluators")
+        or payload.get("evaluationRules")
+        or []
+    )
+    if not isinstance(items, list):
+        return {}
+    return {
+        str(item["name"]): str(item["id"])
+        for item in items
+        if isinstance(item, dict) and item.get("name") and item.get("id")
+    }
+
+
 def apply(dry_run: bool) -> int:
     if dry_run:
         for ev in EVALUATORS:
@@ -279,6 +298,7 @@ def apply(dry_run: bool) -> int:
     # Phase 2: rules. Build the evaluator reference object {name, scope, type}
     # — scope comes from the create response (custom evaluators are "project").
     rule_fail = 0
+    existing_rule_ids = _existing_rule_ids()
     for rule in RULES:
         ev_name = str(rule["evaluatorName"])
         body = {
@@ -294,9 +314,19 @@ def apply(dry_run: bool) -> int:
             "filter": rule["filter"],
             "mapping": rule["mapping"],
         }
-        status, payload = _request("POST", f"{_UNSTABLE}/evaluation-rules", body)
-        ok = status in (200, 201)
-        print(f"rule {rule['name']}: {status} {'OK' if ok else payload}")
+        rule_id = existing_rule_ids.get(str(rule["name"]))
+        if rule_id:
+            status, payload = _request(
+                "PATCH", f"{_UNSTABLE}/evaluation-rules/{rule_id}", body
+            )
+        else:
+            status, payload = _request("POST", f"{_UNSTABLE}/evaluation-rules", body)
+        exists_ok = status == 409 and (
+            "name_conflict" in str(payload) or "already exists" in str(payload)
+        )
+        ok = status in (200, 201) or exists_ok
+        result = "exists (idempotent ok)" if exists_ok else ("OK" if ok else payload)
+        print(f"rule {rule['name']}: {status} {result}")
         rule_fail += 0 if ok else 1
 
     print(

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -9,6 +9,7 @@ PIPELINE_ROOT = Path(__file__).resolve().parents[1]
 if str(PIPELINE_ROOT) not in sys.path:
     sys.path.insert(0, str(PIPELINE_ROOT))
 
+from evals import setup_langfuse_evaluators as mod  # noqa: E402
 from evals.setup_langfuse_evaluators import (  # noqa: E402
     EVALUATORS,
     RULES,
@@ -71,3 +72,82 @@ def test_dry_run_prints_open_source_default(capsys) -> None:
     captured = capsys.readouterr()
     assert "open_source_default" in captured.out
     assert "rule_open_source_default" in captured.out
+
+
+@pytest.mark.unit
+def test_apply_patches_existing_rules(monkeypatch) -> None:
+    existing_rule_ids = {
+        rule["name"]: f"rule-id-{idx}" for idx, rule in enumerate(RULES)
+    }
+    calls = []
+
+    monkeypatch.setattr(mod, "_existing_rule_ids", lambda: existing_rule_ids)
+
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        calls.append((method, path))
+        if path == f"{mod._UNSTABLE}/evaluators":
+            return 200, {"scope": "project"}
+        return 200, {}
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert mod.apply(dry_run=False) == 0
+    rule_calls = calls[len(EVALUATORS) :]
+
+    assert len(rule_calls) == len(RULES)
+    assert all(method == "PATCH" for method, _path in rule_calls)
+    assert all("/evaluation-rules/rule-id-" in path for _method, path in rule_calls)
+    assert not any(
+        method == "POST" and path == f"{mod._UNSTABLE}/evaluation-rules"
+        for method, path in rule_calls
+    )
+
+
+@pytest.mark.unit
+def test_apply_posts_fresh_rules(monkeypatch) -> None:
+    calls = []
+
+    monkeypatch.setattr(mod, "_existing_rule_ids", lambda: {})
+
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        calls.append((method, path))
+        if path == f"{mod._UNSTABLE}/evaluators":
+            return 200, {"scope": "project"}
+        return 200, {}
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert mod.apply(dry_run=False) == 0
+    rule_calls = calls[len(EVALUATORS) :]
+
+    assert rule_calls == [
+        ("POST", f"{mod._UNSTABLE}/evaluation-rules") for _rule in RULES
+    ]
+
+
+@pytest.mark.unit
+def test_apply_treats_rule_name_conflict_as_success(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_existing_rule_ids", lambda: {})
+
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        if path == f"{mod._UNSTABLE}/evaluators":
+            return 200, {"scope": "project"}
+        return 409, '{"code":"name_conflict","message":"already exists"}'
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert mod.apply(dry_run=False) == 0
+
+
+@pytest.mark.unit
+def test_apply_keeps_genuine_rule_failure(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_existing_rule_ids", lambda: {})
+
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        if path == f"{mod._UNSTABLE}/evaluators":
+            return 200, {"scope": "project"}
+        return 500, "boom"
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert mod.apply(dry_run=False) > 0


### PR DESCRIPTION
## What

`apply()` in `pipeline/evals/setup_langfuse_evaluators.py` blindly POSTed evaluation-rules, so re-running 409'd on the already-registered rules (`name_conflict`) and the script/workflow exited **failure** even though nothing was wrong (`summary: rules 1/4 ok`). Surfaced live on 2026-06-18 after registering the `open_source_default` judge.

Fix: `apply()` now GETs existing rules (`_existing_rule_ids()` → name→id), **PATCHes by id** when a rule already exists, else POSTs, and treats a residual `409 name_conflict` as idempotent-success. Evaluators already version on re-create — untouched.

Re-applying the setup is now **green**.

## Test plan

- [x] 4 new unit tests (monkeypatched `_request`, no network): PATCH-on-existing, POST-on-fresh, 409→success, 500→genuine failure
- [x] `pytest pipeline` → 574 passed / 5 skipped
- [x] `--dry-run` unchanged, exit 0, no network
- [ ] post-merge: dispatch `register-langfuse-evaluators.yml` apply **twice** — 2nd run must be all-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)