### PR TITLE
feat(graph): langgraph StateGraph behind GRAPH_IMPL flag, parity-tested (U4)

### DIFF
--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "langchain-anthropic>=0.2",
+  "langgraph>=0.2",
   "pytest>=8.0",
   "pyyaml>=6",
   "requests>=2.32",
@@ -20,7 +21,6 @@ dev = [
   "pytest>=8.0",
 ]
 graph = [
-  "langgraph>=0.2",
   "langsmith>=0.1",
 ]
 eval = [

--- a/pipeline/tests/test_build_lg_parity.py
+++ b/pipeline/tests/test_build_lg_parity.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from wgmesh_pipeline.config import Config, load_config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.graph import build_lg
+from wgmesh_pipeline.graph.build import CompiledGraph, build_graph
+from wgmesh_pipeline.graph.nodes.gate import gate_node
+from wgmesh_pipeline.graph.state import GraphState
+
+
+def _cfg(
+    *,
+    mode: str = "shadow",
+    ladder: tuple[str, ...] = ("cheap", "capable"),
+    max_attempts: int = 2,
+    graph_impl: str = "legacy",
+) -> Config:
+    return Config(
+        target_repo="atvirokodosprendimai/wgmesh",
+        mode=mode,
+        max_files=3,
+        stage_routing={"implement": ladder},
+        max_escalation_attempts=max_attempts,
+        graph_impl=graph_impl,
+    )
+
+
+@dataclass
+class RecordingClient:
+    config: Config
+    calls: list[tuple] | None = None
+
+    def __post_init__(self) -> None:
+        if self.calls is None:
+            self.calls = []
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        self.calls.append(("add_label", issue_number, label))
+
+    def merge_pr(self, pr_number: int, *, commit_title: str) -> None:
+        self.calls.append(("merge_pr", pr_number, commit_title))
+
+
+@dataclass(frozen=True)
+class Nodes:
+    triage: object
+    spec: object
+    spec_pr: object
+    implement: object
+    review: object
+
+
+def _node(name: str, **updates):
+    def run(state: GraphState) -> GraphState:
+        next_state = dict(state)
+        next_state.setdefault("visited", []).append(name)
+        next_state.update(updates)
+        return next_state
+
+    return run
+
+
+def _implement():
+    def run(state: GraphState) -> GraphState:
+        next_state = dict(state)
+        tier = int(next_state.get("escalation_tier", 0))
+        next_state.setdefault("visited", []).append("implement")
+        next_state["diff"] = (
+            f"diff --git a/docs/tier-{tier}.md b/docs/tier-{tier}.md\n+docs\n"
+        )
+        next_state["changed_files"] = [f"docs/tier-{tier}.md"]
+        next_state["impl_pr"] = 123
+        return next_state
+
+    return run
+
+
+def _review_by_tier(results: dict[int, dict]):
+    def run(state: GraphState) -> GraphState:
+        next_state = dict(state)
+        tier = int(next_state.get("escalation_tier", 0))
+        next_state.setdefault("visited", []).append("review")
+        next_state.update(
+            {
+                "tests_passed": True,
+                "sanitise_ok": True,
+                "review_findings": [],
+                **results.get(tier, {}),
+            }
+        )
+        return next_state
+
+    return run
+
+
+def _nodes(
+    *,
+    classification: str = "fix",
+    review_results: dict[int, dict] | None = None,
+) -> Nodes:
+    return Nodes(
+        triage=_node("triage", classification=classification),
+        spec=_node("spec", spec_path="specs/issue-1-spec.md"),
+        spec_pr=_node("spec_pr", spec_pr=101),
+        implement=_implement(),
+        review=_review_by_tier(review_results or {}),
+    )
+
+
+def _state(client: RecordingClient) -> GraphState:
+    return {
+        "issue": GitHubIssue(
+            number=1,
+            title="Fix docs",
+            labels=("needs-triage",),
+            state="open",
+        ),
+        "github": client,
+    }
+
+
+def _assert_parity(
+    monkeypatch,
+    *,
+    config: Config,
+    nodes: Nodes,
+    expected_calls: list[tuple],
+) -> GraphState:
+    monkeypatch.setattr(build_lg, "triage_node", nodes.triage)
+    monkeypatch.setattr(build_lg, "spec_node", nodes.spec)
+    monkeypatch.setattr(build_lg, "spec_pr_node", nodes.spec_pr)
+    monkeypatch.setattr(build_lg, "implement_node", nodes.implement)
+    monkeypatch.setattr(build_lg, "review_node", nodes.review)
+
+    legacy_client = RecordingClient(config)
+    langgraph_client = RecordingClient(config)
+    legacy = CompiledGraph(
+        config=config,
+        triage=nodes.triage,
+        spec=nodes.spec,
+        spec_pr=nodes.spec_pr,
+        implement=nodes.implement,
+        review=nodes.review,
+        gate=gate_node,
+    )
+    langgraph = build_lg.build_state_graph(config)
+
+    legacy_result = legacy.invoke(_state(legacy_client))
+    langgraph_result = langgraph.invoke(_state(langgraph_client))
+
+    assert legacy_result == langgraph_result
+    assert legacy_client.calls == expected_calls
+    assert langgraph_client.calls == expected_calls
+    return langgraph_result
+
+
+def test_langgraph_parity_wont_do_triage_escalates_without_gate_side_effects(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(),
+        nodes=_nodes(classification="wont-do"),
+        expected_calls=[("add_label", 1, "needs-human")],
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["visited"] == ["triage", "escalate"]
+
+
+def test_langgraph_parity_needs_info_triage_escalates_without_gate_side_effects(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(),
+        nodes=_nodes(classification="needs-info"),
+        expected_calls=[("add_label", 1, "needs-human")],
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["visited"] == ["triage", "escalate"]
+
+
+def test_langgraph_parity_spec_only_stops_after_spec_pr(monkeypatch) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(mode="spec-only"),
+        nodes=_nodes(classification="feature"),
+        expected_calls=[],
+    )
+
+    assert result["visited"] == ["triage", "spec", "spec_pr"]
+    assert "decision" not in result
+    assert "escalation_history" not in result
+
+
+def test_langgraph_parity_full_live_path_merges_after_gate_side_effects(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(),
+        nodes=_nodes(review_results={0: {"tests_passed": True}}),
+        expected_calls=[("merge_pr", 123, "Merge issue #1")],
+    )
+
+    assert result["decision"] == "merge"
+    assert result["visited"] == [
+        "triage",
+        "spec",
+        "spec_pr",
+        "implement",
+        "review",
+        "gate",
+    ]
+
+
+def test_langgraph_parity_retryable_failure_retries_next_tier_then_merges(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(ladder=("cheap", "capable")),
+        nodes=_nodes(
+            review_results={
+                0: {"tests_passed": False},
+                1: {"tests_passed": True},
+            }
+        ),
+        expected_calls=[("merge_pr", 123, "Merge issue #1")],
+    )
+
+    assert result["decision"] == "merge"
+    assert result["escalation_history"] == [0, 1]
+    assert result["escalation_attempts"] == 1
+
+
+def test_langgraph_parity_retryable_failure_exhausts_at_ladder_length(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(ladder=("cheap",)),
+        nodes=_nodes(review_results={0: {"tests_passed": False}}),
+        expected_calls=[("add_label", 1, "needs-human")],
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["retryable"] is True
+    assert result["escalation_history"] == [0]
+
+
+def test_langgraph_parity_retryable_failure_exhausts_at_max_attempts(
+    monkeypatch,
+) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(ladder=("cheap", "capable", "premium"), max_attempts=1),
+        nodes=_nodes(
+            review_results={
+                0: {"tests_passed": False},
+                1: {"tests_passed": False},
+            }
+        ),
+        expected_calls=[("add_label", 1, "needs-human")],
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["retryable"] is True
+    assert result["escalation_history"] == [0, 1]
+    assert result["escalation_attempts"] == 1
+
+
+def test_langgraph_parity_non_retryable_failure_escalates(monkeypatch) -> None:
+    result = _assert_parity(
+        monkeypatch,
+        config=_cfg(ladder=("cheap", "capable", "premium")),
+        nodes=_nodes(review_results={0: {"tests_passed": False, "sanitise_ok": False}}),
+        expected_calls=[("add_label", 1, "needs-human")],
+    )
+
+    assert result["decision"] == "escalate"
+    assert result["retryable"] is False
+    assert result["escalation_history"] == [0]
+
+
+def test_build_graph_langgraph_flag_dispatches_and_exposes_poller_nodes() -> None:
+    config = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+            "DATABASE_MODE": "local",
+            "GRAPH_IMPL": " LangGraph ",
+        }
+    )
+
+    graph = build_graph(config)
+
+    assert config.graph_impl == "langgraph"
+    assert isinstance(graph, build_lg.StateGraphWrapper)
+    assert graph.config is config
+    for name in ("triage", "spec", "spec_pr", "implement", "review", "gate"):
+        assert hasattr(graph, name)

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping
 
+from wgmesh_pipeline.models import (
+    ModelProfile,
+    parse_registry,
+    parse_stage_routing,
+)
+
 log = logging.getLogger(__name__)
 
 # GitOps box config: a committed, non-secret JSON file read as a base layer
@@ -54,12 +60,6 @@ def _read_box_config(path: Path = BOX_CONFIG_PATH) -> dict[str, str]:
         k: str(v) for k, v in raw.items() if k in BOX_CONFIG_ALLOWLIST and v is not None
     }
 
-
-from wgmesh_pipeline.models import (
-    ModelProfile,
-    parse_registry,
-    parse_stage_routing,
-)
 
 VALID_MODES = frozenset({"shadow", "spec-only", "live"})
 VALID_DB_MODES = frozenset({"local", "turso"})
@@ -129,6 +129,9 @@ class Config:
     # Executor backend: 'goose' (default) or 'langchain' (U2).
     # Selected via EXECUTOR env var; factory in executor.py fails closed on unknown values.
     executor: str = "goose"
+    # Graph backend: 'legacy' (default) or 'langgraph' (U4).
+    # Selected via GRAPH_IMPL env var; build_graph dispatches on this value.
+    graph_impl: str = "legacy"
 
     @property
     def owner(self) -> str:
@@ -244,6 +247,7 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         observation_live=_get_bool(source, "OBSERVATION_LIVE", False),
         strategy_audit_live=_get_bool(source, "STRATEGY_AUDIT_LIVE", False),
         executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
+        graph_impl=(_get_nonempty(source, "GRAPH_IMPL") or "legacy").strip().lower(),
     )
     _log_control_loop_module_modes(cfg)
     return cfg

--- a/pipeline/wgmesh_pipeline/graph/build.py
+++ b/pipeline/wgmesh_pipeline/graph/build.py
@@ -87,7 +87,12 @@ class CompiledGraph:
         return self.gate(state, max_files=self.config.max_files)
 
 
-def build_graph(config: Config) -> CompiledGraph:
+def build_graph(config: Config) -> object:
+    if getattr(config, "graph_impl", "legacy") == "langgraph":
+        from wgmesh_pipeline.graph.build_lg import build_state_graph
+
+        return build_state_graph(config)
+
     return CompiledGraph(
         config=config,
         triage=trace_node("triage", triage_node),

--- a/pipeline/wgmesh_pipeline/graph/build_lg.py
+++ b/pipeline/wgmesh_pipeline/graph/build_lg.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+from wgmesh_pipeline.graph.nodes.review import review_node
+from wgmesh_pipeline.graph.nodes.spec import spec_node
+from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
+from wgmesh_pipeline.graph.nodes.triage import triage_node
+from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.models import ladder_length_for
+from wgmesh_pipeline.tracing import trace_node
+
+
+@dataclass
+class StateGraphWrapper:
+    config: Config
+    compiled: Any
+    triage: Callable[[GraphState], GraphState]
+    spec: Callable[[GraphState], GraphState]
+    spec_pr: Callable[[GraphState], GraphState]
+    implement: Callable[[GraphState], GraphState]
+    review: Callable[[GraphState], GraphState]
+    gate: Callable[..., GraphState]
+
+    def invoke(self, state: GraphState) -> GraphState:
+        return self.compiled.invoke(state)
+
+    def evaluate_gate(self, state: GraphState) -> GraphState:
+        parameters = inspect.signature(self.gate).parameters
+        if "apply_side_effects" in parameters:
+            return self.gate(
+                state,
+                max_files=self.config.max_files,
+                apply_side_effects=False,
+            )
+        return self.gate(state, max_files=self.config.max_files)
+
+    def ladder_prep(self, state: GraphState) -> GraphState:
+        current = dict(state)
+        tier = int(current.get("escalation_tier", 0))
+        attempts = int(current.get("escalation_attempts", 0))
+        history = list(current.get("escalation_history", []))
+        current["escalation_tier"] = tier
+        current["escalation_attempts"] = attempts
+        history.append(tier)
+        current["escalation_history"] = list(history)
+        return current
+
+    def ladder_retry(self, state: GraphState) -> GraphState:
+        current = dict(state)
+        current["escalation_tier"] = int(current.get("escalation_tier", 0)) + 1
+        current["escalation_attempts"] = int(current.get("escalation_attempts", 0)) + 1
+        return current
+
+    def side_effects(self, state: GraphState) -> GraphState:
+        current = dict(state)
+        apply_gate_side_effects(current)
+        return current
+
+    def escalate(self, state: GraphState) -> GraphState:
+        current = dict(state)
+        current["decision"] = "escalate"
+        if current.get("github") is not None:
+            current["github"].add_label(current["issue"].number, "needs-human")
+        current.setdefault("visited", []).append("escalate")
+        return current
+
+    def route_after_triage(self, state: GraphState) -> str:
+        if state.get("classification") in {"wont-do", "needs-info"}:
+            return "escalate"
+        return "spec"
+
+    def route_after_spec_pr(self, state: GraphState) -> str:
+        if self.config.mode == "spec-only":
+            return "end"
+        return "ladder_prep"
+
+    def route_after_gate(self, state: GraphState) -> str:
+        if state.get("decision") == "merge":
+            return "side_effects"
+        if self.can_retry(state):
+            return "ladder_retry"
+        return "side_effects"
+
+    def can_retry(self, state: GraphState) -> bool:
+        tier = int(state.get("escalation_tier", 0))
+        attempts = int(state.get("escalation_attempts", 0))
+        ladder_length = ladder_length_for(self.config.stage_routing, "implement")
+        return (
+            bool(state.get("retryable", False))
+            and tier + 1 < ladder_length
+            and attempts < self.config.max_escalation_attempts
+        )
+
+
+def build_state_graph(config: Config) -> StateGraphWrapper:
+    from langgraph.graph import END, StateGraph
+
+    triage = trace_node("triage", triage_node)
+    spec = trace_node("spec", spec_node)
+    spec_pr = trace_node("spec_pr", spec_pr_node)
+    implement = trace_node("implement", implement_node)
+    review = trace_node("review", review_node)
+
+    wrapper = StateGraphWrapper(
+        config=config,
+        compiled=None,
+        triage=triage,
+        spec=spec,
+        spec_pr=spec_pr,
+        implement=implement,
+        review=review,
+        gate=gate_node,
+    )
+
+    graph = StateGraph(GraphState)
+    graph.add_node("triage", wrapper.triage)
+    graph.add_node("escalate", wrapper.escalate)
+    graph.add_node("spec", wrapper.spec)
+    graph.add_node("spec_pr", wrapper.spec_pr)
+    graph.add_node("ladder_prep", wrapper.ladder_prep)
+    graph.add_node("implement", wrapper.implement)
+    graph.add_node("review", wrapper.review)
+    graph.add_node("gate", wrapper.evaluate_gate)
+    graph.add_node("ladder_retry", wrapper.ladder_retry)
+    graph.add_node("side_effects", wrapper.side_effects)
+
+    graph.set_entry_point("triage")
+    graph.add_conditional_edges(
+        "triage",
+        wrapper.route_after_triage,
+        {"escalate": "escalate", "spec": "spec"},
+    )
+    graph.add_edge("escalate", END)
+    graph.add_edge("spec", "spec_pr")
+    graph.add_conditional_edges(
+        "spec_pr",
+        wrapper.route_after_spec_pr,
+        {"end": END, "ladder_prep": "ladder_prep"},
+    )
+    graph.add_edge("ladder_prep", "implement")
+    graph.add_edge("implement", "review")
+    graph.add_edge("review", "gate")
+    graph.add_conditional_edges(
+        "gate",
+        wrapper.route_after_gate,
+        {"side_effects": "side_effects", "ladder_retry": "ladder_retry"},
+    )
+    graph.add_edge("ladder_retry", "ladder_prep")
+    graph.add_edge("side_effects", END)
+
+    wrapper.compiled = graph.compile()
+    return wrapper


### PR DESCRIPTION
**U4** of the box LangGraph/executor migration (`docs/plans/2026-06-18-001-feat-box-langgraph-executor-migration-plan.md`).

Adds `build_state_graph` — a real `langgraph.StateGraph` that reproduces `CompiledGraph.invoke` exactly: triage→escalate (wont-do/needs-info, no gate side-effects), spec→spec_pr→spec-only stop, implement→review→gate ladder with retry (`ladder_prep` appends tier to history, `ladder_retry` increments tier/attempts), and deferred `apply_gate_side_effects`. Selected by `config.graph_impl` (`GRAPH_IMPL` env, **default `legacy`** — opt-in, zero behavior change). The wrapper still exposes `.triage/.spec/…` so the **poller is unchanged**.

**Parity is the gate:** `test_build_lg_parity.py` runs BOTH graphs against identical fakes + recording clients and asserts identical terminal `GraphState` **and** identical side-effect call ordering across 9 scenarios — escalate paths, spec-only stop, full merge, retryable→retry→merge (`history==[0,1]`), exhaust-at-ladder-length, exhaust-at-max-attempts, non-retryable escalate, + flag dispatch. The StateGraph is genuinely built/compiled (not delegating to CompiledGraph).

`langgraph>=0.2` promoted to base deps (box Docker runs it).

## Test plan
- [x] `tests/test_build_lg_parity.py` → 9 passed
- [x] `pytest pipeline` → **605 passed / 5 skipped**
- [x] ruff + black clean; `setup_langfuse --dry-run` unaffected

## Next
U5 wires `CallbackHandler` onto this StateGraph (per-stage invoke); U6 live rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)