### PR TITLE
feat(evals): redo_of_shipped_capability Langfuse evaluator

### DIFF
--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -72,6 +72,28 @@ _PIKAPODS_SNAPSHOT = """PikaPods self-hosts these open-source apps (non-exhausti
 - Firebase -> Pocketbase, Directus
 """
 
+# Coarse advisory snapshot of capabilities already shipped for wgmesh/cloudroof,
+# for measuring the redo class the in-loop capabilities digest prevents (the box
+# re-proposing already-built work, e.g. "add web analytics" when OpenPanel ships).
+# This static list WILL drift; the live authority is the auto-derived digest in
+# `.github/workflows/observation-loop.yml` (the `## Already-Shipped Capabilities`
+# block from `company/scripts/collect-capabilities.sh`). This evaluator is an
+# advisory measurement signal, not a gate.
+_SHIPPED_SNAPSHOT = """Capabilities already shipped (non-exhaustive); re-proposing
+any of these is a REDO:
+- Web analytics / event / conversion tracking -> OpenPanel, self-hosted at
+  counter.hackrsvalv.com, on the cloudroof.eu landing pages (wgmesh PR #762)
+- Email capture / newsletter signup form -> Buttondown ("meshletter") form on the
+  landing pages (wgmesh PR #764)
+- Transactional / outreach email sending -> Unsend
+- Payments / checkout / subscription -> Polar checkout CTAs on the landing pages
+- Outreach assets (stargazer list, send-ready copy) -> shipped docs (wgmesh PR #763)
+- Core product (wgmesh): WireGuard mesh, peer discovery, NAT traversal, gossip,
+  encryption, managed ingress
+Building a downstream consumer ON TOP of a shipped capability (e.g. a dashboard or
+report over data OpenPanel already collects) is NOT a redo.
+"""
+
 EVALUATORS = [
     {
         "name": "growth_issue_quality",
@@ -142,6 +164,30 @@ EVALUATORS = [
         "outputDefinition": _NUMERIC,
         "modelConfig": _JUDGE_MODEL,
     },
+    {
+        "name": "redo_of_shipped_capability",
+        "type": "llm_as_judge",
+        "prompt": (
+            "You are scoring a box-PROPOSED ISSUE on whether it RE-PROPOSES a "
+            "capability that already shipped — the redo class the Observation "
+            "Loop's capabilities digest exists to prevent.\n\n"
+            f"{_SHIPPED_SNAPSHOT}\n"
+            "Proposed issue:\n{{output}}\n\n"
+            "Score 0.0-1.0 with these anchors: 1.0 = proposes genuinely new work, "
+            "OR builds a downstream consumer on top of an existing capability, OR "
+            "names no capability in the shipped list (NOT APPLICABLE); ~0.5 = "
+            "overlaps a shipped capability but plausibly extends or replaces it "
+            "for a stated reason; 0.0 = re-proposes adding/implementing a "
+            "capability that already ships (e.g. 'add web analytics tracking' when "
+            "OpenPanel already tracks, 'add an email signup form' when Buttondown "
+            "is live), with no justification. Lower is worse (more of a redo). "
+            "Reasoning: one sentence naming the proposed capability and the shipped "
+            "one it duplicates, or 'not applicable'."
+        ),
+        "variables": ["output"],
+        "outputDefinition": _NUMERIC,
+        "modelConfig": _JUDGE_MODEL,
+    },
 ]
 
 # --- evaluation rules (WHAT to score) ---------------------------------------
@@ -194,6 +240,14 @@ RULES = [
     {
         "name": "rule_open_source_default",
         "evaluatorName": "open_source_default",
+        "target": "observation",
+        "sampling": 1.0,
+        "filter": _GEN_FILTER,
+        "mapping": [{"variable": "output", "source": "output"}],
+    },
+    {
+        "name": "rule_redo_of_shipped_capability",
+        "evaluatorName": "redo_of_shipped_capability",
         "target": "observation",
         "sampling": 1.0,
         "filter": _GEN_FILTER,

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -17,6 +17,7 @@ from evals.setup_langfuse_evaluators import (  # noqa: E402
     _JUDGE_MODEL,
     _NUMERIC,
     _PIKAPODS_SNAPSHOT,
+    _SHIPPED_SNAPSHOT,
     main,
 )
 
@@ -53,6 +54,41 @@ def test_open_source_default_rule_shape() -> None:
 
 
 @pytest.mark.unit
+def test_redo_of_shipped_capability_evaluator_shape_and_prompt() -> None:
+    matches = [
+        ev for ev in EVALUATORS if ev["name"] == "redo_of_shipped_capability"
+    ]
+
+    assert len(matches) == 1
+    evaluator = matches[0]
+    assert evaluator["type"] == "llm_as_judge"
+    assert evaluator["variables"] == ["output"]
+    assert evaluator["outputDefinition"] is _NUMERIC
+    assert evaluator["modelConfig"] is _JUDGE_MODEL
+    assert "{{output}}" in evaluator["prompt"]
+    assert "REDO" in evaluator["prompt"]
+    assert "OpenPanel" in evaluator["prompt"]
+    assert "not applicable" in evaluator["prompt"].lower()
+    assert "downstream consumer" in evaluator["prompt"].lower()
+    assert "OpenPanel" in _SHIPPED_SNAPSHOT
+    assert "Buttondown" in _SHIPPED_SNAPSHOT
+
+
+@pytest.mark.unit
+def test_redo_of_shipped_capability_rule_shape() -> None:
+    matches = [
+        rule for rule in RULES if rule["name"] == "rule_redo_of_shipped_capability"
+    ]
+
+    assert len(matches) == 1
+    rule = matches[0]
+    assert rule["evaluatorName"] == "redo_of_shipped_capability"
+    assert rule["target"] == "observation"
+    assert rule["filter"] is _GEN_FILTER
+    assert rule["mapping"] == [{"variable": "output", "source": "output"}]
+
+
+@pytest.mark.unit
 def test_rules_reference_existing_evaluators() -> None:
     evaluator_names = {ev["name"] for ev in EVALUATORS}
 
@@ -61,8 +97,8 @@ def test_rules_reference_existing_evaluators() -> None:
 
 @pytest.mark.unit
 def test_setup_langfuse_evaluator_counts() -> None:
-    assert len(EVALUATORS) == 4
-    assert len(RULES) == 4
+    assert len(EVALUATORS) == 5
+    assert len(RULES) == 5
 
 
 @pytest.mark.unit
@@ -72,6 +108,8 @@ def test_dry_run_prints_open_source_default(capsys) -> None:
     captured = capsys.readouterr()
     assert "open_source_default" in captured.out
     assert "rule_open_source_default" in captured.out
+    assert "redo_of_shipped_capability" in captured.out
+    assert "rule_redo_of_shipped_capability" in captured.out
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

5th Langfuse LLM-as-judge evaluator — the durable measurement instrument the control replay (PR #1850-1853) couldn't provide. Scores each box-proposed issue on whether it re-proposes an already-shipped capability (the redo class the in-loop digest in #1849 prevents), yielding a redo-rate over real loop runs.

## Design (mirrors `open_source_default`)

- Advisory **NUMERIC**, no gate. 1.0 = new work / build-on-existing / not-applicable; ~0.5 = overlaps-but-justified; 0.0 = re-proposes a shipped capability with no justification.
- Static `_SHIPPED_SNAPSHOT` (OpenPanel/Buttondown/Unsend/Polar/outreach + core wgmesh) — same static-snapshot approach as `_PIKAPODS_SNAPSHOT`. **Will drift; the live authority stays the auto-derived digest** in `observation-loop.yml`. The eval is a coarse advisory measurement, not the prevention mechanism.
- "Build-on-existing (a dashboard over OpenPanel data) is NOT a redo" baked into the rubric — the exact distinction the regex judge got wrong in the control replay.
- One evaluator + one rule (`target: observation`, sampling 1.0); idempotent apply already handles re-runs (PATCH existing rules, 409 = success).

## Tests

- Structural validation passes locally (5 evaluators / 5 rules; evaluator+rule shape; snapshot content).
- `--dry-run` emits the new evaluator + rule.
- Unit tests added (shape, rule, dry-run, counts 4→5); CI `pipeline-tests` runs pytest.

## Apply (operator)

`python pipeline/evals/setup_langfuse_evaluators.py --probe` then `--dry-run` then apply, with `LANGFUSE_*` creds (gh secrets).