### PR TITLE
fix: eval data path — enrich box generations with deliverable text, exclude judge self-calls

### DIFF
--- a/docs/plans/2026-06-19-003-feat-redo-evaluator-dataset-benchmark-plan.md
+++ b/docs/plans/2026-06-19-003-feat-redo-evaluator-dataset-benchmark-plan.md
@@ -1,0 +1,164 @@
+---
+title: "feat: Deterministic dataset benchmark for the redo_of_shipped_capability evaluator"
+type: feat
+date: 2026-06-19
+---
+
+# feat: Deterministic Dataset Benchmark for the redo_of_shipped_capability Evaluator
+
+## Summary
+
+Build an on-demand benchmark that feeds known redo / non-redo issue cases to the deployed `redo_of_shipped_capability` Langfuse evaluator and asserts redo cases score low and non-redo cases score high. It registers the cases as a reusable Langfuse dataset, ingests one synthetic GENERATION observation per case so the live evaluation rule scores it, polls for the scores, and reports PASS/FAIL — replacing "wait hours for a sporadic box generation" with a deterministic correctness check. Stdlib-only, wired as a `mode=benchmark` workflow.
+
+---
+
+## Problem Frame
+
+The redo evaluator is registered and live, but confirming it actually scores — and scores *correctly* — depends on the box convergence engine emitting a post-registration GENERATION observation, which is event-driven and sparse (4 verify checks over ~2h, box idle, redo score still 0). The `--verify` mode confirms *firing readiness* (pipeline alive, filter correct) but cannot confirm *judgment quality* and cannot fire on demand.
+
+A deterministic benchmark closes both gaps: it pushes known inputs through the **deployed** evaluator (not an ad-hoc judge), so it verifies the rubric distinguishes a redo ("Add web analytics tracking" when OpenPanel ships) from legitimate build-on-existing work ("dashboard over OpenPanel data") — the exact distinction a keyword judge got wrong in the earlier control replay — and it runs in seconds, not hours.
+
+---
+
+## Key Technical Decisions
+
+- **Synthetic GENERATION ingestion + live rule scoring, over the SDK experiment path.** The benchmark POSTs synthetic GENERATION observations (output = the case's issue text) via the stdlib public ingestion API; the live evaluation rule (`target: observation`, filter `type=GENERATION`, sampling 1.0) then scores them — the same path that produced the 91 sibling scores, so confidence it fires is high. Rejected the Langfuse Dataset *experiment* runner: it needs the `langfuse` SDK (the script is deliberately stdlib-only) and it is unconfirmed whether project-level eval rules auto-attach to experiment-run observations. The synthetic-ingestion path tests the exact deployed rule with no new dependency.
+
+- **Register a real Langfuse dataset + items anyway.** The cases are also registered as a `redo-eval-benchmark` dataset with `expected_output` per item, via the stdlib public datasets API (`/api/public/datasets`, `/api/public/dataset-items`) — no SDK needed for creation. This gives the reusable, UI-visible benchmark the Datasets docs describe, and each synthetic generation links back to its dataset item (`source_trace_id`). The dataset is the source of truth for cases; the ingestion is how they reach the live evaluator.
+
+- **Tag synthetic observations to isolate them from real box traces.** Each ingested generation carries a distinct name (`redo-benchmark/<case-id>`) and metadata (`{"benchmark": "redo-eval"}`) so the synthetic traces are filterable and never confused with real convergence-engine generations in analytics. Accepted side-effect: the benchmark adds synthetic entries to the project's trace stream (identifiable, not deletable via this API).
+
+- **Match scores by the rule name, with async polling.** Scores are read from `/api/public/scores` filtered to the synthetic traces and the `rule_redo_of_shipped_capability` name (live Langfuse names scores after the rule, not the evaluator — the correction from the verify work). Evaluation is async, so the runner polls with a bounded timeout before giving up.
+
+- **Assert against advisory NUMERIC anchors.** Redo cases must score `<= 0.5`, non-redo cases `>= 0.5` (the evaluator's rubric: 0.0 = redo, 1.0 = new/build-on-existing/N-A). The benchmark fails loudly on any case that lands the wrong side, naming the case and its score.
+
+- **Probe-first.** The exact ingestion event envelope, the datasets/items payloads, and the scores-by-trace query shape are confirmed against the live instance before the runner trusts them (the unstable/stable API mix has surprised us before — the `rule_`-naming and the 409-on-rules bug both came from live data, not docs).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  C[Benchmark cases<br/>redo / non-redo, each w/ expected band]
+  C --> DS[Register dataset + items<br/>/api/public/datasets + dataset-items]
+  C --> IG[Ingest 1 synthetic GENERATION per case<br/>/api/public/ingestion<br/>name=redo-benchmark/&lt;id&gt;, output=issue text<br/>source_trace_id → dataset item]
+  IG --> RULE[Live eval rule rule_redo_of_shipped_capability<br/>type=GENERATION, sampling 1.0 — async]
+  RULE --> SC[(scores)]
+  SC --> POLL[Poll /api/public/scores by trace + rule name<br/>bounded timeout]
+  POLL --> ASSERT{each case on expected side?<br/>redo ≤0.5 / non-redo ≥0.5}
+  ASSERT -->|all| PASS[VERDICT: PASS]
+  ASSERT -->|any wrong| FAIL[VERDICT: FAIL — name case + score, exit 1]
+```
+
+---
+
+## Implementation Units
+
+### U1. Benchmark cases + Langfuse dataset registration
+
+- **Goal:** Define the labelled cases and register them as a reusable `redo-eval-benchmark` dataset with expected-output bands.
+- **Dependencies:** none.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — add `BENCHMARK_CASES` + a `register_dataset()` function)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py` (modify — case-shape tests)
+- **Approach:** Add `BENCHMARK_CASES`: a list of `{id, issue_text, expect}` where `expect` is `redo` or `not_redo`. Cases: redo — `"Add web analytics tracking (Plausible/PostHog) to cloudroof.eu landing"`, `"Add an email newsletter signup form to the landing pages"`; not_redo — `"Build a conversion funnel dashboard over existing OpenPanel data"`, `"Write a cloudroof vs Tailscale comparison page"`. Add `register_dataset()` that creates the dataset (`POST /api/public/datasets`, idempotent — treat already-exists as success like the rules path) and upserts one dataset item per case (`POST /api/public/dataset-items`) with `input`=issue text and `expected_output`=the band. Reuse `_request`/`_auth_header`.
+- **Patterns to follow:** the idempotent create + 409-as-success handling in `apply()`; the `_request` envelope; stdlib-only discipline (no SDK).
+- **Execution note:** Probe first — dump the live `/api/public/datasets` and `/api/public/dataset-items` response shapes (extend `--probe` or a one-off) and confirm the field names before trusting `input`/`expected_output`/`datasetName`.
+- **Test scenarios:**
+  - `BENCHMARK_CASES` has at least one `redo` and one `not_redo` case; each has `id`, `issue_text`, `expect in {redo, not_redo}`.
+  - `register_dataset()` with a mocked `_request` returning 200 issues one dataset POST then one item POST per case; a 409 on the dataset create is treated as success.
+  - The OpenPanel redo case text contains "web analytics"; the dashboard case text contains "dashboard" and "OpenPanel".
+- **Verification:** Dataset `redo-eval-benchmark` exists in the instance with one item per case; re-running registration is idempotent (no error on existing).
+
+### U2. Synthetic GENERATION ingestion per case
+
+- **Goal:** Push one tagged synthetic GENERATION observation per case so the live evaluation rule scores it, linked to its dataset item.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — add `ingest_cases()` returning the synthetic trace/observation ids)
+- **Approach:** For each case, `POST /api/public/ingestion` a batch with a trace + a GENERATION observation whose `output` is the issue text, `name` = `redo-benchmark/<case-id>`, and `metadata` = `{"benchmark": "redo-eval"}`. Capture the generated trace id / observation id per case (client-generated UUIDs, passed in — avoids a read-back round trip) and link each to its dataset item via the dataset-item `source_trace_id`/`source_observation_id` (or a dataset-run-item if probe shows that is the supported link). Return a map `case-id -> {traceId, observationId}` for U3 to poll against.
+- **Patterns to follow:** `_request` POST envelope; the `metadata`/`name` tagging convention; UUID generation via stdlib `uuid`.
+- **Execution note:** Probe the ingestion envelope first — confirm the event `type` (`generation-create`/`observation-create`), required fields, and that an ingested GENERATION appears in `/api/public/observations?type=GENERATION`. The rule only scores what matches `type=GENERATION`.
+- **Test scenarios:**
+  - `ingest_cases()` with a mocked `_request` posts one ingestion batch per case and returns a non-empty `{case-id: {traceId, observationId}}` map with distinct ids.
+  - Each posted observation carries `name` starting `redo-benchmark/` and `metadata.benchmark == "redo-eval"`.
+  - An ingestion HTTP failure for one case is surfaced (not silently dropped) and fails that case rather than the whole run.
+- **Verification:** After a real run, the synthetic generations are visible in the observations table filtered by `type=GENERATION` and name `redo-benchmark/*`.
+
+### U3. Score poll + assertion runner
+
+- **Goal:** Poll for the redo scores on the synthetic generations and assert each case landed on its expected side; report PASS/FAIL.
+- **Dependencies:** U2.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — add `benchmark()` orchestrating register → ingest → poll → assert)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py` (modify — assertion-logic tests)
+- **Approach:** `benchmark()` calls `register_dataset()` + `ingest_cases()`, then polls `/api/public/scores` (filtered to `rule_redo_of_shipped_capability`, matched to each case's trace/observation id) up to a bounded number of attempts with a sleep between (async eval lag). For each case once scored: redo cases assert `value <= 0.5`, not_redo assert `value >= 0.5`. Print a per-case line (`case-id expect=redo score=0.0 OK/WRONG`) and a final `VERDICT: PASS` (all correct + all scored) / `VERDICT: FAIL` (any wrong side — exit 1, name the case) / `VERDICT: INCONCLUSIVE` (timed out before all cases scored — exit 1, name unscored cases). Match scores by trace/observation id from U2, not by recency.
+- **Patterns to follow:** the `verify()` poll-and-classify shape; the `rule_`-prefixed score-name matching; fail-loud exit codes.
+- **Execution note:** Probe the scores query first — confirm whether scores are filterable by `traceId`/`observationId` or must be fetched and matched client-side; tune the poll attempts/interval to the observed eval lag.
+- **Test scenarios:**
+  - All cases scored on the correct side → `benchmark()` returns 0 (PASS).
+  - A redo case scored 0.9 (wrong side) → returns non-zero (FAIL), output names the case.
+  - A not_redo case scored 0.1 (wrong side) → FAIL, names the case.
+  - Polling exhausts with one case unscored → returns non-zero (INCONCLUSIVE), names the unscored case.
+  - Score matching is by the case's observation/trace id, not by latest — a sibling evaluator's score on the same trace is ignored.
+- **Verification:** A live `mode=benchmark` run prints per-case scores and a PASS when the deployed evaluator scores the redo cases low and the non-redo cases high.
+
+### U4. Workflow `mode=benchmark` + docs
+
+- **Goal:** Expose the benchmark as a repeatable workflow mode and document how to run it.
+- **Dependencies:** U3.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — `--benchmark` arg)
+  - `.github/workflows/register-langfuse-evaluators.yml` (modify — `benchmark` case in the mode switch + input description)
+- **Approach:** Add `--benchmark` to argparse routing to `benchmark()` (env-guarded like the other live modes). Add `benchmark) python ... --benchmark ;;` to the workflow case statement and extend the `mode` input description to `probe | dry-run | apply | verify | benchmark`. Keep `permissions: contents: read` (benchmark only reads scores + writes Langfuse via API, no repo writes).
+- **Patterns to follow:** the existing `--verify` arg + `verify)` workflow case added earlier.
+- **Test scenarios:**
+  - `main(["--benchmark"])` returns 2 when `LANGFUSE_*` env is missing (env guard).
+  - `--dry-run` still works and does not require benchmark to run.
+  - Test expectation for the workflow YAML: `bash -n`/`actionlint` clean; behavior covered by U1-U3 unit tests.
+- **Verification:** `gh workflow run register-langfuse-evaluators.yml -f mode=benchmark` runs the benchmark end-to-end and prints the verdict.
+
+---
+
+## Risks & Dependencies
+
+- **Async eval lag** — scores appear seconds-to-minutes after ingestion; too-short a poll yields false INCONCLUSIVE. Mitigation: bounded poll with a generous timeout, tuned against observed lag during U3 probing; INCONCLUSIVE is distinct from FAIL.
+- **API shape unverified** — ingestion envelope, dataset-item linking, and score-by-trace filtering are assumed; a wrong shape silently no-ops. Mitigation: probe-first execution notes on U1-U3; fail-loud on non-2xx (the existing `_request` surfaces status).
+- **Synthetic traces in prod stream** — the benchmark adds identifiable-but-undeletable observations. Mitigation: distinct `redo-benchmark/*` name + `benchmark` metadata for filtering; document that benchmark runs leave traces.
+- **Metered judge budget** — each run spends one judge call per case (~4). Small and bounded; note it in the workflow description.
+- **Evaluator rubric is the thing under test** — if the benchmark FAILs, the fix is the evaluator prompt/snapshot in `redo_of_shipped_capability`, not the harness. The benchmark is the regression guard for that rubric.
+
+---
+
+## Open Questions
+
+*Resolve during implementation (probe):*
+
+- Exact `/api/public/ingestion` event envelope (event `type`, trace+observation linkage, whether client-generated ids are accepted).
+- Whether dataset items link to a source trace via `source_trace_id` on the item or via a dataset-run-item, on this instance.
+- Whether `/api/public/scores` filters by `traceId`/`observationId` or requires client-side matching, and the typical eval lag (sets poll timeout).
+
+---
+
+## Scope Boundaries
+
+### Outside this change
+
+- Not modifying the `redo_of_shipped_capability` rubric or `_SHIPPED_SNAPSHOT` — the benchmark tests them; it does not change them.
+- Not adopting the `langfuse` SDK or the Dataset *experiment* runner (rejected for the dependency + uncertain rule-attachment; revisit only if synthetic ingestion proves unworkable).
+- Not a general multi-evaluator benchmark framework — scoped to the redo evaluator; the pattern can extend later.
+
+### Deferred to Follow-Up Work
+
+- Retiring the 30-minute live `--verify` poll once the benchmark proves correctness AND a first real box generation has scored (firing-on-real-traffic and on-demand-correctness are different checks; keep the poll until both are green).
+- Extending the dataset with more cases (Polar payments redo, outreach-docs redo) once the harness is proven.
+
+---
+
+## Sources & Research
+
+- `pipeline/evals/setup_langfuse_evaluators.py` — the stdlib script the benchmark extends: `_request`/`_auth_header`, idempotent create + 409-as-success in `apply()`, the `verify()` poll-and-classify + `rule_`-prefixed score-name matching, `--probe` schema dump.
+- `.github/workflows/register-langfuse-evaluators.yml` — the `mode` switch the `benchmark` case joins (`probe|dry-run|apply|verify`).
+- Langfuse Datasets docs (user-provided) — dataset + item creation, `expected_output`, `source_trace_id` linking, versioning; the experiment runner (SDK) is the path this plan deliberately does not take.
+- Prior session learnings: live scores are named `rule_<name>` not `<evaluator>`; eval rules score forward-only; the `redo_of_shipped_capability` rubric distinguishes redo from build-on-existing (`docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md`).

--- a/docs/plans/2026-06-19-004-fix-eval-data-path-enrich-generations-plan.md
+++ b/docs/plans/2026-06-19-004-fix-eval-data-path-enrich-generations-plan.md
@@ -1,0 +1,188 @@
+---
+title: "fix: Eval data path — enrich box generations with deliverable text, exclude judge self-calls"
+type: fix
+date: 2026-06-19
+---
+
+# fix: Eval Data Path — Enrich Box Generations With Deliverable Text, Exclude Judge Self-Calls
+
+## Summary
+
+The six Langfuse LLM-judge rules score `{{output}}` from GENERATION observations, but the box's `emit_generation` writes generations carrying only token counts — no text — so every judge scores an empty field (confirmed live: a judge replied *"you've provided the instructions but not the text to be reviewed"*). Fix the data path by enriching box generations with the stage's **deliverable text** (the completion for the langchain path, the written/salvaged stage output for the live goose path), and exclude the eval judges' own LLM calls from being re-scored. Wiring the issue-proposing observation-loop so the redo/growth judges score real proposed issues is deferred.
+
+---
+
+## Problem Frame
+
+`emit_generation` (`pipeline/wgmesh_pipeline/tracing.py`) is post-hoc *usage* telemetry: the goose and langchain runners call it once per stage with only `UsageTotals` (token counts), and it creates a GENERATION observation with `name`, `model`, and `usage_details` — no `input`/`output` text. The actual stage text lives on the `trace_node` **span** (`as_type="span"`), which does not match the rules' `type=GENERATION` filter.
+
+Two consequences, both confirmed against the live instance via a diagnostic dump (`verify` extension, PR #1865):
+
+1. **Empty `{{output}}`** — all six rules map `{{output}}` ← observation `output`; on real box generations that field is empty, so the judges score nothing. NUMERIC judges default high (the redo rubric's "names no capability → NOT APPLICABLE → 1.0"), so the redo evaluator can never flag a real redo.
+2. **Recursive scoring** — the dumped GENERATION whose `output` was a judge's reply shows the eval worker's own judge LLM calls are logged as GENERATIONs and re-scored by all six rules, inflating the score counts with meaningless self-evaluations.
+
+This is the field-level form of the wired-but-off-path trap (`feedback_framework_wired_but_off_execution_path`): the rules fire and produce scores, so the deployment *looks* healthy, but reads the wrong field.
+
+---
+
+## Key Technical Decisions
+
+- **Enrich generations rather than retarget the rules.** Thread the stage's deliverable text into `emit_generation` so the GENERATION observation carries what the judge reads, leaving the six rules' `type=GENERATION` filter and `{{output}}` mapping unchanged. The alternative — retargeting the rules onto the `trace_node` spans — was rejected this round (changes all six filters, pulls non-LLM spans into scope).
+
+- **Thread the deliverable text string, not the `_safe_state` dict.** `_safe_state` returns the state *dict*; feeding the judge a serialized state object gives it JSON to dig through, not the prose its rubric asks for (`impl_faithfulness` wants the diff, `public_safety_pass` the publishable text). The generation `output` is set to the stage's actual deliverable **string** — the agent completion (langchain) or the written/salvaged stage output (goose). Input, where a judge needs it (`impl_faithfulness` wants the spec), is the prompt/spec string.
+
+- **Goose enrichment is in scope — it is the live executor.** Goose runs the live box (the langchain runner is behind `EXECUTOR`/`GRAPH_IMPL` flags, reverted to goose 06-19), and goose usage is reconstructed from token-only logs with no completion text (`goose/usage.py`). But the runner already strips ANSI stdout and writes the deliverable to `output_path` (`goose/runner.py:352`); that written/salvaged text is the goose stage's real output and is what gets enriched. Without this, the fix is a no-op on production.
+
+- **Exclude judge self-calls by a probe-confirmed discriminator, committing the known-schema fallback.** The eval worker's own judge LLM calls land as GENERATIONs and get re-scored. The filter must exclude them. The live eval-rule filter is only demonstrably proven for the `type` column; a `metadata`-column match on a `source: box` marker is preferred *only if* `--probe` confirms the unstable API accepts it. The committed fallback uses the `name` column — box generations are named `f"{stage}-llm"`, an enumerable allowlist — which rides the proven `stringOptions` schema. The discriminator choice is a U-level blocker resolved by probing a judge generation's `name`/`metadata` first, not a during-implementation detail.
+
+- **Keep `emit_generation` best-effort and usage-only-safe.** New `input`/`output` params are optional; the `usage.total_tokens <= 0` short-circuit lives in the callers and is untouched; a missing-text path still emits usage and never raises (`tracing.py` `_announce`).
+
+- **Defer the issue-proposal targeting.** The redo and growth judges expect a *proposed issue*, produced by the GHA observation-loop (raw `curl`, uninstrumented). After this fix they score the box's stage deliverable (triage/spec/impl text) — real content, but not their intended issue-proposal input. Wiring the observation-loop is documented follow-up.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  subgraph before[Before: judge scores empty]
+    G0[emit_generation -> GENERATION<br/>name, model, usage_details only<br/>output = EMPTY]
+    R0[6 rules: type=GENERATION, output<-output] --> G0
+    R0 -.judge sees empty.-> J0[judge: 'no text to review']
+  end
+  subgraph after[After: judge scores deliverable text]
+    LC[langchain stage -> completion string]
+    GO[goose stage -> written/salvaged output_path text]
+    LC --> G1[emit_generation -> GENERATION<br/>output = deliverable TEXT<br/>metadata source=box]
+    GO --> G1
+    R1[6 rules: type=GENERATION<br/>AND box discriminator name/metadata] --> G1
+    R1 --> J1[judge scores real content]
+  end
+```
+
+---
+
+## Implementation Units
+
+### U1. Add text params + box marker to `emit_generation`
+
+- **Goal:** `emit_generation` can carry deliverable input/output text and a `source: box` metadata marker, without disturbing the usage-only path.
+- **Dependencies:** none.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/tracing.py` (modify)
+  - `pipeline/tests/test_tracing.py` (modify)
+- **Approach:** Add optional `input`/`output` string params (default `None`) to `emit_generation`; set them on the `start_observation(as_type="generation", ...)` call alongside the existing `usage_details`, and add `metadata={"source": "box", "stage": stage}`. When text is `None`, omit those fields. Keep the best-effort `try/except` + `_announce_generation`. Mechanics only — callers thread text in U2/U3.
+- **Patterns to follow:** the existing `emit_generation` `start_observation` call + best-effort guard; the span's `input=`/`metadata=` kwargs in `_LangfuseSpan`.
+- **Execution note:** Start with a failing `test_tracing` asserting the emitted generation carries the passed output text and the `source=box` marker.
+- **Test scenarios:**
+  - `emit_generation(output="...")` sets non-empty `output` on the observation (fake tracer captures `start_observation` kwargs).
+  - The `source: box` + `stage` metadata is present on every emitted generation.
+  - Called with no text (`output=None`) emits usage only, omits output, does not raise.
+  - A tracer exception is swallowed (best-effort), warning announced once.
+- **Verification:** `test_tracing` passes; a unit-level fake tracer shows the output/metadata set when text is passed and omitted when not.
+
+### U2. Thread deliverable text from both runners (goose = live path)
+
+- **Goal:** Each stage's deliverable text reaches `emit_generation.output` — the written/salvaged `output_path` text for goose, the completion string for langchain.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/goose/runner.py` (modify)
+  - `pipeline/wgmesh_pipeline/langchain_agent/runner.py` (modify)
+  - `pipeline/tests/test_runner*.py` (modify/add per runner)
+- **Approach:** Goose — after the recipe runs and the deliverable is written/salvaged (`_strip_ansi(stdout)` → `output_path`, `runner.py:352`), read that text (bounded) and pass it as `emit_generation(output=...)`; pass the recipe/spec input as `input=` where available. Langchain — pass the agent's final completion string as `output=` at the existing emit site. Both bound the text to a sane size (mirror the span's `_safe_state` truncation budget) and degrade to usage-only if the deliverable text is unavailable.
+- **Patterns to follow:** `goose/runner.py:352` salvage-to-`output_path`; `_emit_usage_safely`; the span truncation budget in `_safe_state`.
+- **Execution note:** Probe-confirm against a real goose stage that the written `output_path` content is the deliverable text (not raw ANSI noise) before trusting it as the generation output.
+- **Test scenarios:**
+  - Goose runner threads the written `output_path` text into `emit_generation(output=...)` (captured generation output is non-empty + matches the deliverable).
+  - Goose with no written output (salvage empty) degrades to usage-only, no raise.
+  - Langchain runner threads the completion string into `emit_generation(output=...)`.
+  - Oversized deliverable text is truncated to the budget, not emitted whole.
+- **Verification:** A live goose-executed box stage produces a GENERATION whose `output` is the stage deliverable text, visible in the `verify` DIAG dump.
+
+### U3. Exclude judge self-calls from the eval rules
+
+- **Goal:** The six rules score only box generations, not the eval worker's own judge LLM calls.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — rule `filter` + a one-time judge-generation field dump in `verify`)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py` (modify)
+- **Approach:** **Blocker probe first** — extend the `verify` DIAG to print a judge-shaped generation's `name`/`metadata`/`sessionId`, and `--probe` the eval-rule API to confirm which filter columns it accepts (`name`? `metadata`?). Then narrow the shared filter constant: committed path is a `name`-column `stringOptions` allowlist of box stage generation names (`f"{stage}-llm"`), which rides the proven schema; upgrade to a `metadata` `source=box` match only if the probe confirms the API accepts it (more robust to unknown judge names). The filter stays a single shared constant so all six rules move together. Apply idempotently (existing PATCH + 409-as-success).
+- **Patterns to follow:** `_GEN_FILTER` shared constant; the idempotent `apply()`; the `verify` DIAG field dump.
+- **Execution note:** The discriminator (name-allowlist vs metadata) is decided from the probe output, not assumed — do not write the rule change before the judge-generation field dump and the filter-column probe.
+- **Test scenarios:**
+  - Every rule's filter includes the box-generation discriminator (not bare `type=GENERATION`).
+  - The filter remains a single shared constant referenced by all six rules.
+  - `apply()` PATCHes existing rules and treats 409 as success (idempotent, unchanged).
+  - Test expectation note: actual exclusion of judge calls is verified live in U4, not unit-testable.
+- **Verification:** After re-apply, a live score query shows no new scores on judge-shaped generations; box generations still score.
+
+### U4. Confirm enriched generations score real content end-to-end
+
+- **Goal:** Verify the fix on the live (goose) substrate: box generations carry deliverable text and the judges produce content-grounded scores.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (modify — make the `verify` DIAG assert, not just print)
+- **Approach:** Turn the `verify` DIAG into an assertion: a recent box generation has non-empty `output`, and recent score reasonings engage real content (not "no text to review"). Because goose is the live executor, the live success criterion is satisfiable only after U2 enriches goose — note that explicitly so a `verify` run on the current substrate reads correctly.
+- **Patterns to follow:** the `verify()` poll-and-classify + `rule_`-prefixed score-name matching; the DIAG dump (PR #1865).
+- **Test scenarios:**
+  - `verify` flags PASS only when a box generation has non-empty `output` AND a score has content-bearing reasoning.
+  - A generation with empty `output` (regression to the old shape) makes `verify` report the empty-field defect explicitly, not a generic WAIT.
+- **Verification:** A live `mode=verify` after U1/U2/U3 deploy shows non-empty goose-generation output and content-grounded score reasonings.
+
+### U5. Record the fix and the deferred targeting
+
+- **Goal:** Document the confirmed defect, the fix, and the still-deferred observation-loop instrumentation.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:**
+  - `docs/solutions/logic-errors/` (new entry for the eval data-path defect)
+  - `docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md` (modify — note redo scoring is only meaningful post-fix)
+- **Approach:** Document the empty-`{{output}}` defect, the recursive-scoring defect, the enrich fix (deliverable text, goose via `output_path`), the judge-self-call exclusion, and the deferred observation-loop instrumentation the redo/growth judges need. Cross-reference the parked benchmark plan (`docs/plans/2026-06-19-003-...`), resumable once generations carry real text in the shape prod emits.
+- **Patterns to follow:** existing `docs/solutions/logic-errors/` frontmatter + RCA shape.
+- **Test scenarios:** Test expectation: none — documentation.
+- **Verification:** The doc names the defect, fix, and deferred targeting with correct cross-references.
+
+---
+
+## Risks & Dependencies
+
+- **Goose `output_path` text quality** — the salvaged/written content may be partial, ANSI-tainted, or the deliverable file rather than the LLM completion. Mitigation: U2 probe-confirms it is the real deliverable text before trusting it; degrade to usage-only if it isn't clean. This is the load-bearing U2 unknown — probe a real goose stage early.
+- **Filter discriminator schema** — the live eval-rule filter is only proven for `type`; `metadata`/`name` support is unverified. Mitigation: U3 blocker-probe; committed fallback is the `name`-allowlist on the proven `stringOptions` schema. If neither `name` nor `metadata` filtering is accepted, U3 is blocked and the plan says so rather than silently accepting judge-self-call scoring.
+- **Judge-relevant field varies by stage** — even with deliverable text threaded, `impl_faithfulness` (diff) vs `public_safety_pass` (publishable text) want different slices. Mitigation: U2 threads the stage's primary deliverable string; per-judge field precision is a refinement, noted if the scores read coarse.
+- **PII/secrets in generation text** — enriching generations puts box content into Langfuse. The span already carries the same content (no new exposure surface), but confirm Langfuse access stays restricted and truncation/redaction covers the generation path.
+- **Re-apply idempotency** — changing the shared filter re-applies all six rules; the existing PATCH + 409-as-success path must hold (regression-guarded by the apply tests).
+
+---
+
+## Open Questions
+
+*Resolve during implementation (probe), each gated as noted:*
+
+- (U2 blocker) Is the goose `output_path` written/salvaged content the clean stage deliverable text, or raw ANSI/partial output?
+- (U3 blocker) Which filter columns/operators does the live eval-rule API accept (`name`, `metadata`, others)?
+- (U3 blocker) What field distinguishes an eval-worker judge generation from a box generation (name, metadata, absence of session)? — dump it via the `verify` DIAG before choosing the discriminator.
+
+---
+
+## Scope Boundaries
+
+### Outside this change
+
+- Not retargeting the rules off `type=GENERATION` onto spans/traces (the rejected alternative this round).
+- Not changing the judge rubrics or `_SHIPPED_SNAPSHOT` — this is a data-path fix; the prompts are unchanged.
+
+### Deferred to Follow-Up Work
+
+- Instrumenting the GHA observation-loop (raw `curl`) so the redo/growth judges score actual proposed issues — the content-type mismatch fix. Until then redo/growth score box stage deliverables, not issue proposals.
+- Per-judge field precision (threading the diff vs the publishable text vs the issue body to the specific judge that wants it) if coarse deliverable text proves insufficient.
+- The parked redo-evaluator dataset benchmark (`docs/plans/2026-06-19-003-...`) — resume once generations carry real text in the shape prod emits.
+
+---
+
+## Sources & Research
+
+- `pipeline/wgmesh_pipeline/tracing.py` — `emit_generation` (usage-only generation, `:234`), `trace_node` + `_LangfuseSpan` (`_safe_state` dict on the span, `output=` at `:138`; `_safe_state` at `:300`), best-effort `_announce`.
+- `pipeline/wgmesh_pipeline/goose/runner.py` — `_emit_usage_safely` (`:468`), the ANSI-strip salvage to `output_path` (`:352`); `pipeline/wgmesh_pipeline/goose/usage.py` — token-only usage reconstruction, no text.
+- `pipeline/wgmesh_pipeline/langchain_agent/runner.py` — the langchain `emit_generation` call site with the completion in hand.
+- `pipeline/evals/setup_langfuse_evaluators.py` — the six rules' shared `type=GENERATION` filter (`_GEN_FILTER`) + `{{output}}` mapping; idempotent `apply()`; the `verify` DIAG (PR #1865) confirming the empty-output + recursive-scoring defects live; the docstring note to "narrow filter to specific traceName(s)" (non-`type` columns were always treated as unconfirmed).
+- `feedback_langfuse_evaluators_score_empty_output` (memory) — the confirmed defect, the judge's *"you've provided the instructions but not the text to be reviewed"* reply, the recursive-scoring finding.
+- `feedback_framework_wired_but_off_execution_path` (memory) — the field-level form of the same trap; the live executor is goose, not langchain.

--- a/docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md
+++ b/docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md
@@ -1,0 +1,74 @@
+---
+title: "Langfuse LLM-judge evaluators scored an empty field on every real generation"
+category: logic-errors
+date: 2026-06-19
+tags: [langfuse, evaluators, tracing, observability, llm-as-judge, wired-but-off-path]
+related_issues: []
+severity: high
+component: evals
+---
+
+# Langfuse LLM-judge evaluators scored an empty field on every real generation
+
+## Problem
+
+All six Langfuse LLM-as-judge rules (`growth_issue_quality`, `impl_faithfulness`,
+`public_safety_pass`, `no_component_paywall`, `open_source_default`,
+`redo_of_shipped_capability`) map `{{output}}` ← observation `output` and filter
+`type=GENERATION`. They fired and produced scores, so the deployment *looked* healthy
+— but the judges scored an **empty field**. Confirmed live: a dumped GENERATION's
+`output` was a judge replying *"I need to see the actual text content to evaluate it.
+You've provided the instructions/rules for the check, but not the text to be reviewed."*
+
+Two distinct defects:
+
+1. **Empty `{{output}}`.** The box's only generation-emit path, `emit_generation`
+   (`pipeline/wgmesh_pipeline/tracing.py`), wrote GENERATION observations with `name`,
+   `model`, and token-count `usage_details` only — **no text**. The actual stage text
+   lived on the `trace_node` **span** (`as_type="span"`), which the `type=GENERATION`
+   filter does not match. So `{{output}}` was empty; NUMERIC judges defaulted high
+   (the redo rubric's "names no capability → NOT APPLICABLE → 1.0"), so the redo
+   evaluator could never flag a real redo.
+2. **Recursive scoring.** The eval worker's own judge LLM calls are logged as
+   GENERATIONs named `ChatAnthropic`, matched `type=GENERATION`, and were re-scored by
+   all six rules — the judges scoring each other's calls, inflating the score counts
+   with meaningless self-evaluations.
+
+This is the field-level form of the wired-but-off-path trap: "firing" ≠ "scoring real
+content." The fix it took was tracing the judge's `{{var}}` to the exact observation
+field that carries it, on a *real* trace.
+
+## Root cause
+
+`emit_generation` was post-hoc *usage* telemetry — the goose and langchain runners call
+it once per stage with only token totals — never the LLM-call site with the completion
+text. The eval rules were pointed at it anyway, and nothing distinguished box
+generations from the eval worker's own judge generations.
+
+## Fix
+
+- **Enrich generations with deliverable text.** `emit_generation` gained optional
+  `input`/`output` text params plus a `metadata={"source":"box","stage":...}` marker.
+  The runners thread the stage deliverable: the langchain completion string, and — for
+  the live goose executor — the written/salvaged `output_path` content (goose usage is
+  token-only with no completion text, so the deliverable file is the real output). Emit
+  fires once per non-timeout run: usage-only on failure/timeout, usage+deliverable on
+  success.
+- **Exclude judge self-calls.** The shared rule filter adds `name "none of"
+  ["ChatAnthropic"]` (the eval worker's judge generations), keeping every box
+  `<stage>-llm` generation. Confirmed live: the unstable eval-rule API accepts the
+  `name` column + `none of` operator (6/6 rules applied 200 OK).
+- **`verify` surfaces the box-generation output state** so a regression to empty output
+  reads as "enrichment not live on the box," not a generic WAIT.
+
+## Deferred / residual
+
+- The redo and growth judges expect a *proposed issue*, produced by the GHA
+  observation-loop (raw `curl`, uninstrumented). After this fix they score the box's
+  stage deliverable (triage/spec/impl text), not issue proposals. Instrumenting the
+  observation-loop is follow-up.
+- Live confirmation that box generations carry text requires the box to deploy this
+  tracing change (it runs the legacy goose executor); `verify` distinguishes
+  not-yet-deployed from fixed.
+- The parked redo-evaluator dataset benchmark (`docs/plans/2026-06-19-003-...`) resumes
+  once generations carry real text in the shape prod emits.

--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -363,6 +363,23 @@ def verify() -> int:
         print(f"  input={json.dumps(g0.get('input'))[:200]}")
         print(f"  usageDetails={json.dumps(g0.get('usageDetails') or g0.get('usage'))[:200]}")
 
+    # U4: box generations (name `<stage>-llm`, emit_generation) must carry deliverable
+    # text after the enrich fix (U1/U2). Judge self-calls are named `ChatAnthropic`
+    # and are now filtered out of scoring (U3). Distinguish "enrichment live" from
+    # "box still emitting empty output" (fix not deployed to the box yet).
+    box_gens = [
+        g for g in gens if isinstance(g, dict) and str(g.get("name", "")).endswith("-llm")
+    ]
+    enriched = [g for g in box_gens if g.get("output")]
+    print(
+        f"box generations (<stage>-llm): {len(box_gens)}, with non-empty output: {len(enriched)}"
+    )
+    if box_gens and not enriched:
+        print(
+            "DIAG box generations carry EMPTY output — enrichment (U1/U2) not yet live on "
+            "the box; the judges still score nothing until the box deploys this fix."
+        )
+
     # All recent scores, tallied by evaluator name — distinguishes "redo rule
     # just hasn't seen a post-registration generation yet" (other evaluators ARE
     # scoring → pipeline alive) from "no evaluator has ever scored" (score

--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -214,16 +214,29 @@ EVALUATORS = [
 #   enabled = bool; sampling = 0..1
 #   filter = [{type:"stringOptions", column, operator:"any of", value:[...]}]
 #   mapping = [{variable, source}]
-# Filter starts at type=GENERATION (all LLM generations). NOTE: narrow `filter`
-# to specific traceName(s) once the box's per-stage trace names are confirmed in
-# the UI — otherwise growth_issue_quality also scores non-observation generations.
+# Filter to type=GENERATION AND exclude the eval worker's own judge LLM calls.
+# The judges (LLM-as-judge via langchain) surface as GENERATION observations named
+# `ChatAnthropic`; without excluding them the rules RE-SCORE each other's calls
+# (recursive feedback, confirmed live 06-19). Box generations are named
+# `<stage>-llm` (triage-llm, spec-llm, implement-llm, ...) by emit_generation, so a
+# single `name none of ["ChatAnthropic"]` condition excludes the judge calls while
+# keeping every box stage. Filter conditions are ANDed.
+# (If the unstable API rejects `none of` / `name`, the 400 body enumerates the
+# valid operators/columns — fall back to a `name any of [<stage>-llm...]` allowlist
+# or a metadata `source=box` match; box generations carry metadata.source=box.)
 _GEN_FILTER = [
     {
         "type": "stringOptions",
         "column": "type",
         "operator": "any of",
         "value": ["GENERATION"],
-    }
+    },
+    {
+        "type": "stringOptions",
+        "column": "name",
+        "operator": "none of",
+        "value": ["ChatAnthropic"],
+    },
 ]
 
 RULES = [

--- a/pipeline/tests/test_goose_runner.py
+++ b/pipeline/tests/test_goose_runner.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from wgmesh_pipeline.config import Config
-from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.goose.runner import GooseRunner, _read_deliverable_safely
 from wgmesh_pipeline.goose.usage import UsageTotals
 
 
@@ -19,6 +19,19 @@ def cfg() -> Config:
 
 def completed(code: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=["goose"], returncode=code, stdout=stdout, stderr=stderr)
+
+
+def write_usage(logs: Path, *, input_tokens: int = 12, output_tokens: int = 7, total_tokens: int = 19) -> None:
+    (logs / "llm_request.1.jsonl").write_text(
+        (
+            '{"usage":{'
+            f'"input_tokens":{input_tokens},'
+            f'"output_tokens":{output_tokens},'
+            f'"total_tokens":{total_tokens}'
+            "}}\n"
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_mocked_goose_writes_spec_file_and_returns_ok(tmp_path) -> None:
@@ -172,10 +185,7 @@ def test_goose_runner_populates_usage_and_emits_generation(tmp_path, monkeypatch
     def run(command, **kwargs):
         output.parent.mkdir()
         output.write_text("content")
-        (logs / "llm_request.1.jsonl").write_text(
-            '{"usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19}}\n',
-            encoding="utf-8",
-        )
+        write_usage(logs)
         return completed(stdout="wrote spec")
 
     result = GooseRunner(cfg(), runner=run).run_recipe(
@@ -195,8 +205,190 @@ def test_goose_runner_populates_usage_and_emits_generation(tmp_path, monkeypatch
             "stage": "spec",
             "model": cfg().goose_model,
             "usage": result.usage,
+            "output": "content",
         }
     ]
+
+
+def test_goose_runner_failure_emits_usage_without_output(tmp_path, monkeypatch) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        (logs / "llm_request.1.jsonl").write_text(
+            '{"usage":{"input_tokens":5,"output_tokens":8,"total_tokens":13}}\n',
+            encoding="utf-8",
+        )
+        return completed(2, stdout="partial", stderr="bad recipe")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-implementation.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+        session_id="issue-20",
+    )
+
+    assert result.ok is False
+    assert len(emitted) == 1
+    assert emitted[0]["session_id"] == "issue-20"
+    assert emitted[0]["stage"] == "implement"
+    assert emitted[0]["model"] == cfg().goose_model
+    assert emitted[0]["usage"] == result.usage
+    assert emitted[0].get("output") is None
+
+
+def test_goose_runner_success_emits_generation_once_with_deliverable_text(tmp_path, monkeypatch) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    output = tmp_path / "specs/issue-21-spec.md"
+    deliverable = "## Deliverable\n\nConcrete stage text."
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        output.parent.mkdir()
+        output.write_text(deliverable, encoding="utf-8")
+        write_usage(logs)
+        return completed(stdout="wrote spec")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="recipe.yaml",
+        workdir=tmp_path,
+        params={},
+        expected_output=output,
+        stage="spec",
+        session_id="issue-21",
+    )
+
+    assert result.ok is True
+    assert len(emitted) == 1
+    assert emitted[0]["usage"] == result.usage
+    assert emitted[0]["output"] == deliverable
+
+
+def test_goose_runner_nonzero_emits_usage_once_without_deliverable(tmp_path, monkeypatch) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        write_usage(logs)
+        return completed(2, stdout="partial", stderr="bad recipe")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-implementation.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+        session_id="issue-22",
+    )
+
+    assert result.ok is False
+    assert len(emitted) == 1
+    assert emitted[0]["usage"] == result.usage
+    assert emitted[0].get("output") is None
+
+
+def test_goose_runner_salvage_write_failure_emits_usage_once_without_deliverable(
+    tmp_path, monkeypatch
+) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        write_usage(logs)
+        return completed(0, stdout="# Spec\n\n" + ("body\n" * 80))
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "blocked/out.md"},
+        expected_output="blocked/out.md",
+        stage="spec",
+        session_id="issue-23",
+    )
+
+    assert result.ok is False
+    assert "salvage write failed" in (result.error or "")
+    assert len(emitted) == 1
+    assert emitted[0]["usage"] == result.usage
+    assert emitted[0].get("output") is None
+
+
+def test_goose_runner_empty_output_guard_emits_usage_once_without_deliverable(
+    tmp_path, monkeypatch
+) -> None:
+    logs = tmp_path / "goose-logs"
+    logs.mkdir()
+    emitted: list[dict[str, Any]] = []
+
+    monkeypatch.setattr("wgmesh_pipeline.goose.runner.default_logs_dir", lambda: logs)
+    monkeypatch.setattr(
+        "wgmesh_pipeline.goose.runner.tracing.emit_generation",
+        lambda **kwargs: emitted.append(kwargs),
+    )
+
+    def run(command, **kwargs):
+        write_usage(logs)
+        return completed(0, stdout="done, no file written")
+
+    result = GooseRunner(cfg(), runner=run).run_recipe(
+        recipe="wgmesh-triage-spec.yaml",
+        workdir=tmp_path,
+        params={"spec_file": "specs/issue-24-spec.md"},
+        expected_output="specs/issue-24-spec.md",
+        stage="spec",
+        session_id="issue-24",
+    )
+
+    assert result.ok is False
+    assert "empty output guard" in (result.error or "")
+    assert len(emitted) == 1
+    assert emitted[0]["usage"] == result.usage
+    assert emitted[0].get("output") is None
+
+
+def test_read_deliverable_safely_reads_and_truncates(tmp_path) -> None:
+    output = tmp_path / "out.txt"
+    output.write_text("abcdef", encoding="utf-8")
+
+    assert _read_deliverable_safely(output, limit=4) == "abcd"
+
+
+def test_read_deliverable_safely_returns_none_on_oserror(tmp_path) -> None:
+    missing = tmp_path / "missing.txt"
+
+    assert _read_deliverable_safely(missing) is None
 
 
 def test_goose_runner_usage_collection_exception_does_not_break_run(tmp_path, monkeypatch) -> None:

--- a/pipeline/tests/test_langchain_agent_runner.py
+++ b/pipeline/tests/test_langchain_agent_runner.py
@@ -162,6 +162,7 @@ def test_emit_generation_called_with_stage_model_and_usage(
             "stage": "implement",
             "model": cfg().goose_model,
             "usage": result.usage,
+            "output": "finished",
         }
     ]
 

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -90,6 +90,19 @@ def test_redo_of_shipped_capability_rule_shape() -> None:
 
 
 @pytest.mark.unit
+def test_gen_filter_excludes_judge_self_calls() -> None:
+    # type=GENERATION plus a name-exclusion of the eval worker's own ChatAnthropic
+    # judge calls (recursive-scoring fix).
+    type_cond = [c for c in _GEN_FILTER if c["column"] == "type"]
+    name_cond = [c for c in _GEN_FILTER if c["column"] == "name"]
+
+    assert type_cond and type_cond[0]["value"] == ["GENERATION"]
+    assert name_cond, "filter must exclude judge self-calls by name"
+    assert name_cond[0]["operator"] == "none of"
+    assert "ChatAnthropic" in name_cond[0]["value"]
+
+
+@pytest.mark.unit
 def test_rules_reference_existing_evaluators() -> None:
     evaluator_names = {ev["name"] for ev in EVALUATORS}
 

--- a/pipeline/tests/test_tracing.py
+++ b/pipeline/tests/test_tracing.py
@@ -6,7 +6,13 @@ from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubIssue
 from wgmesh_pipeline.goose.usage import UsageTotals
 from wgmesh_pipeline import tracing
-from wgmesh_pipeline.tracing import _LangfuseSpan, LangfuseTracer, NoopTracer, init_tracing, trace_node
+from wgmesh_pipeline.tracing import (
+    _LangfuseSpan,
+    LangfuseTracer,
+    NoopTracer,
+    init_tracing,
+    trace_node,
+)
 
 
 class _FakeSdkSpan:
@@ -30,7 +36,9 @@ class _FakeLangfuseV4:
         self.flushed = False
 
     def start_observation(self, *, name, as_type, input, metadata):
-        self.record.update({"name": name, "as_type": as_type, "input": input, "metadata": metadata})
+        self.record.update(
+            {"name": name, "as_type": as_type, "input": input, "metadata": metadata}
+        )
         return _FakeSdkSpan(self.record)
 
     def flush(self):
@@ -109,13 +117,18 @@ class FakeTracer:
 
 def test_key_set_with_mocked_tracer_emits_span_with_tags() -> None:
     tracer = FakeTracer()
-    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"), tracer=tracer)
+    init_tracing(
+        Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"),
+        tracer=tracer,
+    )
 
     def node(state):
         return {**state, "classification": "fix"}
 
     wrapped = trace_node("triage", node)
-    result = wrapped({"issue": GitHubIssue(number=12, title="Fix", labels=(), state="open")})
+    result = wrapped(
+        {"issue": GitHubIssue(number=12, title="Fix", labels=(), state="open")}
+    )
 
     assert result["classification"] == "fix"
     assert tracer.records[0]["name"] == "triage"
@@ -129,10 +142,11 @@ def test_key_unset_noop_still_runs_node_normally() -> None:
     def node(state):
         return {**state, "classification": "feature"}
 
-    result = trace_node("triage", node)({"issue": GitHubIssue(number=13, title="Feature", labels=(), state="open")})
+    result = trace_node("triage", node)(
+        {"issue": GitHubIssue(number=13, title="Feature", labels=(), state="open")}
+    )
 
     assert result["classification"] == "feature"
-
 
 
 def test_langfuse_span_groups_into_issue_session(monkeypatch) -> None:
@@ -141,6 +155,7 @@ def test_langfuse_span_groups_into_issue_session(monkeypatch) -> None:
     session (the issue's pipeline lifecycle)."""
     import contextlib
     import pytest
+
     lf_mod = pytest.importorskip("langfuse")
 
     calls = {}
@@ -152,13 +167,16 @@ def test_langfuse_span_groups_into_issue_session(monkeypatch) -> None:
 
     monkeypatch.setattr(lf_mod, "propagate_attributes", fake_propagate, raising=False)
 
-    _LangfuseSpan(_FakeLangfuseV4(), "triage", {"x": 1}, {"stage": "triage", "issue": "584"})
+    _LangfuseSpan(
+        _FakeLangfuseV4(), "triage", {"x": 1}, {"stage": "triage", "issue": "584"}
+    )
     assert calls.get("session_id") == "issue-584"
 
 
 def test_langfuse_span_no_issue_uses_no_session(monkeypatch) -> None:
     import contextlib
     import pytest
+
     lf_mod = pytest.importorskip("langfuse")
 
     calls = {"used": False}
@@ -179,7 +197,10 @@ def test_safe_state_strips_config_secrets_from_trace(monkeypatch) -> None:
     """config carries zai_api_key/wgmesh_bot_pat in plaintext — it must never be
     serialized into a Langfuse trace input/output (bug #13 secret leak)."""
     tracer = FakeTracer()
-    init_tracing(Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"), tracer=tracer)
+    init_tracing(
+        Config(target_repo="atvirokodosprendimai/wgmesh", langsmith_api_key="key"),
+        tracer=tracer,
+    )
 
     class _Cfg:
         zai_api_key = "secret-zai-key"
@@ -211,13 +232,17 @@ def test_emit_generation_noop_tracer_is_silent_noop(caplog) -> None:
             session_id="issue-21",
             stage="spec",
             model="GLM-4.7",
-            usage=UsageTotals(input_tokens=1, output_tokens=2, total_tokens=3, requests=1, skipped=0),
+            usage=UsageTotals(
+                input_tokens=1, output_tokens=2, total_tokens=3, requests=1, skipped=0
+            ),
         )
 
     assert "generation emitted" not in caplog.text
 
 
-def test_emit_generation_langfuse_tracer_starts_generation_observation(monkeypatch) -> None:
+def test_emit_generation_langfuse_tracer_starts_generation_observation(
+    monkeypatch,
+) -> None:
     class _FakeGeneration:
         def __init__(self, record):
             self.record = record
@@ -246,12 +271,118 @@ def test_emit_generation_langfuse_tracer_starts_generation_observation(monkeypat
         session_id="issue-22",
         stage="implement",
         model="openai/gpt-5-mini",
-        usage=UsageTotals(input_tokens=10, output_tokens=4, total_tokens=14, requests=1, skipped=0),
+        usage=UsageTotals(
+            input_tokens=10, output_tokens=4, total_tokens=14, requests=1, skipped=0
+        ),
     )
 
     assert fake_lf.record["name"] == "implement-llm"
     assert fake_lf.record["as_type"] == "generation"
     assert fake_lf.record["model"] == "openai/gpt-5-mini"
     assert fake_lf.record["usage_details"] == {"input": 10, "output": 4}
+    assert fake_lf.record["metadata"] == {"source": "box", "stage": "implement"}
     assert fake_lf.record["ended"] is True
     assert fake_lf.flushed is True
+
+
+def test_emit_generation_langfuse_tracer_passes_output_text(monkeypatch) -> None:
+    class _FakeGeneration:
+        def __init__(self, record):
+            self.record = record
+
+        def end(self):
+            self.record["ended"] = True
+
+    class _FakeLf:
+        def __init__(self):
+            self.record = {}
+
+        def start_observation(self, **kwargs):
+            self.record.update(kwargs)
+            return _FakeGeneration(self.record)
+
+        def flush(self):
+            pass
+
+    fake_lf = _FakeLf()
+    tracer = object.__new__(LangfuseTracer)
+    tracer._lf = fake_lf
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+
+    tracing.emit_generation(
+        session_id="issue-23",
+        stage="spec",
+        model="GLM-4.7",
+        usage=UsageTotals(
+            input_tokens=3, output_tokens=5, total_tokens=8, requests=1, skipped=0
+        ),
+        input="prompt text",
+        output="some text",
+    )
+
+    assert fake_lf.record["input"] == "prompt text"
+    assert fake_lf.record["output"] == "some text"
+    assert fake_lf.record["metadata"] == {"source": "box", "stage": "spec"}
+
+
+def test_emit_generation_langfuse_tracer_without_text_omits_output_kwarg(
+    monkeypatch,
+) -> None:
+    class _FakeGeneration:
+        def __init__(self, record):
+            self.record = record
+
+        def end(self):
+            self.record["ended"] = True
+
+    class _FakeLf:
+        def __init__(self):
+            self.record = {}
+
+        def start_observation(self, **kwargs):
+            self.record.update(kwargs)
+            return _FakeGeneration(self.record)
+
+        def flush(self):
+            pass
+
+    fake_lf = _FakeLf()
+    tracer = object.__new__(LangfuseTracer)
+    tracer._lf = fake_lf
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+
+    tracing.emit_generation(
+        session_id="issue-24",
+        stage="implement",
+        model="openai/gpt-5-mini",
+        usage=UsageTotals(
+            input_tokens=7, output_tokens=11, total_tokens=18, requests=1, skipped=0
+        ),
+    )
+
+    assert "output" not in fake_lf.record
+    assert "input" not in fake_lf.record
+    assert fake_lf.record["usage_details"] == {"input": 7, "output": 11}
+    assert fake_lf.record["metadata"] == {"source": "box", "stage": "implement"}
+    assert fake_lf.record["ended"] is True
+
+
+def test_emit_generation_langfuse_tracer_swallows_start_observation_error(
+    monkeypatch,
+) -> None:
+    class _BrokenLf:
+        def start_observation(self, **kwargs):
+            raise RuntimeError("langfuse unavailable")
+
+    tracer = object.__new__(LangfuseTracer)
+    tracer._lf = _BrokenLf()
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+
+    tracing.emit_generation(
+        session_id="issue-25",
+        stage="spec",
+        model="GLM-4.7",
+        usage=UsageTotals(
+            input_tokens=1, output_tokens=1, total_tokens=2, requests=1, skipped=0
+        ),
+    )

--- a/pipeline/wgmesh_pipeline/goose/runner.py
+++ b/pipeline/wgmesh_pipeline/goose/runner.py
@@ -315,7 +315,9 @@ class GooseRunner:
         except subprocess.TimeoutExpired as exc:
             duration = time.monotonic() - started
             usage = _collect_usage_safely(logs_dir, usage_snapshot)
-            _emit_usage_safely(session_id=session_id, stage=stage, model=resolved_model, usage=usage)
+            _emit_usage_safely(
+                session_id=session_id, stage=stage, model=resolved_model, usage=usage
+            )
             return GooseResult(
                 ok=False,
                 output_path=None,
@@ -327,10 +329,15 @@ class GooseRunner:
             )
         duration = time.monotonic() - started
         usage = _collect_usage_safely(logs_dir, usage_snapshot)
-        _emit_usage_safely(session_id=session_id, stage=stage, model=resolved_model, usage=usage)
         raw_log = _join_log(completed.stdout, completed.stderr)
 
         if completed.returncode != 0:
+            _emit_usage_safely(
+                session_id=session_id,
+                stage=stage,
+                model=resolved_model,
+                usage=usage,
+            )
             return GooseResult(
                 ok=False,
                 output_path=None,
@@ -355,6 +362,12 @@ class GooseRunner:
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_text(salvaged, encoding="utf-8")
                 except OSError as exc:
+                    _emit_usage_safely(
+                        session_id=session_id,
+                        stage=stage,
+                        model=resolved_model,
+                        usage=usage,
+                    )
                     return GooseResult(
                         ok=False,
                         output_path=output_path,
@@ -366,6 +379,12 @@ class GooseRunner:
                     )
 
         if not output_path.exists() or output_path.stat().st_size == 0:
+            _emit_usage_safely(
+                session_id=session_id,
+                stage=stage,
+                model=resolved_model,
+                usage=usage,
+            )
             return GooseResult(
                 ok=False,
                 output_path=output_path,
@@ -376,6 +395,14 @@ class GooseRunner:
                 usage=usage,
             )
 
+        deliverable = _read_deliverable_safely(output_path)
+        _emit_usage_safely(
+            session_id=session_id,
+            stage=stage,
+            model=resolved_model,
+            usage=usage,
+            output=deliverable,
+        )
         return GooseResult(
             ok=True,
             output_path=output_path,
@@ -442,6 +469,13 @@ def _decode_timeout_output(value: str | bytes | None) -> str | None:
     return value
 
 
+def _read_deliverable_safely(output_path: Path, limit: int = 8000) -> str | None:
+    try:
+        return output_path.read_text(encoding="utf-8")[:limit]
+    except OSError:
+        return None
+
+
 def _resolved_model(config: Config, profile: ModelProfile | None) -> str:
     if profile is not None:
         return profile.model
@@ -464,10 +498,13 @@ def _emit_usage_safely(
     stage: str | None,
     model: str,
     usage: UsageTotals | None,
+    output: str | None = None,
 ) -> None:
     if usage is None or usage.total_tokens <= 0:
         return
-    tracing.emit_generation(session_id=session_id, stage=stage, model=model, usage=usage)
+    tracing.emit_generation(
+        session_id=session_id, stage=stage, model=model, usage=usage, output=output
+    )
 
 
 def _warn_usage_once(phase: str, exc: BaseException) -> None:

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -75,6 +75,7 @@ class LangchainAgentRunner:
             raw_log.append(f"human: {rendered_prompt}")
 
             iterations = 0
+            completion_text: str | None = None
             while iterations < MAX_ITERATIONS:
                 if time.monotonic() - started > WALL_CLOCK_LIMIT_SECONDS:
                     _emit_usage(
@@ -82,6 +83,7 @@ class LangchainAgentRunner:
                         stage=stage,
                         model=profile.model,
                         usage=usage,
+                        output=completion_text,
                     )
                     return _result(
                         ok=False,
@@ -96,7 +98,8 @@ class LangchainAgentRunner:
                 ai_message = llm.invoke(messages)
                 messages.append(ai_message)
                 usage = _add_usage(usage, getattr(ai_message, "usage_metadata", None))
-                raw_log.append(f"assistant: {_message_content(ai_message)}")
+                completion_text = _message_content(ai_message)
+                raw_log.append(f"assistant: {completion_text}")
 
                 tool_calls = list(getattr(ai_message, "tool_calls", None) or [])
                 if not tool_calls:
@@ -120,7 +123,11 @@ class LangchainAgentRunner:
                     )
             else:
                 _emit_usage(
-                    session_id=session_id, stage=stage, model=profile.model, usage=usage
+                    session_id=session_id,
+                    stage=stage,
+                    model=profile.model,
+                    usage=usage,
+                    output=completion_text,
                 )
                 return _result(
                     ok=False,
@@ -133,7 +140,11 @@ class LangchainAgentRunner:
                 )
 
             _emit_usage(
-                session_id=session_id, stage=stage, model=profile.model, usage=usage
+                session_id=session_id,
+                stage=stage,
+                model=profile.model,
+                usage=usage,
+                output=completion_text,
             )
             if output_path.exists():
                 return _result(
@@ -280,11 +291,12 @@ def _emit_usage(
     stage: str | None,
     model: str,
     usage: UsageTotals,
+    output: str | None = None,
 ) -> None:
     if usage.total_tokens <= 0:
         return
     tracing.emit_generation(
-        session_id=session_id, stage=stage, model=model, usage=usage
+        session_id=session_id, stage=stage, model=model, usage=usage, output=output
     )
 
 

--- a/pipeline/wgmesh_pipeline/tracing.py
+++ b/pipeline/wgmesh_pipeline/tracing.py
@@ -232,22 +232,34 @@ def trace_node(name: str, fn: Callable[P, R]) -> Callable[P, R]:
 
 
 def emit_generation(
-    *, session_id: str | None, stage: str | None, model: str, usage
+    *,
+    session_id: str | None,
+    stage: str | None,
+    model: str,
+    usage,
+    input: Any = None,
+    output: Any = None,
 ) -> None:
     if not isinstance(_tracer, LangfuseTracer):
         return
     try:
         lf = _tracer._lf
         with _session_id_ctx(session_id):
-            observation = lf.start_observation(
-                name=f"{stage or 'goose'}-llm",
-                as_type="generation",
-                model=model,
-                usage_details={
+            kwargs = {
+                "name": f"{stage or 'goose'}-llm",
+                "as_type": "generation",
+                "model": model,
+                "usage_details": {
                     "input": usage.input_tokens,
                     "output": usage.output_tokens,
                 },
-            )
+                "metadata": {"source": "box", "stage": stage},
+            }
+            if input is not None:
+                kwargs["input"] = input
+            if output is not None:
+                kwargs["output"] = output
+            observation = lf.start_observation(**kwargs)
             observation.end()
         lf.flush()
         log.info(


### PR DESCRIPTION
## What

The six Langfuse LLM-judge rules scored an **empty `{{output}}`** on every real box generation (confirmed live: a judge replied *"you've provided the instructions but not the text to be reviewed"*), and the judges' own `ChatAnthropic` calls were re-scored recursively. Fixes the data path so judges see real content.

## Units

- **U1** `e787b5d` — `emit_generation` carries optional input/output text + `metadata source=box`.
- **U2** `2195781` — runners thread the stage deliverable: goose via the written/salvaged `output_path` (live executor), langchain via the completion. Emit once/run: usage-only on failure/timeout, usage+text on success.
- **U3** `8faad4d` — shared rule filter adds `name "none of" ["ChatAnthropic"]` to drop judge self-calls. **Live-validated: applied 6/6 rules 200 OK from this branch.**
- **U4** — `verify` surfaces box-generation output state (enriched vs empty/not-deployed).
- **U5** — `docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md`.

## Deferred

- Instrumenting the GHA observation-loop so redo/growth score real proposed issues (they currently score box stage deliverables).
- Live confirmation needs the box to deploy this tracing change (legacy goose executor).

## Test plan

- [x] U1/U2 unit tests (tracing, goose/langchain runners) — 93 passed local focused run
- [x] U3 filter applied live: 6/6 rules 200 OK (`name`/`none of` accepted)
- [ ] Post-deploy: `mode=verify` shows non-empty `<stage>-llm` output + content-grounded reasonings