### PR TITLE
feat(tracing): CallbackHandler on the StateGraph invoke path (U5)

### DIFF
--- a/pipeline/tests/test_callback_handler_tracing.py
+++ b/pipeline/tests/test_callback_handler_tracing.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import builtins
+from dataclasses import dataclass, field
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.graph import build_lg
+from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.tracing import build_callback_handler
+
+pytestmark = pytest.mark.unit
+
+
+def _cfg(**kwargs) -> Config:
+    return Config(target_repo="atvirokodosprendimai/wgmesh", **kwargs)
+
+
+@dataclass
+class RecordingCompiled:
+    result: GraphState | None = None
+    configs: list[dict | None] = field(default_factory=list)
+
+    def invoke(self, state: GraphState, config: dict | None = None) -> GraphState:
+        self.configs.append(config)
+        return self.result if self.result is not None else state
+
+
+def _node(state: GraphState) -> GraphState:
+    return state
+
+
+def _gate(
+    state: GraphState,
+    *,
+    max_files: int,
+    apply_side_effects: bool = False,
+) -> GraphState:
+    return state
+
+
+def _wrapper(config: Config, compiled: RecordingCompiled) -> build_lg.StateGraphWrapper:
+    return build_lg.StateGraphWrapper(
+        config=config,
+        compiled=compiled,
+        triage=_node,
+        spec=_node,
+        spec_pr=_node,
+        implement=_node,
+        review=_node,
+        gate=_gate,
+        raw_gate=_gate,
+    )
+
+
+def _state() -> GraphState:
+    return {
+        "issue": GitHubIssue(
+            number=17,
+            title="Trace StateGraph",
+            labels=("fn:dev",),
+            state="open",
+        )
+    }
+
+
+def test_build_callback_handler_returns_none_without_langfuse_env() -> None:
+    assert build_callback_handler(_cfg()) is None
+
+
+def test_build_callback_handler_returns_none_when_import_fails(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "langfuse.langchain":
+            raise ImportError("langfuse not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    handler = build_callback_handler(
+        _cfg(
+            langfuse_host="https://langfuse.example",
+            langfuse_public_key="pk",
+            langfuse_secret_key="sk",
+        )
+    )
+
+    assert handler is None
+
+
+def test_state_graph_invoke_attaches_callbacks(monkeypatch) -> None:
+    fake_handler = object()
+    compiled = RecordingCompiled(result={"ok": True})
+    wrapper = _wrapper(_cfg(), compiled)
+    monkeypatch.setattr(
+        build_lg,
+        "build_callback_handler",
+        lambda config: fake_handler,
+    )
+
+    result = wrapper.invoke(_state())
+
+    assert result == {"ok": True}
+    assert compiled.configs == [{"callbacks": [fake_handler]}]
+
+
+def test_state_graph_invoke_uses_no_config_when_handler_absent(monkeypatch) -> None:
+    compiled = RecordingCompiled()
+    wrapper = _wrapper(_cfg(), compiled)
+    state = _state()
+    monkeypatch.setattr(build_lg, "build_callback_handler", lambda config: None)
+
+    result = wrapper.invoke(state)
+
+    assert result == state
+    assert compiled.configs == [None]
+
+
+def test_state_graph_invoke_ignores_handler_construction_failure(monkeypatch) -> None:
+    compiled = RecordingCompiled()
+    wrapper = _wrapper(_cfg(), compiled)
+    state = _state()
+
+    def boom(config):
+        raise RuntimeError("callback init failed")
+
+    monkeypatch.setattr(build_lg, "build_callback_handler", boom)
+
+    result = wrapper.invoke(state)
+
+    assert result == state
+    assert compiled.configs == [None]

--- a/pipeline/wgmesh_pipeline/graph/build_lg.py
+++ b/pipeline/wgmesh_pipeline/graph/build_lg.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from wgmesh_pipeline.config import Config
@@ -13,7 +13,11 @@ from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
 from wgmesh_pipeline.graph.nodes.triage import triage_node
 from wgmesh_pipeline.graph.state import GraphState
 from wgmesh_pipeline.models import ladder_length_for
-from wgmesh_pipeline.tracing import trace_node
+from wgmesh_pipeline.tracing import (
+    _session_id_ctx,
+    build_callback_handler,
+    trace_node,
+)
 
 
 @dataclass
@@ -26,19 +30,37 @@ class StateGraphWrapper:
     implement: Callable[[GraphState], GraphState]
     review: Callable[[GraphState], GraphState]
     gate: Callable[..., GraphState]
+    raw_gate: Callable[..., GraphState]
+    _callback_handler: object | None = field(default=None, init=False, repr=False)
+    _callback_handler_initialized: bool = field(default=False, init=False, repr=False)
 
     def invoke(self, state: GraphState) -> GraphState:
-        return self.compiled.invoke(state)
+        issue = state.get("issue")
+        issue_number = getattr(issue, "number", None)
+        session_id = f"issue-{issue_number}" if issue_number is not None else None
+        handler = self._callback_handler_for_invoke()
+        cfg = {"callbacks": [handler]} if handler is not None else None
+        with _session_id_ctx(session_id):
+            return self.compiled.invoke(state, config=cfg)
+
+    def _callback_handler_for_invoke(self) -> object | None:
+        if not self._callback_handler_initialized:
+            self._callback_handler_initialized = True
+            try:
+                self._callback_handler = build_callback_handler(self.config)
+            except Exception:
+                self._callback_handler = None
+        return self._callback_handler
 
     def evaluate_gate(self, state: GraphState) -> GraphState:
-        parameters = inspect.signature(self.gate).parameters
+        parameters = inspect.signature(self.raw_gate).parameters
         if "apply_side_effects" in parameters:
-            return self.gate(
+            return self.raw_gate(
                 state,
                 max_files=self.config.max_files,
                 apply_side_effects=False,
             )
-        return self.gate(state, max_files=self.config.max_files)
+        return self.raw_gate(state, max_files=self.config.max_files)
 
     def ladder_prep(self, state: GraphState) -> GraphState:
         current = dict(state)
@@ -106,6 +128,7 @@ def build_state_graph(config: Config) -> StateGraphWrapper:
     spec_pr = trace_node("spec_pr", spec_pr_node)
     implement = trace_node("implement", implement_node)
     review = trace_node("review", review_node)
+    gate = trace_node("gate", gate_node)
 
     wrapper = StateGraphWrapper(
         config=config,
@@ -115,17 +138,18 @@ def build_state_graph(config: Config) -> StateGraphWrapper:
         spec_pr=spec_pr,
         implement=implement,
         review=review,
-        gate=gate_node,
+        gate=gate,
+        raw_gate=gate_node,
     )
 
     graph = StateGraph(GraphState)
-    graph.add_node("triage", wrapper.triage)
+    graph.add_node("triage", triage_node)
     graph.add_node("escalate", wrapper.escalate)
-    graph.add_node("spec", wrapper.spec)
-    graph.add_node("spec_pr", wrapper.spec_pr)
+    graph.add_node("spec", spec_node)
+    graph.add_node("spec_pr", spec_pr_node)
     graph.add_node("ladder_prep", wrapper.ladder_prep)
-    graph.add_node("implement", wrapper.implement)
-    graph.add_node("review", wrapper.review)
+    graph.add_node("implement", implement_node)
+    graph.add_node("review", review_node)
     graph.add_node("gate", wrapper.evaluate_gate)
     graph.add_node("ladder_retry", wrapper.ladder_retry)
     graph.add_node("side_effects", wrapper.side_effects)

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import logging
 import sys
 import time
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Any, Callable, Protocol, TypeVar
+from typing import Any, Callable, ParamSpec, Protocol, TypeVar
 
 from wgmesh_pipeline.config import Config
 
 log = logging.getLogger("wgmesh_pipeline.tracing")
 
-T = TypeVar("T")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def _session_ctx(issue: str | None):
@@ -44,18 +45,28 @@ def _session_id_ctx(session_id: str | None):
 
 
 class Span(Protocol):
-    def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
-        ...
+    def end(
+        self,
+        *,
+        outputs: Any = None,
+        error: BaseException | None = None,
+        latency_seconds: float = 0.0,
+    ) -> None: ...
 
 
 class Tracer(Protocol):
-    def start_span(self, *, name: str, inputs: Any, tags: dict[str, str]) -> Span:
-        ...
+    def start_span(self, *, name: str, inputs: Any, tags: dict[str, str]) -> Span: ...
 
 
 @dataclass
 class NoopSpan:
-    def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
+    def end(
+        self,
+        *,
+        outputs: Any = None,
+        error: BaseException | None = None,
+        latency_seconds: float = 0.0,
+    ) -> None:
         return None
 
 
@@ -94,7 +105,9 @@ class _LangfuseSpan:
             # issue's session context so all its stage spans group together.
             with _session_ctx(tags.get("issue")):
                 if hasattr(lf, "start_observation"):
-                    self._span = lf.start_observation(name=name, as_type="span", input=inputs, metadata=tags)
+                    self._span = lf.start_observation(
+                        name=name, as_type="span", input=inputs, metadata=tags
+                    )
                 else:
                     self._span = lf.start_span(name=name, input=inputs, metadata=tags)
         except Exception as exc:  # never raise into the loop
@@ -105,9 +118,18 @@ class _LangfuseSpan:
     def _announce(cls, exc: BaseException) -> None:
         if not cls._warned:
             cls._warned = True
-            print(f"[tracing] langfuse span creation failed, tracing degraded: {exc!r}", file=sys.stderr)
+            print(
+                f"[tracing] langfuse span creation failed, tracing degraded: {exc!r}",
+                file=sys.stderr,
+            )
 
-    def end(self, *, outputs: Any = None, error: BaseException | None = None, latency_seconds: float = 0.0) -> None:
+    def end(
+        self,
+        *,
+        outputs: Any = None,
+        error: BaseException | None = None,
+        latency_seconds: float = 0.0,
+    ) -> None:
         try:
             if self._span is not None:
                 if error is not None:
@@ -136,6 +158,23 @@ class LangfuseTracer:
 
 _tracer: Tracer = NoopTracer()
 _generation_warned = False
+_callback_handler_warned = False
+
+
+def build_callback_handler(config: Config) -> object | None:
+    if not (
+        config.langfuse_host
+        and config.langfuse_public_key
+        and config.langfuse_secret_key
+    ):
+        return None
+    try:
+        from langfuse.langchain import CallbackHandler
+
+        return CallbackHandler()
+    except Exception as exc:
+        _announce_cb_handler_error(exc)
+        return None
 
 
 def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
@@ -145,7 +184,11 @@ def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
     global _tracer
     if tracer is not None:
         _tracer = tracer
-    elif config.langfuse_host and config.langfuse_public_key and config.langfuse_secret_key:
+    elif (
+        config.langfuse_host
+        and config.langfuse_public_key
+        and config.langfuse_secret_key
+    ):
         try:
             _tracer = LangfuseTracer(config)
         except Exception:
@@ -159,31 +202,38 @@ def init_tracing(config: Config, *, tracer: Tracer | None = None) -> Tracer:
     else:
         log.info(
             "tracing: Langfuse env incomplete (host=%s public_key=%s secret_key=%s) — NoopTracer",
-            bool(config.langfuse_host), bool(config.langfuse_public_key), bool(config.langfuse_secret_key),
+            bool(config.langfuse_host),
+            bool(config.langfuse_public_key),
+            bool(config.langfuse_secret_key),
         )
         _tracer = NoopTracer()
     log.info("tracing: active tracer=%s", type(_tracer).__name__)
     return _tracer
 
 
-def trace_node(name: str, fn: Callable[[T], T]) -> Callable[[T], T]:
-    def wrapped(state: T) -> T:
+def trace_node(name: str, fn: Callable[P, R]) -> Callable[P, R]:
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        state = args[0] if args else kwargs.get("state")
         tags = _tags_for_state(state, name)
         span = _tracer.start_span(name=name, inputs=_safe_state(state), tags=tags)
         started = time.monotonic()
         try:
-            result = fn(state)
+            result = fn(*args, **kwargs)
         except BaseException as exc:
             span.end(error=exc, latency_seconds=time.monotonic() - started)
             raise
-        span.end(outputs=_safe_state(result), latency_seconds=time.monotonic() - started)
+        span.end(
+            outputs=_safe_state(result), latency_seconds=time.monotonic() - started
+        )
         return result
 
     wrapped.__name__ = getattr(fn, "__name__", name)
     return wrapped
 
 
-def emit_generation(*, session_id: str | None, stage: str | None, model: str, usage) -> None:
+def emit_generation(
+    *, session_id: str | None, stage: str | None, model: str, usage
+) -> None:
     if not isinstance(_tracer, LangfuseTracer):
         return
     try:
@@ -193,7 +243,10 @@ def emit_generation(*, session_id: str | None, stage: str | None, model: str, us
                 name=f"{stage or 'goose'}-llm",
                 as_type="generation",
                 model=model,
-                usage_details={"input": usage.input_tokens, "output": usage.output_tokens},
+                usage_details={
+                    "input": usage.input_tokens,
+                    "output": usage.output_tokens,
+                },
             )
             observation.end()
         lf.flush()
@@ -212,7 +265,20 @@ def _announce_generation(exc: BaseException) -> None:
     global _generation_warned
     if not _generation_warned:
         _generation_warned = True
-        print(f"[tracing] langfuse generation creation failed, tracing degraded: {exc!r}", file=sys.stderr)
+        print(
+            f"[tracing] langfuse generation creation failed, tracing degraded: {exc!r}",
+            file=sys.stderr,
+        )
+
+
+def _announce_cb_handler_error(exc: BaseException) -> None:
+    global _callback_handler_warned
+    if not _callback_handler_warned:
+        _callback_handler_warned = True
+        print(
+            f"[tracing] langfuse CallbackHandler init failed, tracing degraded: {exc!r}",
+            file=sys.stderr,
+        )
 
 
 def _tags_for_state(state: Any, stage: str) -> dict[str, str]:


### PR DESCRIPTION
**U5** of the box LangGraph/executor migration (`docs/plans/2026-06-18-001-feat-box-langgraph-executor-migration-plan.md`).

Wires `langfuse.langchain.CallbackHandler` onto the U4 StateGraph's full-graph `invoke`:
- `build_callback_handler(config)` — returns a guarded handler, or **None** when Langfuse is unconfigured **or** the package is absent (it's an optional `trace` extra). Never raises (matches tracing.py's "never raise into the loop" contract).
- **No double-tracing:** StateGraph internal nodes run **raw** (the CallbackHandler is the sole tracer on `invoke`), while the wrapper's exposed `.triage/.spec/…` callables stay `trace_node`-wrapped for the **per-stage poller path** (unchanged). `evaluate_gate` uses `raw_gate` for the multi-arg gate call.
- `invoke()` groups spans per issue (`issue-<N>` session via `_session_id_ctx`) and attaches the handler via the run config; handler build is cached + guarded, graph-execution errors are NOT swallowed.
- `trace_node`/`emit_generation` retained — retired in U6 after live parity.

Poller unaffected (it calls `graph.<stage>` single-arg + `gate_node` directly).

## Test plan
- [x] `tests/test_callback_handler_tracing.py` — None when unconfigured, None+no-raise on import failure, callbacks attached on invoke, no-handler→config None, handler-build error→invoke still completes
- [x] `tests/test_build_lg_parity.py` → 9 passed (parity intact with raw nodes)
- [x] `pytest pipeline` → **610 passed / 5 skipped**
- [x] ruff + black clean

## Next
U6 — live rollout (shadow→spec-only compare→staged live), then retire Goose + trace_node/emit_generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)