### PR TITLE
feat(state): surgical requeue of failed issues (un-quarantine without wiping state)

### DIFF
--- a/.github/workflows/requeue-failed-issues.yml
+++ b/.github/workflows/requeue-failed-issues.yml
@@ -1,0 +1,92 @@
+name: Requeue Failed Issues
+
+# One-shot: SSH to the pipeline box and surgically move failed issues back to
+# an actionable stage, WITHOUT restarting the service or wiping durable state.
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+      issues:
+        description: 'optional comma-separated issue numbers (empty = all failed)'
+        default: ''
+      target_stage:
+        description: 'actionable target stage'
+        default: 'spec_ready'
+
+permissions:
+  contents: read
+
+jobs:
+  requeue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
+          : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Resolve box IP
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SERVER_NAME: ${{ github.event.inputs.server_name }}
+        run: |
+          set -euo pipefail
+          IP=$(hcloud server ip "$SERVER_NAME")
+          echo "BOX_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Requeue failed issues (no restart)
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          ISSUES: ${{ github.event.inputs.issues }}
+          TARGET_STAGE: ${{ github.event.inputs.target_stage }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$ISSUES" =~ ^[0-9,]*$ ]]; then
+            echo "issues must be empty or a comma-separated list of numbers" >&2
+            exit 1
+          fi
+          if [[ ! "$TARGET_STAGE" =~ ^[a-z_]+$ ]]; then
+            echo "target_stage must contain only lowercase letters and underscores" >&2
+            exit 1
+          fi
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          SSH_ISSUES=$(printf '%q' "$ISSUES")
+          SSH_TARGET_STAGE=$(printf '%q' "$TARGET_STAGE")
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+              "ISSUES=$SSH_ISSUES TARGET_STAGE=$SSH_TARGET_STAGE bash -se" <<'REMOTE'
+          set -euo pipefail
+          set -a
+          . /etc/wgmesh-pipeline/env
+          set +a
+          cd /opt/wgmesh-pipeline
+          cmd=(/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main --requeue-failed)
+          if [ -n "${ISSUES}" ]; then
+            cmd+=(--issues "$ISSUES")
+          fi
+          cmd+=(--target-stage "$TARGET_STAGE")
+          echo '===== requeue failed issues ====='
+          printf 'command:'
+          printf ' %q' "${cmd[@]}"
+          printf '\n'
+          "${cmd[@]}" 2>&1
+          REMOTE
+
+      - name: Cleanup
+        if: always()
+        run: rm -f "$RUNNER_TEMP/deploy_key"

--- a/docs/plans/2026-06-20-003-feat-surgical-requeue-failed-issues-plan.md
+++ b/docs/plans/2026-06-20-003-feat-surgical-requeue-failed-issues-plan.md
@@ -1,0 +1,221 @@
+---
+title: "feat: surgical requeue of failed issues (un-quarantine without wiping state)"
+type: feat
+date: 2026-06-20
+depth: standard
+origin: none (diagnosis from box journal; convergence stall layer 2)
+---
+
+# feat: surgical requeue of `failed` issues
+
+**Target files:** `pipeline/wgmesh_pipeline/state/store.py`,
+`pipeline/wgmesh_pipeline/main.py`, `.github/workflows/requeue-failed-issues.yml` (+ tests).
+Deploys to the box via `update-pipeline-box`; the workflow itself runs one-shot over SSH.
+
+## Summary
+
+The convergence engine is stalled at the claim step: `reconcile seen=19 queued=0; claimed=none`
+every tick. Root cause — the 17 growth issues hit `bump_attempt`'s `max_attempts=3` cap during
+yesterday's implement-runner failure storm, so each was set to `stage="failed"`, which is **not
+in `ACTIONABLE_STAGES`** (store.py:24). `claim_next` will never pick them up again. The
+implement-runner fix (#1886) is deployed but can't be exercised because no issue ever reaches the
+implement node.
+
+The only built-in recovery is `RESET_QUEUE=1`, which **wipes the entire state DB** (all issues +
+runs) and re-reconciles from scratch — blunt, risks duplicate spec PRs, loses `spec_pr`/`impl_pr`
+linkage. This plan adds a **surgical** path: requeue specific (or all) `failed` issues back to an
+actionable stage with `attempts` cleared, preserving their PR linkage, exposed via a one-shot
+workflow that needs no full reprovision and no service restart.
+
+## Problem Frame
+
+- **Observed:** post-deploy box journal — `claimed=none` on every tick; 0 implement advances; the
+  17 issues are `stage=failed`.
+- **Mechanism:** `bump_attempt` (store.py:333) sets `stage="failed"` at `attempts >= 3`; `failed`
+  ∉ `ACTIONABLE_STAGES`; `claim_next` skips it permanently.
+- **Goal:** re-admit chosen `failed` issues to the funnel (at the stage matching their artifacts,
+  default `spec_ready`) with `attempts=0`, without wiping state — so the fixed runner gets
+  exercised and the backlog can drain.
+- **Operator decision (2026-06-20):** "Build surgical reset" (not the `RESET_QUEUE` wipe).
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- A targeted `requeue_failed` store method.
+- A one-shot `--requeue-failed` CLI path in `main.py` that requeues then exits (never enters the
+  poll loop).
+- A `requeue-failed-issues.yml` dispatch workflow that runs the one-shot over SSH on the box.
+- Tests for the store method and the CLI one-shot path.
+
+**Out of scope**
+- Layer 1 (implement runner) — fixed in #1886.
+- Layer 3 (disabled GHA merge lane) — separate; even requeued+implemented PRs won't auto-merge
+  until that's addressed. Flag it; don't solve it here.
+- Raising `max_attempts` or auto-recovery of `failed` issues — a durable alternative, deferred.
+- The `RESET_QUEUE` full-wipe path — left intact, untouched.
+
+### Deferred to Follow-Up Work
+- Auto-recovery: a periodic sweep that requeues `failed` issues whose `last_error` matches a
+  now-fixed signature, so manual requeue isn't needed next time.
+- Decide layer-3 PR-merge ownership (re-enable `Bot PR Review and Merge` / `Spec Auto-Approve`,
+  or add a box merge action).
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Targeted UPDATE, not wipe.** `requeue_failed` flips `stage='failed'` rows to an
+  actionable target stage and zeroes `attempts` (and clears `last_error`), preserving
+  `spec_pr`/`impl_pr`/title. Preserves linkage the `RESET_QUEUE` wipe would destroy.
+- **KTD2 — Default target stage `spec_ready`.** The quarantined issues failed the
+  `spec_ready → implemented` advance and already have spec PRs; `spec_ready` re-enters them at the
+  implement step. Make the target a parameter (default `spec_ready`) and validate it is in
+  `ACTIONABLE_STAGES`.
+- **KTD3 — Optional issue-number filter.** Requeue a given list of numbers, or all `failed` when
+  none supplied. Lets the operator scope to the 17 (or a subset) and avoids touching unrelated
+  failures.
+- **KTD4 — One-shot CLI that exits.** `--requeue-failed` opens config + store, runs the requeue,
+  prints a summary, and returns — it must NOT build the poller/forge or enter `run_forever`
+  (unlike `--reset-queue`, which resets then polls). The long-running systemd service keeps
+  running separately and claims the requeued issues on its next tick.
+- **KTD5 — SSH one-shot workflow, no restart.** Mirror `diagnose-box-journal.yml` (hcloud resolve
+  IP + deploy key) to run the one-shot against the box's shared state DB. No service restart,
+  no reprovision. libsql/Turso tolerates the brief concurrent writer.
+
+---
+
+## High-Level Technical Design
+
+```
+operator dispatches requeue-failed-issues.yml (issues="730,731,…" | empty=all; target=spec_ready)
+        │  SSH (deploy key) to box
+        ▼
+box: python -m wgmesh_pipeline.main --requeue-failed [--issues N,N] [--target-stage S]
+        │  load_config → open_state_store
+        ▼
+store.requeue_failed(numbers, target_stage) :
+        UPDATE issues SET stage=:target, attempts=0, last_error=NULL, updated_at=:now
+        WHERE stage='failed' AND (:numbers empty OR number IN :numbers)
+        │  prints "requeued=N numbers=[…]"; process EXITS (no poll loop)
+        ▼
+running systemd service (already on #1886 fix): next tick claim_next() now finds the
+requeued spec_ready issues → implement node runs with bounded context → impl PR opens
+```
+
+Completion of the requeue is the UPDATE; convergence resumes on the service's own cadence.
+
+---
+
+## Implementation Units
+
+### U1. `store.requeue_failed` — targeted un-quarantine
+
+- **Goal:** Flip `failed` issues back to an actionable stage with cleared attempts, preserving
+  linkage.
+- **Requirements:** KTD1, KTD2, KTD3.
+- **Dependencies:** none.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/state/store.py`
+  - `pipeline/tests/` (the store test module — match the existing one, e.g. `test_state_store.py`)
+- **Approach:** Add `requeue_failed(self, numbers: Sequence[int] | None = None, *,
+  target_stage: str = "spec_ready", now: datetime | None = None) -> dict[str, Any]`. Validate
+  `target_stage in ACTIONABLE_STAGES` (raise `ValueError` otherwise). Build the UPDATE with
+  `stage='failed'` plus an optional `number IN (…)` clause from `numbers`; set
+  `stage=target_stage, attempts=0, last_error=NULL, updated_at=now`. Return
+  `{"requeued": <rowcount>, "numbers": [<affected numbers>], "target_stage": target_stage}`.
+  Mirror the parametrised-SQL + `_iso(_dt(now))` style already in the module.
+- **Patterns to follow:** `reset_queue` (commit + return counts), `bump_attempt` (UPDATE shape,
+  `now` handling), `claim_next` (cooldown/stage semantics) in the same file.
+- **Test scenarios:**
+  - One `failed` issue, no filter → its stage becomes `spec_ready`, `attempts=0`,
+    `last_error` cleared; `spec_pr`/`impl_pr`/title preserved; return `requeued=1`.
+  - Multiple `failed`, numbers filter to a subset → only listed issues change; others stay
+    `failed`.
+  - Non-`failed` issue in the numbers list → untouched (the `stage='failed'` guard).
+  - `target_stage` not in `ACTIONABLE_STAGES` → raises `ValueError`, no writes.
+  - Empty/no `failed` issues → `requeued=0`, no error.
+  - After requeue, `claim_next` returns the requeued issue (it is now claimable).
+- **Verification:** New tests green; a requeued issue is claimable immediately (no residual
+  cooldown because `attempts=0` → `_cooldown(0)=0`).
+
+### U2. `--requeue-failed` one-shot CLI path
+
+- **Goal:** A box-runnable command that requeues then exits, never entering the poll loop.
+- **Requirements:** KTD4.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/main.py`
+  - `pipeline/tests/` (main/CLI test module)
+- **Approach:** Add argparse flags: `--requeue-failed` (store_true), `--issues` (comma-separated
+  numbers, optional), `--target-stage` (default `spec_ready`). In `main()`, when
+  `--requeue-failed` is set, run a dedicated one-shot (`requeue_failed_main`): `load_config()` →
+  `open_state_store(config)` → `store.requeue_failed(numbers, target_stage=…)` → print the summary
+  → return. Do NOT construct the poller/forge/graph or call `asyncio.run(async_main(...))` on this
+  path. Keep `--reset-queue` behaviour unchanged.
+- **Patterns to follow:** existing `main()` argparse + the `reset_queue` print/summary style;
+  `open_state_store(config)` usage from `async_main`.
+- **Test scenarios:**
+  - `main(["--requeue-failed"])` with a fake/in-memory store containing `failed` issues → calls
+    `requeue_failed` with no number filter, prints the summary, does NOT start the poller
+    (assert the poller / `async_main` loop is never invoked).
+  - `main(["--requeue-failed", "--issues", "730,731"])` → parses `[730, 731]` and passes them
+    through.
+  - `main(["--requeue-failed", "--target-stage", "queued"])` → passes `queued` through.
+  - Malformed `--issues` (e.g. `730,x`) → clear error, no partial run.
+  - `--reset-queue` path still resets-then-polls (regression guard).
+- **Verification:** The one-shot path returns without entering `run_forever`; existing
+  `--reset-queue` tests still pass.
+
+### U3. `requeue-failed-issues.yml` dispatch workflow
+
+- **Goal:** Operator-triggerable, runs the one-shot on the box over SSH; no restart/reprovision.
+- **Requirements:** KTD5.
+- **Dependencies:** U2.
+- **Files:**
+  - `.github/workflows/requeue-failed-issues.yml`
+- **Approach:** Copy the structure of `.github/workflows/diagnose-box-journal.yml`: inputs
+  `server_name` (default `wgmesh-pipeline`), `issues` (CSV, default empty = all `failed`),
+  `target_stage` (default `spec_ready`); `permissions: contents: read`; validate
+  `DEPLOY_SSH_KEY` + `HCLOUD_TOKEN`; install hcloud; resolve box IP; SSH (with
+  `UserKnownHostsFile=/dev/null`) and run the box venv python:
+  `cd /opt/wgmesh-pipeline && <python> -m wgmesh_pipeline.main --requeue-failed
+  [--issues "$ISSUES"] [--target-stage "$TARGET"]`, passing inputs as quoted env vars (scope-guard
+  the `issues` value to `^[0-9,]*$` and `target_stage` to `^[a-z_]+$` before use). Echo the
+  command output (the requeue summary).
+- **Patterns to follow:** `diagnose-box-journal.yml` end-to-end (secret validation, hcloud,
+  IP resolve, SSH key handling, cleanup); use the same box python entrypoint the service uses.
+- **Test scenarios:** `Test expectation: none — declarative GHA workflow.` Validation is the
+  post-merge dispatch (see end-to-end verification); statically confirm the input scope-guards and
+  that the SSH command matches the U2 CLI surface.
+- **Verification:** Dispatch with `issues` empty on a box that has `failed` issues → workflow logs
+  `requeued=N`; the box's next tick logs `claimed=#<n>@spec_ready` and an advance.
+
+---
+
+## Risks & Dependencies
+
+- **R1 — Concurrent DB access.** The one-shot writes while the systemd service reads/writes the
+  same libsql/Turso DB. Mitigation: a single short UPDATE+commit; libsql serialises writers. If a
+  transient lock appears, the workflow can be re-dispatched (idempotent: re-running requeues the
+  same rows to the same stage, `requeued` may be 0 the second time).
+- **R2 — Requeue to the wrong stage.** If an issue actually needs re-spec (no usable spec PR),
+  `spec_ready` would send it to implement against a stale/missing spec. Mitigation: default fits
+  the current 17 (they have spec PRs); `--target-stage queued` is available to force re-triage;
+  `last_error` is cleared so the journal will show the fresh outcome.
+- **R3 — Layer 3 still open.** Requeued issues that implement successfully produce impl PRs that
+  **won't auto-merge** (GHA merge lane disabled). This plan exercises the runner fix and unblocks
+  the funnel up to PR creation; merging is the separate deferred follow-up. State this when
+  reporting results.
+- **Dependency:** the implement-runner fix (#1886) must be live on the box first (it is) so the
+  requeued issues don't immediately re-fail and re-quarantine.
+
+## Verification (end-to-end)
+
+1. Unit suites green: store + main CLI tests.
+2. Merge → run `update-pipeline-box` (so the box has the new `--requeue-failed` entrypoint).
+3. Dispatch `requeue-failed-issues.yml` (issues empty or the 17 numbers) → logs `requeued=N`.
+4. `diagnose-box-journal` within ~1–2 ticks: `claimed=#<n>@spec_ready` → `advanced … -> implemented`
+   with NO `reached max iterations`; a `fix: Issue #N` impl PR opens; implement tokens bounded.
+5. Note remaining layer-3 gap: the new impl PRs need a merge path before `aged_open_items` falls.

--- a/pipeline/tests/test_main.py
+++ b/pipeline/tests/test_main.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from wgmesh_pipeline import main
 from wgmesh_pipeline.config import Config
 
@@ -9,10 +11,24 @@ from wgmesh_pipeline.config import Config
 class Store:
     def __init__(self) -> None:
         self.reset_calls = 0
+        self.requeue_calls = []
 
     def reset_queue(self) -> dict[str, int]:
         self.reset_calls += 1
         return {"issues": 3, "runs": 4}
+
+    def requeue_failed(
+        self,
+        numbers=None,
+        *,
+        target_stage: str = "spec_ready",
+    ) -> dict[str, object]:
+        self.requeue_calls.append((numbers, target_stage))
+        return {
+            "requeued": 2,
+            "numbers": [730, 731],
+            "target_stage": target_stage,
+        }
 
 
 class DummyPoller:
@@ -64,3 +80,68 @@ def test_main_reset_queue_flag_requests_reset(monkeypatch) -> None:
     main.main(["--reset-queue"])
 
     assert calls == [True]
+
+
+def test_main_requeue_failed_runs_one_shot_and_does_not_poll(monkeypatch, capsys) -> None:
+    store = Store()
+    cfg = Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local"
+    )
+
+    async def fail_async_main(*, reset_queue: bool = False) -> None:
+        raise AssertionError("requeue_failed must not enter async_main")
+
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    monkeypatch.setattr(main, "open_state_store", lambda config: store)
+    monkeypatch.setattr(main, "async_main", fail_async_main)
+
+    main.main(["--requeue-failed"])
+
+    assert store.requeue_calls == [(None, "spec_ready")]
+    assert (
+        "[pipeline] requeue_failed requeued=2 target_stage=spec_ready numbers=[730, 731]"
+        in capsys.readouterr().err
+    )
+
+
+def test_main_requeue_failed_passes_issue_filter(monkeypatch) -> None:
+    store = Store()
+    cfg = Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local"
+    )
+
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    monkeypatch.setattr(main, "open_state_store", lambda config: store)
+
+    main.main(["--requeue-failed", "--issues", "730,731"])
+
+    assert store.requeue_calls == [([730, 731], "spec_ready")]
+
+
+def test_main_requeue_failed_passes_target_stage(monkeypatch) -> None:
+    store = Store()
+    cfg = Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local"
+    )
+
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    monkeypatch.setattr(main, "open_state_store", lambda config: store)
+
+    main.main(["--requeue-failed", "--target-stage", "queued"])
+
+    assert store.requeue_calls == [(None, "queued")]
+
+
+def test_main_requeue_failed_rejects_malformed_issues_before_running(monkeypatch) -> None:
+    calls = []
+
+    def fail_requeue_failed_main(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(main, "requeue_failed_main", fail_requeue_failed_main)
+
+    with pytest.raises(SystemExit) as exc:
+        main.main(["--requeue-failed", "--issues", "730,x"])
+
+    assert exc.value.code == 2
+    assert calls == []

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -82,6 +82,97 @@ def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
     assert versions == ["0001", "0002"]
 
 
+def test_requeue_failed_all_preserves_linkage_and_clears_attempts(tmp_path) -> None:
+    db = store(tmp_path)
+    now = datetime(2026, 6, 20, 12, tzinfo=timezone.utc)
+    db.upsert_issue(
+        730,
+        "Growth issue",
+        classification="fn:gtm",
+        stage="spec_ready",
+        spec_pr=1730,
+        impl_pr=2730,
+    )
+    db.bump_attempt(730, "runner storm", max_attempts=1, now=now - timedelta(minutes=1))
+
+    result = db.requeue_failed(now=now)
+
+    issue = db.get_issue(730)
+    assert result == {"requeued": 1, "numbers": [730], "target_stage": "spec_ready"}
+    assert issue.stage == "spec_ready"
+    assert issue.attempts == 0
+    assert issue.last_error is None
+    assert issue.title == "Growth issue"
+    assert issue.spec_pr == 1730
+    assert issue.impl_pr == 2730
+    assert issue.updated_at == now
+
+
+def test_requeue_failed_numbers_filter_only_updates_subset(tmp_path) -> None:
+    db = store(tmp_path)
+    for number in (730, 731, 732):
+        db.upsert_issue(number, f"issue {number}", stage="queued")
+        db.bump_attempt(number, "failed", max_attempts=1)
+
+    result = db.requeue_failed([730, 732], target_stage="queued")
+
+    assert result == {"requeued": 2, "numbers": [730, 732], "target_stage": "queued"}
+    assert db.get_issue(730).stage == "queued"
+    assert db.get_issue(731).stage == "failed"
+    assert db.get_issue(732).stage == "queued"
+
+
+def test_requeue_failed_ignores_non_failed_issue_in_filter(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(730, "failed", stage="queued")
+    db.bump_attempt(730, "failed", max_attempts=1)
+    db.upsert_issue(731, "still queued", stage="queued")
+
+    result = db.requeue_failed([730, 731])
+
+    assert result == {"requeued": 1, "numbers": [730], "target_stage": "spec_ready"}
+    assert db.get_issue(730).stage == "spec_ready"
+    assert db.get_issue(731).stage == "queued"
+
+
+def test_requeue_failed_rejects_non_actionable_target_without_writes(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(730, "failed", stage="queued")
+    db.bump_attempt(730, "failed once", max_attempts=1)
+
+    with pytest.raises(ValueError, match="target_stage"):
+        db.requeue_failed(target_stage="failed")
+
+    issue = db.get_issue(730)
+    assert issue.stage == "failed"
+    assert issue.attempts == 1
+    assert issue.last_error == "failed once"
+
+
+def test_requeue_failed_no_failed_issues_returns_zero(tmp_path) -> None:
+    db = store(tmp_path)
+    db.upsert_issue(730, "queued", stage="queued")
+
+    result = db.requeue_failed()
+
+    assert result == {"requeued": 0, "numbers": [], "target_stage": "spec_ready"}
+    assert db.get_issue(730).stage == "queued"
+
+
+def test_requeue_failed_issue_is_claimable_immediately(tmp_path) -> None:
+    db = store(tmp_path)
+    now = datetime(2026, 6, 20, 12, tzinfo=timezone.utc)
+    db.upsert_issue(730, "claim me", stage="queued", updated_at=now - timedelta(minutes=5))
+    db.bump_attempt(730, "failed", max_attempts=1, now=now - timedelta(minutes=1))
+
+    db.requeue_failed([730], now=now)
+    claimed = db.claim_next(now=now)
+
+    assert claimed is not None
+    assert claimed.number == 730
+    assert claimed.stage == "spec_ready"
+
+
 def test_upsert_and_transition_persist(tmp_path) -> None:
     db = store(tmp_path)
     db.upsert_issue(1, "Fix relay")

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -25,6 +25,38 @@ def _truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _parse_issue_numbers(value: str) -> list[int]:
+    raw_value = value.strip()
+    if not raw_value:
+        return []
+    numbers: list[int] = []
+    for raw_number in raw_value.split(","):
+        item = raw_number.strip()
+        if not item or not item.isdigit():
+            raise argparse.ArgumentTypeError(
+                "--issues must be a comma-separated list of issue numbers"
+            )
+        numbers.append(int(item))
+    return numbers
+
+
+def requeue_failed_main(
+    *,
+    numbers: list[int] | None = None,
+    target_stage: str = "spec_ready",
+) -> None:
+    config = load_config()
+    store = open_state_store(config)
+    result = store.requeue_failed(numbers, target_stage=target_stage)
+    print(
+        "[pipeline] requeue_failed "
+        f"requeued={result['requeued']} "
+        f"target_stage={result['target_stage']} "
+        f"numbers={result['numbers']}",
+        file=sys.stderr,
+    )
+
+
 async def async_main(*, reset_queue: bool = False) -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -77,8 +109,30 @@ async def async_main(*, reset_queue: bool = False) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--reset-queue", action="store_true", help="clear durable issue queue and run history before polling")
+    parser.add_argument(
+        "--reset-queue",
+        action="store_true",
+        help="clear durable issue queue and run history before polling",
+    )
+    parser.add_argument(
+        "--requeue-failed",
+        action="store_true",
+        help="move failed issues back to an actionable stage and exit",
+    )
+    parser.add_argument(
+        "--issues",
+        type=_parse_issue_numbers,
+        help="comma-separated issue numbers to requeue",
+    )
+    parser.add_argument(
+        "--target-stage",
+        default="spec_ready",
+        help="actionable stage to assign to requeued issues",
+    )
     args = parser.parse_args(argv)
+    if args.requeue_failed:
+        requeue_failed_main(numbers=args.issues, target_stage=args.target_stage)
+        return
     asyncio.run(async_main(reset_queue=args.reset_queue))
 
 

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from importlib import resources
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 
 ALLOWED_TRANSITIONS: dict[str, set[str]] = {
@@ -319,6 +319,49 @@ class StateStore:
         self._conn.execute("DELETE FROM issues")
         self._conn.commit()
         return {"issues": issue_count, "runs": run_count}
+
+    def requeue_failed(
+        self,
+        numbers: Sequence[int] | None = None,
+        *,
+        target_stage: str = "spec_ready",
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Move failed issues back to an actionable stage without wiping state."""
+        if target_stage not in ACTIONABLE_STAGES:
+            raise ValueError(f"target_stage must be actionable: {target_stage}")
+
+        params: list[Any] = []
+        where = "stage = 'failed'"
+        if numbers:
+            issue_numbers = [int(number) for number in numbers]
+            where += f" AND number IN ({','.join('?' for _ in issue_numbers)})"
+            params.extend(issue_numbers)
+
+        rows = self._conn.execute(
+            f"SELECT number FROM issues WHERE {where} ORDER BY number",
+            params,
+        ).fetchall()
+        affected_numbers = [int(row["number"]) for row in rows]
+        requeued = 0
+        if affected_numbers:
+            placeholders = ",".join("?" for _ in affected_numbers)
+            cursor = self._conn.execute(
+                f"""
+                UPDATE issues
+                   SET stage = ?, attempts = 0, last_error = NULL, updated_at = ?
+                 WHERE stage = 'failed'
+                   AND number IN ({placeholders})
+                """,
+                (target_stage, _iso(_dt(now)), *affected_numbers),
+            )
+            requeued = int(cursor.rowcount)
+        self._conn.commit()
+        return {
+            "requeued": requeued,
+            "numbers": affected_numbers,
+            "target_stage": target_stage,
+        }
 
     def bump_attempt(
         self,


### PR DESCRIPTION
## Why

Convergence is stalled at the claim step (`reconcile seen=19 queued=0; claimed=none` every tick). The 17 growth issues hit `bump_attempt`'s `max_attempts=3` cap during the implement-runner failure storm → each is `stage="failed"`, which is **not in `ACTIONABLE_STAGES`** → `claim_next` skips them forever. The runner fix (#1886) is deployed but can't be exercised because no issue reaches the implement node.

The only built-in recovery was `RESET_QUEUE=1` — a **full state-DB wipe** (risks duplicate spec PRs, loses PR linkage). This adds a surgical alternative.

## What

- **`store.requeue_failed(numbers, target_stage="spec_ready")`** — flips `stage='failed'` rows back to an actionable stage, `attempts=0`, `last_error=NULL`, preserving `spec_pr`/`impl_pr`/title. Validates `target_stage ∈ ACTIONABLE_STAGES`; SELECTs candidates then UPDATEs; returns `{requeued, numbers, target_stage}`.
- **`main.py --requeue-failed [--issues N,N] [--target-stage S]`** — one-shot: requeue then **exit**, never constructs the poller/graph or enters `run_forever` (distinct from `--reset-queue`, which resets-then-polls).
- **`.github/workflows/requeue-failed-issues.yml`** — SSH dispatch (mirrors `diagnose-box-journal.yml`), scope-guards `issues` (`^[0-9,]*$`) and `target_stage` (`^[a-z_]+$`), sources `/etc/wgmesh-pipeline/env`, runs the box venv one-shot. No service restart.

## Scope

- Fixes **layer 2** of the convergence stall (quarantined issues). Layer 1 (runner) = #1886. **Layer 3 (disabled GHA merge lane) is still open** — requeued+implemented PRs won't auto-merge until that's addressed.

## Test plan

- `pytest pipeline/tests/test_state.py pipeline/tests/test_main.py -q` → **32 passed** (verified locally, CI-parity). Covers: requeue scoping/guard/ValueError/claimability-after, CLI no-poller guarantee, issues parsing, malformed input, `--reset-queue` regression.
- [ ] CI green.
- [ ] **Deploy:** `update-pipeline-box` after merge (box needs the new `--requeue-failed` entrypoint).
- [ ] Dispatch `requeue-failed-issues.yml` → expect `requeued=N`; next box tick `claimed=#<n>@spec_ready` → advance with NO max-iter; `fix: Issue #N` impl PR opens.

Plan: `docs/plans/2026-06-20-003-feat-surgical-requeue-failed-issues-plan.md`