### PR TITLE
fix(reconcile): de-escalate escalated issues when needs-human is removed

### DIFF
--- a/pipeline/tests/test_reconcile.py
+++ b/pipeline/tests/test_reconcile.py
@@ -249,6 +249,54 @@ def test_needs_human_label_escalates_and_excludes_from_claim(tmp_path) -> None:
     assert store.claim_next(now=datetime.now(timezone.utc)) is None
 
 
+def test_escalated_issue_requeues_when_needs_human_removed(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(539, "was escalated", stage="escalated", status="open")
+
+    result = reconcile_issues(
+        Client([issue(539, ("copilot-triaging",), title="Back to triage")]), store
+    )
+
+    record = store.get_issue(539)
+    assert result.queued == 1
+    assert record.stage == "queued"
+    assert record.status == "open"
+
+
+def test_escalated_issue_stays_escalated_while_needs_human_remains(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(539, "still needs human", stage="escalated", status="open")
+
+    result = reconcile_issues(
+        Client([issue(539, ("copilot-triaging", "needs-human"))]), store
+    )
+
+    assert result.queued == 0
+    assert store.get_issue(539).stage == "escalated"
+
+
+def test_escalated_issue_without_triage_label_stays_escalated(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(539, "no triage label", stage="escalated", status="open")
+
+    result = reconcile_issues(Client([issue(539, ("fn:dev",))]), store)
+
+    assert result.queued == 0
+    assert store.get_issue(539).stage == "escalated"
+
+
+def test_merged_issue_with_triage_label_stays_terminal(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(539, "already merged", stage="merged", status="closed")
+
+    result = reconcile_issues(Client([issue(539, ("copilot-triaging",))]), store)
+
+    record = store.get_issue(539)
+    assert result.queued == 0
+    assert record.stage == "merged"
+    assert record.status == "closed"
+
+
 def test_reconcile_removes_needs_triage_without_raising_in_spec_only(tmp_path) -> None:
     # Regression: in spec-only the write-gate blocks remove_label unless
     # spec_pr=True. reconcile omitting the flag raised PermissionError every

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -58,6 +58,16 @@ def reconcile_issues(
         labels = set(issue.labels)
         current_stage = _current_stage(store, issue.number)
         if current_stage in TERMINAL_STAGES:
+            if (
+                current_stage == "escalated"
+                and issue.state != "closed"
+                and "needs-human" not in labels
+                and labels & {"needs-triage", "copilot-triaging"}
+            ):
+                store.upsert_issue(
+                    issue.number, issue.title, stage="queued", status="open"
+                )
+                queued += 1
             continue
 
         if issue.state == "closed" or labels & MERGED_LABELS:


### PR DESCRIPTION
**Second half of the box-unjam** (after #1871 pagination). `escalated` is in `TERMINAL_STAGES`, and reconcile does `if current_stage in TERMINAL_STAGES: continue` BEFORE reading labels — so once an issue is escalated, stripping its `needs-human` label can **never** un-stick it (labels never re-read). Combined with a stale-sweep that falsely escalates stuck `copilot-triaging` issues to `needs-human`, codeable work got permanently jammed.

Now an `escalated`, still-open issue whose `needs-human` is gone and that still carries a triage label (`copilot-triaging`/`needs-triage`) is **re-queued**. `merged`/`failed` and still-`needs-human` issues stay terminal.

Scope: de-escalation path only. The stale-sweep that *causes* the false escalation is a separate follow-up (#2b) — without it, re-escalation can recur.

## Test plan
- [x] de-escalation re-queues (escalated + copilot-triaging + no needs-human → queued)
- [x] still-needs-human stays escalated; escalated w/o triage label stays; merged stays terminal
- [x] existing escalation tests green
- [x] `pytest pipeline` → **651 passed / 5 skipped**; ruff + black clean

## Next
Deploy → the 6 GTM issues I de-labeled (#732/733/734/745/752/753) re-queue → box specs+impls via LangChain. Then fix the stale-sweep (#2b) so it doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)