### PR TITLE
feat(executor): Executor protocol + config-flag factory (U1)

### DIFF
--- a/pipeline/tests/test_executor_factory.py
+++ b/pipeline/tests/test_executor_factory.py
@@ -1,0 +1,90 @@
+"""Tests for the Executor protocol and build_executor factory (U1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.executor import Executor, build_executor
+from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.config import load_config
+
+# ---------------------------------------------------------------------------
+# Minimal env dict that satisfies load_config's required fields.
+# ---------------------------------------------------------------------------
+_BASE_ENV = {
+    "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+    "DATABASE_MODE": "local",
+    "WGMESH_BOT_PAT": "token",
+    "ZAI_API_KEY": "zai",
+}
+
+
+def _cfg(**extra: str) -> object:
+    """Return a Config built from the base env plus any extra overrides."""
+    return load_config({**_BASE_ENV, **extra})
+
+
+# ---------------------------------------------------------------------------
+# Factory — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_returns_goose_runner() -> None:
+    """Default Config (EXECUTOR unset) → build_executor returns a GooseRunner."""
+    cfg = _cfg()
+    assert cfg.executor == "goose"
+    result = build_executor(cfg)
+    assert isinstance(result, GooseRunner)
+
+
+def test_explicit_goose_with_fake_runner() -> None:
+    """Config(executor='goose') with a stub runner forwarded → GooseRunner."""
+    cfg = _cfg(EXECUTOR="goose")
+    fake_runner = object()  # not called in this test
+    result = build_executor(cfg, runner=fake_runner)  # type: ignore[arg-type]
+    assert isinstance(result, GooseRunner)
+
+
+# ---------------------------------------------------------------------------
+# Factory — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_raises_not_implemented() -> None:
+    """config.executor == 'langchain' → NotImplementedError (U2 not yet landed)."""
+    cfg = _cfg(EXECUTOR="langchain")
+    with pytest.raises(NotImplementedError, match="langchain"):
+        build_executor(cfg)
+
+
+def test_unknown_executor_raises_value_error() -> None:
+    """Unknown executor value → ValueError (fail-closed)."""
+    cfg = _cfg(EXECUTOR="bogus")
+    with pytest.raises(ValueError, match="unknown executor"):
+        build_executor(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Env parsing — mixed case + whitespace
+# ---------------------------------------------------------------------------
+
+
+def test_executor_env_normalised_lower_strip() -> None:
+    """EXECUTOR='LangChain ' (mixed case + trailing space) → config.executor == 'langchain'."""
+    cfg = _cfg(EXECUTOR="LangChain ")
+    assert cfg.executor == "langchain"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_goose_runner_satisfies_executor_protocol() -> None:
+    """GooseRunner is structurally compatible with the Executor protocol."""
+    cfg = _cfg()
+    runner = build_executor(cfg)
+    # runtime_checkable Protocol — isinstance works.
+    assert isinstance(runner, Executor)
+    # Also verify the method is present as a double-check.
+    assert callable(getattr(runner, "run_recipe", None))

--- a/pipeline/tests/test_main.py
+++ b/pipeline/tests/test_main.py
@@ -29,7 +29,9 @@ class DummyPoller:
 def test_async_main_honors_reset_queue_env_before_polling(monkeypatch, capsys) -> None:
     DummyPoller.instances = []
     store = Store()
-    cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local")
+    cfg = Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local"
+    )
     goose_runner = object()
 
     monkeypatch.setenv("RESET_QUEUE", "1")
@@ -39,7 +41,9 @@ def test_async_main_honors_reset_queue_env_before_polling(monkeypatch, capsys) -
     monkeypatch.setattr(main, "open_state_store", lambda config: store)
     monkeypatch.setattr(main, "make_forge", lambda config: object())
     monkeypatch.setattr(main, "build_graph", lambda config: object())
-    monkeypatch.setattr(main, "GooseRunner", lambda config: goose_runner, raising=False)
+    monkeypatch.setattr(
+        main, "build_executor", lambda config: goose_runner, raising=False
+    )
     monkeypatch.setattr(main, "Poller", DummyPoller)
 
     asyncio.run(main.async_main())

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -126,6 +126,9 @@ class Config:
     selfheal_live: bool = False
     observation_live: bool = False
     strategy_audit_live: bool = False
+    # Executor backend: 'goose' (default) or 'langchain' (U2).
+    # Selected via EXECUTOR env var; factory in executor.py fails closed on unknown values.
+    executor: str = "goose"
 
     @property
     def owner(self) -> str:
@@ -240,6 +243,7 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         selfheal_live=_get_bool(source, "SELFHEAL_LIVE", False),
         observation_live=_get_bool(source, "OBSERVATION_LIVE", False),
         strategy_audit_live=_get_bool(source, "STRATEGY_AUDIT_LIVE", False),
+        executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
     )
     _log_control_loop_module_modes(cfg)
     return cfg

--- a/pipeline/wgmesh_pipeline/executor.py
+++ b/pipeline/wgmesh_pipeline/executor.py
@@ -1,0 +1,58 @@
+"""Executor protocol and factory for wgmesh_pipeline.
+
+Defines the ``Executor`` protocol (matching ``GooseRunner.run_recipe``) and
+``build_executor(config)`` which selects the concrete implementation via
+``config.executor`` (populated from the ``EXECUTOR`` env var, default "goose").
+
+LangChain executor (U2) is not yet implemented — selecting it raises
+``NotImplementedError``.  Any unknown value fails closed with ``ValueError``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Protocol, runtime_checkable
+
+from wgmesh_pipeline.goose.runner import GooseResult, GooseRunner, SubprocessRunner
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Protocol satisfied by any executor that can run a Goose recipe.
+
+    The signature is identical to ``GooseRunner.run_recipe`` so existing
+    call sites need no changes when a different backend is substituted.
+    """
+
+    def run_recipe(
+        self,
+        *,
+        recipe: str | Path,
+        workdir: str | Path,
+        params: Mapping[str, str],
+        expected_output: str | Path,
+        stage: str | None = None,
+        tier: int = 0,
+        session_id: str | None = None,
+    ) -> GooseResult: ...
+
+
+def build_executor(
+    config: object,
+    *,
+    runner: SubprocessRunner | None = None,
+) -> Executor:
+    """Return an ``Executor`` selected by ``config.executor``.
+
+    * ``"goose"``    → :class:`~wgmesh_pipeline.goose.runner.GooseRunner`
+    * ``"langchain"``→ raises :exc:`NotImplementedError` (U2)
+    * anything else  → raises :exc:`ValueError` (fail-closed)
+
+    ``runner`` is forwarded to ``GooseRunner.__init__`` for test injection.
+    """
+    executor_name: str = getattr(config, "executor", "goose")
+    if executor_name == "goose":
+        return GooseRunner(config, runner=runner)  # type: ignore[arg-type]
+    if executor_name == "langchain":
+        raise NotImplementedError("langchain executor lands in U2")
+    raise ValueError(f"unknown executor: {executor_name!r}")

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -12,7 +12,8 @@ from wgmesh_pipeline.config import load_config
 from wgmesh_pipeline.control_loop import ControlLoopScheduler
 from wgmesh_pipeline.forge.factory import make_forge
 from wgmesh_pipeline.forge.gitfacts import make_resolution_lookup
-from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.executor import build_executor
+from wgmesh_pipeline.goose.runner import GooseRunner  # noqa: F401 — kept for downstream compat
 from wgmesh_pipeline.graph.build import build_graph
 from wgmesh_pipeline.poller import Poller
 from wgmesh_pipeline.scoring import init_scoring
@@ -33,8 +34,8 @@ async def async_main(*, reset_queue: bool = False) -> None:
     )
     config = load_config()
     logging.getLogger("wgmesh_pipeline").info(
-        "starting: mode=%s database_mode=%s poll_interval=%ss",
-        config.mode, config.database_mode, config.poll_interval_seconds,
+        "starting: mode=%s database_mode=%s poll_interval=%ss executor=%s",
+        config.mode, config.database_mode, config.poll_interval_seconds, config.executor,
     )
     init_tracing(config)
     init_scoring(config)
@@ -55,7 +56,7 @@ async def async_main(*, reset_queue: bool = False) -> None:
         client=client,
         resolution_lookup=make_resolution_lookup(config.repo_path, client),
         graph=build_graph(config),
-        goose_runner=GooseRunner(config),
+        goose_runner=build_executor(config),
     )
 
     stop = asyncio.Event()


### PR DESCRIPTION
**U1** of the box LangGraph/executor migration (`docs/plans/2026-06-18-001-feat-box-langgraph-executor-migration-plan.md`).

Introduces an `Executor` Protocol matching `GooseRunner.run_recipe` and a `build_executor(config)` factory selected by `config.executor` (`EXECUTOR` env, default `"goose"`). **Zero behavior change** — goose stays default; `"langchain"` raises `NotImplementedError` (lands in U2); unknown values fail closed with `ValueError`. `main.py` now builds the runner via the factory.

This is the seam the LangChain tool-agent executor (U2) plugs into without touching node code.

## Test plan
- [x] `tests/test_executor_factory.py` — default→GooseRunner, goose+fake runner, langchain→NotImplementedError, bogus→ValueError, `EXECUTOR` env normalize, protocol conformance
- [x] `test_main.py` updated to patch `build_executor`
- [x] `pytest pipeline` → 580 passed / 5 skipped
- [x] ruff + black clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)