### PR TITLE
fix(heal): make pipeline-health stale-sweeps box-aware

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -96,6 +96,8 @@ jobs:
             cutoff=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
                      date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
           fi
+          recent_cutoff=$(date -u -d '6 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+                          date -u -v-6H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
 
           if [ -z "$cutoff" ]; then
             echo "::warning::Could not compute 24h cutoff — skipping stale triage sweep"
@@ -106,7 +108,7 @@ jobs:
 
           if ! gh issue list --repo "$TARGET_REPO" --state open \
             --label "needs-triage" --limit 50 \
-            --json number,title,createdAt,labels \
+            --json number,title,createdAt,updatedAt,labels \
             --jq ".[] | select(.createdAt < \"$cutoff\") | @json" \
             > /tmp/stale_triage.json; then
             echo "::error::stale needs-triage detection query failed"
@@ -145,6 +147,12 @@ jobs:
               --jq "[.[] | select(.title | test(\"Issue #${number}\\\\b\"))] | length" 2>/dev/null || echo 0)
             if [ "${merged_pr:-0}" -gt 0 ]; then
               echo "Skipping #${number} — completed (merged spec/impl PR exists), not stuck"
+              continue
+            fi
+
+            updated=$(echo "$issue" | jq -r '.updatedAt // .updated_at // empty')
+            if [ -n "$recent_cutoff" ] && [ -n "$updated" ] && [ "$updated" '>' "$recent_cutoff" ]; then
+              echo "Skipping #${number} — recent activity ($updated > $recent_cutoff); box is working it"
               continue
             fi
 
@@ -268,6 +276,8 @@ jobs:
             cutoff=$(date -u -d '48 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
                      date -u -v-48H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
           fi
+          recent_cutoff=$(date -u -d '6 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+                          date -u -v-6H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
 
           if [ -z "$cutoff" ]; then
             echo "::warning::Could not compute 48h cutoff — skipping stale copilot sweep"
@@ -278,7 +288,7 @@ jobs:
 
           if ! gh issue list --repo "$TARGET_REPO" --state open \
             --label "copilot-triaging" --limit 50 \
-            --json number,title,createdAt,labels \
+            --json number,title,createdAt,updatedAt,labels \
             --jq ".[] | select(.createdAt < \"$cutoff\") | @json" \
             > /tmp/stale_copilot.json; then
             echo "::error::stale copilot-triaging detection query failed"
@@ -305,6 +315,12 @@ jobs:
 
             if [ -n "$spec_pr" ]; then
               echo "Skipping #${number} — spec PR #${spec_pr} in progress"
+              continue
+            fi
+
+            updated=$(echo "$issue" | jq -r '.updatedAt // .updated_at // empty')
+            if [ -n "$recent_cutoff" ] && [ -n "$updated" ] && [ "$updated" '>' "$recent_cutoff" ]; then
+              echo "Skipping #${number} — recent activity ($updated > $recent_cutoff); box is working it"
               continue
             fi
 


### PR DESCRIPTION
**Root cause of the box-jam's `needs-human` escalations** (running as the operator PAT via `pipeline-health.yml`'s 30-min cron). The `needs-triage` and `copilot-triaging` stale sweeps escalate stuck issues to `needs-human` keying only on `createdAt > 24h/48h`. These predate the box's poller **owning triage** — the box now claims those labels and triages issues one stage per 5-min tick (with a backlog), so the sweeps couldn't tell "genuinely stuck" from "in the box's queue, being processed" → they **false-escalated the box's own in-flight work**, which then jammed it.

Fix: both issue sweeps now also skip any issue whose `updatedAt` is within the last **6h** — the box bumps `updatedAt` as it advances issues (label changes, claim, spec-PR), so in-flight work is left alone. Genuinely-dead issues (old **and** no recent activity) still hit the existing 2-retry escalation breaker. Fail-open if the date can't be computed. PR/build-clog step, circuit breaker, and state/audit logic untouched.

This is the durability half of the box-unjam (after #1871 pagination, #1872 de-escalation, #1873 langchain dep).

## Validation
- [x] YAML parses; `bash -n` on both edited steps; `actionlint` clean
- [x] diff touches only `stale_triage` + `stale_copilot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)