### PR TITLE
feat(social): weekly @wgmesh drip — Mixpost draft (ship-news or evergreen)

### DIFF
--- a/.github/workflows/wgmesh-social-drip.yml
+++ b/.github/workflows/wgmesh-social-drip.yml
@@ -1,0 +1,536 @@
+name: wgmesh social drip
+
+on:
+  schedule:
+    - cron: "0 15 * * 4"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "true = assemble + log, do NOT draft/send/update state"
+        type: boolean
+        default: false
+      since_hours:
+        description: "Look back window (hours)"
+        default: "168"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  social-drip:
+    runs-on: ubuntu-latest
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      UNSEND_API_KEY: ${{ secrets.UNSEND_API_KEY }}
+      UNSEND_URL: ${{ vars.UNSEND_URL || 'https://unsend.admin.lt' }}
+      RELEASE_NOTES_FROM: ${{ secrets.RELEASE_NOTES_FROM }}
+      RELEASE_NOTES_TO: ${{ secrets.RELEASE_NOTES_TO }}
+      MIXPOST_API_TOKEN: ${{ secrets.MIXPOST_API_TOKEN }}
+      MIXPOST_WORKSPACE: ${{ secrets.MIXPOST_WORKSPACE }}
+      MIXPOST_BASE: ${{ vars.MIXPOST_BASE || 'https://mixpost.infrawei.com/mixpost' }}
+      WGMESH_REPO: ${{ vars.WGMESH_REPO || 'atvirokodosprendimai/wgmesh' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      SINCE_HOURS: ${{ github.event.inputs.since_hours || '168' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect merged PRs
+        run: |
+          set -uo pipefail
+          since_iso=$(date -u -d "${SINCE_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ')
+          echo "SINCE_ISO=${since_iso}" >> "$GITHUB_ENV"
+          echo "Collecting merged PRs for ${WGMESH_REPO} since ${since_iso}"
+
+          if ! gh pr list -R "$WGMESH_REPO" --state merged \
+            --search "merged:>=${since_iso}" \
+            --json number,title,url,labels,body > /tmp/wgmesh_prs.json; then
+            echo "::warning::failed to collect merged PRs from ${WGMESH_REPO}; continuing with empty PR list"
+            echo "[]" > /tmp/wgmesh_prs.json
+          fi
+
+          python3 - <<'PY' > /tmp/filtered_prs.json
+          import json
+          import re
+
+          title_re = re.compile(r"(heal:|chore:|supervisor|bot-pr|pipeline-health|\[bot\])", re.I)
+          internal_labels = {"chore", "internal", "bot", "automated"}
+
+          try:
+              with open("/tmp/wgmesh_prs.json", encoding="utf-8") as fh:
+                  prs = json.load(fh)
+          except Exception:
+              prs = []
+
+          filtered = []
+          for pr in prs:
+              title = pr.get("title") or ""
+              labels = {
+                  (label.get("name") if isinstance(label, dict) else str(label)).lower()
+                  for label in pr.get("labels", [])
+              }
+              if title_re.search(title):
+                  continue
+              if labels & internal_labels:
+                  continue
+              filtered.append({
+                  "number": pr.get("number"),
+                  "title": title,
+                  "url": pr.get("url"),
+                  "labels": sorted(labels),
+                  "body": pr.get("body") or "",
+              })
+
+          print(json.dumps(filtered, ensure_ascii=False, indent=2))
+          PY
+
+          count=$(python3 - <<'PY'
+          import json
+          with open("/tmp/filtered_prs.json", encoding="utf-8") as fh:
+              print(len(json.load(fh)))
+          PY
+          )
+          echo "Filtered candidate PRs: ${count}"
+          {
+            echo "FILTERED_PRS<<EOF"
+            cat /tmp/filtered_prs.json
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: LLM classify + generate post
+        run: |
+          set -uo pipefail
+          if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            echo "::warning::OPENROUTER_API_KEY unset; skipping social drip generation"
+            echo "SKIP_REMAINDER=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if [ -s company/social-drip-state.json ]; then
+            cp company/social-drip-state.json /tmp/social-drip-state.json
+          else
+            printf '{"recent_angles":[],"last_run":null}\n' > /tmp/social-drip-state.json
+          fi
+          head -n 80 STRATEGY.md > /tmp/strategy_head.txt 2>/dev/null || true
+          head -n 60 FEATURE_MATRIX.md > /tmp/feature_matrix_head.txt 2>/dev/null || true
+
+          python3 - <<'PY'
+          import json
+
+          with open("/tmp/filtered_prs.json", encoding="utf-8") as fh:
+              prs = json.load(fh)
+          with open("/tmp/social-drip-state.json", encoding="utf-8") as fh:
+              state = json.load(fh)
+          try:
+              with open("/tmp/strategy_head.txt", encoding="utf-8") as fh:
+                  strategy = fh.read()
+          except FileNotFoundError:
+              strategy = ""
+          try:
+              with open("/tmp/feature_matrix_head.txt", encoding="utf-8") as fh:
+                  feature_matrix = fh.read()
+          except FileNotFoundError:
+              feature_matrix = ""
+
+          prompt = f"""Write one concise social post for @wgmesh.
+
+          Candidate merged PRs from the last window:
+          {json.dumps(prs, ensure_ascii=False)}
+
+          Current rotation state:
+          {json.dumps(state, ensure_ascii=False)}
+
+          Product strategy context:
+          {strategy}
+
+          Feature matrix context:
+          {feature_matrix}
+
+          Instructions:
+          - If candidate PRs exist, classify whether there is meaningful user-facing ship news: SHIP_NEWS=1 or SHIP_NEWS=0.
+          - If SHIP_NEWS=1, write one highlight post about the single most user-relevant change.
+          - If SHIP_NEWS=0, pick an unused evergreen angle from exactly: differentiator, how-it-works, use-case, tip.
+          - Avoid angles listed in recent_angles when possible.
+          - Keep the post technical, specific, and human. No hashtags. No markdown. No private/internal pipeline details.
+          - Mention wgmesh by name and prefer a useful concrete claim over generic hype.
+          - Output JSON exactly matching: {{"ship_news":0|1,"post_body":"...","chosen_angle":"differentiator|how-it-works|use-case|tip|"}}
+          """
+
+          payload = {
+              "model": "z-ai/glm-5.2",
+              "response_format": {"type": "json_object"},
+              "messages": [
+                  {
+                      "role": "system",
+                      "content": "You are a concise technical social media writer. Output ONLY valid JSON.",
+                  },
+                  {"role": "user", "content": prompt},
+              ],
+          }
+          with open("/tmp/social_drip_llm_req.json", "w", encoding="utf-8") as fh:
+              json.dump(payload, fh, ensure_ascii=False)
+          PY
+
+          http=$(curl -sS -m 60 -w '%{http_code}' -o /tmp/social_drip_llm_resp.json \
+            -X POST "https://openrouter.ai/api/v1/chat/completions" \
+            -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: Mozilla/5.0" \
+            -d @/tmp/social_drip_llm_req.json) || http="000"
+
+          if [ "$http" != "200" ]; then
+            echo "::warning::OpenRouter social drip generation failed (HTTP ${http}); skipping remainder"
+            echo "SKIP_REMAINDER=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if ! python3 - <<'PY' > /tmp/social_drip_env
+          import json
+          import re
+          import sys
+
+          def trim_post(text, limit=280):
+              text = re.sub(r"\s+", " ", str(text or "")).strip()
+              if len(text) <= limit:
+                  return text
+              cut = text[: limit - 3].rstrip()
+              if " " in cut:
+                  cut = cut.rsplit(" ", 1)[0].rstrip()
+              return cut + "..."
+
+          try:
+              with open("/tmp/social_drip_llm_resp.json", encoding="utf-8") as fh:
+                  response = json.load(fh)
+              raw = response["choices"][0]["message"]["content"]
+              data = json.loads(raw)
+          except Exception as exc:
+              print(f"parse_error={exc}", file=sys.stderr)
+              sys.exit(1)
+
+          ship_news = 1 if str(data.get("ship_news")) in {"1", "true", "True"} else 0
+          post_body = trim_post(data.get("post_body", ""))
+          chosen_angle = str(data.get("chosen_angle") or "").strip()
+          if ship_news == 1:
+              chosen_angle = ""
+          allowed = {"", "differentiator", "how-it-works", "use-case", "tip"}
+          if chosen_angle not in allowed:
+              chosen_angle = ""
+
+          print(f"SHIP_NEWS={ship_news}")
+          print(f"CHOSEN_ANGLE={chosen_angle}")
+          print("POST_BODY<<EOF")
+          print(post_body)
+          print("EOF")
+          PY
+          then
+            echo "::warning::OpenRouter response was not valid strict JSON; skipping remainder"
+            echo "SKIP_REMAINDER=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          cat /tmp/social_drip_env >> "$GITHUB_ENV"
+          post_body=$(awk 'BEGIN{capture=0} /^POST_BODY<<EOF$/{capture=1; next} /^EOF$/{capture=0} capture{print}' /tmp/social_drip_env)
+          chars=$(python3 - <<'PY'
+          import os
+          post = os.environ.get("POST_BODY", "")
+          if not post:
+              try:
+                  with open("/tmp/social_drip_env", encoding="utf-8") as fh:
+                      lines = fh.read().splitlines()
+                  capture = False
+                  parts = []
+                  for line in lines:
+                      if line == "POST_BODY<<EOF":
+                          capture = True
+                          continue
+                      if capture and line == "EOF":
+                          break
+                      if capture:
+                          parts.append(line)
+                  post = "\n".join(parts)
+              except FileNotFoundError:
+                  post = ""
+          print(len(post))
+          PY
+          )
+          echo "Generated post (${chars} chars):"
+          if ! printf '%s\n' "$post_body" | bash company/scripts/sanitise.sh; then
+            echo "::warning::generated post failed sanitise preview; body suppressed until gate"
+          fi
+          echo "Char count: ${chars}"
+
+      - name: Sanitise gate
+        run: |
+          set -uo pipefail
+          if [ "${SKIP_REMAINDER:-false}" = "true" ]; then
+            echo "Skipping sanitise gate because generation was skipped"
+            exit 0
+          fi
+          if [ -z "${POST_BODY:-}" ]; then
+            echo "::error::POST_BODY empty; refusing to continue"
+            exit 1
+          fi
+          if ! printf '%s\n' "$POST_BODY" | bash company/scripts/sanitise.sh > /tmp/social_post_sanitised.txt; then
+            echo "::error::sanitise.sh rejected generated post"
+            exit 1
+          fi
+
+      - name: DRY_RUN output
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN}" != "true" ]; then
+            exit 0
+          fi
+          chars=$(python3 - <<'PY'
+          import os
+          print(len(os.environ.get("POST_BODY", "")))
+          PY
+          )
+          mode="Ship News"
+          if [ "${SHIP_NEWS:-0}" = "0" ]; then
+            mode="Evergreen ${CHOSEN_ANGLE:-unselected}"
+          fi
+          echo "Classification: ${mode}"
+          echo "Post body:"
+          printf '%s\n' "${POST_BODY:-}"
+          echo "Char count: ${chars}"
+          echo "Would create Mixpost draft (skipped in dry run)"
+          exit 0
+
+      - name: Resolve Mixpost accounts
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN}" = "true" ] || [ "${SKIP_REMAINDER:-false}" = "true" ]; then
+            exit 0
+          fi
+          if [ -z "${MIXPOST_API_TOKEN:-}" ] || [ -z "${MIXPOST_WORKSPACE:-}" ]; then
+            echo "::warning::MIXPOST_API_TOKEN or MIXPOST_WORKSPACE unset; skipping Mixpost draft"
+            echo "SKIP_MIXPOST=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          accounts_url="${MIXPOST_BASE%/}/api/${MIXPOST_WORKSPACE}/accounts"
+          http=$(curl -sS -m 30 -w '%{http_code}' -o /tmp/mixpost_accounts.json \
+            -H "Authorization: Bearer ${MIXPOST_API_TOKEN}" \
+            -H "Accept: application/json" \
+            -H "User-Agent: Mozilla/5.0" \
+            "$accounts_url") || http="000"
+
+          if [ "$http" != "200" ]; then
+            echo "::warning::Mixpost accounts fetch failed (HTTP ${http}); skipping Mixpost draft"
+            echo "SKIP_MIXPOST=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if ! python3 - <<'PY' > /tmp/account_ids.txt
+          import json
+          import sys
+          try:
+              with open("/tmp/mixpost_accounts.json", encoding="utf-8") as fh:
+                  data = json.load(fh)
+              ids = [item.get("id") for item in data.get("data", []) if item.get("id") is not None]
+          except Exception as exc:
+              print(f"parse_error={exc}", file=sys.stderr)
+              sys.exit(1)
+          print(json.dumps(ids))
+          PY
+          then
+            echo "::warning::Could not parse Mixpost accounts; skipping Mixpost draft"
+            echo "SKIP_MIXPOST=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          account_ids=$(cat /tmp/account_ids.txt)
+          if [ "$account_ids" = "[]" ]; then
+            echo "::warning::No Mixpost accounts resolved; skipping Mixpost draft"
+            echo "SKIP_MIXPOST=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "ACCOUNT_IDS=${account_ids}" >> "$GITHUB_ENV"
+          echo "Resolved Mixpost accounts"
+
+      - name: Create Mixpost draft
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN}" = "true" ] || [ "${SKIP_MIXPOST:-false}" = "true" ]; then
+            exit 0
+          fi
+          if [ "${SKIP_REMAINDER:-false}" = "true" ]; then
+            exit 0
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+
+          account_ids = json.loads(os.environ.get("ACCOUNT_IDS", "[]"))
+          payload = {
+              "schedule": False,
+              "accounts": account_ids,
+              "versions": [
+                  {
+                      "account_id": 0,
+                      "is_original": True,
+                      "content": [{"body": os.environ.get("POST_BODY", ""), "media": []}],
+                      "options": {"mastodon": {"sensitive": False}},
+                  }
+              ],
+          }
+          with open("/tmp/mixpost_post_payload.json", "w", encoding="utf-8") as fh:
+              json.dump(payload, fh, ensure_ascii=False)
+          PY
+
+          posts_url="${MIXPOST_BASE%/}/api/${MIXPOST_WORKSPACE}/posts"
+          http=$(curl -sS -m 30 -w '%{http_code}' -o /tmp/mixpost_post_response.json \
+            -X POST "$posts_url" \
+            -H "Authorization: Bearer ${MIXPOST_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "User-Agent: Mozilla/5.0" \
+            -d @/tmp/mixpost_post_payload.json) || http="000"
+
+          echo "Mixpost draft HTTP ${http}"
+          echo "MIXPOST_STATUS=${http}" >> "$GITHUB_ENV"
+          case "$http" in
+            200|201|202) echo "MIXPOST_CREATED=true" >> "$GITHUB_ENV" ;;
+            *)
+              echo "::error::Mixpost draft creation failed (HTTP ${http})"
+              echo "MIXPOST_CREATED=false" >> "$GITHUB_ENV"
+              ;;
+          esac
+
+      - name: Send review-ping email
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN}" = "true" ]; then
+            exit 0
+          fi
+          if [ "${SKIP_REMAINDER:-false}" = "true" ]; then
+            exit 0
+          fi
+          if [ -z "${UNSEND_API_KEY:-}" ] || [ -z "${RELEASE_NOTES_FROM:-}" ] || [ -z "${RELEASE_NOTES_TO:-}" ]; then
+            echo "::warning::email secrets unset (UNSEND_API_KEY / RELEASE_NOTES_FROM / RELEASE_NOTES_TO); skipping review ping"
+            exit 0
+          fi
+
+          chars=$(python3 - <<'PY'
+          import os
+          print(len(os.environ.get("POST_BODY", "")))
+          PY
+          )
+          mode="Ship News"
+          if [ "${SHIP_NEWS:-0}" = "0" ]; then
+            mode="Evergreen + ${CHOSEN_ANGLE:-unselected}"
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+
+          post = os.environ.get("POST_BODY", "")
+          chars = len(post)
+          mode = "Ship News" if os.environ.get("SHIP_NEWS", "0") == "1" else f"Evergreen + {os.environ.get('CHOSEN_ANGLE', 'unselected') or 'unselected'}"
+          mixpost_base = os.environ.get("MIXPOST_BASE", "")
+          status = os.environ.get("MIXPOST_STATUS", "not attempted")
+          text = (
+              "A wgmesh social drip draft is ready for review.\n\n"
+              f"Mode: {mode}\n"
+              f"Character count: {chars}\n"
+              f"Mixpost draft HTTP status: {status}\n"
+              f"Mixpost: {mixpost_base}\n\n"
+              f"{post}\n"
+          )
+          payload = {
+              "from": os.environ.get("RELEASE_NOTES_FROM", ""),
+              "to": [item.strip() for item in os.environ.get("RELEASE_NOTES_TO", "").split(",") if item.strip()],
+              "subject": "wgmesh social drip draft ready",
+              "text": text,
+          }
+          with open("/tmp/unsend_social_payload.json", "w", encoding="utf-8") as fh:
+              json.dump(payload, fh, ensure_ascii=False)
+          PY
+
+          http=$(curl -sS -m 30 -w '%{http_code}' -o /tmp/unsend_social_response.json \
+            -X POST "${UNSEND_URL%/}/api/v1/emails" \
+            -H "Authorization: Bearer ${UNSEND_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: Mozilla/5.0" \
+            -d @/tmp/unsend_social_payload.json) || http="000"
+
+          case "$http" in
+            200|201|202) echo "Review ping sent" ;;
+            *) echo "::warning::review ping email failed (HTTP ${http})" ;;
+          esac
+
+      - name: Update state + commit via PR
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN}" = "true" ] || [ "${SKIP_REMAINDER:-false}" = "true" ]; then
+            exit 0
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          path = "company/social-drip-state.json"
+          try:
+              with open(path, encoding="utf-8") as fh:
+                  state = json.load(fh)
+          except Exception:
+              state = {"recent_angles": [], "last_run": None}
+
+          recent = state.get("recent_angles")
+          if not isinstance(recent, list):
+              recent = []
+          ship_news = os.environ.get("SHIP_NEWS", "0") == "1"
+          chosen_angle = os.environ.get("CHOSEN_ANGLE", "").strip()
+          if not ship_news and chosen_angle:
+              recent.append(chosen_angle)
+              recent = recent[-4:]
+          state["recent_angles"] = recent
+          state["last_run"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+          with open(path, "w", encoding="utf-8") as fh:
+              json.dump(state, fh, ensure_ascii=False, indent=2)
+              fh.write("\n")
+          PY
+
+          if ! cat company/social-drip-state.json | bash company/scripts/sanitise.sh > /dev/null; then
+            echo "::error::sanitise.sh rejected company/social-drip-state.json"
+            exit 1
+          fi
+
+          git config user.name "pupabobas[bot]"
+          git config user.email "pupabobas[bot]@users.noreply.github.com"
+          git add company/social-drip-state.json
+          if git diff --cached --quiet; then
+            echo "No social drip state changes to commit"
+            exit 0
+          fi
+
+          timestamp=$(date -u '+%Y%m%d%H%M%S')
+          today=$(date -u '+%Y-%m-%d')
+          branch="social-drip-state/${timestamp}"
+          if ! git checkout -b "$branch" origin/main; then
+            echo "::warning::could not create state branch; skipping state PR"
+            exit 0
+          fi
+          git commit -m "chore(social-drip): update state ${today}"
+          if ! git push -u origin "$branch"; then
+            echo "::warning::could not push social drip state branch"
+            exit 0
+          fi
+          if ! gh pr create \
+            --title "chore(social-drip): update state ${today}" \
+            --body "Automated social drip state update." \
+            --base main \
+            --head "$branch" \
+            --label chore; then
+            echo "::warning::could not open social drip state PR"
+            exit 0
+          fi

--- a/company/social-drip-state.json
+++ b/company/social-drip-state.json
@@ -1,0 +1,1 @@
+{"recent_angles":[],"last_run":null}

--- a/docs/brainstorms/2026-06-19-wgmesh-social-drip-requirements.md
+++ b/docs/brainstorms/2026-06-19-wgmesh-social-drip-requirements.md
@@ -1,0 +1,69 @@
+# Weekly @wgmesh Social Drip — Requirements
+
+**Date:** 2026-06-19
+**Status:** Ready for planning
+**Scope:** Standard feature (new scheduled workflow, mirrors the daily release-notes digest)
+
+## Problem
+
+`@wgmesh` is now live on Bluesky + Mastodon (via the InfraWei Mixpost Pro instance), with profiles dressed and a first post out. But a new account with one post and then silence reads as abandoned. We need a sustainable weekly cadence that keeps the account alive **without** turning it into a botty changelog or posting internal pipeline noise to the public.
+
+Two hard realities shape this:
+1. The **daily release-notes digest** is an exhaustive internal PR list — the opposite of what a follower wants. Social must be curated and human-sounding.
+2. wgmesh **rarely ships user-facing changes** most weeks (the org's effort skews to pipeline/infra). A purely shipping-driven drip would skip most weeks → dead account.
+
+## Decisions (resolved this brainstorm)
+
+1. **Publish gate:** Generate as a **Mixpost draft**; human (operator/lempa) reviews + publishes. **No unattended auto-publish.** Protects a public account from awkward/incorrect posts.
+2. **Post shape:** **Single curated highlight** — one punchy post (what + why a user cares + link), not a roundup or thread. Reads like a person wrote it.
+3. **Quiet weeks → evergreen fallback:** If there's no user-facing shipping news, draft an **educational/evergreen** post instead (how-it-works, a differentiator like the "works offline on LAN" post, a use-case). The generator picks: ship-news if present, else evergreen. Cadence never goes dark.
+4. **Source/filter:** wgmesh **product repo only** (merged PRs / release notes), filtered to **user-facing** changes. Never org-wide plumbing, never the pipeline repo.
+
+## Requirements
+
+- **R1.** Runs weekly on a schedule (cron) + manual `workflow_dispatch`, like `daily-release-notes.yml`.
+- **R2.** Pulls the past week's merged PRs from the wgmesh repo; an LLM judges which (if any) are **user-facing** (a feature, fix, or capability a wgmesh user would notice) vs internal.
+- **R3.** If ≥1 user-facing change: generate a single highlight post — lead with the most relevant change, plain-English "what shipped + why it matters", link to wgmesh.dev or the repo. Stay within **Bluesky's 300-char limit** (Mastodon allows more; one body serves both).
+- **R4.** If no user-facing change: generate an **evergreen** post from a rotating set of angles (differentiator, how-it-works, use-case, tip). Avoid repeating recent evergreen topics.
+- **R5.** Create the post as a **draft** via the Mixpost API (`POST /api/<ws>/posts`, `schedule:false`), targeting both connected @wgmesh accounts (Bluesky id 1, Mastodon id 2).
+- **R6.** **Notify** the operator the draft is ready to review + publish — include the draft text + a Mixpost link. Reuse the existing Unsend send path (transactional email).
+- **R7.** Best-effort + non-blocking: any failure (no PRs, LLM error, Mixpost/API error) logs a warning and does not hard-fail or post garbage. Same discipline as the digest.
+- **R8.** Public-safety: run generated copy through the existing sanitise gate before drafting (no secrets, no internal/PII, no exact revenue) — it's headed to a public account.
+
+## Scope boundaries
+
+**In:**
+- One weekly workflow producing one draft post (ship-news or evergreen) to @wgmesh on Bluesky + Mastodon.
+- Human-approve publish loop via Mixpost + an email ping.
+
+**Out (deferred):**
+- Auto-publish after a review timeout (see Outstanding Questions).
+- X / LinkedIn (need paid/dev apps), Reddit (Mixpost can't; n8n later).
+- Threads, image/media in posts, engagement/reply automation, analytics-driven topic selection.
+- Fully autonomous (no-human) posting — explicitly rejected for a public account.
+
+## Success criteria
+
+- @wgmesh posts ~1×/week with **zero** weeks of unintended silence and **zero** pipeline-plumbing/changelog-dump posts.
+- Each post is something the operator would publish as-is or with a tiny edit (low review friction).
+- Operator effort per week ≈ a glance + one click (or a skip).
+
+## Dependencies / assumptions
+
+- Mixpost Pro API: token + workspace `e134432b-…`, accounts connected (Bluesky id 1, Mastodon id 2). **Verified live this session.**
+- Unsend transactional email (for the review ping) — already wired for the digest. SES now in production access.
+- Reuses the digest workflow pattern (`daily-release-notes.yml`): cron + LLM-via-OpenRouter + best-effort steps.
+- **Assumption:** the wgmesh repo's merged PRs are a sufficient signal for "what shipped"; release-notes/tags optional refinement.
+- **Assumption:** evergreen angles can be LLM-generated from wgmesh's positioning (STRATEGY.md / FEATURE_MATRIX.md) without a hand-curated backlog — to validate during planning.
+
+## Outstanding questions (for planning)
+
+- **Q1.** Where does the workflow live + run — the template repo's GitHub Actions (like the digest), or the box? (Leaning: template Actions, same as digest.)
+- **Q2.** Auto-publish after N hours if not rejected, or always manual publish? (Default: manual; revisit if review becomes a bottleneck.)
+- **Q3.** Cron day/time — e.g. Tue or Thu ~15:00–16:00 UTC for EU+US dev overlap.
+- **Q4.** Evergreen topic rotation — track recently-used angles where? (state file vs let LLM vary by week.)
+- **Q5.** Should ship-news posts also link the specific PR/release, or just wgmesh.dev?
+
+## Recommended approach
+
+Reuse, don't invent: clone the `daily-release-notes.yml` skeleton (cron, OpenRouter LLM call, best-effort guards, sanitise gate) but swap the output sink from Unsend-email to **Mixpost-draft**, the source to **wgmesh repo only**, and add the **ship-news-vs-evergreen** branch. The email step becomes a *review ping*, not the deliverable. This is an **extend-existing-pattern** build, low new surface.

--- a/docs/plans/2026-06-19-001-feat-wgmesh-social-drip-plan.md
+++ b/docs/plans/2026-06-19-001-feat-wgmesh-social-drip-plan.md
@@ -1,0 +1,157 @@
+# feat: Weekly @wgmesh social drip
+
+**Date:** 2026-06-19
+**Type:** feat
+**Depth:** Standard
+**Origin:** `docs/brainstorms/2026-06-19-wgmesh-social-drip-requirements.md`
+
+---
+
+## Summary
+
+A weekly GitHub Actions workflow that drafts one social post for `@wgmesh` (Bluesky + Mastodon) and pings the operator to review + publish. Clones the proven `daily-release-notes.yml` skeleton; swaps the output sink from Unsend-email to the **Mixpost draft API**, scopes the source to the **wgmesh repo only**, and adds a **ship-news-vs-evergreen** branch so cadence never goes dark. No unattended auto-publish.
+
+---
+
+## Problem Frame
+
+`@wgmesh` is live but a one-post-then-silence account reads as dead. wgmesh rarely ships user-facing changes (most org effort is internal pipeline), so a purely shipping-driven drip would skip most weeks. We need sustainable weekly cadence that is curated (never a PR dump), product-facing (never plumbing), and human-gated (never botty auto-posts). See origin for full rationale.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Reuse the digest skeleton.** Clone `.github/workflows/daily-release-notes.yml` structure (cron + `workflow_dispatch`, OpenRouter LLM via curl, best-effort guarded steps, sanitise gate). Extend-existing-pattern, minimal new surface.
+- **KTD2 — Output sink = Mixpost draft, not email.** `POST {MIXPOST_BASE}/api/{ws}/posts` with `schedule:false` → draft to both accounts. Email becomes a *review ping*, not the deliverable. (Mixpost API verified live; see origin Dependencies.)
+- **KTD3 — Source = wgmesh repo only.** `gh pr list -R atvirokodosprendimai/wgmesh --state merged --search merged:>=<7d>`; LLM classifies user-facing vs internal. Never org-wide.
+- **KTD4 — Ship-vs-evergreen branch.** If ≥1 user-facing PR → highlight post; else → evergreen post from a rotating angle set, avoiding recent repeats via a small state file.
+- **KTD5 — No unattended auto-publish.** Draft + ping only; operator publishes in Mixpost. (Honors origin decision 1.)
+- **KTD6 — Secrets, not hardcoded IDs.** Mixpost token/workspace/account-ids + base URL via repo secrets/vars (`MIXPOST_*`). Account ids resolved at runtime via `GET /accounts` (avoids hardcoding 1/2).
+
+---
+
+## Requirements Traceability
+
+- R1 (weekly cron + dispatch) → U1
+- R2 (fetch wgmesh PRs + user-facing classify) → U2
+- R3 (single highlight, ≤300 char) → U3
+- R4 (evergreen fallback, no repeats) → U3, U4
+- R5 (Mixpost draft, both accounts) → U5
+- R6 (review ping email) → U5
+- R7 (best-effort non-blocking) → all units
+- R8 (sanitise gate before draft) → U3
+
+---
+
+## Implementation Units
+
+### U1. Workflow skeleton + scheduling + config
+
+**Goal:** New workflow file with weekly cron, manual dispatch, and env/secret wiring; mirrors the digest's job shape.
+**Requirements:** R1, R7
+**Dependencies:** none
+**Files:** `.github/workflows/wgmesh-social-drip.yml` (new)
+**Approach:** Copy the job scaffold from `.github/workflows/daily-release-notes.yml` (permissions, `runs-on`, `workflow_dispatch` inputs incl `dry_run`, env block). Cron `0 15 * * 4` (Thu 15:00 UTC). Env: `OPENROUTER_API_KEY`, `UNSEND_*`, `RELEASE_NOTES_FROM/TO` (reuse for ping), new `MIXPOST_BASE` (var, default `https://mixpost.infrawei.com/mixpost`), `MIXPOST_WORKSPACE` (secret/var), `MIXPOST_API_TOKEN` (secret), `WGMESH_REPO` (var, default `atvirokodosprendimai/wgmesh`), `GH_TOKEN`. `since_hours` input default `168`.
+**Patterns to follow:** `daily-release-notes.yml` job/env/dispatch blocks.
+**Test scenarios:** `Test expectation: none — scaffolding`; validated by U-wide dry-run + YAML/`bash -n` lint.
+**Verification:** `python3 -c yaml.safe_load` parses; `gh workflow run` dispatchable with `dry_run=true`.
+
+### U2. Collect wgmesh PRs + user-facing classification
+
+**Goal:** Fetch the week's merged wgmesh PRs and have the LLM decide if any are user-facing.
+**Requirements:** R2, R3, R7
+**Dependencies:** U1
+**Files:** `.github/workflows/wgmesh-social-drip.yml`
+**Approach:** Step "Collect merged PRs": `gh pr list -R "$WGMESH_REPO" --state merged --search "merged:>=$since" --json number,title,url,labels,body`. LLM (OpenRouter `z-ai/glm-5.2`, JSON-strict) classifies each as `user_facing` bool + one-line "why a user cares"; emit `SHIP_NEWS=1|0` to `$GITHUB_ENV` + a shortlist file. `set -uo pipefail`; gh failure → warning + `SHIP_NEWS=0` (fall to evergreen). Filter out bot/`chore`/`heal`/plumbing by label+title before the LLM to save tokens.
+**Patterns to follow:** digest collect step + its JSON-strict LLM call.
+**Test scenarios:**
+- Happy: 2 user-facing PRs in window → `SHIP_NEWS=1`, shortlist has both. Covers R2.
+- All-internal: only heal/chore/supervisor PRs → `SHIP_NEWS=0`.
+- Empty: no merged PRs → `SHIP_NEWS=0`, no error.
+- Error: `gh` non-zero → warning, `SHIP_NEWS=0`, job continues.
+**Verification:** dry-run logs show classification + correct `SHIP_NEWS`.
+
+### U3. Content generation (highlight or evergreen) + sanitise
+
+**Goal:** Produce one post body — highlight if ship-news, else evergreen — within Bluesky's 300-char limit, sanitise-gated.
+**Requirements:** R3, R4, R8
+**Dependencies:** U2
+**Files:** `.github/workflows/wgmesh-social-drip.yml`, `company/social-drip-state.json` (new; read here)
+**Approach:** Branch on `SHIP_NEWS`. **Highlight:** LLM picks the single most user-relevant change → punchy post (what + why + `https://wgmesh.dev`, release tag if present). **Evergreen:** read `company/social-drip-state.json` `recent_angles[]`; prompt LLM to pick an unused angle from a fixed set (differentiator / how-it-works / use-case / tip), grounded in `STRATEGY.md` + `FEATURE_MATRIX.md` positioning; output post + chosen `angle`. Enforce ≤300 chars (regen/trim if over). Pipe final body through `company/scripts/sanitise.sh`; fail-closed → skip draft + warn. Capture `POST_BODY` + `POST_ANGLE`.
+**Patterns to follow:** digest LLM step; `company/scripts/sanitise.sh` gate per [[feedback_llm_emit_must_gate_on_sanitise]].
+**Test scenarios:**
+- Highlight happy: `SHIP_NEWS=1` → body references the change + link, ≤300 chars.
+- Evergreen happy: `SHIP_NEWS=0` → body is an angle not in `recent_angles`, ≤300 chars.
+- Rotation: `recent_angles` has 3 of 4 → picks the 4th.
+- Over-limit: LLM returns 350 chars → trimmed/regenerated ≤300.
+- Sanitise block: body with a secret-shaped string → sanitise fails → no draft, warning. Covers R8.
+**Verification:** dry-run prints final body + char count + angle; sanitise runs.
+
+### U4. Evergreen rotation state persistence
+
+**Goal:** Record the angle used so future weeks don't repeat; commit back like other state files.
+**Requirements:** R4
+**Dependencies:** U3
+**Files:** `.github/workflows/wgmesh-social-drip.yml`, `company/social-drip-state.json`
+**Approach:** After a successful evergreen draft, append `POST_ANGLE` to `recent_angles` (keep last 4, FIFO) + `last_run` date; commit via branch+PR or fast-lane per repo state-commit convention (mirror supervisor-rank/pipeline-health state commits — protected main → branch+PR per [[feedback_state_commit_to_protected_main_fails]]). Only on real (non-dry-run) evergreen sends. Skip on ship-news weeks.
+**Patterns to follow:** existing state-file commit workflows (`company/pipeline-health-state.json`, `supervisor-rank-state.json`).
+**Test scenarios:**
+- Append: evergreen post angle=tip → state gains `tip`, trims to last 4.
+- No-op: ship-news week → state untouched.
+- Dry-run: `dry_run=true` → no commit.
+**Test expectation:** assert via dry-run log (no commit) + a state-file unit check if a test harness exists; else manual verify first live run.
+**Verification:** after a live evergreen run, `social-drip-state.json` updated on main via PR.
+
+### U5. Mixpost draft creation + review ping
+
+**Goal:** Create the post as a Mixpost draft to both @wgmesh accounts and email the operator to review/publish.
+**Requirements:** R5, R6, R7
+**Dependencies:** U3
+**Files:** `.github/workflows/wgmesh-social-drip.yml`
+**Approach:** Resolve account ids: `GET {BASE}/api/{ws}/accounts` (Bearer `MIXPOST_API_TOKEN`, UA `Mozilla/5.0` for the Cloudflare gate) → collect all ids (avoid hardcoding 1/2). `POST {BASE}/api/{ws}/posts` body `{schedule:false, accounts:[ids], versions:[{account_id:0,is_original:true,content:[{body:POST_BODY,media:[]}],options:{mastodon:{sensitive:false}}}]}`. On 201, send review-ping via existing Unsend path (`POST {UNSEND_URL}/api/v1/emails`) with the post body + a `mixpost.infrawei.com` link to the drafts. `dry_run=true` → print body + skip POST + skip email. Best-effort: non-200 from Mixpost or Unsend → `::error`/`::warning` per severity; never post garbage.
+**Patterns to follow:** Mixpost create-post API (origin Dependencies); digest Unsend send step + its UA/CF handling per [[feedback_cloudflare_1010_urllib_user_agent]].
+**Test scenarios:**
+- Happy: valid body → `POST /posts` 201 status `draft`; ping email accepted (200).
+- Account resolve: `GET /accounts` returns 2 → both ids in `accounts[]`.
+- Mixpost fail: 4xx/5xx → `::error`, no ping with false success.
+- Dry-run: no POST, no email, body logged.
+- Secrets unset: missing `MIXPOST_API_TOKEN` → warn + skip (graceful, like digest's unset-secret path).
+**Verification:** live dry-run logs the would-be draft; one real run creates a visible draft in Mixpost + delivers the ping.
+
+---
+
+## Scope Boundaries
+
+**In:** one weekly workflow → one draft (ship or evergreen) → both @wgmesh networks → review ping. Account-id resolution at runtime. Evergreen rotation state.
+
+**Deferred to Follow-Up Work:**
+- Auto-publish after review timeout (origin Q2; default manual now).
+- A hand-curated evergreen backlog (LLM-generated for v1).
+- Per-PR/release deep-linking beyond wgmesh.dev.
+
+**Outside this product's identity (from origin):** X/LinkedIn (paid/dev apps), Reddit (Mixpost can't; n8n later), threads, media-in-posts, engagement/reply automation, analytics-driven topic choice, fully autonomous no-human posting.
+
+---
+
+## Risks & Dependencies
+
+- **Mixpost token/workspace** must be set as secrets (`MIXPOST_API_TOKEN`, `MIXPOST_WORKSPACE`) — values exist (operator's private store), not yet in repo secrets. **Prereq before first live run.**
+- **Cloudflare 1010:** Mixpost + OpenPanel hosts CF-gate non-browser UAs → all curl calls send `User-Agent: Mozilla/5.0` ([[feedback_cloudflare_1010_urllib_user_agent]]).
+- **SES production access** already granted → review ping delivers.
+- **Quality drift:** LLM evergreen could feel generic → human gate (KTD5) is the backstop; monitor first weeks.
+- **State-commit to protected main** must go via branch+PR ([[feedback_state_commit_to_protected_main_fails]]).
+
+---
+
+## System-Wide Impact
+
+New workflow only; no change to the daily digest or pipeline. Adds repo secrets (`MIXPOST_*`). New committed state file `company/social-drip-state.json`. Public-facing output (social posts) → sanitise gate is mandatory (R8).
+
+---
+
+## Sources & Research
+
+- Origin: `docs/brainstorms/2026-06-19-wgmesh-social-drip-requirements.md`
+- Pattern: `.github/workflows/daily-release-notes.yml` (digest skeleton, LLM call, Unsend send, CF-UA, graceful-unset)
+- Mixpost API verified live this session (create-post, accounts, schedule); see private operator notes for token/workspace.
+- `company/scripts/sanitise.sh` (public-emit gate).


### PR DESCRIPTION
Weekly GitHub Actions workflow that drafts one @wgmesh social post (Bluesky + Mastodon) and pings the operator to review+publish. Clones the daily-digest skeleton; output sink = **Mixpost draft API** (`schedule:false`), source = **wgmesh repo only**, with a **ship-news-vs-evergreen** branch so cadence never goes dark. No unattended auto-publish (human gate). Sanitise-gated (public account); best-effort/non-blocking; CF `User-Agent` on curl.

Cron Thu 15:00 UTC + `workflow_dispatch` (`dry_run`/`since_hours`). Evergreen angle rotation persisted in `company/social-drip-state.json` via branch+PR.

Plan: `docs/plans/2026-06-19-001-feat-wgmesh-social-drip-plan.md`. Validated: YAML + `bash -n` all steps. New workflow → dry-run after merge (GH requires dispatch workflows on the default branch). Mixpost secrets set.