### PR TITLE
feat: capabilities grounding to stop autobuilders re-proposing shipped work

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -104,6 +104,20 @@ jobs:
             echo "No CLAUDE.md found in $primary." > /tmp/product_summary.txt
           fi
 
+      - name: Collect already-shipped capabilities
+        env:
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+          TARGET_REPO: atvirokodosprendimai/wgmesh
+        run: |
+          # Derive a digest of already-shipped capabilities from recent merged
+          # implementation PRs + docs/solutions/, so the LLM stops re-proposing
+          # shipped work (e.g. OpenPanel analytics #762 -> redundant #767).
+          # Best-effort: never blocks the loop; writes a sentinel on failure.
+          bash company/scripts/collect-capabilities.sh > /tmp/capabilities.txt || {
+            echo "::warning::collect-capabilities.sh failed — proceeding without capabilities digest"
+            echo "(capabilities digest unavailable this run)" > /tmp/capabilities.txt
+          }
+
       - name: Collect shared memory
         run: |
           # Semantic memory (MEMORY.md) + recent episodic entries.
@@ -440,6 +454,14 @@ jobs:
           This is the actual state of the primary product repo (from CLAUDE.md). Use this to
           understand what features ALREADY EXIST. Do NOT create issues for features listed here.
           $(cat /tmp/product_summary.txt)
+
+          ## Already-Shipped Capabilities
+          Capabilities already shipped via merged PRs (and documented solutions),
+          newest first. Treat every item here as DONE — do NOT create issues to
+          build, add, or re-implement anything already listed, even when it is
+          worded differently from the capability name. Reconcile any open issue
+          that duplicates one of these to closure.
+          $(cat /tmp/capabilities.txt)
 
           ## Shared Memory
           Curated knowledge and recent agent activity from the shared memory subsystem.

--- a/company/scripts/collect-capabilities.sh
+++ b/company/scripts/collect-capabilities.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Collect already-shipped capabilities for the company control loop.
+# Reads recent merged implementation PRs plus docs/solutions/ entries,
+# reconciles Revert PRs, and outputs budget-aware text to stdout.
+# Output: plain-text capabilities digest to stdout.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+TARGET_REPO="${TARGET_REPO:-${GITHUB_REPOSITORY:-}}"
+
+BUDGET=4096
+LIMIT=200
+PR_LIST_FILE=""
+SOLUTIONS_DIR="$ROOT/docs/solutions"
+SENTINEL="(capabilities digest unavailable this run)"
+
+warn() {
+  echo "::warning::collect-capabilities: $*" >&2
+}
+
+# -- Parse args ---------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --budget)        BUDGET="$2"; shift 2 ;;
+    --limit)         LIMIT="$2"; shift 2 ;;
+    --pr-list-file)  PR_LIST_FILE="$2"; shift 2 ;;
+    --solutions-dir) SOLUTIONS_DIR="$2"; shift 2 ;;
+    *) warn "Unknown option: $1"; shift ;;
+  esac
+done
+
+fetch_prs() {
+  if [ -n "$PR_LIST_FILE" ]; then
+    if [ ! -s "$PR_LIST_FILE" ]; then
+      warn "PR list file missing or empty: $PR_LIST_FILE"
+      return 1
+    fi
+    cat "$PR_LIST_FILE" || return 1
+    return 0
+  fi
+
+  if [ -z "$TARGET_REPO" ]; then
+    warn "TARGET_REPO/GITHUB_REPOSITORY not set"
+    return 1
+  fi
+
+  gh pr list \
+    --repo "$TARGET_REPO" \
+    --state merged \
+    --limit "$LIMIT" \
+    --json number,title,body 2>/dev/null || {
+      warn "gh pr list failed for $TARGET_REPO"
+      return 1
+    }
+}
+
+parse_prs() {
+  jq -r '
+    def strip_prefix:
+      sub("^(feat|fix|refactor|perf|chore|docs|ci|test|style|build)(\\([^)]*\\))?:\\s*"; ""; "i");
+    def trim:
+      gsub("^\\s+|\\s+$"; "");
+    def summary:
+      ((.body // "")
+        | split("\n")
+        | map(trim)
+        | map(select(length > 0))
+        | .[0] // "")
+      | if length > 100 then .[0:100] + "..." else . end;
+    def capability_line:
+      (.title | strip_prefix) as $title
+      | summary as $summary
+      | $title + " (PR #" + (.number | tostring) + ")"
+        + (if $summary == "" then "" else " — " + $summary end);
+
+    if type != "array" then
+      error("expected PR JSON array")
+    else
+      . as $prs
+      | [
+          $prs[]
+          | (.title // "")
+          | capture("^Revert \"(?<inner>.*)\"$"; "i")?
+          | .inner
+          | strip_prefix
+        ] as $reverted_titles
+      | [
+          $prs[]
+          | select((.title // "" | test("^(chore|docs|ci|test|style|build)(\\([^)]*\\))?:\\s*"; "i")) | not)
+          | select((.title // "" | test("^Revert \""; "i")) | not)
+          | (.title | strip_prefix) as $capability_title
+          | select(($reverted_titles | index($capability_title)) | not)
+          | {key: $capability_title, line: capability_line}
+        ]
+      | reduce .[] as $item (
+          {seen: {}, lines: []};
+          if .seen[$item.key] then
+            .
+          else
+            .seen[$item.key] = true | .lines += [$item.line]
+          end
+        )
+      | .lines[]
+    end
+  ' 2>/dev/null
+}
+
+solution_title() {
+  local file="$1"
+  awk '
+    BEGIN { in_frontmatter = 0 }
+    NR == 1 && /^---$/ { in_frontmatter = 1; next }
+    in_frontmatter && /^---$/ { in_frontmatter = 0; next }
+    in_frontmatter && /^title:[[:space:]]*/ {
+      line = $0
+      sub(/^title:[[:space:]]*/, "", line)
+      gsub(/^["\047]|["\047]$/, "", line)
+      print line
+      exit
+    }
+    !in_frontmatter && /^# / {
+      line = $0
+      sub(/^# /, "", line)
+      print line
+      exit
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+collect_solutions() {
+  if [ ! -d "$SOLUTIONS_DIR" ]; then
+    return 0
+  fi
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    title=$(solution_title "$file")
+    [ -n "$title" ] || continue
+    if [ "${#title}" -gt 160 ]; then
+      title="${title:0:160}..."
+    fi
+    printf '%s\n' "$title"
+  done < <(find "$SOLUTIONS_DIR" -type f -name '*.md' | sort)
+}
+
+dedup_lines() {
+  awk 'NF && !seen[$0]++'
+}
+
+apply_budget() {
+  local total=0
+  local line
+  local bytes
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    bytes=$(printf '%s\n' "$line" | wc -c | tr -d ' ')
+    if [ $((total + bytes)) -le "$BUDGET" ]; then
+      printf '%s\n' "$line"
+      total=$((total + bytes))
+    else
+      break
+    fi
+  done
+}
+
+main() {
+  local pr_json
+  local pr_lines=""
+  local solution_lines=""
+  local output=""
+
+  if ! pr_json=$(fetch_prs); then
+    echo "$SENTINEL"
+    return 0
+  fi
+
+  if ! pr_lines=$(printf '%s\n' "$pr_json" | parse_prs); then
+    warn "failed to parse PR JSON"
+    echo "$SENTINEL"
+    return 0
+  fi
+
+  solution_lines=$(collect_solutions || true)
+  output=$(printf '%s\n%s\n' "$pr_lines" "$solution_lines" | dedup_lines | apply_budget)
+
+  if [ -z "$output" ]; then
+    warn "no capabilities found"
+    echo "$SENTINEL"
+    return 0
+  fi
+
+  printf '%s\n' "$output"
+}
+
+main

--- a/company/scripts/test-collect-capabilities.sh
+++ b/company/scripts/test-collect-capabilities.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Tests for collect-capabilities.sh
+# Run: bash company/scripts/test-collect-capabilities.sh
+set -euo pipefail
+
+SCRIPT="company/scripts/collect-capabilities.sh"
+PASS=0
+FAIL=0
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# -- Helpers ------------------------------------------------------
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "  FAIL: $desc (expected not to contain '$needle')"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_status_zero() {
+  local desc="$1" status="$2"
+  if [ "$status" -eq 0 ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0, got $status)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+write_prs() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+}
+
+setup_fixtures() {
+  rm -rf "$TMPROOT/solutions"
+  mkdir -p "$TMPROOT/solutions/logic-errors"
+}
+
+# -- Tests --------------------------------------------------------
+
+echo "=== collect-capabilities.sh tests ==="
+
+echo ""
+echo "1. Extracts implementation PR capability with PR number"
+setup_fixtures
+prs="$TMPROOT/openpanel.json"
+write_prs "$prs" '[
+  {"number":762,"title":"feat(landing): OpenPanel analytics — track Polar CTA clicks","body":""}
+]'
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+assert_contains "names OpenPanel capability" "OpenPanel analytics" "$out"
+assert_contains "cites PR #762" "PR #762" "$out"
+
+echo ""
+echo "2. Strips conventional-commit prefix"
+assert_eq "exact stripped capability line" "OpenPanel analytics — track Polar CTA clicks (PR #762)" "$out"
+
+echo ""
+echo "3. Excludes non-implementation PR types"
+setup_fixtures
+prs="$TMPROOT/non-impl.json"
+write_prs "$prs" '[
+  {"number":801,"title":"chore: rotate stale workflow labels","body":""},
+  {"number":802,"title":"docs: explain pipeline review checkpoints","body":""},
+  {"number":803,"title":"ci: tune observation-loop cron","body":""}
+]'
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+assert_not_contains "chore PR excluded" "rotate stale" "$out"
+assert_not_contains "docs PR excluded" "review checkpoints" "$out"
+assert_not_contains "ci PR excluded" "observation-loop cron" "$out"
+assert_contains "empty implementation set emits sentinel" "(capabilities digest unavailable this run)" "$out"
+
+echo ""
+echo "4. Revert PR subtracts matching capability"
+setup_fixtures
+prs="$TMPROOT/revert.json"
+write_prs "$prs" '[
+  {"number":763,"title":"Revert \"feat(landing): OpenPanel analytics — track Polar CTA clicks\"","body":""},
+  {"number":762,"title":"feat(landing): OpenPanel analytics — track Polar CTA clicks","body":""}
+]'
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+assert_not_contains "reverted capability absent" "OpenPanel analytics" "$out"
+assert_contains "reverted-only result emits sentinel" "(capabilities digest unavailable this run)" "$out"
+
+echo ""
+echo "5. Budget keeps newest whole lines"
+setup_fixtures
+prs="$TMPROOT/budget.json"
+write_prs "$prs" '[
+  {"number":3,"title":"feat: Newest capability","body":""},
+  {"number":2,"title":"fix: Middle capability","body":""},
+  {"number":1,"title":"refactor: Oldest capability","body":""}
+]'
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" --budget 60 2>/dev/null)
+assert_contains "newest survives budget" "Newest capability (PR #3)" "$out"
+assert_contains "middle survives budget" "Middle capability (PR #2)" "$out"
+assert_not_contains "oldest dropped first" "Oldest capability" "$out"
+assert_not_contains "no mid-line truncation" "Oldest" "$out"
+
+echo ""
+echo "6. Dedups repeated capability titles"
+setup_fixtures
+prs="$TMPROOT/dedup.json"
+write_prs "$prs" '[
+  {"number":901,"title":"feat: Duplicate capability","body":""},
+  {"number":900,"title":"feat(api): Duplicate capability","body":""}
+]'
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+count=$(echo "$out" | grep -c "Duplicate capability" || true)
+assert_eq "duplicate capability appears once" "1" "$count"
+
+echo ""
+echo "7. Missing or empty PR fixture degrades gracefully"
+setup_fixtures
+set +e
+out=$(bash "$SCRIPT" --pr-list-file "$TMPROOT/missing.json" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+status=$?
+set -e
+assert_status_zero "missing PR fixture exits zero" "$status"
+assert_eq "missing PR fixture emits sentinel" "(capabilities digest unavailable this run)" "$out"
+empty="$TMPROOT/empty.json"
+: > "$empty"
+set +e
+out=$(bash "$SCRIPT" --pr-list-file "$empty" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+status=$?
+set -e
+assert_status_zero "empty PR fixture exits zero" "$status"
+assert_eq "empty PR fixture emits sentinel" "(capabilities digest unavailable this run)" "$out"
+
+echo ""
+echo "8. Includes docs/solutions titles"
+setup_fixtures
+prs="$TMPROOT/no-prs.json"
+write_prs "$prs" '[]'
+cat > "$TMPROOT/solutions/logic-errors/capability.md" <<'EOF'
+---
+title: Capabilities digest grounds shipped analytics
+module: observation-loop
+tags: [capabilities]
+problem_type: logic-error
+---
+
+# Fallback heading should not be used
+EOF
+out=$(bash "$SCRIPT" --pr-list-file "$prs" --solutions-dir "$TMPROOT/solutions" 2>/dev/null)
+assert_contains "solution title appears" "Capabilities digest grounds shipped analytics" "$out"
+
+echo ""
+echo "9. State-free run leaves no collector state file"
+if find . -name '*capabilities*state*' -print -quit | grep -q .; then
+  echo "  FAIL: no capabilities state file should exist"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no capabilities state file exists"
+  PASS=$((PASS + 1))
+fi
+
+# Bite check: this harness must fail if capability extraction is broken.
+# Temporarily replacing the stripped-title extraction with an empty string
+# should make tests 1, 2, 5, 6, and 8 fail; do not commit that mutation.
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/company/system-prompt.md
+++ b/company/system-prompt.md
@@ -112,6 +112,8 @@ You will receive a **Product Codebase Summary** in each run. This describes the 
 
 **NEVER create issues for features that already exist in the codebase.** Before adding anything to `issues_to_create`, verify it is not already described in the Product Codebase Summary. If the summary describes peer discovery, NAT traversal, gossip protocol, encryption, etc. — those features exist. Create issues only for bugs, improvements, or genuinely missing capabilities.
 
+You will also receive an **Already-Shipped Capabilities** block — a digest of capabilities already shipped via recent merged PRs (and documented solutions). Treat every item there as authoritative shipped state. Before adding anything to `issues_to_create`, check it against this block too, and do not propose building, adding, or re-implementing anything already listed — even when the proposed issue is worded differently from the capability name (e.g. "add web analytics" when analytics already shipped).
+
 If no Product Codebase Summary is provided, state this as a blocker rather than assuming the product doesn't exist.
 
 ## Issue and PR hygiene
@@ -140,7 +142,7 @@ Before finalising your assessment, reconcile **every open issue** against curren
 **For every open `fn:dev` issue:**
 
 1. Read the issue title
-2. Check the Product Codebase Summary for an existing implementation
+2. Check the Product Codebase Summary **and the Already-Shipped Capabilities block** for an existing implementation
 3. If the feature already exists → add to `issues_to_close` with reason
 4. If a spec PR exists for that issue → add to `prs_to_close` with reason
 

--- a/docs/brainstorms/2026-06-19-capabilities-grounding-redo-prevention-requirements.md
+++ b/docs/brainstorms/2026-06-19-capabilities-grounding-redo-prevention-requirements.md
@@ -1,0 +1,93 @@
+---
+date: 2026-06-19
+topic: capabilities-grounding-redo-prevention
+---
+
+# Capabilities Grounding — Stop Autobuilders Re-Proposing Shipped Work
+
+## Summary
+
+Give the Observation Loop an auto-derived manifest of capabilities the pipeline has already shipped, built from merged implementation PRs plus `docs/solutions/`, and feed it into the loop's existing Product Codebase Summary. The loop then stops proposing work that already exists, at the source — no new reject gate. OpenPanel analytics (#762 shipped, #767 redundantly filed) is the acceptance test.
+
+## Problem Frame
+
+The Observation Loop filed wgmesh **#767** "Add web analytics tracking (Plausible/PostHog) to cloudroof.eu landing" on 2026-06-19, while OpenPanel analytics had already shipped via merged PR **#762** (`feat(landing): OpenPanel analytics`) the day before. The redo was not free: #767 advanced into the pipeline and produced open PR **#769**, a Build agent re-implementing analytics that is already live. The same blindness closed #590 ("customer usage analytics") earlier in the same theme.
+
+The loop is not missing a dedup step — it has two, and both failed here. Its issue-creation step does a fuzzy keyword match on issue **titles** only, requiring 2+ keyword hits (`.github/workflows/observation-loop.yml:680-706`); "Add web analytics tracking" and "OpenPanel analytics" share no keywords. Its system prompt instructs the LLM "NEVER create issues for features that already exist," checked against a **Product Codebase Summary** (`company/system-prompt.md:109-113`). But that summary is assembled from the head of the seed repo's `CLAUDE.md` (`.github/workflows/observation-loop.yml:100-105`), and the OpenPanel deployment was never written there. The LLM was told to check a document that did not mention the thing it was about to duplicate.
+
+The cost shape is wasted Build cycles plus operator triage on every redundant issue, recurring for any capability that ships through code but isn't reflected in the loop's grounding.
+
+## Key Decisions
+
+- **Fix the grounding, not the gate.** The remedy is to make the loop *see* what shipped, not to add a stage that rejects duplicate issues after the LLM proposes them. Prevention at the assessment source keeps a single decision point and avoids a second fuzzy-matching surface that would fail the same way the title matcher did.
+
+- **Auto-derive the manifest from merged work.** The capabilities signal is aggregated by a collector from merged implementation PRs and `docs/solutions/` entries each loop run. No hand-maintained file and no live probing of deployed surfaces. This is drift-proof — it cannot fall out of sync with reality because it *is* derived from the record of what shipped.
+
+- **Completeness rests on the pipeline being the only way to ship.** In the autonomous company, every capability reaches production through Issue → Spec → Build → Merge, so every capability leaves a merged-PR trace. The manifest is therefore complete by construction. Hand-deployment would break this, but hand-deployment is itself a constitution violation to fix at its source, not a coverage case this mechanism must absorb.
+
+- **The semantic match is the LLM's job, not new code.** "Add web analytics" and "OpenPanel analytics shipped" do not keyword-match; bridging them is semantic. The design surfaces the capabilities manifest to the LLM richly enough that the model makes the link, rather than adding deterministic matching code that would reproduce the title-matcher's failure.
+
+## Design Rationale (TRIZ/ARIZ)
+
+The contradiction: improve the loop's ability to detect an already-shipped capability (amount of information, detectability) without worsening system and control complexity (a separately-maintained registry that drifts). Matrix 2003 over this contradiction ranks the inventive principles that the chosen approach already embodies:
+
+- **Self-Service (#25)** — *use by-products for useful purposes.* The pipeline's own exhaust — merged implementation PRs — feeds the loop. The capability index is a by-product of shipping, not a new component.
+- **Preliminary Action (#10)** — arrange the information in advance so it acts without wasting time. The manifest is pre-computed each run and present at assessment time, ahead of any proposal.
+- **Local Quality (#3)** — different parts do different jobs. The merged-PR record carries the recognition data; the LLM does the semantic match. Neither does the other's job (this is why a second deterministic matcher is rejected — it would reproduce the title-matcher's failure).
+- **Universality (#6)** — the merged-PR record serves double duty (ship history and capability index), making a separate registry unnecessary.
+
+The Ideal Final Result is the loop knowing shipped state *without the registry existing*; Self-Service realizes it. In resource terms, the **informational resource** (merged PR titles/bodies, `docs/solutions/`) is a hidden resource already in the system — a registry would add a *material* resource and raise complexity. The contradiction dissolves by **separation in time** (derive at run-time, so no persisted state can drift) and **separation between part and whole** (each PR carries its own capability description; there is no maintained whole to keep in sync).
+
+## Requirements
+
+**Capabilities manifest**
+
+- R1. A collector produces a structured manifest of capabilities the pipeline has shipped, derived from merged implementation PRs in the seed repo plus `docs/solutions/` entries.
+- R2. The manifest is regenerated each Observation Loop run from current source data, holding no hand-maintained state that could drift from what actually shipped.
+- R3. Each manifest entry carries enough description for an LLM to recognize a semantic duplicate of it (the capability's substance, not only an issue title).
+
+**Loop grounding**
+
+- R4. The manifest feeds the Observation Loop's existing Product Codebase Summary, so the LLM sees shipped capabilities during assessment without a new reject stage downstream.
+- R5. The grounding surfaces capabilities richly enough that the LLM can link a newly-proposed issue to an existing capability that is worded differently.
+
+**Acceptance proof and cleanup**
+
+- R6. Replaying the conditions that produced #767, with the manifest in place, the loop does not file the redundant analytics issue.
+- R7. The live #767 (and its in-flight PR #769) is dispositioned as already-shipped, closed with a reason citing #762.
+
+## Acceptance Examples
+
+- AE1. **Covers R6.** **Given** OpenPanel analytics shipped via merged PR #762 and the capabilities manifest is generated for the loop run, **when** the Observation Loop assesses GTM state and considers proposing web analytics tracking, **then** it recognizes analytics as already shipped and does not add it to `issues_to_create`.
+- AE2. **Covers R3, R5.** **Given** a manifest entry derived from #762 whose title says "OpenPanel analytics" and a candidate issue titled "Add web analytics tracking (Plausible/PostHog)," **when** the LLM evaluates the candidate against the manifest, **then** it links the two despite zero shared title keywords and declines the candidate.
+- AE3. **Covers R7.** **Given** #767 open and PR #769 in flight, **when** the cleanup runs, **then** #767 is closed with a reason citing #762 as the existing implementation.
+
+## Scope Boundaries
+
+- Live probing of deployed surfaces (e.g. fetching cloudroof.eu to detect the analytics snippet) is rejected — flaky, and per-capability detection code.
+- A human-maintained `capabilities.json` is rejected — drift-prone, defeats the zero-maintenance goal.
+- A new post-LLM dedup/reject gate is out of scope — the fix lives in grounding, not enforcement.
+- Strengthening the existing fuzzy title matcher is not the approach; the manifest plus LLM semantic matching supersedes it for this class.
+
+## Dependencies / Assumptions
+
+- Every shippable capability leaves a merged-PR trace, because the pipeline is the only path to production. The manifest is complete only while this holds; hand-deployment would create an invisible capability and is treated as a violation to fix upstream, not a coverage requirement here.
+- Merged implementation PRs carry enough signal in title/body (and `docs/solutions/` enough in content) to describe a capability recognizably. If merged work records capabilities too thinly, R3 weakens — derivation is only as good as what merged work writes down.
+- The seed repo is the unit of grounding (currently `atvirokodosprendimai/wgmesh`, resolved as `TARGET_REPO`); cross-repo capability indexing is not assumed.
+
+## Outstanding Questions
+
+*Deferred to planning:*
+
+- The manifest's exact shape, storage location, and the collector script's home in `company/scripts/`.
+- How merged-PR derivation handles capabilities later removed or superseded (a shipped-then-reverted capability should not linger in the manifest).
+- Whether the grounding augments or replaces the current `CLAUDE.md`-head Product Codebase Summary.
+- How the #767/#769 cleanup is triggered — manual disposition now versus the loop's normal reconciliation closing it once the manifest lands.
+
+## Sources / Research
+
+- `.github/workflows/observation-loop.yml:100-105` — Product Codebase Summary built from seed `CLAUDE.md` head.
+- `.github/workflows/observation-loop.yml:680-706` — existing fuzzy title-keyword dedup (open + closed issues, 2+ hits).
+- `company/system-prompt.md:109-113`, `:136-147` — "NEVER create issues for features that already exist" rule and mandatory reconciliation against the codebase summary.
+- `scripts/goal-sprint/fingerprint.sh:40-86` — goal-sprint's fingerprint state file pattern; the Observation Loop has no equivalent "already proposed/shipped" state.
+- wgmesh #762 (merged, `feat(landing): OpenPanel analytics`), #767 (open, redundant), #769 (open, redo impl), #590 (closed, prior analytics dup).

--- a/docs/plans/2026-06-19-002-feat-capabilities-grounding-redo-prevention-plan.md
+++ b/docs/plans/2026-06-19-002-feat-capabilities-grounding-redo-prevention-plan.md
@@ -1,0 +1,215 @@
+---
+title: "feat: Capabilities grounding to stop autobuilders re-proposing shipped work"
+type: feat
+date: 2026-06-19
+origin: docs/brainstorms/2026-06-19-capabilities-grounding-redo-prevention-requirements.md
+---
+
+# feat: Capabilities Grounding to Stop Autobuilders Re-Proposing Shipped Work
+
+## Summary
+
+Add a `collect-capabilities.sh` collector that derives a digest of already-shipped capabilities from recent merged implementation PRs and `docs/solutions/` entries, and feed it into the Observation Loop's assessment grounding as its own labeled block. The loop then sees what already shipped and stops proposing duplicate work at the assessment source — no new dedup gate. Disposition the live OpenPanel redo (#767/#769) and record the mechanism as a `docs/solutions/` learning.
+
+Throughout this plan, **digest** is the single name for the artifact the collector emits (`/tmp/capabilities.txt`); it realizes the brainstorm's "capabilities manifest" concept.
+
+---
+
+## Problem Frame
+
+The Observation Loop filed wgmesh #767 "Add web analytics tracking (Plausible/PostHog)" while OpenPanel analytics had already shipped via merged PR #762 (`feat(landing): OpenPanel analytics`). The redo advanced into the pipeline and produced open PR #769, a Build agent re-implementing live analytics.
+
+The loop already has two dedup mechanisms and both missed this. The issue-creation step does fuzzy keyword matching on issue **titles** only (`.github/workflows/observation-loop.yml:688-705`); "Add web analytics tracking" and "OpenPanel analytics" share no title keywords. The system prompt instructs the LLM to never duplicate features described in a **Product Codebase Summary** (`company/system-prompt.md:109-115`), but that summary is assembled only from the head of the seed repo's `CLAUDE.md` (`.github/workflows/observation-loop.yml:88-105`), where the OpenPanel deployment was never written. The capability shipped through a merged PR — invisible to issue-title dedup, absent from the grounding the LLM reads.
+
+This is the next iteration of a documented failure class. `docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md` records the loop filing greenfield issues (#453/#458/#460) for already-shipped features; that fix created the Product Codebase Summary. The carry-forward rule from that RCA: *a single corrective signal cannot override compounding LLM priors, and metadata alone is insufficient — the LLM needs structural/capability awareness.* That lesson shapes two decisions below — the digest rides in its own labeled block (not buried in the CLAUDE.md-head summary), and it is bounded so it stays short enough to attend to rather than diluting into noise.
+
+---
+
+## Requirements
+
+Traceability to origin (`see origin: docs/brainstorms/2026-06-19-capabilities-grounding-redo-prevention-requirements.md`). R1-R7 carry origin IDs; R8-R9 are plan-local, resolving origin Outstanding Questions deferred to planning.
+
+**Capabilities collector**
+
+- R1. A collector derives a digest of shipped capabilities from merged implementation PRs in the seed repo (bounded to a recency window, see R9) plus `docs/solutions/` entries (origin R1).
+- R2. The digest is regenerated each loop run from current source data, holding no persisted cross-run state that could drift from what shipped (origin R2).
+- R3. Each digest entry carries the capability's substance and its source PR number, enough for an LLM to recognize a semantic duplicate (origin R3).
+- R8. Reverted or superseded capabilities are reconciled out of the digest — a `Revert "<title>"` PR subtracts the matching capability so the digest never asserts a removed capability is shipped (resolves origin Outstanding Question on revert/supersession).
+- R9. The collector bounds its derivation to a recency window (a `--limit` and/or date scope), emits newest-first, and dedups, so growth stays bounded and budget truncation never drops the newest (highest-risk) capabilities.
+
+**Loop grounding**
+
+- R4. The digest feeds the assessment prompt as its own labeled block, adding no post-LLM reject stage (origin R4).
+- R5. The grounding surfaces capabilities richly enough that the LLM links a differently-worded proposed issue to an existing capability (origin R5).
+
+**Acceptance proof and cleanup**
+
+- R6. A live control replay demonstrates the mechanism bites: with the digest present the loop does not re-produce the #767-shaped analytics issue, and with the digest empty/removed it does (origin R6).
+- R7. The live #767 and its in-flight PR #769 are dispositioned as already-shipped, closed with a reason citing #762 (origin R7).
+
+---
+
+## Acceptance Examples
+
+Carried from origin for in-plan traceability.
+
+- AE1. Covers R6. Given OpenPanel analytics shipped via merged PR #762 and the digest generated for the loop run, when the loop assesses GTM state and considers proposing web analytics tracking, then it recognizes analytics as already shipped and does not add it to `issues_to_create`.
+- AE2. Covers R3, R5. Given a digest entry derived from #762 and a candidate issue titled "Add web analytics tracking (Plausible/PostHog)," when the LLM evaluates the candidate against the digest, then it links the two despite zero shared title keywords and declines the candidate.
+- AE3. Covers R7. Given #767 open and PR #769 in flight, when the cleanup runs, then #767 is closed with a reason citing #762.
+
+---
+
+## Key Technical Decisions
+
+- **Read merged PRs deliberately, not issues.** The collector sources capabilities via `gh pr list --repo "$TARGET_REPO" --state merged --json number,title,body`, never `gh issue list`. The GitHub `/issues` API returns PRs too (`pull_request` key); a digest built from "issues" would ingest the loop's own spec PRs and runaway (`feedback_github_issues_api_includes_prs`). The #762 capability *is* a PR, so PR reading is both correct and required.
+
+- **Bounded recency window, not full history.** Derivation is scoped with `gh pr list --state merged --limit N` over a recency window (last N merged PRs / last ~180 days), newest-first, deduped — not the full merged-PR history (the seed and template repos are already past PR #1800). This bounds API cost on the loop's critical path, keeps the digest short enough to attend to, and guarantees budget truncation drops oldest-first, never the freshest capabilities. The long-tail backstop for older capabilities remains the existing CLAUDE.md-head Product Codebase Summary; the digest targets the recent-ship redo class (#762 shipped one day before #767).
+
+- **Stateless across runs.** The digest is rebuilt fresh every run from `gh pr list` + `docs/solutions/`; no cross-run cache or state file is read or written. The only output is the session-scoped `/tmp/capabilities.txt`, discarded with the job. The `scripts/goal-sprint/fingerprint.sh` state-file/skip precedent was considered and rejected: a persisted cache reintroduces the drift R2 forbids.
+
+- **Reverts subtract capabilities.** Derivation from merged PRs is complete for additions but blind to removals — a revert is itself a merged PR. The collector detects `Revert "<title>"` PRs and subtracts the matching capability, so a shipped-then-reverted feature does not linger and suppress legitimate re-work (R8). Residual supersession that does not use a `Revert` title is documented as known residual risk in the RCA (U4).
+
+- **Plain text to stdout, in its own grounding block.** The collector emits text (like `collect-memory.sh`), not JSON. It is surfaced as a dedicated `## Already-Shipped Capabilities` block in the assessment prompt — not appended into the CLAUDE.md-head Product Codebase Summary — so provenance is honest and the block is structurally distinct (the prior RCA's lesson: a signal buried among priors loses).
+
+- **The LLM does the semantic match; no new keyword code.** "Add web analytics" vs "OpenPanel analytics shipped" is a semantic link, not lexical. The design surfaces capabilities richly and leaves the match to the model, rather than adding deterministic matching that would reproduce the title-matcher's miss. This is the plan's load-bearing bet (origin Key Decision), and R6's control replay is what makes the bet falsifiable rather than assumed.
+
+- **Best-effort, but visibly degraded.** The collector step must never block the loop: failure falls to `|| true`. But an empty/failed run writes a sentinel line (e.g. `(capabilities digest unavailable this run)`) to `/tmp/capabilities.txt` — mirroring the product-summary step's `"No CLAUDE.md found"` (`observation-loop.yml:104`) — so a degraded run is visible *in the prompt*, not silently blank. A loud `::warning::` also goes to stderr (`feedback_telemetry_writes_must_be_best_effort`, `feedback_defensive_guard_must_announce`).
+
+- **Offline real-path test via injected PR fixture.** The collector's two inputs are heterogeneous: `docs/solutions/` (filesystem, overridable with a `--solutions-dir` flag like `collect-memory.sh`'s `--memory-dir`) and `gh pr list` (network). For the network half, the collector reads PRs through a single seam that a `--pr-list-file <json>` flag overrides with a canned `gh pr list --json number,title,body`-shaped fixture, and the real path and the fixture feed the *same* parse function. The test thus exercises the real parser against fixture bytes without live `gh`, satisfying the real-path rule (`AGENTS.md:66-67`).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  subgraph collect[Observation Loop — collect steps]
+    A[Collect product codebase summary<br/>observation-loop.yml:88-105<br/>→ /tmp/product_summary.txt]
+    B[NEW: collect-capabilities.sh step<br/>env GH_TOKEN, TARGET_REPO<br/>gh pr list --state merged --limit N --json number,title,body<br/>+ docs/solutions/ ; reverts subtracted ; newest-first ; budget<br/>→ /tmp/capabilities.txt]
+  end
+  A --> P
+  B -->|own labeled block| P[Assessment prompt heredoc<br/>observation-loop.yml:432-465<br/>NEW: ## Already-Shipped Capabilities block]
+  P --> L[LLM assessment<br/>OpenRouter]
+  L -->|semantic match against digest| D{Capability<br/>already shipped?}
+  D -->|yes| S[Omit from issues_to_create<br/>+ reconcile open dups → issues_to_close]
+  D -->|no| C[issues_to_create → sanitise.sh gate → gh issue create]
+```
+
+The digest is a sibling of the existing Product Codebase Summary step, surfaced as its own block the system prompt binds the LLM to (U3). The match and reconciliation stay inside the existing LLM assessment — no new branch in the create/dedup bash.
+
+---
+
+## Implementation Units
+
+### U1. `collect-capabilities.sh` collector + offline test
+
+- **Goal:** Produce a plain-text capabilities digest from recent merged implementation PRs and `docs/solutions/` entries — newest-first, deduped, revert-reconciled, budget-bounded — with an offline real-path test.
+- **Requirements:** R1, R2, R3, R8, R9.
+- **Dependencies:** none.
+- **Files:**
+  - `company/scripts/collect-capabilities.sh` (new)
+  - `company/scripts/test-collect-capabilities.sh` (new)
+- **Approach:** Mirror `collect-github.sh`/`collect-memory.sh` conventions: `#!/usr/bin/env bash`, `set -euo pipefail`, header comment with an `Output:` line, repo root via `git rev-parse --show-toplevel`, graceful `|| true` fallbacks, warnings to stderr via `echo "::warning::..." >&2`. Resolve the target repo from env (`TARGET_REPO`/`GITHUB_REPOSITORY`), never a re-hardcoded literal. Fetch PRs once via `gh pr list --state merged --limit N --json number,title,body` (N a recency-window constant), routed through one overridable seam (`--pr-list-file` reads the same JSON shape from a fixture). Parse each PR: skip non-implementation types (chore/docs/ci); for `Revert "<title>"` PRs, subtract the capability whose title matches `<title>`; otherwise emit one line carrying the title stripped of its `type(scope):` prefix, the PR number, and a truncated first line of the body — e.g. `OpenPanel analytics — track Polar CTA clicks (PR #762)`. Add `docs/solutions/` entry capabilities (titles/frontmatter) via `--solutions-dir`-overridable read. Emit newest-first, dedup by capability, then apply a `--budget` cap that truncates **oldest-first by whole lines** (not `head -c` mid-line). On empty/failed derivation write the sentinel line. No state file read or written.
+- **Patterns to follow:** `company/scripts/collect-memory.sh` (flag parsing `:24-34`, text-to-stdout, budget), `company/scripts/collect-github.sh` (gh usage, graceful degradation), `company/scripts/test-collect-memory.sh:1-192` (test structure: `mktemp -d` + `trap` cleanup, `assert_eq`/`assert_contains` helpers, fixture setup, numbered blocks, `=== Results ===` + `exit 1` on failure).
+- **Execution note:** Start with the failing collector test against fixtures (a canned `--pr-list-file` JSON including a #762-shaped OpenPanel entry and a `Revert "...OpenPanel..."` entry, plus a `docs/solutions/` fixture), then implement to satisfy it.
+- **Test scenarios:**
+  - Covers AE2. Given a `--pr-list-file` fixture containing `feat(landing): OpenPanel analytics` (#762), the digest contains a line naming OpenPanel and citing PR #762.
+  - The emitted line strips the conventional-commit prefix (`feat(landing): `) and includes the PR number; a fixed-format assertion pins the shape.
+  - A merged PR of type chore/docs/ci is excluded (no capability line).
+  - Given a `Revert "feat(landing): OpenPanel analytics"` PR in the fixture, the OpenPanel capability is absent from the digest (R8 bite).
+  - Given a fixture set exceeding `--budget`, the newest capabilities survive and the oldest are dropped first, with no mid-line truncation (R9 bite).
+  - Duplicate capabilities across two PRs collapse to one line (dedup).
+  - With `gh`/`--pr-list-file` unavailable (simulated), the script exits 0, emits `::warning::` to stderr, and writes the sentinel line rather than an empty file.
+  - No state file exists in the repo after a run (statelessness).
+  - Bite check: reverting the capability-extraction line turns the OpenPanel assertion RED.
+- **Verification:** `bash -n` clean; `bash company/scripts/test-collect-capabilities.sh` all pass; `shellcheck` clean if available; the #762 fixture yields a line citing #762; the revert fixture removes it.
+
+### U2. Wire the collector into the Observation Loop grounding
+
+- **Goal:** Run the collector each loop with the right auth, and surface its digest as a dedicated prompt block.
+- **Requirements:** R2, R4, R5, R9.
+- **Dependencies:** U1.
+- **Files:**
+  - `.github/workflows/observation-loop.yml` (modify)
+- **Approach:** Add a step after `Collect product codebase summary` (`:88-105`) with an explicit `env:` block — `GH_TOKEN: ${{ secrets.PUSH_TOKEN }}` and `TARGET_REPO: atvirokodosprendimai/wgmesh` (matching `:672-674`) — running `bash company/scripts/collect-capabilities.sh > /tmp/capabilities.txt || true`. Without `GH_TOKEN` the step would silently fall to the empty path every run and the feature would be a no-op (the wired-but-off-execution-path trap), so the env block is required, not optional. In the assessment prompt heredoc (`:432-465`), add a new `## Already-Shipped Capabilities` block fed by `$(cat /tmp/capabilities.txt)`, adjacent to the Product Codebase Summary block (`~439-442`), with header text directing the LLM to treat listed capabilities as already shipped. Do not append into `/tmp/product_summary.txt` (keeps CLAUDE.md provenance honest) and do not touch the create/dedup step (`:671-718`).
+- **Patterns to follow:** adjacent collector steps writing `/tmp/infra.json` (`:83`), `/tmp/shared_memory.txt` (`:111`); the create-step `env:` block (`:672-674`); the product-summary heredoc block (`:439-442`).
+- **Test scenarios:**
+  - `bash -n` / `actionlint` (if available) clean on the modified workflow.
+  - Test expectation: workflow-step behavior is exercised by U1's collector test and U4's live control replay; the best-effort + sentinel fallback is asserted by U1's gh-unavailable scenario. No separate YAML unit harness.
+- **Verification:** A dry-run assembled prompt contains the `## Already-Shipped Capabilities` block populated from the digest; a forced collector failure leaves the loop running with the sentinel line visible in the block and the rest of the prompt intact.
+
+### U3. Assert the digest as ground truth in the system prompt
+
+- **Goal:** Name the `## Already-Shipped Capabilities` block in the no-duplicate rule so the LLM treats it as authoritative shipped-state, including during the mandatory reconciliation pass.
+- **Requirements:** R5.
+- **Dependencies:** U2.
+- **Files:**
+  - `company/system-prompt.md` (modify)
+- **Approach:** Extend the "Critical: Do not duplicate existing work" rule (`:109-115`) with one line stating that an `## Already-Shipped Capabilities` block (derived from recent merged PRs) accompanies the Product Codebase Summary and must be checked before adding to `issues_to_create`. Point the mandatory reconciliation pass (`:136-148`) at the same block. No output-schema change — the loop has only `issues_to_create`/`issues_to_close` (no relabel), so a redundant in-flight issue is retired via `issues_to_close`. The block name here must match the block name chosen in U2 verbatim.
+- **Patterns to follow:** existing rule prose at `system-prompt.md:109-148`.
+- **Test scenarios:** Test expectation: none — prose grounding change, no behavioral code. Verified through U4's live control replay.
+- **Verification:** The rule text references the `## Already-Shipped Capabilities` block by the same name U2 uses; reconciliation language points at it.
+
+### U4. Control replay, disposition #767/#769, and record the learning
+
+- **Goal:** Falsifiably verify R6, close the live redo, and document the mechanism plus residual risks.
+- **Requirements:** R6, R7.
+- **Dependencies:** U2, U3.
+- **Files:**
+  - `docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md` (new)
+- **Approach:** Run a control replay of the assessment against the #767 conditions: once with the digest populated (expect: analytics not in `issues_to_create` — AE1) and once with the digest replaced by the sentinel/empty (expect: analytics *is* proposed). Recording both halves is what distinguishes "digest works" from "loop happened not to re-file." Close wgmesh #767 and PR #769 with a reason citing #762 (operator-run `gh` against the seed repo; the loop's reconciliation would also close #767 once the digest lands, but disposition explicitly now). Author a `docs/solutions/` RCA following the frontmatter schema of `observation-loop-creates-bogus-issues-for-existing-features.md` (`title, category, date, tags, related_issues, severity, component`), generalizing the Product Codebase Summary into the capabilities digest, recording the load-bearing LLM-semantic-match bet, the control-replay result, and the known residual risks (non-`Revert`-titled supersession; capabilities older than the recency window relying on the CLAUDE.md backstop).
+- **Patterns to follow:** `docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md` (frontmatter + RCA shape).
+- **Test scenarios:**
+  - Covers AE1, AE3. The control replay records both arms (digest-present → not proposed; digest-empty → proposed); #767 and #769 are closed citing #762.
+  - Test expectation: no unit test — live-system verification and documentation. R6's bite is the control replay's two arms, not a unit assertion.
+- **Verification:** The replay shows the two-arm result; #767/#769 closed with reasons citing #762; the RCA exists with correct frontmatter, links the related issues, and names the residual risks.
+
+---
+
+## Alternatives Considered
+
+- **Candidate-relevant scoping (post-draft check) instead of static grounding.** After the LLM drafts `issues_to_create`, check each draft title against the digest scoped to that candidate, rather than surfacing the whole digest up front. This bounds what the model attends to per decision and is robust to digest growth. Rejected for now: it adds a second LLM pass and edges toward the post-LLM stage the brainstorm explicitly ruled out; the bounded recency window plus a dedicated block addresses the dilution concern more simply. Revisit if the recency-windowed digest still dilutes at scale.
+- **Persisted cache with fingerprint skip (`fingerprint.sh` pattern).** Rejected: reintroduces cross-run state that R2 forbids; per-run derivation is bounded by the recency window, so the cost it would save is already capped.
+
+---
+
+## Scope Boundaries
+
+### Outside this change
+
+- No new post-LLM dedup/reject gate — the fix lives in grounding (origin Key Decision).
+- The existing fuzzy title matcher (`observation-loop.yml:688-705`) is left untouched; the digest plus LLM semantic match supersedes it for this class.
+- Live probing of deployed surfaces and a human-maintained `capabilities.json` are both rejected (origin Scope Boundaries).
+
+### Deferred to Follow-Up Work
+
+- Capabilities older than the recency window (R9) rely on the existing CLAUDE.md-head Product Codebase Summary; widening the window or adding a long-tail capability index is deferred.
+- Supersession that does not use a `Revert "<title>"` PR title (e.g. a silent rewrite) is not reconciled; the residual suppression risk is documented in the RCA (U4), and closing it is deferred.
+- Cross-repo capability indexing (secondary repos); seed repo only for now.
+- A Langfuse eval scoring whether the loop re-proposed already-shipped work across many runs — the durable measurement instrument, beyond U4's one-shot control replay. Any future cache must stay session-scoped and never be committed to this public repo.
+
+---
+
+## Risks & Dependencies
+
+- **LLM-semantic-match bet underperforms** — the model may still miss a differently-worded duplicate. Mitigation: surface each capability with its source PR richly in a dedicated block; the R6 control replay (U4) falsifiably checks the bite; the deferred Langfuse eval is the durable instrument if one-shot proof proves thin.
+- **Digest dilution at scale** — a long digest buried among priors loses (the prior RCA's lesson). Mitigation: recency window (R9) keeps it short, dedicated block keeps it structurally distinct; the candidate-scoping alternative is the fallback if dilution persists.
+- **Revert blindness** — derivation is complete for additions, blind to removals. Mitigation: `Revert "<title>"` reconciliation (R8); non-`Revert` supersession documented as residual (U4).
+- **Critical-path cost** — `gh pr list` on every tick. Mitigation: `--limit N` recency window bounds it to a single bounded call with no per-PR fan-out (`--json` returns bodies in the one call); step is best-effort so a slow run cannot hang the loop (`feedback_telemetry_writes_must_be_best_effort`).
+- **Best-effort failure masking** — `|| true` could hide a broken collector. Mitigation: sentinel line in the prompt plus a loud `::warning::` (U1) so degradation is visible both in the prompt and the logs.
+- **Public-repo safety** — the digest is internal prompt context (not committed), built from already-public merged-PR titles. Any path that emits derived content into issue bodies stays behind the existing `sanitise.sh` gate (`observation-loop.yml:708-712`); any future cache must stay session-scoped and PII-free per `CLAUDE.md`.
+
+---
+
+## Sources & Research
+
+- `.github/workflows/observation-loop.yml:88-105` — Product Codebase Summary build (sink `/tmp/product_summary.txt`).
+- `.github/workflows/observation-loop.yml:432-465` — assessment prompt heredoc; summary block `~439-442`, consumed at `:442`.
+- `.github/workflows/observation-loop.yml:671-718` — create-issues step + fuzzy title dedup (`:688-705`); `TARGET_REPO`/`GH_TOKEN` env `:672-674`; sanitise gate `:708-712`.
+- `company/system-prompt.md:109-115` — no-duplicate rule; `:136-148` — mandatory reconciliation.
+- `company/scripts/collect-memory.sh:24-34` — flag parsing; `:27/:49` — `head -c "$BUDGET"` byte-truncation (the precedent R9 deliberately does NOT inherit); `collect-github.sh` — gh/curl usage and graceful degradation; `company/scripts/test-collect-memory.sh:1-192` — test template with `--memory-dir` override.
+- `scripts/goal-sprint/fingerprint.sh:1-86` — derive-and-compare/state-file precedent (considered, not used).
+- `AGENTS.md:50-67` — bash test/lint conventions; input-producing scripts must test the real path.
+- `docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md` — the on-point prior RCA the digest generalizes.
+- `docs/solutions/logic-errors/observation-loop-board-hygiene-gaps.md` — fuzzy-dedup and merged-PR-invisibility precedent.
+- wgmesh #762 (merged, OpenPanel analytics), #767 (open, redundant), #769 (open, redo impl).

--- a/docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md
+++ b/docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md
@@ -1,0 +1,95 @@
+---
+title: "Capabilities digest grounds the observation loop against re-proposing shipped work"
+category: logic-errors
+date: 2026-06-19
+tags: [observation-loop, llm, dedup, codebase-awareness, capabilities, grounding]
+related_issues:
+  - https://github.com/atvirokodosprendimai/wgmesh/issues/767
+  - https://github.com/atvirokodosprendimai/wgmesh/pull/769
+  - https://github.com/atvirokodosprendimai/wgmesh/pull/762
+severity: high
+component: observation-loop
+---
+
+# Capabilities digest grounds the observation loop against re-proposing shipped work
+
+## Problem
+
+The Observation Loop filed wgmesh #767 "Add web analytics tracking (Plausible/PostHog)"
+while OpenPanel analytics had already shipped one day earlier via merged PR #762
+(`feat(landing): OpenPanel analytics`). The redundant issue advanced into the pipeline and
+produced open PR #769 — a Build agent re-implementing analytics that is already live.
+
+Both existing dedup mechanisms missed it:
+
+- The issue-creation step's fuzzy keyword match runs on issue **titles** only
+  (`.github/workflows/observation-loop.yml:688-705`). "Add web analytics tracking" and
+  "OpenPanel analytics" share no title keywords.
+- The system prompt's "do not duplicate" rule checks a **Product Codebase Summary** built
+  only from the head of the seed repo's `CLAUDE.md` (`observation-loop.yml:88-105`). The
+  OpenPanel deployment was never written there, so the LLM had no grounding for it.
+
+The capability shipped through a merged PR — invisible to issue-title dedup and absent from
+the grounding the LLM reads.
+
+## Root cause
+
+This is the same failure class as
+[observation-loop-creates-bogus-issues-for-existing-features](./observation-loop-creates-bogus-issues-for-existing-features.md)
+(the loop filing #453/#458/#460 for shipped features), whose fix created the Product
+Codebase Summary. The carry-forward rule from that RCA holds here: *a single corrective
+signal cannot override compounding LLM priors, and metadata alone is insufficient — the LLM
+needs structural/capability awareness.* The Product Codebase Summary delivered that awareness
+only for what is documented in `CLAUDE.md`; a capability shipped via PR but not written into
+`CLAUDE.md` stayed invisible.
+
+## Fix
+
+Generalize the Product Codebase Summary into an auto-derived **capabilities digest**, fed
+into the loop's grounding at the assessment source — not a new dedup gate.
+
+- `company/scripts/collect-capabilities.sh` derives a plain-text digest from recent merged
+  implementation PRs (`gh pr list --state merged --limit N --json number,title,body`) plus
+  `docs/solutions/` entries. Newest-first, deduped, budget-bounded by whole lines.
+- Reverted capabilities are reconciled out: a `Revert "<title>"` PR subtracts the matching
+  capability so the digest never asserts a removed capability is shipped.
+- The observation loop runs the collector each tick (best-effort, `GH_TOKEN` + `TARGET_REPO`
+  env) and surfaces it as a dedicated `## Already-Shipped Capabilities` block in the
+  assessment prompt — distinct from the CLAUDE.md-head summary so provenance stays honest
+  and the block is not buried among priors.
+- The system prompt's no-duplicate rule and mandatory reconciliation pass both reference the
+  new block.
+
+Reads PRs deliberately via `gh pr list`, never `gh issue list` — the `/issues` API also
+returns PRs (`pull_request` key), and a digest built from "issues" would ingest the loop's
+own spec PRs and runaway.
+
+## Why it works (and the load-bearing bet)
+
+The match between a differently-worded proposed issue ("add web analytics") and a shipped
+capability ("OpenPanel analytics") is **semantic, not lexical** — no keyword code bridges it.
+The design surfaces capabilities richly into grounding and leaves the match to the LLM,
+rather than adding deterministic matching that would reproduce the title-matcher's miss. This
+is the load-bearing bet: the model reads the block and declines the duplicate.
+
+That bet is verified by a **control replay**, not a single observation: run the #767-condition
+assessment twice — once with the digest populated (expect: analytics not proposed) and once
+with it empty (expect: analytics proposed). A single non-occurrence cannot distinguish "the
+digest works" from "the loop happened not to re-file"; the two-arm control can.
+
+## Status
+
+- Collector, loop wiring, and system-prompt grounding: shipped (this change, U1-U3).
+- Control replay (R6) and disposition of the live #767 / #769: pending the change deploying
+  to the box and operator authorization to close the live issues. Recorded here when run.
+
+## Residual risks
+
+- **Non-`Revert` supersession.** A capability rewritten or removed by a PR that does not use a
+  `Revert "<title>"` title is not reconciled out, and could suppress legitimate re-work. Only
+  `Revert`-titled removals are handled today.
+- **Recency window.** The digest is bounded to recent merged PRs; capabilities older than the
+  window rely on the existing CLAUDE.md-head Product Codebase Summary as the long-tail backstop.
+- **Grounding dilution at scale.** A long digest among priors can lose attention; the recency
+  bound and the dedicated block mitigate this, and a candidate-relevant scoping pass is the
+  fallback if dilution recurs.


### PR DESCRIPTION
## What

Auto-derived **capabilities digest** that grounds the Observation Loop so it stops re-proposing already-shipped work — at the assessment source, no new dedup gate.

Origin: filed wgmesh #767 "Add web analytics tracking" while OpenPanel analytics already shipped via merged PR #762; the redo reached PR #769. Both existing dedups missed it (title-keyword match; `CLAUDE.md`-head summary that never named OpenPanel).

Generalizes the Product Codebase Summary fix in `docs/solutions/logic-errors/observation-loop-creates-bogus-issues-for-existing-features.md`.

## Units

- **U1** `company/scripts/collect-capabilities.sh` (+ offline test): derives a plain-text digest from recent merged impl PRs (`gh pr list --state merged --json number,title,body`) + `docs/solutions/`. Newest-first, deduped, whole-line budget, `Revert "<title>"` subtraction, sentinel on degrade. Reads PRs deliberately (not `gh issue list`). Stateless. 20/20 offline tests.
- **U2** wire into `observation-loop.yml`: best-effort collector step with `GH_TOKEN`+`TARGET_REPO` env, surfaced as a dedicated `## Already-Shipped Capabilities` prompt block (not appended to the CLAUDE.md summary).
- **U3** `system-prompt.md`: no-duplicate rule + mandatory reconciliation reference the new block.
- **U4 (doc)** RCA `docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md`.

## Design

Load-bearing bet: the **LLM** makes the semantic match ("add web analytics" ↔ "OpenPanel analytics shipped"), no new keyword code. Verified by a two-arm **control replay** (digest present → not proposed; digest empty → proposed), not a single observation.

Reviewed via `/ce-brainstorm` → `/ce-plan` → adversarial doc-review (R6 falsifiability, budget recency-blindness, revert suppression, critical-path cost all folded in) → `/ce-work`.

## Pending (not in this PR)

- Control replay (R6) — needs the change deployed to the box.
- Closing live wgmesh #767 / #769 as already-shipped (cites #762) — operator-authorized, separate repo.

## Test plan

- [x] `bash company/scripts/test-collect-capabilities.sh` → 20/20
- [x] `bash -n` + `shellcheck` clean
- [x] `actionlint` clean on `observation-loop.yml`
- [ ] Post-deploy: control replay two-arm result recorded in the RCA