### PR TITLE
feat(executor): robust recipe->prompt loader for the LangChain agent (U3)

### DIFF
--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
   "langchain-anthropic>=0.2",
   "pytest>=8.0",
+  "pyyaml>=6",
   "requests>=2.32",
 ]
 

--- a/pipeline/tests/test_langchain_agent_prompts.py
+++ b/pipeline/tests/test_langchain_agent_prompts.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wgmesh_pipeline.langchain_agent.prompts import (
+    PromptRenderError,
+    render_recipe_prompt,
+)
+
+pytestmark = pytest.mark.unit
+
+RECIPES_DIR = Path(__file__).parent.parent / "recipes"
+
+
+def test_spec_recipe_renders_required_params() -> None:
+    rendered = render_recipe_prompt(
+        RECIPES_DIR / "wgmesh-triage-spec.yaml",
+        {
+            "issue_number": "42",
+            "issue_title": "Test title",
+            "spec_file": "spec.md",
+        },
+    )
+
+    assert "42" in rendered
+    assert "Test title" in rendered
+    assert "spec.md" in rendered
+    assert "{{" not in rendered
+    assert "}}" not in rendered
+
+
+def test_implementation_recipe_renders_required_params() -> None:
+    rendered = render_recipe_prompt(
+        RECIPES_DIR / "wgmesh-implementation.yaml",
+        {
+            "spec_file": "spec.md",
+            "diff_file": "diff.patch",
+        },
+    )
+
+    assert "spec.md" in rendered
+    assert "diff.patch" in rendered
+    assert "{{" not in rendered
+    assert "}}" not in rendered
+
+
+def test_missing_required_param_names_missing_key(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "version: '1'\nprompt: 'Write {{ output_file }}.'\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PromptRenderError, match="output_file"):
+        render_recipe_prompt(recipe, {})
+
+
+def test_extra_unknown_param_is_ignored(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "version: '1'\nprompt: 'Write {{ output_file }}.'\n",
+        encoding="utf-8",
+    )
+
+    rendered = render_recipe_prompt(
+        recipe,
+        {"output_file": "out.txt", "unknown": "ignored"},
+    )
+
+    assert rendered == "Write out.txt."
+
+
+def test_recipe_missing_prompt_field_raises_prompt_error(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text("version: '1'\n", encoding="utf-8")
+
+    with pytest.raises(PromptRenderError, match="recipe missing top-level prompt"):
+        render_recipe_prompt(recipe, {})
+
+
+def test_recipe_yaml_list_raises_prompt_error(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text("- prompt: nope\n", encoding="utf-8")
+
+    with pytest.raises(PromptRenderError):
+        render_recipe_prompt(recipe, {})
+
+
+def test_workdir_resolves_relative_recipe_path(tmp_path: Path) -> None:
+    recipe = tmp_path / "recipe.yaml"
+    recipe.write_text(
+        "version: '1'\nprompt: 'Write {{ output_file }}.'\n",
+        encoding="utf-8",
+    )
+
+    rendered = render_recipe_prompt(
+        "recipe.yaml",
+        {"output_file": "out.txt"},
+        workdir=tmp_path,
+    )
+
+    assert rendered == "Write out.txt."

--- a/pipeline/wgmesh_pipeline/langchain_agent/prompts.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/prompts.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+
+
+class PromptRenderError(Exception):
+    pass
+
+
+def load_recipe(recipe_path: str | Path) -> dict:
+    try:
+        data = yaml.safe_load(Path(recipe_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise PromptRenderError(f"could not read recipe {recipe_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PromptRenderError("recipe must be a mapping")
+    return data
+
+
+def render_recipe_prompt(
+    recipe: str | Path,
+    params: Mapping[str, str],
+    *,
+    workdir: str | Path | None = None,
+) -> str:
+    recipe_path = Path(recipe)
+    if workdir is not None and not recipe_path.is_absolute():
+        recipe_path = Path(workdir) / recipe_path
+
+    data = load_recipe(recipe_path)
+    prompt_text = data.get("prompt")
+    if not isinstance(prompt_text, str):
+        raise PromptRenderError("recipe missing top-level prompt")
+
+    declared_required = {
+        param["key"]
+        for param in data.get("parameters", [])
+        if param.get("requirement") == "required"
+    }
+    placeholders_in_prompt = set(_PLACEHOLDER_RE.findall(prompt_text))
+    must_supply = declared_required | placeholders_in_prompt
+    missing = must_supply - set(params)
+    if missing:
+        raise PromptRenderError(
+            f"missing required recipe params: {', '.join(sorted(missing))}"
+        )
+
+    return _PLACEHOLDER_RE.sub(lambda match: str(params[match.group(1)]), prompt_text)

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import time
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -10,6 +9,7 @@ from wgmesh_pipeline import tracing
 from wgmesh_pipeline.config import DEFAULT_GOOSE_MODEL, DEFAULT_GOOSE_PROVIDER, Config
 from wgmesh_pipeline.goose.runner import GooseResult
 from wgmesh_pipeline.goose.usage import UsageTotals
+from wgmesh_pipeline.langchain_agent import prompts
 from wgmesh_pipeline.langchain_agent.tools import build_tools, resolve_workspace_path
 from wgmesh_pipeline.models import (
     ModelProfile,
@@ -20,7 +20,6 @@ from wgmesh_pipeline.models import (
 ClientFactory = Callable[[ModelProfile, Config], Any]
 MAX_ITERATIONS = 25
 WALL_CLOCK_LIMIT_SECONDS = 1800
-_PLACEHOLDER_RE = re.compile(r"{{\s*([A-Za-z0-9_-]+)\s*}}")
 
 
 class LangchainAgentRunner:
@@ -48,14 +47,17 @@ class LangchainAgentRunner:
             root = Path(workdir).resolve()
             output_path = resolve_workspace_path(root, expected_output)
             profile = self._resolve_profile(stage, tier)
-            prompt = _render_prompt(recipe, root, params)
-            if isinstance(prompt, _PromptError):
+            try:
+                rendered_prompt = prompts.render_recipe_prompt(
+                    recipe, params, workdir=root
+                )
+            except prompts.PromptRenderError as exc:
                 return _result(
                     ok=False,
                     output_path=output_path,
                     started=started,
                     raw_log=raw_log,
-                    error=prompt.message,
+                    error=str(exc),
                     profile=profile,
                     usage=usage,
                 )
@@ -67,10 +69,10 @@ class LangchainAgentRunner:
             HumanMessage, SystemMessage, ToolMessage = _message_classes()
             messages: list[Any] = [
                 SystemMessage(content=_system_prompt()),
-                HumanMessage(content=prompt),
+                HumanMessage(content=rendered_prompt),
             ]
             raw_log.append(f"system: {_system_prompt()}")
-            raw_log.append(f"human: {prompt}")
+            raw_log.append(f"human: {rendered_prompt}")
 
             iterations = 0
             while iterations < MAX_ITERATIONS:
@@ -209,51 +211,6 @@ def _system_prompt() -> str:
         "inspect and modify files. Keep all work inside the workspace, and write "
         "the requested expected output before finishing."
     )
-
-
-class _PromptError:
-    def __init__(self, message: str):
-        self.message = message
-
-
-def _render_prompt(
-    recipe: str | Path, workdir: Path, params: Mapping[str, str]
-) -> str | _PromptError:
-    recipe_path = Path(recipe)
-    if not recipe_path.is_absolute():
-        recipe_path = workdir / recipe_path
-    try:
-        prompt = _extract_top_level_prompt(recipe_path.read_text(encoding="utf-8"))
-    except OSError as exc:
-        return _PromptError(f"could not read recipe {recipe_path}: {exc}")
-    except ValueError as exc:
-        return _PromptError(str(exc))
-
-    missing = sorted(
-        {key for key in _PLACEHOLDER_RE.findall(prompt) if key not in params}
-    )
-    if missing:
-        return _PromptError(f"missing required recipe params: {', '.join(missing)}")
-    for key, value in params.items():
-        prompt = re.sub(r"{{\s*" + re.escape(key) + r"\s*}}", str(value), prompt)
-    return prompt
-
-
-def _extract_top_level_prompt(text: str) -> str:
-    lines = text.splitlines()
-    for index, line in enumerate(lines):
-        if line == "prompt: |" or line == "prompt: |-":
-            block: list[str] = []
-            for candidate in lines[index + 1 :]:
-                if candidate and not candidate.startswith((" ", "\t")):
-                    break
-                block.append(
-                    candidate[2:] if candidate.startswith("  ") else candidate.lstrip()
-                )
-            return "\n".join(block).rstrip() + "\n"
-        if line.startswith("prompt: "):
-            return line.removeprefix("prompt: ").strip().strip("\"'")
-    raise ValueError("recipe missing top-level prompt")
 
 
 def _tool_call_parts(call: Any) -> tuple[str, dict[str, Any], str]:


### PR DESCRIPTION
**U3** of the box LangGraph/executor migration (`docs/plans/2026-06-18-001-feat-box-langgraph-executor-migration-plan.md`).

Replaces U2's fragile hand-rolled YAML slicer in `LangchainAgentRunner` with `prompts.render_recipe_prompt`:
- `yaml.safe_load` (real parser) via `load_recipe` — errors on unreadable / non-mapping recipes.
- Param validation: must-supply = declared-`required` params ∪ `{{placeholders}}` actually in the prompt; missing → `PromptRenderError` naming them.
- Whitespace-tolerant `{{ key }}` interpolation; extra params ignored.
- Deletes the dead `_extract_top_level_prompt`/`_render_prompt`/`_PromptError` helpers from runner.py.
- Declares the previously-**undeclared** `pyyaml>=6` dependency (was importable only transitively).

Spec + implement recipes stay the single source of prompt text. Observation (separate injected assessor, not `run_recipe`) is out of scope.

## Test plan
- [x] `tests/test_langchain_agent_prompts.py` (7) — spec/impl render, missing-required→error, extra ignored, no-prompt-field→error, non-mapping→error
- [x] `pytest pipeline` → **596 passed / 5 skipped**
- [x] `setup_langfuse_evaluators.py --dry-run` clean
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)