### PR TITLE
fix(langchain): bound tool output, finish on expected diff, configurable iter cap

### DIFF
--- a/docs/plans/2026-06-20-002-fix-langchain-implement-runner-stall-plan.md
+++ b/docs/plans/2026-06-20-002-fix-langchain-implement-runner-stall-plan.md
@@ -1,0 +1,227 @@
+---
+title: "fix: LangChain implement runner — context runaway + no completion detection"
+type: fix
+date: 2026-06-20
+depth: standard
+origin: none (diagnosis from box journal; pulse 2026-06-20_02-27 followup #2 — convergence stall)
+---
+
+# fix: LangChain implement runner — bound context + finish on expected output
+
+**Target file:** `pipeline/wgmesh_pipeline/langchain_agent/runner.py` (+ tests). Deploys to the
+Hetzner box via `update-pipeline-box` after merge.
+
+## Summary
+
+The autobox convergence engine is stalled: **every spec→impl advance fails** with
+`RuntimeError: langchain agent reached max iterations (25)` at
+`graph/nodes/implement.py:55`. Box journal shows the implement agent burning **800K–1M input
+tokens per attempt** (glm-4.7, tiny output) before hitting the cap. 17 growth issues
+(#732/#734/#745/#752/#779…) are frozen at `spec_ready`; 0 product PRs merge.
+
+Root cause is in the ReAct loop in `runner.py` (`run_recipe`):
+1. **No context bounding** — every tool result (`read_file`, `run_bash`, `search` all return
+   unbounded text) is appended verbatim as a `ToolMessage`; `messages` is never pruned, so
+   context balloons to ~1M tokens. At that size glm-4.7 degrades and never emits a terminal
+   (no-tool-call) message → loops to the cap.
+2. **No completion-on-expected-output** — the runner only checks `output_path.exists()`
+   *after* the loop ends (line 149). The recipe's job is to write the unified diff to
+   `diff_file`; once it exists the work is done, but the runner keeps looping waiting for the
+   model to volunteer a no-tool-call turn.
+3. **Flat `MAX_ITERATIONS = 25`** — too tight for a real implementation, but raising it
+   without (1) just burns more tokens.
+
+The fix bounds tool-output size, finishes as soon as the expected deliverable is written, and
+makes the iteration cap configurable with a higher default.
+
+## Problem Frame
+
+- **Observed:** `advance #<n>@spec_ready failed: langchain agent reached max iterations (25)`,
+  repeating; `tracing generation emitted stage=implement model=glm-4.7 tokens=820606/674`.
+- **Box is healthy** — ticking every ~5 min, IP 204.168.186.39; this is purely the implement
+  executor.
+- **Operator decision (2026-06-20):** stay on `EXECUTOR=langchain` (no goose revert); fix the
+  runner.
+- **Goal:** the implement agent completes a normal implementation well within the cap, with
+  bounded context, and the spec→impl→PR→merge flow resumes.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- The ReAct loop in `pipeline/wgmesh_pipeline/langchain_agent/runner.py`: tool-output bounding,
+  completion-on-expected-output, configurable iteration cap.
+- Tests in `pipeline/tests/test_langchain_agent_runner.py`.
+
+**Out of scope**
+- The shadow-mode control-loop modules (`selfheal`/`supervisor` `*_LIVE` flags) — separate
+  parked gate, not the convergence blocker.
+- `observation` module `LLM assessment failed` — separate live-module error, own follow-up.
+- The orphaned PR-merge lane (GHA `Bot PR Review and Merge` disabled) — relevant once impls
+  start landing again; revisit after this fix produces real impl PRs.
+- Goose executor path (`goose/runner.py`) — unchanged; operator chose to stay on langchain.
+- Prompt/recipe wording (`wgmesh-implementation.yaml`) — only touch if testing shows the agent
+  needs an explicit "write the diff then stop" instruction (see Open Questions).
+
+### Deferred to Follow-Up Work
+- Smarter context management (summarise old tool turns vs. truncate) if truncation proves
+  insufficient.
+- Per-tool output caps inside `tools.py` (vs. the single runner-side cap chosen here).
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Cap tool output at the runner chokepoint, not in each tool.** All tool results pass
+  through one place (the `ToolMessage` append, runner.py ~117). Truncate there → executor-wide,
+  one code path, tools stay pure. Head+tail truncation with an explicit
+  `…[truncated N chars]…` marker so the model knows output was clipped.
+- **KTD2 — Finish as soon as the expected output exists.** After each tool-dispatch round,
+  check `output_path.exists()` and non-empty; if so, emit usage and return `ok=True`. The diff
+  file is the deliverable contract (`implement_node` passes `expected_output=diff_rel`); its
+  presence is a more reliable completion signal than the model volunteering no tool call.
+- **KTD3 — Configurable cap, higher default.** Replace the flat `MAX_ITERATIONS = 25` with an
+  env-driven value (default 40). Bounded context (KTD1) makes extra iterations cheap; the
+  higher default gives real implementations room. Fail behavior on cap is unchanged.
+- **KTD4 — Preserve all existing failure semantics.** Timeout, prompt-render error,
+  output-never-written, unknown-tool — all keep their current `_result(ok=False, …)` returns.
+  This fix only adds an earlier success path and bounds growth.
+
+---
+
+## High-Level Technical Design
+
+The loop today (runner.py 79–167), with the two new behaviors marked ★:
+
+```
+while iterations < MAX_ITERATIONS:            # ← MAX_ITERATIONS now configurable (KTD3)
+    if wall-clock exceeded: return fail
+    ai_message = llm.invoke(messages)
+    append ai_message; accumulate usage
+    tool_calls = ai_message.tool_calls
+    if not tool_calls: break                  # existing terminal signal
+    for call in tool_calls:
+        result = dispatch[name](**args)
+        result = _bounded(result)             # ★ KTD1: head+tail truncate to budget
+        append ToolMessage(result)
+    if output_path exists and non-empty:      # ★ KTD2: deliverable written → done
+        emit usage; return ok=True
+else:
+    return fail("reached max iterations")     # unchanged
+# post-loop: existing output_path.exists() check unchanged
+```
+
+Completion priority: model-stops (existing `break`) OR deliverable-written (new) → success;
+wall-clock / cap / no-output → failure (unchanged).
+
+---
+
+## Implementation Units
+
+### U1. Bound tool-output size before appending to context
+
+- **Goal:** Stop the ~1M-token runaway by truncating each tool result to a fixed budget before
+  it enters `messages`.
+- **Requirements:** KTD1. Root-cause fix for the context balloon.
+- **Dependencies:** none.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/langchain_agent/runner.py`
+  - `pipeline/tests/test_langchain_agent_runner.py`
+- **Approach:** Add a module-level budget constant (e.g. `MAX_TOOL_OUTPUT_CHARS`, ~16000) and a
+  small pure helper `_bounded(text)` that returns text unchanged when within budget, else
+  head + `…[truncated N chars]…` + tail. Apply it to `str(result)` at the single
+  `ToolMessage(content=…)` site. Keep the full untruncated result in `raw_log` (observability),
+  only the model-facing `ToolMessage` is bounded.
+- **Patterns to follow:** existing helper style in runner.py (`_message_content`, `_result`);
+  keep the helper pure and unit-tested.
+- **Test scenarios:**
+  - Tool result under budget → passed through unchanged into `ToolMessage`.
+  - Tool result over budget → `ToolMessage.content` length ≤ budget (+marker), contains head and
+    tail, contains the truncation marker with the dropped char count.
+  - `raw_log` still records the full untruncated result (observability preserved).
+  - Helper is pure: same input → same output, no side effects.
+- **Verification:** Unit tests green; a simulated large `run_bash` output no longer grows the
+  message context beyond the budget per tool call.
+
+### U2. Finish as soon as the expected output is written
+
+- **Goal:** Return success the moment the diff file exists, instead of waiting for the model to
+  emit a no-tool-call turn.
+- **Requirements:** KTD2. Removes the "never terminates" failure mode.
+- **Dependencies:** U1 (same loop region).
+- **Files:**
+  - `pipeline/wgmesh_pipeline/langchain_agent/runner.py`
+  - `pipeline/tests/test_langchain_agent_runner.py`
+- **Approach:** After the `for call in tool_calls` dispatch round, add a check: if
+  `output_path.exists()` and the file is non-empty, emit usage and `return _result(ok=True, …)`
+  with the current `completion_text`/usage. Mirror the existing post-loop success branch
+  (149–158) so the return shape is identical. Non-empty guard avoids finishing on a zero-byte
+  placeholder.
+- **Patterns to follow:** the existing post-loop `if output_path.exists()` success return
+  (runner.py 149–158) and `_emit_usage` call ordering.
+- **Test scenarios:**
+  - Agent writes the expected output at iteration k < cap while still requesting tools → runner
+    returns `ok=True` at iteration k; loop does not run to the cap. (Covers the live failure.)
+  - Expected output written but empty (0 bytes) → does NOT early-return; loop continues.
+  - Expected output never written, model keeps calling tools → still fails at the cap (unchanged).
+  - Model stops with no tool calls and output exists → existing post-loop success path still
+    works (no regression).
+  - Usage/`raw_log` are emitted on the early-success path same as the post-loop path.
+- **Verification:** A fake client that writes the diff file mid-loop then keeps calling tools
+  yields `ok=True` without reaching the cap; existing runner tests still pass.
+
+### U3. Make the iteration cap configurable with a higher default
+
+- **Goal:** Give real implementations room now that context is bounded.
+- **Requirements:** KTD3.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/langchain_agent/runner.py`
+  - `pipeline/tests/test_langchain_agent_runner.py`
+- **Approach:** Resolve the cap from the environment (e.g. `LANGCHAIN_MAX_ITERATIONS`) with a
+  default of 40, read once in `run_recipe` (mirror the env-reading discipline already used for
+  the agent). Keep `MAX_ITERATIONS` as the default constant. Invalid/absent → default. The
+  failure message keeps reporting the actual cap used.
+- **Patterns to follow:** `_get_nonempty`/`_get_bool` env-reading style in `config.py`; keep the
+  resolution local and fail-safe (bad value → default, never raise).
+- **Test scenarios:**
+  - Default (no env) → cap is 40.
+  - Env override to a small value (e.g. 3) → loop caps at 3, failure message reports `(3)`.
+  - Non-integer env value → falls back to default, no exception.
+  - `Test expectation: none` for the constant rename itself — covered by the override tests.
+- **Verification:** Override test drives the cap deterministically; default test confirms 40.
+
+---
+
+## Risks & Dependencies
+
+- **R1 — Truncation hides needed detail.** If the agent genuinely needs a large file's full
+  contents, head+tail truncation could drop the relevant middle. Mitigation: 16KB budget is
+  generous for code files; the marker tells the model to narrow its next read (e.g. `search` or
+  a ranged read) rather than re-dump. Deferred follow-up: summarise instead of truncate.
+- **R2 — Early-exit on a partial diff.** If the recipe writes the diff file incrementally, the
+  non-empty check could fire mid-write. Mitigation: the recipe writes the diff as its final
+  step (per `implement_node` contract); the non-empty guard covers the common placeholder case.
+  If observed, gate on a trailing-newline/size-stable check (follow-up).
+- **R3 — Deploy step.** Code reaches the box via `update-pipeline-box` (not auto on merge).
+  After merge, that workflow must run to pick up the fix; then watch the box journal for a clean
+  `advance …@spec_ready` (no max-iter error).
+- **Dependency:** none external; single module + its test file. No new pip deps (the box agent
+  is langchain-based; no new imports needed beyond stdlib `os`).
+
+## Open Questions (resolve at implementation)
+
+- Does the agent reliably write `diff_file` as its final action, or does it sometimes narrate
+  without writing? If U2 doesn't fully drain the cap failures in box validation, add an explicit
+  "write the unified diff to {diff_file} then stop" line to `wgmesh-implementation.yaml`
+  (out of current scope; note for the post-deploy check).
+
+## Verification (end-to-end)
+
+1. Unit suite green: `python -m pytest pipeline/tests/test_langchain_agent_runner.py -q`.
+2. Merge → run `update-pipeline-box`.
+3. Watch box journal (`diagnose-box-journal`): a spec_ready advance completes without
+   `reached max iterations`; an `impl` PR (`fix: Issue #N`) opens; implement-stage token counts
+   drop from ~1M to a bounded range.
+4. Next pulse: seed product PRs begin merging; `aged_open_items` starts falling.

--- a/docs/pulse-reports/2026-06-20_02-27.md
+++ b/docs/pulse-reports/2026-06-20_02-27.md
@@ -1,0 +1,45 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-19 00:12Z → 2026-06-20 00:12Z (24h, 15m buffer)
+**Surfaces:** meta-repo `ai-pipeline-template` · seed product `atvirokodosprendimai/wgmesh`
+_Prior pulse 2026-06-20_00-10 ~2h earlier; this run captures the two fixes merged since._
+
+## Headlines
+
+- **Action-success KPI: improving.** The dominant defect (Langfuse `--verify` red ×9) is now **FIXED** — fix #1879 merged this session; reds will stop once it runs. Remaining failures are transient/alarm noise.
+- **Open-item aging KPI (new): 34 aged >48h — still breaching.** Unchanged; the two merges cleared fresh items, not the aged backlog. Driver is the seed convergence stall.
+- **Product convergence still flat:** 0 `impl:`/`spec:` merges in 24h; last seed dispatch 2026-06-16 (4 days stale).
+
+## Usage (product convergence — seed repo)
+
+- Primary (`product_pr_merged`): **0** impl/spec merges. Only seed merge remains #770 `pp.html`.
+- Value (`autonomous_impl_merge_clean`): **0**.
+- Completions (`paid_customer_added`): no data (Polar not wired; chimney:ok).
+- Meta-repo merged: **38** (self-maintenance + this session's #1879 verify fix, #1880 aging KPI).
+- Stuck issues (seed): unchanged — `needs-human` #778 pricing, #775 outreach; copilot-triaging #752/#753/#773/#774.
+
+## Open-item aging KPI (target 0 aged >48h, both repos)
+
+**aged_open_items = 34. Breach.**
+
+- meta-repo: 2 PRs (#1767, #1733 strategy-drift audits) + 2 issues (#1599, #934).
+- seed wgmesh: **17 PRs + 13 issues** — the 06-17 growth backlog (#730–#757) still unmerged, now ~3d old.
+- No change since last pulse: #1879/#1880 were fresh and merged fast; the aged items are exactly the unprocessed backlog this KPI exists to surface.
+
+## System performance
+
+- Meta runs in window: **442**, failed **18**:
+  - `Register Langfuse Evaluators` ×9 — **FIXED**. Root cause: `--verify` returned exit 1 in the expected WAIT state. Fix #1879 (PASS→0/WAIT→0/FAIL→1 + evidence discriminator) merged 00:21Z. All 9 reds predate the merge.
+  - `Pipeline Error Rate` ×3 — alarm workflow firing on the above; meta-signal, resolves when verify reds stop.
+  - `CI` ×4 — TRANSIENT, superseded/flaky check runs on PRs that merged green.
+  - `Control Replay — Capabilities Grounding` ×2 — synthetic control-replay; non-blocking verification noise.
+- Seed runs in window: **34**, failed **1**: `Deploy Dashboard to GitHub Pages` (tied to #770) — recheck.
+- Self-heal: checks_run 898, healed 35 (cum), last run actions 0 / errors 0 / 9 stale-copilot skipped. idle=false, 23 open PRs, last dispatch 2026-06-16.
+
+## Followups
+
+1. **Verify the Langfuse fix live** — dispatch `Register Langfuse Evaluators` mode=verify → expect **green** (WAIT exit 0). Confirms #1879 end-to-end; closes the KPI breach.
+2. **Convergence stall is now the #1 problem** — 0 product merges/24h, 17 seed PRs dwelling, last dispatch 4 days ago. Both the product-convergence metric AND the new aging KPI point at it. Diagnose why the box emits work then stops merging.
+3. **Disposition the seed backlog** — the 17 unmerged #730–#757 PRs need merge-or-close-with-reason; they're the aging KPI's entire seed contribution.
+4. **Flaky `test_poller.py`** merge-side-effect (`merged_prs==[321]`) — caused 1 false CI red on #1880; harden isolation.
+5. **Human-side revenue blockers** unmoved: #778 pricing, #775 outreach.

--- a/pipeline/tests/test_langchain_agent_runner.py
+++ b/pipeline/tests/test_langchain_agent_runner.py
@@ -8,7 +8,11 @@ import pytest
 
 from wgmesh_pipeline.config import Config, load_config
 from wgmesh_pipeline.goose.usage import UsageTotals
-from wgmesh_pipeline.langchain_agent.runner import LangchainAgentRunner
+from wgmesh_pipeline.langchain_agent.runner import (
+    MAX_TOOL_OUTPUT_CHARS,
+    LangchainAgentRunner,
+    _bounded,
+)
 from wgmesh_pipeline.models import ModelProfile
 
 pytestmark = pytest.mark.unit
@@ -25,12 +29,14 @@ class FakeClient:
     def __init__(self, messages: list[FakeAIMessage]):
         self._messages = messages
         self.bound_specs: list[object] | None = None
+        self.invocations: list[list[Any]] = []
 
     def bind_tools(self, specs):
         self.bound_specs = list(specs)
         return self
 
     def invoke(self, messages):
+        self.invocations.append(list(messages))
         if len(self._messages) == 1:
             return self._messages[0]
         return self._messages.pop(0)
@@ -54,6 +60,77 @@ def write_recipe(tmp_path: Path, body: str | None = None) -> Path:
         encoding="utf-8",
     )
     return recipe
+
+
+def test_bounded_under_budget_passthrough_and_pure() -> None:
+    text = "under budget"
+
+    assert _bounded(text) == text
+    assert _bounded(text) == _bounded(text)
+
+
+def test_bounded_over_budget_keeps_head_tail_and_marker() -> None:
+    text = "head" + ("x" * MAX_TOOL_OUTPUT_CHARS) + "tail"
+    bounded = _bounded(text)
+    dropped = len(text) - MAX_TOOL_OUTPUT_CHARS
+
+    assert len(bounded) <= MAX_TOOL_OUTPUT_CHARS + 64
+    assert bounded.startswith("head")
+    assert bounded.endswith("tail")
+    assert f"[truncated {dropped} chars]" in bounded
+
+
+def test_tool_output_is_bounded_but_raw_log_keeps_full_output(tmp_path) -> None:
+    recipe = write_recipe(tmp_path)
+    large_output = "head" + ("x" * MAX_TOOL_OUTPUT_CHARS) + "tail"
+    (tmp_path / "large.txt").write_text(large_output, encoding="utf-8")
+    fake_client: FakeClient | None = None
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        nonlocal fake_client
+        fake_client = FakeClient(
+            [
+                FakeAIMessage(
+                    content="reading",
+                    tool_calls=[
+                        {
+                            "name": "read_file",
+                            "args": {"path": "large.txt"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+            ]
+        )
+        return fake_client
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is False
+    assert large_output in result.raw_log
+    assert fake_client is not None
+    tool_message = fake_client.invocations[1][-1]
+    assert tool_message.content == _bounded(large_output)
+    assert tool_message.content != large_output
 
 
 def test_happy_path_writes_expected_output_and_sums_usage(tmp_path) -> None:
@@ -101,7 +178,7 @@ def test_happy_path_writes_expected_output_and_sums_usage(tmp_path) -> None:
     assert result.output_path == tmp_path / "out.txt"
     assert (tmp_path / "out.txt").read_text(encoding="utf-8") == "done"
     assert result.usage == UsageTotals(
-        input_tokens=14, output_tokens=5, total_tokens=19, requests=2, skipped=0
+        input_tokens=10, output_tokens=3, total_tokens=13, requests=1, skipped=0
     )
     assert result.model_key == "default"
 
@@ -162,7 +239,7 @@ def test_emit_generation_called_with_stage_model_and_usage(
             "stage": "implement",
             "model": cfg().goose_model,
             "usage": result.usage,
-            "output": "finished",
+            "output": "writing",
         }
     ]
 
@@ -196,7 +273,8 @@ def test_missing_expected_output_returns_not_ok(tmp_path) -> None:
     assert "expected output was not written" in (result.error or "")
 
 
-def test_max_iterations_is_bounded(tmp_path) -> None:
+def test_max_iterations_default_is_40(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("LANGCHAIN_MAX_ITERATIONS", raising=False)
     recipe = write_recipe(tmp_path)
 
     def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
@@ -228,9 +306,200 @@ def test_max_iterations_is_bounded(tmp_path) -> None:
     )
 
     assert result.ok is False
-    assert "max iterations" in (result.error or "")
+    assert "max iterations (40)" in (result.error or "")
     assert result.usage is not None
-    assert result.usage.requests == 25
+    assert result.usage.requests == 40
+
+
+def test_max_iterations_env_override_reports_actual_cap(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "3")
+    recipe = write_recipe(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="again",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "scratch.txt", "content": "again"},
+                            "id": "call-loop",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is False
+    assert "max iterations (3)" in (result.error or "")
+    assert result.usage is not None
+    assert result.usage.requests == 3
+
+
+def test_max_iterations_invalid_env_falls_back_to_default(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "not-an-int")
+    recipe = write_recipe(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="again",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "scratch.txt", "content": "again"},
+                            "id": "call-loop",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is False
+    assert "max iterations (40)" in (result.error or "")
+    assert result.usage is not None
+    assert result.usage.requests == 40
+
+
+def test_expected_output_written_mid_loop_returns_before_cap(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "5")
+    recipe = write_recipe(tmp_path)
+    fake_client: FakeClient | None = None
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        nonlocal fake_client
+        fake_client = FakeClient(
+            [
+                FakeAIMessage(
+                    content="writing",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "out.txt", "content": "diff"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+        return fake_client
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is True
+    assert fake_client is not None
+    assert len(fake_client.invocations) == 1
+    assert result.usage.requests == 1
+
+
+def test_empty_expected_output_does_not_return_early(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "3")
+    recipe = write_recipe(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="writing placeholder",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "out.txt", "content": ""},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is False
+    assert "max iterations (3)" in (result.error or "")
+    assert result.usage.requests == 3
+
+
+def test_model_stops_with_existing_output_still_succeeds(tmp_path) -> None:
+    recipe = write_recipe(tmp_path)
+    (tmp_path / "out.txt").write_text("done", encoding="utf-8")
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert result.ok is True
 
 
 def test_model_routing_passes_resolved_profile_to_client_factory(

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import time
 from pathlib import Path
@@ -18,8 +19,10 @@ from wgmesh_pipeline.models import (
 )
 
 ClientFactory = Callable[[ModelProfile, Config], Any]
-MAX_ITERATIONS = 25
+MAX_ITERATIONS = 40
+MAX_TOOL_OUTPUT_CHARS = 16_000
 WALL_CLOCK_LIMIT_SECONDS = 1800
+_LOGGER = logging.getLogger(__name__)
 
 
 class LangchainAgentRunner:
@@ -43,6 +46,7 @@ class LangchainAgentRunner:
         usage = _empty_usage()
         profile: ModelProfile | None = None
         output_path: Path | None = None
+        max_iterations = _max_iterations()
         try:
             root = Path(workdir).resolve()
             output_path = resolve_workspace_path(root, expected_output)
@@ -76,7 +80,7 @@ class LangchainAgentRunner:
 
             iterations = 0
             completion_text: str | None = None
-            while iterations < MAX_ITERATIONS:
+            while iterations < max_iterations:
                 if time.monotonic() - started > WALL_CLOCK_LIMIT_SECONDS:
                     _emit_usage(
                         session_id=session_id,
@@ -116,10 +120,27 @@ class LangchainAgentRunner:
                     raw_log.append(f"tool {name}: {result}")
                     messages.append(
                         ToolMessage(
-                            content=str(result),
+                            content=_bounded(str(result)),
                             tool_call_id=call_id,
                             name=name,
                         )
+                    )
+                if output_path.exists() and output_path.stat().st_size > 0:
+                    _emit_usage(
+                        session_id=session_id,
+                        stage=stage,
+                        model=profile.model,
+                        usage=usage,
+                        output=completion_text,
+                    )
+                    return _result(
+                        ok=True,
+                        output_path=output_path,
+                        started=started,
+                        raw_log=raw_log,
+                        error=None,
+                        profile=profile,
+                        usage=usage,
                     )
             else:
                 _emit_usage(
@@ -134,7 +155,7 @@ class LangchainAgentRunner:
                     output_path=output_path,
                     started=started,
                     raw_log=raw_log,
-                    error=f"langchain agent reached max iterations ({MAX_ITERATIONS})",
+                    error=f"langchain agent reached max iterations ({max_iterations})",
                     profile=profile,
                     usage=usage,
                 )
@@ -208,6 +229,31 @@ def _credential_env(config: Config) -> Mapping[str, str]:
     if getattr(config, "zai_api_key", None):
         env.setdefault("ZAI_API_KEY", config.zai_api_key or "")
     return env
+
+
+def _max_iterations() -> int:
+    raw = os.environ.get("LANGCHAIN_MAX_ITERATIONS")
+    if raw is None:
+        return MAX_ITERATIONS
+    try:
+        return int(raw)
+    except ValueError:
+        _LOGGER.warning(
+            "invalid LANGCHAIN_MAX_ITERATIONS=%r; using default %s",
+            raw,
+            MAX_ITERATIONS,
+        )
+        return MAX_ITERATIONS
+
+
+def _bounded(text: str) -> str:
+    if len(text) <= MAX_TOOL_OUTPUT_CHARS:
+        return text
+    head_chars = MAX_TOOL_OUTPUT_CHARS // 2
+    tail_chars = MAX_TOOL_OUTPUT_CHARS - head_chars
+    dropped_chars = len(text) - MAX_TOOL_OUTPUT_CHARS
+    marker = f"\n...[truncated {dropped_chars} chars]...\n"
+    return f"{text[:head_chars]}{marker}{text[-tail_chars:]}"
 
 
 def _message_classes() -> tuple[type[Any], type[Any], type[Any]]:


### PR DESCRIPTION
## Problem (autobox convergence stall)

Every spec→impl advance on the box was failing with `RuntimeError: langchain agent reached max iterations (25)` (`graph/nodes/implement.py:55`). Box journal: the implement agent burned **800K–1M input tokens per attempt** (glm-4.7, tiny output) before hitting the cap. 17 growth issues frozen at `spec_ready`; **0 product PRs merging**.

Root cause is the ReAct loop in `langchain_agent/runner.py`: tool outputs (`read_file`/`run_bash`/`search` all return unbounded text) are appended verbatim as `ToolMessage`s and `messages` is never pruned → context balloons to ~1M tokens → glm-4.7 never emits a terminal (no-tool-call) turn → loops to the cap.

## Fix

- **U1 — bound tool output.** `_bounded()` head+tail truncates each tool result to `MAX_TOOL_OUTPUT_CHARS=16000` with a `...[truncated N chars]...` marker, applied only at the `ToolMessage` append site. `raw_log` keeps the full untruncated output (observability preserved).
- **U2 — finish on expected output.** After each tool round, if the diff file (`output_path`) exists and is non-empty, return `ok=True` immediately instead of waiting for the model to volunteer a no-tool-call turn. Zero-byte files don't trigger early return.
- **U3 — configurable cap.** `MAX_ITERATIONS` default 25→40; `LANGCHAIN_MAX_ITERATIONS` env override (fail-safe to default on absent/invalid). Failure message reports the actual cap.

All existing failure semantics (timeout, prompt-render error, output-never-written, unknown-tool) unchanged.

## Test plan

- `python -m pytest pipeline/tests/test_langchain_agent_runner.py -q` → **14 passed** (verified locally, CI-parity).
- Key biting test: agent writes the diff mid-loop while still calling tools → returns `ok=True` before the cap (reproduces + fixes the live failure).
- [ ] CI green.
- [ ] **Deploy:** run `update-pipeline-box` after merge (code is not auto-deployed to the box).
- [ ] Post-deploy: `diagnose-box-journal` shows a clean `advance #N@spec_ready` (no max-iter), a `fix: Issue #N` impl PR opens, implement-stage tokens drop from ~1M.

Plan: `docs/plans/2026-06-20-002-fix-langchain-implement-runner-stall-plan.md`
Diagnosis origin: pulse `docs/pulse-reports/2026-06-20_02-27.md` followup #2.