### PR TITLE
fix(deps): add langchain so langfuse CallbackHandler can init

### DIFF
--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -9,6 +9,7 @@ description = "Shadow-mode autonomous pipeline service for wgmesh."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "langchain>=0.3",
   "langchain-anthropic>=0.2",
   "langgraph>=0.2",
   "pytest>=8.0",


### PR DESCRIPTION
Deploy-to-learn from the live box: `[tracing] langfuse CallbackHandler init failed, tracing degraded: ModuleNotFoundError("Please install langchain ...")`.

`langfuse.langchain.CallbackHandler` imports the **top-level `langchain`** package. The box had `langchain-anthropic` + `langchain-core` but not `langchain`, so `build_callback_handler` (U5, guarded) caught the import error and degraded to no-handler → per-stage CallbackHandler spans never emitted. Adding `langchain>=0.3` to base deps fixes it.

The guard worked exactly as designed (announced once, didn't crash the loop) — this just supplies the missing dep.

## Test plan
- [x] guarded tracing tests green (handler absence already covered): 25 passed
- [ ] box: after `update-pipeline-box` reinstall, `build_callback_handler` returns a handler; per-stage node spans appear in Langfuse on the next claimed issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)