### PR TITLE
feat(pulse): open-item aging KPI — 0 open issues/PRs aged >48h (both repos)

### DIFF
--- a/.compound-engineering/config.local.yaml
+++ b/.compound-engineering/config.local.yaml
@@ -49,13 +49,31 @@ pulse_lookback_default: 24h
 #                           Open PRs are not "processed"; they are work-in-flight or dwell.
 #   pr_dwell_violations   = open PRs older than pulse_pr_processing_sla_days with no
 #                           review/merge action — the unprocessed-defect count.
-pulse_metric_sources: paid_customers=chimney-html,autonomous_ship_rate=seed-repo-pr-data,lead_time_hours=seed-repo-pr-data,spec_coverage=seed-repo-pr-data,self_heal_rate=company/pipeline-health-state.json,active_stuck_issues=seed-repo-issues,cycle_time_to_revenue=polar,supervisor_rank_state=company/supervisor-rank-state.json,pr_processing_rate=meta-repo-pr-data,pr_dwell_violations=meta-repo-pr-data
+#   aged_open_items       = open issues AND open PRs whose age (now - createdAt) exceeds
+#                           pulse_open_age_sla_hours, in EITHER repo, with no terminal
+#                           action. The unprocessed-defect count at 48h granularity —
+#                           tighter than pr_dwell_violations (7d, PRs only) and also
+#                           covers issues. Target 0.
+pulse_metric_sources: paid_customers=chimney-html,autonomous_ship_rate=seed-repo-pr-data,lead_time_hours=seed-repo-pr-data,spec_coverage=seed-repo-pr-data,self_heal_rate=company/pipeline-health-state.json,active_stuck_issues=seed-repo-issues,cycle_time_to_revenue=polar,supervisor_rank_state=company/supervisor-rank-state.json,pr_processing_rate=meta-repo-pr-data,pr_dwell_violations=meta-repo-pr-data,aged_open_items=both-repos-issues-and-prs
 pulse_pending_metrics: cycle_time_to_revenue,spec_coverage
 # --- PR-processing KPI (added 2026-06-05) ---
 # Intent: open PRs must be ACTED ON per the goal, never bulk-closed to clear backlog.
 # Every disposition needs a goal-aligned reason. Dwelling = defect, not idle.
 pulse_pr_processing_kpi: enabled
 pulse_pr_processing_sla_days: 7
+
+# --- Open-item aging KPI (added 2026-06-20) ---
+# Every OPEN issue AND OPEN pull request must reach a terminal action (merge, or
+# close-with-goal-reason) within 48h of creation. Anything open and aged > 48h is a
+# tracked breach to drive to zero — never normalised as backlog. SCOPE = BOTH repos
+# (meta-repo AND seed via pulse_seed_product_repo), mirroring the action-success KPI
+# scope so a seed-repo pileup can't hide behind a healthy meta-repo. Age uses createdAt
+# (not updatedAt — a bumped label must not reset the clock). A window is clean only when
+# aged_open_items == 0; if > 0, the pulse lists each aged item with a disposition.
+pulse_open_age_kpi: enabled
+pulse_open_age_sla_hours: 48
+pulse_open_age_target: 0
+pulse_open_age_scope: meta-repo,seed-repo
 
 # --- Action-success KPI (added 2026-06-06) ---
 # Andon/jidoka: EVERY autonomous action the pipeline attempts must succeed.

--- a/docs/pulse-reports/2026-06-20_00-10.md
+++ b/docs/pulse-reports/2026-06-20_00-10.md
@@ -27,6 +27,14 @@
 - Seed runs in window: **30**, failed **1**: `Deploy Dashboard to GitHub Pages` @07:26 (tied to #770 pp.html merge) — recheck; likely transient gh-pages deploy.
 - Self-heal: checks_run 896, issues_healed_total 35 (cum). Last run: actions_taken 0, errors 0, 9 stale-copilot skipped (box-aware, #1876). idle=false, 22 open PRs, last dispatch 2026-06-16.
 
+## Open-item aging KPI (new — target 0 aged >48h, both repos)
+
+**aged_open_items = 34** (createdAt-based, >48h). **Breach.**
+
+- meta-repo: 2 PRs (#1767, #1733 — strategy-drift audits), 2 issues (#1599 GHA-retire, #934 supervisor clogs).
+- seed wgmesh: **17 PRs + 13 issues**. The 17 PRs are spec/fix pairs from 2026-06-17 (#730–#757) — the box generated the whole growth backlog but **nothing merged**; they've dwelled ~2.5d. Plus 13 issues, several `needs-human` (#748, #727, pricing/outreach).
+- Root: same stall as Followup #2 — convergence engine emitted work then stopped converging (last dispatch 2026-06-16). The seed PR pileup is the unprocessed-defect signature this KPI is built to catch.
+
 ## Followups
 
 1. **Fix `Register Langfuse Evaluators` for real** — 9 red runs/day. Confirm the 409→PATCH path covers evaluation-*rules*, not just evaluators. Highest-frequency OPEN defect → fails the KPI.


### PR DESCRIPTION
## What

Adds an **open-item aging KPI** to the pulse config: every open issue AND open PR must reach a terminal action (merge, or close-with-goal-reason) within **48h** of creation. Anything open and aged >48h is a tracked breach to drive to zero.

```yaml
pulse_open_age_kpi: enabled
pulse_open_age_sla_hours: 48
pulse_open_age_target: 0
pulse_open_age_scope: meta-repo,seed-repo
```

## Why

- Tighter granularity than the existing `pr_dwell_violations` (7d, PRs only) and — critically — **also covers issues**, which had no aging KPI.
- **Scope = both repos** (meta + seed via `pulse_seed_product_repo`), mirroring the action-success KPI so a seed-repo pileup can't hide behind a healthy meta-repo.
- Age uses **createdAt**, not updatedAt — a bumped label must not reset the clock.

## Current value (recorded in `docs/pulse-reports/2026-06-20_00-10.md`)

**aged_open_items = 34** — breach:
- meta-repo: 2 PRs (strategy-drift audits #1767/#1733) + 2 issues (#1599, #934)
- seed wgmesh: **17 PRs + 13 issues** — the box generated the whole growth backlog (#730–#757, 2026-06-17) but nothing merged; the convergence engine emitted work then stopped converging (last dispatch 2026-06-16). This pileup is exactly the unprocessed-defect signature the KPI is built to catch.

## Test plan

- [x] Config parses (flat `pulse_*` keys, consistent with existing KPI blocks).
- [x] Current value computed live across both repos (createdAt < now-48h).
- [ ] Next pulse run surfaces `aged_open_items` and drives disposition.