### PR TITLE
fix(evals): --verify WAIT exits 0; FAIL only on broken redo filter

### DIFF
--- a/docs/plans/2026-06-20-001-fix-langfuse-verify-exit-semantics-plan.md
+++ b/docs/plans/2026-06-20-001-fix-langfuse-verify-exit-semantics-plan.md
@@ -1,0 +1,238 @@
+---
+title: "fix: Langfuse --verify exit semantics (WAIT is not a failure)"
+type: fix
+date: 2026-06-20
+depth: standard
+origin: none (solo; sourced from docs/pulse-reports/2026-06-20_00-10.md followup #1)
+---
+
+# fix: Langfuse `--verify` exit semantics — WAIT is not a failure
+
+## Summary
+
+`Register Langfuse Evaluators` ran red 9× on 2026-06-19. Every red run was a manual
+`workflow_dispatch` of **`--verify`**, not the apply path. `verify()` returns exit `1`
+in its **WAIT** branch — "score pipeline alive (91 sibling scores), but the redo
+evaluator hasn't seen a post-registration generation yet; re-run later." WAIT is an
+expected, non-terminal state, but CI reads any non-zero exit as failure, so each poll
+painted the job red and the Action-Success KPI counted it as a breach.
+
+This plan makes `verify()` map three verdicts to two exit codes correctly: **PASS** and
+**WAIT** → exit `0`, **FAIL** → exit `1`. WAIT stays honest via an **evidence-based
+discriminator**: WAIT degrades to FAIL once a box generation that the redo rule *should*
+have scored exists (enriched `<stage>-llm` output created at/after the redo rule's
+registration) yet `redo_scores == 0` — that means the rule's filter is broken, not that
+we are "too early."
+
+## Problem Frame
+
+- **Observed:** 9 red `Register Langfuse Evaluators` runs in 24h; KPI marks the window
+  dirty (see `docs/pulse-reports/2026-06-20_00-10.md`).
+- **Root cause:** `verify()` conflates WAIT (transient/expected) with FAIL (terminal
+  defect) — both `return 1`. CI has no neutral signal, so WAIT reads as failure.
+- **Not the cause:** the apply path is already 409-idempotent (POST→409→`exists_ok`;
+  existing rules go through PATCH — #1813/#1858). No live 409 re-apply bug.
+- **Goal:** WAIT stops failing CI, without letting a genuinely stuck redo rule hide
+  behind a permanent green.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- Exit-code semantics of `verify()` in `pipeline/evals/setup_langfuse_evaluators.py`.
+- The evidence-based WAIT→FAIL discriminator and its supporting signal (redo-rule
+  registration time, with a fallback).
+- Tests in `pipeline/tests/test_setup_langfuse_evaluators.py`.
+
+**Out of scope**
+- The empty-`{{output}}` box-generation substrate (judges scoring blank deliverable
+  text). Already shipped in #1866; awaiting box redeploy. `verify()` already *reports*
+  it (`box generations ... with non-empty output: 0`); this plan does not change that
+  diagnostic.
+- Apply-path 409 handling (already idempotent).
+- Why `--verify` is being polled hourly by an operator — behavioral, not a code defect.
+
+### Deferred to Follow-Up Work
+- A hard staleness time-cap on WAIT (e.g., "WAIT longer than N hours → FAIL even with no
+  enriched generation"). The enriched/registration discriminator below is the agreed
+  evidence signal; a wall-clock cap is a cruder secondary guard, deferred unless the
+  discriminator proves insufficient in production.
+- Splitting apply vs. verify into separate workflow jobs so a verify verdict can never
+  share a red/green with registration. Not needed once exit codes are correct.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — WAIT and PASS both exit 0; only FAIL exits 1.** CI's only lever is the exit
+  code. WAIT is an expected state, so it must be green. PASS stays green. FAIL (dead
+  pipeline, no traces, or broken redo filter) stays red.
+- **KTD2 — Evidence-based WAIT→FAIL discriminator (user-chosen).** WAIT is only valid
+  while there is nothing the redo rule *should* have scored. Discriminator: a box
+  generation with non-empty output (`name` ending `-llm`) whose `startTime` is at/after
+  the redo rule's registration time exists, yet `redo_scores == 0` → **FAIL** (filter
+  broken). Otherwise → **WAIT**. Reuses `enriched`, already computed in `verify()`.
+- **KTD3 — Registration-time signal with a fallback.** Primary: read the redo rule's
+  `createdAt` (or equivalent) from `GET /api/public/unstable/evaluation-rules`. The
+  unstable API's exact field name is an execution-time unknown (probe to confirm). If no
+  timestamp field is returned, fall back to **enriched-existence**: any enriched
+  `<stage>-llm` generation with `redo_scores == 0` → FAIL. This fallback is sound because
+  the enrichment fix (#1866) landed *after* the redo rule was registered (#1854), so an
+  enriched generation is necessarily post-registration.
+- **KTD4 — Verdict logic is a pure function, exit/printing at the boundary.** Extract a
+  testable classifier returning `(verdict, message)`; `verify()` prints and maps verdict
+  → exit. Enables unit tests without HTTP mocking of the whole flow.
+- **KTD5 — Keep `verify()` as a gating CI job.** Demoting to always-exit-0 advisory was
+  the alternative; rejected so a real broken-filter or dead-pipeline state still goes red.
+
+---
+
+## High-Level Technical Design
+
+Verdict → exit-code decision matrix (the classifier's contract):
+
+| Condition (evaluated in order) | Verdict | Exit |
+|---|---|---|
+| No GENERATION observations at all | FAIL | 1 |
+| `redo_scores > 0` | PASS | 0 |
+| Sibling scores exist, `redo_scores == 0`, **and** a post-registration enriched box generation exists | FAIL | 1 |
+| Sibling scores exist, `redo_scores == 0`, no such generation yet | **WAIT** | **0** |
+| Box generations exist but **zero** scores from any evaluator | FAIL | 1 |
+
+Only the bolded WAIT row changes behavior (was exit 1). The new FAIL row (broken redo
+filter) is split out of the old WAIT branch by the discriminator.
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoGens: gens == 0
+    NoGens --> FAIL
+    [*] --> RedoScored: redo_scores > 0
+    RedoScored --> PASS
+    [*] --> SiblingsAlive: siblings > 0, redo == 0
+    SiblingsAlive --> FAIL: enriched gen newer than redo-rule reg
+    SiblingsAlive --> WAIT: nothing scoreable yet (exit 0)
+    [*] --> NoScores: gens exist, 0 scores
+    NoScores --> FAIL
+```
+_Directional — the matrix above is authoritative on ordering._
+
+---
+
+## Implementation Units
+
+### U1. Extract a pure verdict classifier (characterize current behavior)
+
+- **Goal:** Pull the PASS/WAIT/FAIL decision out of `verify()` into a pure function that
+  returns `(verdict, message)`, with `verify()` mapping verdict → exit code. No behavior
+  change yet — WAIT still exits 1 at this step; this unit locks current behavior under test.
+- **Requirements:** Advances KTD4. Prerequisite for the semantics change in U3.
+- **Dependencies:** none.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (extract classifier; `verify()` calls it)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py` (characterization tests)
+- **Approach:** New `_classify_verify(...)` taking already-derived inputs — `gens` count,
+  `box_gens`, `enriched`, `redo_scores`, `other_eval_scores` — and returning a verdict
+  enum/string plus the human message. `verify()` keeps all HTTP/printing; at the end it
+  calls the classifier and maps `{PASS:0, WAIT:1, FAIL:1}` (unchanged codes for now). Keep
+  the existing printed messages verbatim so output is stable.
+- **Execution note:** Characterization-first — write tests that pin the *current*
+  verdict/exit for each branch before extracting, so the refactor is provably behavior-preserving.
+- **Patterns to follow:** existing helper style in the module (`_count`, `_get_list`,
+  small private functions); existing assertions in `pipeline/tests/test_setup_langfuse_evaluators.py`.
+- **Test scenarios:**
+  - No generations → verdict FAIL, exit 1.
+  - `redo_scores > 0` → verdict PASS, exit 0.
+  - Siblings score, `redo_scores == 0` → verdict WAIT, **exit 1** (current behavior pinned).
+  - Box gens exist, zero scores anywhere → verdict FAIL, exit 1.
+  - Classifier is pure: same inputs → same `(verdict, message)`, no network calls.
+- **Verification:** New tests pass; running `--verify` against a live/mocked instance
+  produces byte-identical stdout and the same exit code as before the refactor.
+
+### U2. Surface the redo-rule registration-time signal (with enriched fallback)
+
+- **Goal:** Make available the evidence the discriminator needs: when was the redo rule
+  registered, and which enriched box generations post-date it.
+- **Requirements:** Advances KTD2, KTD3.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (rule-timestamp getter; post-registration filter)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py`
+- **Approach:** Extend the existing `GET /api/public/unstable/evaluation-rules` read
+  (currently `_existing_rule_ids` captures only name→id) to also capture a registration
+  timestamp for the `redo_of_shipped_capability` rule when present. Add a helper that,
+  given `enriched` generations and the registration timestamp, returns whether any
+  enriched generation has `startTime >= registered_at`. **Fallback (KTD3):** if no
+  timestamp field is present in the rules payload, treat *any* enriched `<stage>-llm`
+  generation as post-registration.
+- **Patterns to follow:** `_existing_rule_ids()` (same GET, same payload-shape tolerance
+  with `data`/`evaluationRules` fallbacks); `startTime` access as already used in `verify()`.
+- **Test scenarios:**
+  - Rules payload includes `createdAt` for the redo rule → getter returns it.
+  - Rules payload omits a timestamp field → getter returns `None`; discriminator helper
+    falls back to enriched-existence.
+  - Enriched generation `startTime` after registration → "post-registration scoreable gen" True.
+  - Enriched generation `startTime` before registration (timestamp path) → False (still WAIT).
+  - No enriched generations → False regardless of timestamp.
+- **Verification:** Helpers return correct booleans/timestamps across the matrix above;
+  no live redo score required to exercise them (inputs injected).
+- **Deferred to implementation:** exact timestamp field name on the unstable rules
+  endpoint — confirm via `--probe` against the live instance before finalizing the getter.
+
+### U3. Apply correct exit semantics + the WAIT→FAIL discriminator
+
+- **Goal:** WAIT exits 0; a broken-redo-filter state (post-registration enriched gen,
+  zero redo scores) becomes a distinct FAIL at exit 1.
+- **Requirements:** Advances KTD1, KTD2, KTD5. Closes the pulse followup.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `pipeline/evals/setup_langfuse_evaluators.py` (`_classify_verify` verdict + exit map)
+  - `pipeline/tests/test_setup_langfuse_evaluators.py`
+- **Approach:** In the classifier, split the old "siblings alive, redo == 0" WAIT branch
+  using the U2 signal: post-registration enriched generation present → FAIL with a message
+  naming the broken-filter suspicion; else → WAIT. Change the exit map to
+  `{PASS:0, WAIT:0, FAIL:1}`. Update the WAIT message to state plainly that this is a
+  non-failing "awaiting first post-registration generation" state.
+- **Patterns to follow:** existing message tone/format in `verify()` (e.g.
+  `VERIFY: WAIT — ...`, `VERIFY: FAIL — ...`).
+- **Test scenarios:**
+  - Siblings score, redo 0, **no** post-registration enriched gen → WAIT, **exit 0** (the fix).
+  - Siblings score, redo 0, **post-registration enriched gen exists** → FAIL, exit 1,
+    message cites broken redo filter.
+  - `redo_scores > 0` → PASS, exit 0 (unchanged).
+  - No generations → FAIL, exit 1 (unchanged).
+  - Box gens exist, zero scores anywhere → FAIL, exit 1 (unchanged).
+  - Timestamp-unavailable fallback: enriched gen present, redo 0 → FAIL (fallback treats
+    enriched as post-registration).
+- **Verification:** `--verify` against the current live state (siblings scoring, redo 0,
+  box output still empty per #1866 not-yet-redeployed) returns **WAIT exit 0**; the
+  `Register Langfuse Evaluators` workflow goes green on a verify dispatch. A subsequent
+  pulse shows zero `Register Langfuse Evaluators` failures attributable to WAIT.
+
+---
+
+## Risks & Dependencies
+
+- **R1 — WAIT masking a real stall.** If the redo rule's filter is subtly wrong *and* no
+  enriched generation ever appears (box redeploy of #1866 still pending), the discriminator
+  stays in WAIT/green indefinitely and the broken filter is invisible. Mitigation: the
+  deferred wall-clock staleness cap; for now, the verify message still prints the empty-output
+  diagnostic, and the box redeploy that lands #1866 will produce enriched gens that then
+  exercise the FAIL path. Accepted for this scope.
+- **R2 — Unstable API field drift.** The rules endpoint is the v3 *unstable* API; a
+  timestamp field may be absent or renamed. Mitigation: KTD3 fallback to enriched-existence;
+  `--probe` before finalizing (U2).
+- **Dependency:** none external; single module + its test file. No new pip deps
+  (stdlib-only constraint of the workflow preserved).
+
+---
+
+## Sources & Research
+
+- `docs/pulse-reports/2026-06-20_00-10.md` — followup #1 (origin signal).
+- Failing run logs (2026-06-19 `Register Langfuse Evaluators`, MODE=verify) — confirmed
+  all 9 reds are WAIT-branch exit 1, not 409.
+- Memory: `[[feedback_create_endpoint_409_breaks_reapply]]` (the apply-path bug already
+  fixed — confirms 409 is not the live defect), `[[feedback_langfuse_evaluators_score_empty_output]]`
+  (#1866 substrate fix, out of scope here), `[[project_langfuse_evaluators]]`.
+- No external research: internal unstable API, fully codebase-local; no external option set.

--- a/docs/pulse-reports/2026-06-20_00-10.md
+++ b/docs/pulse-reports/2026-06-20_00-10.md
@@ -1,0 +1,36 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-18 21:53Z → 2026-06-19 21:53Z (24h, 15m buffer)
+**Surfaces:** meta-repo `ai-pipeline-template` · seed product `atvirokodosprendimai/wgmesh`
+
+## Headlines
+
+- Product convergence flat: **0 `impl:`/`spec:` product PRs merged** in the seed repo this window. Only ship to wgmesh was #770 `Create pp.html` (privacy-policy page) — not convergence-engine output.
+- Meta-pipeline churned **43 self-maintenance PRs** (heal/loop/supervisor/audit/eval-fix). Motion ≠ product.
+- **Action-success KPI: FAIL.** 16 failed runs in window; 9 are the Langfuse evaluator 409 re-apply bug, still live (OPEN).
+
+## Usage (product convergence — seed repo)
+
+- Primary (`product_pr_merged`): **0** impl/spec merges in window.
+- Value (`autonomous_impl_merge_clean`): **0** — nothing to score.
+- Completions (`paid_customer_added`): **no data** — Polar webhook not integrated; chimney endpoint live (chimney:ok). Milestone "1 paying customer / 2026-05-31" still unconfirmed here.
+- Seed pipeline in flight: spec PRs #771–#777 building (Status Checks green); none merged in window.
+- Stuck issues (seed): needs-human → #778 Stripe pricing, #775 stargazer outreach, #759 zero-subscriber. copilot-triaging → #752/#753/#773/#774. Real blockers remain human-side (pricing decision + outreach send), matching prior pulses.
+
+## System performance
+
+- Meta runs in window: **466**, failed **16**:
+  - `Register Langfuse Evaluators` ×9 — **OPEN**. 409 `name_conflict` on re-apply (create-only script not idempotent). "PATCH on 409" fix merged earlier but still red — fix incomplete or new rule. See [[feedback_create_endpoint_409_breaks_reapply]].
+  - `CI` ×4 — **TRANSIENT**. Superseded/flaky check runs; the heal/supervisor/constitution PRs they sit on all merged green (#1860, #1876, #1878, constitution).
+  - `Control Replay — Capabilities Grounding` ×2 — synthetic control-replay (new #1850); can't force causal contrast on a synthetic snapshot — non-blocking verification noise.
+  - `Pipeline Error Rate` ×1 — the KPI alarm itself firing on the above; meta-signal, not a new defect.
+- Seed runs in window: **30**, failed **1**: `Deploy Dashboard to GitHub Pages` @07:26 (tied to #770 pp.html merge) — recheck; likely transient gh-pages deploy.
+- Self-heal: checks_run 896, issues_healed_total 35 (cum). Last run: actions_taken 0, errors 0, 9 stale-copilot skipped (box-aware, #1876). idle=false, 22 open PRs, last dispatch 2026-06-16.
+
+## Followups
+
+1. **Fix `Register Langfuse Evaluators` for real** — 9 red runs/day. Confirm the 409→PATCH path covers evaluation-*rules*, not just evaluators. Highest-frequency OPEN defect → fails the KPI.
+2. **Convergence engine produced no product PRs** in 24h while 43 meta PRs merged. Verify the box is dispatching seed work (last dispatch 06-16, 3+ days stale) vs. just self-maintaining.
+3. **3 `audit: strategy drift` PRs dwelling** unmerged in meta-repo (#1733 ~5.5d, #1767 ~3d, #1862 fresh). None past 7d SLA yet, but the drift loop isn't closing — founder apply needed.
+4. **Human-side revenue blockers** unmoved: #778 pricing decision, #775 outreach send. No autonomous path; needs operator.
+5. Re-check seed `Deploy Dashboard` failure — confirm TRANSIENT or chase.

--- a/pipeline/evals/setup_langfuse_evaluators.py
+++ b/pipeline/evals/setup_langfuse_evaluators.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from datetime import datetime, timezone
 import json
 import os
 import sys
@@ -294,6 +295,12 @@ RULES = [
 ]
 
 _UNSTABLE = "/api/public/unstable"
+_REDO_RULE_NAME = "rule_redo_of_shipped_capability"
+_RULE_TIMESTAMP_KEYS = (
+    "createdAt",
+    "created_at",
+    "timestamp",
+)
 
 
 def _auth_header() -> str:
@@ -340,6 +347,104 @@ def _get_list(path: str) -> list:
         return []
     data = payload.get("data")
     return data if isinstance(data, list) else []
+
+
+def _parse_langfuse_time(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _post_registration_enriched_gen(
+    enriched: list, registered_at: str | None
+) -> object | None:
+    scoreable = [
+        gen
+        for gen in enriched
+        if isinstance(gen, dict)
+        and str(gen.get("name", "")).endswith("-llm")
+    ]
+    if not scoreable:
+        return None
+    if registered_at is None:
+        return scoreable[0]
+    registered = _parse_langfuse_time(registered_at)
+    if registered is None:
+        return scoreable[0]
+    for gen in scoreable:
+        started = _parse_langfuse_time(gen.get("startTime"))
+        if started is not None and started >= registered:
+            return gen
+    return None
+
+
+def _has_post_registration_enriched_box_generation(
+    enriched: list, registered_at: str | None
+) -> bool:
+    return _post_registration_enriched_gen(enriched, registered_at) is not None
+
+
+_VERIFY_EXIT_CODES = {"PASS": 0, "WAIT": 0, "FAIL": 1}
+
+
+def _verify_exit_code(verdict: str) -> int:
+    return _VERIFY_EXIT_CODES[verdict]
+
+
+def _classify_verify(
+    *,
+    gens_count: int,
+    box_gens: list,
+    enriched: list,
+    redo_scores: int,
+    other_eval_scores: int,
+    post_registration_enriched_gen: object | None,
+) -> tuple[str, str]:
+    if not gens_count:
+        return (
+            "FAIL",
+            "VERIFY: NO GENERATION observations in Langfuse — the box is not emitting "
+            "generation traces, so the evaluator has nothing to score (wired but off the "
+            "execution path). Instrument the box's LLM calls before this eval can fire.",
+        )
+    if redo_scores > 0:
+        return (
+            "PASS",
+            f"VERIFY: PASS — {redo_scores} redo_of_shipped_capability score(s) on real "
+            "generations. Evaluator is firing end-to-end.",
+        )
+    if other_eval_scores > 0:
+        if post_registration_enriched_gen:
+            return (
+                "FAIL",
+                f"VERIFY: FAIL — the score pipeline is ALIVE ({other_eval_scores} score(s) from sibling "
+                "evaluators), and a post-registration enriched box generation exists, but "
+                "redo_of_shipped_capability still has zero scores. The redo rule's "
+                "GENERATION filter appears broken; inspect the rule filter/mapping before "
+                "trusting this evaluator.",
+            )
+        return (
+            "WAIT",
+            f"VERIFY: WAIT — the score pipeline is ALIVE ({other_eval_scores} score(s) "
+            "from sibling evaluators), but no redo score yet. This is a non-failing "
+            "awaiting-the-first-post-registration-generation state; re-run verify after "
+            "the next box generation.",
+        )
+    return (
+        "FAIL",
+        "VERIFY: FAIL — box generations exist but NO evaluator (redo or sibling) has any "
+        "score. The eval-rule -> score path is not firing at all; fix that before trusting "
+        "any judge. Check the Langfuse default eval-model connection and rule enablement.",
+    )
 
 
 def verify() -> int:
@@ -415,34 +520,20 @@ def verify() -> int:
     print(f"redo_of_shipped_capability scores: {redo_scores}")
 
     print("---")
-    if not gens:
-        print(
-            "VERIFY: NO GENERATION observations in Langfuse — the box is not emitting "
-            "generation traces, so the evaluator has nothing to score (wired but off the "
-            "execution path). Instrument the box's LLM calls before this eval can fire."
-        )
-        return 1
-    if redo_scores > 0:
-        print(
-            f"VERIFY: PASS — {redo_scores} redo_of_shipped_capability score(s) on real "
-            "generations. Evaluator is firing end-to-end."
-        )
-        return 0
-    if other_eval_scores > 0:
-        print(
-            f"VERIFY: WAIT — the score pipeline is ALIVE ({other_eval_scores} score(s) "
-            "from sibling evaluators), but no redo score yet. Langfuse rules score only "
-            "generations created AFTER the rule was registered; re-run verify after the "
-            "next box generation. If it stays zero while siblings keep scoring, the redo "
-            "rule's GENERATION filter is the suspect."
-        )
-        return 1
-    print(
-        "VERIFY: FAIL — box generations exist but NO evaluator (redo or sibling) has any "
-        "score. The eval-rule -> score path is not firing at all; fix that before trusting "
-        "any judge. Check the Langfuse default eval-model connection and rule enablement."
+    redo_registered_at = _redo_rule_registered_at()
+    post_registration_enriched_gen = _post_registration_enriched_gen(
+        enriched, redo_registered_at
     )
-    return 1
+    verdict, message = _classify_verify(
+        gens_count=len(gens),
+        box_gens=box_gens,
+        enriched=enriched,
+        redo_scores=redo_scores,
+        other_eval_scores=other_eval_scores,
+        post_registration_enriched_gen=post_registration_enriched_gen,
+    )
+    print(message)
+    return _verify_exit_code(verdict)
 
 
 def _existing_names(path: str, key: str = "data") -> set[str]:
@@ -458,10 +549,10 @@ def _existing_names(path: str, key: str = "data") -> set[str]:
     return {str(i.get("name")) for i in items if isinstance(i, dict) and i.get("name")}
 
 
-def _existing_rule_ids() -> dict[str, str]:
+def _existing_rule_items() -> list:
     status, payload = _request("GET", f"{_UNSTABLE}/evaluation-rules")
     if status != 200 or not isinstance(payload, dict):
-        return {}
+        return []
     items = (
         payload.get("data")
         or payload.get("evaluators")
@@ -469,12 +560,32 @@ def _existing_rule_ids() -> dict[str, str]:
         or []
     )
     if not isinstance(items, list):
+        return []
+    return items
+
+
+def _existing_rule_ids() -> dict[str, str]:
+    items = _existing_rule_items()
+    if not items:
         return {}
     return {
         str(item["name"]): str(item["id"])
         for item in items
         if isinstance(item, dict) and item.get("name") and item.get("id")
     }
+
+
+def _redo_rule_registered_at() -> str | None:
+    for item in _existing_rule_items():
+        if (
+            isinstance(item, dict)
+            and str(item.get("name", "")) == _REDO_RULE_NAME
+        ):
+            for key in _RULE_TIMESTAMP_KEYS:
+                value = item.get(key)
+                if value:
+                    return str(value)
+    return None
 
 
 def apply(dry_run: bool) -> int:

--- a/pipeline/tests/test_setup_langfuse_evaluators.py
+++ b/pipeline/tests/test_setup_langfuse_evaluators.py
@@ -14,10 +14,13 @@ from evals.setup_langfuse_evaluators import (  # noqa: E402
     EVALUATORS,
     RULES,
     _BOOLEAN,
+    _classify_verify,
     _GEN_FILTER,
     _JUDGE_MODEL,
     _NUMERIC,
+    _post_registration_enriched_gen,
     _PIKAPODS_SNAPSHOT,
+    _redo_rule_registered_at,
     _SHIPPED_SNAPSHOT,
     main,
 )
@@ -236,15 +239,239 @@ def test_apply_keeps_genuine_rule_failure(monkeypatch) -> None:
     assert mod.apply(dry_run=False) > 0
 
 
-def _verify_request(gens: list, scores: list):
+def _verify_request(gens: list, scores: list, rules: list | None = None):
     def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
         if "observations" in path:
             return 200, {"data": gens}
         if "scores" in path:
             return 200, {"data": scores}
+        if "evaluation-rules" in path:
+            return 200, {"data": rules or []}
         return 200, {"data": []}
 
     return fake_request
+
+
+@pytest.mark.unit
+def test_classify_verify_no_generations_fails() -> None:
+    verdict, message = _classify_verify(
+        gens_count=0,
+        box_gens=[],
+        enriched=[],
+        redo_scores=0,
+        other_eval_scores=0,
+        post_registration_enriched_gen=False,
+    )
+
+    assert verdict == "FAIL"
+    assert (
+        message
+        == "VERIFY: NO GENERATION observations in Langfuse — the box is not emitting "
+        "generation traces, so the evaluator has nothing to score (wired but off the "
+        "execution path). Instrument the box's LLM calls before this eval can fire."
+    )
+    assert mod._verify_exit_code(verdict) == 1
+
+
+@pytest.mark.unit
+def test_classify_verify_redo_score_passes() -> None:
+    verdict, message = _classify_verify(
+        gens_count=1,
+        box_gens=[],
+        enriched=[],
+        redo_scores=2,
+        other_eval_scores=0,
+        post_registration_enriched_gen=True,
+    )
+
+    assert verdict == "PASS"
+    assert (
+        message
+        == "VERIFY: PASS — 2 redo_of_shipped_capability score(s) on real "
+        "generations. Evaluator is firing end-to-end."
+    )
+    assert mod._verify_exit_code(verdict) == 0
+
+
+@pytest.mark.unit
+def test_classify_verify_waits_without_post_registration_generation() -> None:
+    verdict, message = _classify_verify(
+        gens_count=1,
+        box_gens=[{"name": "triage-llm"}],
+        enriched=[],
+        redo_scores=0,
+        other_eval_scores=3,
+        post_registration_enriched_gen=False,
+    )
+
+    assert verdict == "WAIT"
+    assert (
+        message
+        == "VERIFY: WAIT — the score pipeline is ALIVE (3 score(s) "
+        "from sibling evaluators), but no redo score yet. This is a non-failing "
+        "awaiting-the-first-post-registration-generation state; re-run verify after "
+        "the next box generation."
+    )
+    assert mod._verify_exit_code(verdict) == 0
+
+
+@pytest.mark.unit
+def test_classify_verify_fails_when_redo_filter_appears_broken() -> None:
+    verdict, message = _classify_verify(
+        gens_count=1,
+        box_gens=[{"name": "triage-llm"}],
+        enriched=[{"name": "triage-llm", "output": "ship this"}],
+        redo_scores=0,
+        other_eval_scores=3,
+        post_registration_enriched_gen=True,
+    )
+
+    assert verdict == "FAIL"
+    assert (
+        message
+        == "VERIFY: FAIL — the score pipeline is ALIVE (3 score(s) from sibling "
+        "evaluators), and a post-registration enriched box generation exists, but "
+        "redo_of_shipped_capability still has zero scores. The redo rule's "
+        "GENERATION filter appears broken; inspect the rule filter/mapping before "
+        "trusting this evaluator."
+    )
+    assert mod._verify_exit_code(verdict) == 1
+
+
+@pytest.mark.unit
+def test_classify_verify_no_scores_fails() -> None:
+    verdict, message = _classify_verify(
+        gens_count=1,
+        box_gens=[{"name": "triage-llm"}],
+        enriched=[],
+        redo_scores=0,
+        other_eval_scores=0,
+        post_registration_enriched_gen=False,
+    )
+
+    assert verdict == "FAIL"
+    assert (
+        message
+        == "VERIFY: FAIL — box generations exist but NO evaluator (redo or sibling) has any "
+        "score. The eval-rule -> score path is not firing at all; fix that before trusting "
+        "any judge. Check the Langfuse default eval-model connection and rule enablement."
+    )
+    assert mod._verify_exit_code(verdict) == 1
+
+
+@pytest.mark.unit
+def test_classify_verify_is_pure(monkeypatch) -> None:
+    def fail_request(*_args, **_kwargs):
+        raise AssertionError("classifier must not perform network I/O")
+
+    monkeypatch.setattr(mod, "_request", fail_request)
+    args = {
+        "gens_count": 1,
+        "box_gens": [{"name": "triage-llm"}],
+        "enriched": [],
+        "redo_scores": 0,
+        "other_eval_scores": 3,
+        "post_registration_enriched_gen": False,
+    }
+
+    assert _classify_verify(**args) == _classify_verify(**args)
+
+
+@pytest.mark.unit
+def test_redo_rule_registered_at_reads_created_at(monkeypatch) -> None:
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        assert method == "GET"
+        assert path == f"{mod._UNSTABLE}/evaluation-rules"
+        return (
+            200,
+            {
+                "data": [
+                    {
+                        "name": "rule_redo_of_shipped_capability",
+                        "id": "rule-id",
+                        "createdAt": "2026-06-20T01:00:00Z",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert _redo_rule_registered_at() == "2026-06-20T01:00:00Z"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("timestamp_key", ["createdAt", "created_at", "timestamp"])
+def test_redo_rule_registered_at_accepts_common_timestamp_keys(
+    monkeypatch, timestamp_key: str
+) -> None:
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        return (
+            200,
+            {
+                "evaluationRules": [
+                    {
+                        "name": "rule_redo_of_shipped_capability",
+                        "id": "rule-id",
+                        timestamp_key: "2026-06-20T01:00:00Z",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert _redo_rule_registered_at() == "2026-06-20T01:00:00Z"
+
+
+@pytest.mark.unit
+def test_redo_rule_registered_at_returns_none_without_timestamp(monkeypatch) -> None:
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        return (
+            200,
+            {
+                "data": [
+                    {
+                        "name": "rule_redo_of_shipped_capability",
+                        "id": "rule-id",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert _redo_rule_registered_at() is None
+
+
+@pytest.mark.unit
+def test_post_registration_enriched_gen_after_registration() -> None:
+    enriched = [{"name": "triage-llm", "startTime": "2026-06-20T01:00:01Z"}]
+
+    assert (
+        _post_registration_enriched_gen(enriched, "2026-06-20T01:00:00Z")
+        is enriched[0]
+    )
+
+
+@pytest.mark.unit
+def test_post_registration_enriched_gen_before_registration() -> None:
+    enriched = [{"name": "triage-llm", "startTime": "2026-06-20T00:59:59Z"}]
+
+    assert _post_registration_enriched_gen(enriched, "2026-06-20T01:00:00Z") is None
+
+
+@pytest.mark.unit
+def test_post_registration_enriched_gen_timestamp_absent_fallback() -> None:
+    enriched = [{"name": "triage-llm", "startTime": "2026-06-20T00:59:59Z"}]
+
+    assert _post_registration_enriched_gen(enriched, None) is enriched[0]
+
+
+@pytest.mark.unit
+def test_post_registration_enriched_gen_no_enriched_generations() -> None:
+    assert _post_registration_enriched_gen([], None) is None
+    assert _post_registration_enriched_gen([], "2026-06-20T01:00:00Z") is None
 
 
 @pytest.mark.unit
@@ -287,5 +514,67 @@ def test_verify_waits_when_siblings_score_but_redo_absent(monkeypatch) -> None:
             scores=[{"name": "rule_growth_issue_quality", "value": 0.8}],
         ),
     )
-    # pipeline alive but redo not yet scored — non-zero, surfaces the WAIT state
+    # pipeline alive but no scoreable redo generation yet — WAIT is non-failing
+    assert mod.verify() == 0
+
+
+@pytest.mark.unit
+def test_verify_fails_when_siblings_score_but_redo_filter_appears_broken(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_request",
+        _verify_request(
+            gens=[
+                {
+                    "startTime": "2026-06-20T10:01:00Z",
+                    "name": "triage-llm",
+                    "traceId": "x",
+                    "output": "real issue text",
+                }
+            ],
+            scores=[{"name": "rule_growth_issue_quality", "value": 0.8}],
+            rules=[
+                {
+                    "name": "rule_redo_of_shipped_capability",
+                    "createdAt": "2026-06-20T10:00:00Z",
+                }
+            ],
+        ),
+    )
+
     assert mod.verify() == 1
+
+
+@pytest.mark.unit
+def test_verify_waits_when_enriched_generation_predates_rule(monkeypatch) -> None:
+    def fake_request(method: str, path: str, body=None) -> tuple[int, object]:
+        if "observations" in path:
+            return 200, {
+                "data": [
+                    {
+                        "startTime": "2026-06-20T09:59:00Z",
+                        "name": "triage-llm",
+                        "traceId": "x",
+                        "output": "real issue text",
+                    }
+                ]
+            }
+        if "scores" in path:
+            return 200, {"data": [{"name": "rule_growth_issue_quality", "value": 0.8}]}
+        if "evaluation-rules" in path:
+            return 200, {
+                "data": [
+                    {
+                        "id": "rule-id",
+                        "name": "rule_redo_of_shipped_capability",
+                        "createdAt": "2026-06-20T10:00:00Z",
+                    }
+                ]
+            }
+        return 200, {"data": []}
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+
+    assert mod.verify() == 0


### PR DESCRIPTION
## Problem

`Register Langfuse Evaluators` ran red 9× in 24h (2026-06-19). Every red was a manual `workflow_dispatch` of **`--verify`**, not the apply path. `verify()` returned exit `1` in its **WAIT** branch — *"score pipeline alive (sibling evaluators scoring), but redo evaluator hasn't seen a post-registration generation yet; re-run later."* WAIT is an expected, non-terminal state, but CI reads any non-zero exit as failure, so each poll painted the job red and the Action-Success KPI counted it as a breach.

The apply path was **already** 409-idempotent (#1813/#1858) — the "409 re-apply" framing was stale. The real defect is exit-code semantics in `--verify`.

## Fix

Map verdicts to exit codes deliberately: **PASS → 0, WAIT → 0, FAIL → 1**. WAIT stays honest with an evidence-based discriminator — WAIT degrades to FAIL once a box generation the redo rule *should* have scored exists (enriched `<stage>-llm` output created at/after the redo rule's registration) yet `redo_scores == 0` (broken filter, not "too early").

Three units, TDD:
- **U1** — extracted pure `_classify_verify(...)` → `(verdict, message)`; `verify()` keeps HTTP/printing, maps verdict → exit. Characterization-pinned current behavior first.
- **U2** — `_redo_rule_registered_at()` (tries `createdAt`/`created_at`/`timestamp`, tolerates absence) + `_post_registration_enriched_gen(...)`. Fallback: no timestamp → treat any enriched gen as post-registration (enrichment #1866 landed after redo rule #1854).
- **U3** — flipped exit map to `{PASS:0, WAIT:0, FAIL:1}`; split old WAIT branch via the discriminator.

## Out of scope

- Empty-`{{output}}` box-generation substrate (#1866, awaiting box redeploy) — `verify()` still reports it.
- Apply-path 409 (already idempotent).

## Test plan

- `python -m pytest pipeline/tests/test_setup_langfuse_evaluators.py -q` → **35 passed** (verified locally, CI-parity from repo root).
- Tests assert: WAIT (no post-registration gen) → exit 0; post-registration enriched gen + 0 redo scores → FAIL exit 1; PASS/no-gens/zero-scores unchanged.
- [ ] CI green on this PR.
- [ ] Post-merge: dispatch `Register Langfuse Evaluators` mode=verify → expect **green** (WAIT exit 0) against current live state.

Plan: `docs/plans/2026-06-20-001-fix-langfuse-verify-exit-semantics-plan.md`
Origin: `docs/pulse-reports/2026-06-20_00-10.md` followup #1.