### PR TITLE
fix(test): control-replay uses OPENROUTER_API_KEY (was 401)

### DIFF
--- a/.github/workflows/control-replay-capabilities.yml
+++ b/.github/workflows/control-replay-capabilities.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TARGET_REPO: atvirokodosprendimai/wgmesh
       GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
-      OBSERVER_API_KEY: ${{ secrets.OBSERVER_API_KEY }}
+      OBSERVER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
First dispatch hit `OpenRouter HTTP 401: Missing Authentication header` — the workflow referenced `secrets.OBSERVER_API_KEY` (nonexistent → empty Bearer). The live loop maps `OBSERVER_API_KEY: secrets.OPENROUTER_API_KEY` (`observation-loop.yml:424`). One-line fix to match.