### PR TITLE
fix(social): OpenRouter timeout on wgmesh drip (HTTP 000)

### DIFF
--- a/.github/workflows/wgmesh-social-drip.yml
+++ b/.github/workflows/wgmesh-social-drip.yml
@@ -174,11 +174,10 @@ jobs:
               json.dump(payload, fh, ensure_ascii=False)
           PY
 
-          http=$(curl -sS -m 60 -w '%{http_code}' -o /tmp/social_drip_llm_resp.json \
+          http=$(curl -sS -m 180 -w '%{http_code}' -o /tmp/social_drip_llm_resp.json \
             -X POST "https://openrouter.ai/api/v1/chat/completions" \
             -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
             -H "Content-Type: application/json" \
-            -H "User-Agent: Mozilla/5.0" \
             -d @/tmp/social_drip_llm_req.json) || http="000"
 
           if [ "$http" != "200" ]; then


### PR DESCRIPTION
Dry-run showed the drip's OpenRouter call returning HTTP 000 (curl timeout) → no post generated. GLM-5.2 on the bigger social prompt (full PR bodies + STRATEGY + FEATURE_MATRIX) exceeds the `-m 60` cap. Bump to `-m 180` and drop the unnecessary `User-Agent: Mozilla` (OpenRouter isn't Cloudflare-gated; the digest's working call has neither). Found via dry-run.