### PR TITLE
fix(evals): verify counts rule_-prefixed score names

### DIFF
--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -325,9 +325,17 @@ def verify() -> int:
     for s in all_scores:
         if isinstance(s, dict) and s.get("name"):
             by_name[str(s["name"])] = by_name.get(str(s["name"]), 0) + 1
+    # Live Langfuse names each score after its RULE (e.g. `rule_open_source_default`),
+    # not the evaluator — confirmed from the instance, contradicting older assumptions.
+    # Count both forms so the check is robust to either naming.
+    def _count(ev_name: str) -> int:
+        return by_name.get(ev_name, 0) + by_name.get(f"rule_{ev_name}", 0)
+
     our_names = {ev["name"] for ev in EVALUATORS}
-    redo_scores = by_name.get("redo_of_shipped_capability", 0)
-    other_eval_scores = sum(v for k, v in by_name.items() if k in our_names and k != "redo_of_shipped_capability")
+    redo_scores = _count("redo_of_shipped_capability")
+    other_eval_scores = sum(
+        _count(ev) for ev in our_names if ev != "redo_of_shipped_capability"
+    )
     print(f"recent scores by name (latest 100 sampled): {by_name or '{}'}")
     print(f"redo_of_shipped_capability scores: {redo_scores}")
 

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -209,7 +209,8 @@ def test_verify_pass_when_redo_scores_present(monkeypatch) -> None:
         "_request",
         _verify_request(
             gens=[{"startTime": "t", "name": "gate", "traceId": "x"}],
-            scores=[{"name": "redo_of_shipped_capability", "value": 1.0}],
+            # live Langfuse names scores after the rule, not the evaluator
+            scores=[{"name": "rule_redo_of_shipped_capability", "value": 1.0}],
         ),
     )
     assert mod.verify() == 0
@@ -238,7 +239,7 @@ def test_verify_waits_when_siblings_score_but_redo_absent(monkeypatch) -> None:
         "_request",
         _verify_request(
             gens=[{"startTime": "t", "name": "gate"}],
-            scores=[{"name": "growth_issue_quality", "value": 0.8}],
+            scores=[{"name": "rule_growth_issue_quality", "value": 0.8}],
         ),
     )
     # pipeline alive but redo not yet scored — non-zero, surfaces the WAIT state


### PR DESCRIPTION
Live verify reported FAIL (no eval scores) but the instance actually had 91 sibling scores named `rule_public_safety_pass` etc — Langfuse names each score after its RULE, not the evaluator (contradicting the script's old comment). verify now counts both `<name>` and `rule_<name>`, so the real state surfaces: pipeline ALIVE, redo awaiting a post-registration generation (WAIT).