### PR TITLE
feat(tracing): route poller per-stage calls through StateGraph for CallbackHandler (U7)

### DIFF
--- a/pipeline/tests/test_poller_stage_tracing.py
+++ b/pipeline/tests/test_poller_stage_tracing.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.graph import build_lg
+from wgmesh_pipeline.graph.state import GraphState
+
+pytestmark = pytest.mark.unit
+
+
+STAGES = ("triage", "spec", "spec_pr", "implement", "review")
+STAGE_UPDATES = {
+    "triage": {"classification": "fix"},
+    "spec": {"spec_path": "specs/issue-7-spec.md"},
+    "spec_pr": {"spec_pr": 107},
+    "implement": {"impl_pr": 207, "changed_files": ["README.md"]},
+    "review": {"tests_passed": True, "sanitise_ok": True},
+}
+
+
+def _cfg() -> Config:
+    return Config(target_repo="atvirokodosprendimai/wgmesh")
+
+
+def _state(*, issue_number: int | None = 7) -> GraphState:
+    state: GraphState = {"visited": []}
+    if issue_number is not None:
+        state["issue"] = GitHubIssue(
+            number=issue_number,
+            title="Trace poller stage",
+            labels=("fn:dev",),
+            state="open",
+        )
+    return state
+
+
+def _node(name: str):
+    def run(state: GraphState) -> GraphState:
+        next_state = dict(state)
+        next_state["visited"] = [*next_state.get("visited", []), name]
+        next_state.update(STAGE_UPDATES[name])
+        return next_state
+
+    return run
+
+
+@dataclass
+class FakeStageGraph:
+    result: GraphState | None = None
+    configs: list[dict | None] = field(default_factory=list)
+
+    def invoke(self, state: GraphState, config: dict | None = None) -> GraphState:
+        self.configs.append(config)
+        return self.result if self.result is not None else state
+
+
+@pytest.fixture
+def fake_nodes(monkeypatch):
+    nodes = {name: _node(name) for name in STAGES}
+    for name, fn in nodes.items():
+        monkeypatch.setattr(build_lg, f"{name}_node", fn)
+    return nodes
+
+
+def test_poller_stage_calls_match_raw_node_results(fake_nodes) -> None:
+    wrapper = build_lg.build_state_graph(_cfg())
+
+    for name in STAGES:
+        state = _state()
+        expected = fake_nodes[name](state)
+
+        result = getattr(wrapper, name)(_state())
+
+        assert result == expected
+
+
+def test_poller_stage_calls_attach_callback_handler(monkeypatch, fake_nodes) -> None:
+    fake_handler = object()
+    wrapper = build_lg.build_state_graph(_cfg())
+    stage_graphs = {name: FakeStageGraph(result={"stage": name}) for name in STAGES}
+    wrapper._stage_graphs = stage_graphs
+    monkeypatch.setattr(build_lg, "build_callback_handler", lambda config: fake_handler)
+
+    for name in STAGES:
+        result = getattr(wrapper, name)(_state())
+
+        assert result == {"stage": name}
+        assert stage_graphs[name].configs == [{"callbacks": [fake_handler]}]
+
+
+def test_poller_stage_calls_invoke_plainly_without_handler(
+    monkeypatch,
+    fake_nodes,
+) -> None:
+    wrapper = build_lg.build_state_graph(_cfg())
+    stage_graph = FakeStageGraph(result={"ok": True})
+    wrapper._stage_graphs = {"triage": stage_graph}
+    monkeypatch.setattr(build_lg, "build_callback_handler", lambda config: None)
+
+    result = wrapper.triage(_state())
+
+    assert result == {"ok": True}
+    assert stage_graph.configs == [None]
+
+
+def test_poller_stage_calls_group_issue_session(monkeypatch, fake_nodes) -> None:
+    sessions: list[str | None] = []
+    wrapper = build_lg.build_state_graph(_cfg())
+    wrapper._stage_graphs = {"triage": FakeStageGraph(result={"ok": True})}
+    monkeypatch.setattr(build_lg, "build_callback_handler", lambda config: object())
+
+    @contextmanager
+    def record_session(session_id: str | None):
+        sessions.append(session_id)
+        yield
+
+    monkeypatch.setattr(build_lg, "_session_id_ctx", record_session)
+
+    result = wrapper.triage(_state(issue_number=7))
+
+    assert result == {"ok": True}
+    assert sessions == ["issue-7"]
+
+
+def test_poller_stage_tracing_setup_failure_is_non_fatal(
+    monkeypatch,
+    fake_nodes,
+) -> None:
+    wrapper = build_lg.build_state_graph(_cfg())
+    stage_graph = FakeStageGraph(result={"ok": True})
+    wrapper._stage_graphs = {"triage": stage_graph}
+
+    def boom(config):
+        raise RuntimeError("callback unavailable")
+
+    monkeypatch.setattr(build_lg, "build_callback_handler", boom)
+
+    result = wrapper.triage(_state())
+
+    assert result == {"ok": True}
+    assert stage_graph.configs == [None]

--- a/pipeline/wgmesh_pipeline/graph/build_lg.py
+++ b/pipeline/wgmesh_pipeline/graph/build_lg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -31,6 +32,7 @@ class StateGraphWrapper:
     review: Callable[[GraphState], GraphState]
     gate: Callable[..., GraphState]
     raw_gate: Callable[..., GraphState]
+    _stage_graphs: dict[str, Any] = field(default_factory=dict, init=False, repr=False)
     _callback_handler: object | None = field(default=None, init=False, repr=False)
     _callback_handler_initialized: bool = field(default=False, init=False, repr=False)
 
@@ -51,6 +53,35 @@ class StateGraphWrapper:
             except Exception:
                 self._callback_handler = None
         return self._callback_handler
+
+    def _run_stage(self, name: str, state: GraphState) -> GraphState:
+        stage_graph = self._stage_graphs[name]
+        issue = state.get("issue")
+        issue_number = getattr(issue, "number", None)
+        session_id = f"issue-{issue_number}" if issue_number is not None else None
+        try:
+            handler = self._callback_handler_for_invoke()
+            cfg = {"callbacks": [handler]} if handler is not None else None
+            session_ctx = _session_id_ctx(session_id)
+            session_ctx.__enter__()
+        except Exception:
+            return stage_graph.invoke(state)
+
+        try:
+            result = stage_graph.invoke(state, config=cfg)
+        except BaseException:
+            exc_info = sys.exc_info()
+            try:
+                session_ctx.__exit__(*exc_info)
+            except Exception:
+                pass
+            raise
+        else:
+            try:
+                session_ctx.__exit__(None, None, None)
+            except Exception:
+                pass
+            return result
 
     def evaluate_gate(self, state: GraphState) -> GraphState:
         parameters = inspect.signature(self.raw_gate).parameters
@@ -123,24 +154,38 @@ class StateGraphWrapper:
 def build_state_graph(config: Config) -> StateGraphWrapper:
     from langgraph.graph import END, StateGraph
 
-    triage = trace_node("triage", triage_node)
-    spec = trace_node("spec", spec_node)
-    spec_pr = trace_node("spec_pr", spec_pr_node)
-    implement = trace_node("implement", implement_node)
-    review = trace_node("review", review_node)
     gate = trace_node("gate", gate_node)
+
+    def _compile_single(name: str, fn: Callable[[GraphState], GraphState]) -> Any:
+        graph = StateGraph(GraphState)
+        graph.add_node(name, fn)
+        graph.set_entry_point(name)
+        graph.add_edge(name, END)
+        return graph.compile()
 
     wrapper = StateGraphWrapper(
         config=config,
         compiled=None,
-        triage=triage,
-        spec=spec,
-        spec_pr=spec_pr,
-        implement=implement,
-        review=review,
+        triage=lambda state: state,
+        spec=lambda state: state,
+        spec_pr=lambda state: state,
+        implement=lambda state: state,
+        review=lambda state: state,
         gate=gate,
         raw_gate=gate_node,
     )
+    wrapper._stage_graphs = {
+        "triage": _compile_single("triage", triage_node),
+        "spec": _compile_single("spec", spec_node),
+        "spec_pr": _compile_single("spec_pr", spec_pr_node),
+        "implement": _compile_single("implement", implement_node),
+        "review": _compile_single("review", review_node),
+    }
+    wrapper.triage = lambda state: wrapper._run_stage("triage", state)
+    wrapper.spec = lambda state: wrapper._run_stage("spec", state)
+    wrapper.spec_pr = lambda state: wrapper._run_stage("spec_pr", state)
+    wrapper.implement = lambda state: wrapper._run_stage("implement", state)
+    wrapper.review = lambda state: wrapper._run_stage("review", state)
 
     graph = StateGraph(GraphState)
     graph.add_node("triage", triage_node)


### PR DESCRIPTION
**U7** — closes the gap U6 step-1 surfaced: `GRAPH_IMPL=langgraph` was a runtime no-op because the poller calls per-stage callables that bypass the compiled graph, so `CallbackHandler` never fired.

Now each exposed per-stage callable (`triage/spec/spec_pr/implement/review`) invokes a **single-node compiled langgraph** with the CallbackHandler attached and the issue session grouped — so the per-stage poller path emits spans natively (realizes KTD-3). Returned state is **identical** to a direct node call (single-node invoke returns the same merged state). Full-graph `.invoke()`, the gate path (`gate_node` direct), and the legacy `CompiledGraph` are unchanged.

Tracing setup is guarded (handler/session failure → plain invoke); node exceptions propagate.

## Test plan
- [x] `tests/test_poller_stage_tracing.py` — result parity vs direct node call, handler attached per stage, no-handler→plain invoke, `issue-<N>` session grouping, tracing-failure non-fatal
- [x] `tests/test_build_lg_parity.py` (9) + `test_callback_handler_tracing.py` green
- [x] `pytest pipeline` → **615 passed / 5 skipped**
- [x] ruff + black clean

## Next
Re-run U6 step 1: flip `GRAPH_IMPL=langgraph`+shadow and verify CallbackHandler node spans land in Langfuse (now reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)