### PR TITLE
feat(evals): --verify mode for redo evaluator (end-to-end firing check)

### DIFF
--- a/.github/workflows/register-langfuse-evaluators.yml
+++ b/.github/workflows/register-langfuse-evaluators.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "probe | dry-run | apply"
+        description: "probe | dry-run | apply | verify"
         default: "probe"
 
 permissions:
@@ -41,5 +41,6 @@ jobs:
             probe)   python pipeline/evals/setup_langfuse_evaluators.py --probe ;;
             dry-run) python pipeline/evals/setup_langfuse_evaluators.py --dry-run ;;
             apply)   python pipeline/evals/setup_langfuse_evaluators.py ;;
-            *) echo "::error::mode must be probe|dry-run|apply"; exit 2 ;;
+            verify)  python pipeline/evals/setup_langfuse_evaluators.py --verify ;;
+            *) echo "::error::mode must be probe|dry-run|apply|verify"; exit 2 ;;
           esac

--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -295,6 +295,61 @@ def probe() -> None:
         )
 
 
+def _get_list(path: str) -> list:
+    status, payload = _request("GET", path)
+    if status != 200 or not isinstance(payload, dict):
+        print(f"  GET {path} -> {status} {str(payload)[:200]}")
+        return []
+    data = payload.get("data")
+    return data if isinstance(data, list) else []
+
+
+def verify() -> int:
+    """End-to-end check that the redo evaluator is actually scoring real box
+    generations: are there GENERATION observations at all, and are
+    redo_of_shipped_capability scores landing on them? Registered != firing."""
+    gens = _get_list("/api/public/observations?type=GENERATION&limit=50")
+    print(f"GENERATION observations (latest 50 sampled): {len(gens)}")
+    for g in gens[:5]:
+        if isinstance(g, dict):
+            print(f"  - {g.get('startTime')} name={g.get('name')} trace={g.get('traceId')}")
+
+    scores = _get_list(
+        "/api/public/scores?name=redo_of_shipped_capability&limit=50"
+    ) or _get_list(
+        "/api/public/v2/scores?name=redo_of_shipped_capability&limit=50"
+    )
+    print(f"redo_of_shipped_capability scores: {len(scores)}")
+    for s in scores[:5]:
+        if isinstance(s, dict):
+            print(
+                f"  - {s.get('timestamp')} value={s.get('value')} "
+                f"obs={s.get('observationId')} comment={str(s.get('comment'))[:80]}"
+            )
+
+    print("---")
+    if not gens:
+        print(
+            "VERIFY: NO GENERATION observations in Langfuse — the box is not emitting "
+            "generation traces, so the evaluator has nothing to score (wired but off the "
+            "execution path). Instrument the box's LLM calls before this eval can fire."
+        )
+        return 1
+    if not scores:
+        print(
+            "VERIFY: box generations exist but ZERO redo scores. Evaluation rules score "
+            "NEW observations after registration only — either no box run since apply, or "
+            "the GENERATION filter does not match the box's observation type. Re-run verify "
+            "after the next box generation; if still zero, inspect the rule filter."
+        )
+        return 1
+    print(
+        f"VERIFY: PASS — {len(scores)} redo_of_shipped_capability score(s) on real "
+        "generations. Evaluator is firing end-to-end."
+    )
+    return 0
+
+
 def _existing_names(path: str, key: str = "data") -> set[str]:
     status, payload = _request("GET", path)
     if status != 200 or not isinstance(payload, dict):
@@ -400,6 +455,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--dry-run", action="store_true", help="print payloads, do not write"
     )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="check the redo evaluator is scoring real box generations end-to-end",
+    )
     args = parser.parse_args(argv)
     if not args.dry_run:  # dry-run prints payloads only, never hits the API
         for key in ("LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
@@ -409,6 +469,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.probe:
         probe()
         return 0
+    if args.verify:
+        return verify()
     failures = apply(args.dry_run)
     if failures:
         print(

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -189,3 +189,43 @@ def test_apply_keeps_genuine_rule_failure(monkeypatch) -> None:
     monkeypatch.setattr(mod, "_request", fake_request)
 
     assert mod.apply(dry_run=False) > 0
+
+
+def _verify_request(gens: list, scores: list):
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        if "observations" in path:
+            return 200, {"data": gens}
+        if "scores" in path:
+            return 200, {"data": scores}
+        return 200, {"data": []}
+
+    return fake_request
+
+
+@pytest.mark.unit
+def test_verify_pass_when_scores_present(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_request",
+        _verify_request(
+            gens=[{"startTime": "t", "name": "gate", "traceId": "x"}],
+            scores=[{"value": 1.0, "observationId": "o"}],
+        ),
+    )
+    assert mod.verify() == 0
+
+
+@pytest.mark.unit
+def test_verify_fails_when_no_generations(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_request", _verify_request(gens=[], scores=[]))
+    assert mod.verify() == 1
+
+
+@pytest.mark.unit
+def test_verify_fails_when_generations_but_no_scores(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_request",
+        _verify_request(gens=[{"startTime": "t", "name": "gate"}], scores=[]),
+    )
+    assert mod.verify() == 1


### PR DESCRIPTION
Adds `--verify` (and a `verify` workflow mode) to check the redo evaluator is actually scoring real box generations — registered != firing (the recurring wired-but-off-path trap). Queries live GENERATION observations + redo scores and reports: no generations → box not emitting traces; generations but no scores → no run since apply / filter mismatch; scores present → firing end-to-end. +3 unit tests.