### PR TITLE
feat(langchain): agent-native implement executor (non-goose core)

### DIFF
--- a/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
+++ b/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
@@ -237,9 +237,11 @@ code actually changing.
 
 ## Resolved Decisions (operator, 2026-06-20)
 
-- **Agent model(s):** test **DeepSeek (metered, cheap)** and **MiniMax (flat-rate)** — move off
-  GLM-4.7 (it produced 844 tokens / no edits); skip frontier unless both fail. Route the implement
-  stage to these via the model-routing layer (`MODEL_REGISTRY`/`STAGE_ROUTING`).
+- **Agent model(s):** test **DeepSeek (metered, cheap)**, **MiniMax (flat-rate)**, and
+  **GLM-5.2 (flat-rate flagship)** — move off GLM-4.7 (it produced 844 tokens / no edits; 4.7 may
+  simply be too weak — 5.2 is the current flagship and flat-rate, so likely the best value if it
+  can drive the agent loop). Skip frontier (Anthropic/OpenAI) unless all three fail. Route the
+  implement stage per-model via the model-routing layer (`MODEL_REGISTRY`/`STAGE_ROUTING`).
 - **Run env for real experiments:** **box shadow run** — execute the agent executor on the box
   (has creds) against one issue WITHOUT flipping global `EXECUTOR`; goose stays live. No local key.
 

--- a/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
+++ b/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
@@ -235,13 +235,19 @@ code actually changing.
 - **Dependency:** local real runs need `ZAI_API_KEY` (and possibly a stronger model's creds). If
   unavailable locally, U3/U5 real-validation happens in a box shadow run instead — note the gap.
 
+## Resolved Decisions (operator, 2026-06-20)
+
+- **Agent model(s):** test **DeepSeek (metered, cheap)** and **MiniMax (flat-rate)** — move off
+  GLM-4.7 (it produced 844 tokens / no edits); skip frontier unless both fail. Route the implement
+  stage to these via the model-routing layer (`MODEL_REGISTRY`/`STAGE_ROUTING`).
+- **Run env for real experiments:** **box shadow run** — execute the agent executor on the box
+  (has creds) against one issue WITHOUT flipping global `EXECUTOR`; goose stays live. No local key.
+
 ## Open Questions (resolve during implementation)
 
-- **Which model drives the agent?** Keep GLM-4.7, or route implement to a more capable coding model
-  (DeepSeek / frontier via OpenRouter, per the model-routing layer)? Decide empirically with the U2
-  harness — this likely matters more than the prompt.
 - **New recipe file vs inline prompt?** A `recipes/wgmesh-implementation-agent.md` keeps prompts
   editable without code changes; an inline template is simpler. Pick during U3.
+- **DeepSeek vs MiniMax** — decide from the shadow A/B (real edits + `go build` clean + cost).
 
 ## Verification (end-to-end)
 

--- a/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
+++ b/docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md
@@ -1,0 +1,252 @@
+---
+title: "feat: non-goose agent executor — make the LangChain implementer actually implement"
+type: feat
+date: 2026-06-20
+depth: deep
+origin: none (diagnosis this session; convergence-stall layer 4 + strategic "build non-goose autobox")
+---
+
+# feat: non-goose agent executor
+
+**Target files:** `pipeline/wgmesh_pipeline/langchain_agent/*`, a new prompt, a local replay
+harness + tests. Deploys to the box via `update-pipeline-box` only after local proof.
+
+## Summary
+
+Strategic direction (operator, 2026-06-20): **goose stays as KTLO** (it converges today —
+opened real impl PR #785), **all new work targets the non-goose executor.** The non-goose path
+(`EXECUTOR=langchain`, `langchain_agent/runner.py`) is wired and its tools/loop work, but it
+**does not implement**: a live run produced 844 input tokens, no file reads, an empty diff, and
+`implement.py` raised `goose implementation produced no tree changes`.
+
+**Diagnosed root cause:** the agent is driven like a goose *recipe*, not an autonomous agent. It
+is handed `pipeline/recipes/wgmesh-implementation.yaml`, whose step 6 literally says
+*"Run exactly: `git add -A && git reset … && git diff --cached > diff_file`"*. The ReAct agent
+latches onto that literal command, runs it **first**, skips the actual implementation (steps 1–5),
+and writes an empty diff. The runner then accepts it because completion is **existence-of-diff-file**
+(`runner.py` post-loop checks `output_path.exists()`), not real tree changes. The system prompt
+reinforces this — *"use the tools to write the requested expected output before finishing."* The
+tools (`read_file`/`write_file`/`edit_file`/`run_bash`/`search`) are fine; the **driving** is wrong.
+
+This plan makes the non-goose executor actually implement: an agent-native task prompt (do the
+work, edit files, verify), a completion contract based on **real workspace changes** rather than a
+diff-file artifact, agent-trace observability, and a **local replay harness** so we can iterate the
+agent without the box (goose keeps the lights on throughout).
+
+## Problem Frame
+
+- **Observed:** `advance #N@spec_ready failed: goose implementation produced no tree changes`;
+  `stage=implement tokens=844/34`; agent reads nothing, edits nothing.
+- **Mechanism:** goose-shaped recipe + existence-only completion → agent games "produce the diff
+  file" instead of implementing.
+- **Constraint:** goose remains the live executor (`EXECUTOR=goose`) and the only converging path
+  until this is proven. No box disruption; iterate locally.
+- **Goal:** the LangChain agent reads the spec, edits real source via tools, verifies build/test,
+  and the runner reports success **only when the workspace actually changed** — producing real
+  impl PRs equivalent to goose's.
+
+---
+
+## Scope Boundaries
+
+**In scope**
+- `langchain_agent/runner.py` — completion contract, agent-trace logging, prompt wiring.
+- A new **agent-native implement prompt** (not the goose recipe).
+- A **local replay harness** + deterministic fake-client tests + an optional creds-gated real run.
+- `langchain_agent/prompts.py` and `langchain_agent/tools.py` as needed.
+
+**Out of scope**
+- **Goose** (`goose/runner.py`, `recipes/`) — untouched; KTLO. Removed only after this is proven.
+- The **merge model** (judge-gated automerge, drop reviewer-PAT) — its own separate program; this
+  plan ends at "real impl PR opens," not at merge.
+- The `EXECUTOR=langchain` production flip — gated behind local proof + a shadow/parallel pass.
+
+### Deferred to Follow-Up Work
+- Retire goose + recipe layer + reviewer-PAT (#1898) once the agent executor is proven in prod.
+- Judge-gated automerge (the merge-side non-goose work).
+- Model selection tuning for the agent (see Open Questions).
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Drive the agent, don't run a recipe.** Replace the goose recipe input for the langchain
+  implement path with an **agent-native task prompt**: read the spec, read the real source the spec
+  touches, **edit files with `edit_file`/`write_file`**, run `go build/test/vet`, iterate, then
+  stop. No `diff_file`, no "Run exactly: <git command>" — those are goose packaging steps the agent
+  games.
+- **KTD2 — Completion = real workspace changes, not a diff artifact.** For the implement stage, the
+  runner's success condition becomes "the agent stopped **and** the workspace has uncommitted
+  changes" (git-dirty), instead of `output_path.exists()`. The diff is derived from git by
+  `implement.py` (`_stage_impl_tree` + `git diff --cached`), which already exists — so the runner
+  should hand back "the agent did work," and let `implement.py` own diff capture. This removes the
+  gameable artifact and the existing `"no tree changes"` guard stays as the backstop.
+- **KTD3 — Keep the runner/tools/loop; change the contract.** The ReAct loop, the tools, the
+  context-bounding (#1886) all stay. This is a prompt + completion-contract change, not a rewrite.
+- **KTD4 — Local replay harness is the dev loop.** A standalone entrypoint runs
+  `LangchainAgentRunner` against a real spec + a checkout and dumps the agent trace, so we iterate
+  without touching the box. Deterministic tests use a **recorded/fake tool-calling client** (no
+  network); a real-LLM run is **opt-in, creds-gated** (`ZAI_API_KEY`).
+- **KTD5 — Agent-trace observability is permanent.** Per-iteration tool-call logging (already added)
+  stays in `runner.py` — both for local replay and for the eventual shadow run on the box.
+- **KTD6 — Prove before flip.** `EXECUTOR=langchain` goes live only after: (a) local replay shows
+  real edits + passing `go build` on ≥1 real spec, and (b) a shadow/parallel pass on the box. Goose
+  stays the floor until then.
+
+---
+
+## High-Level Technical Design
+
+```
+spec_ready issue
+   │
+   ▼  implement_node (real_path)
+   ├─ materialize spec, prepare workspace (unchanged)
+   ▼
+LangChain agent (run_recipe → run_task):
+   system: "You are an autonomous coding agent. IMPLEMENT the spec by editing files."
+   task:   read spec → read source → edit_file/write_file → run_bash(go build/test/vet) → iterate
+   loop:   bounded tool output (#1886), per-iter trace log
+   STOP when: model emits no tool call  (NOT "a diff file exists")
+   │
+   ▼  success contract = workspace is git-dirty (real edits)   ← KTD2
+implement_node: _stage_impl_tree + git diff --cached → derive diff → commit → open PR
+   (existing "no tree changes" guard remains the backstop)
+```
+
+Contrast with today: the agent was told to *produce `diff_file`*; it produced an empty one and the
+runner accepted existence. New: the agent is told to *edit the code*; success is measured by the
+code actually changing.
+
+---
+
+## Implementation Units
+
+### U1. Agent-trace logging (observability) — DONE on branch
+
+- **Goal:** Surface the per-iteration tool sequence so agent behavior is explainable.
+- **Requirements:** KTD5.
+- **Dependencies:** none.
+- **Files:** `pipeline/wgmesh_pipeline/langchain_agent/runner.py` (already edited).
+- **Approach:** `_LOGGER.info("agent trace stage=%s iter=%d tools=%s text_len=%d", …)` each
+  iteration. Full untruncated results still only in `raw_log`.
+- **Test scenarios:** existing runner tests still pass; a fake-client run emits one trace line per
+  iteration naming the tools called.
+- **Verification:** local replay (U2) prints `tools=['run_bash']` for the current broken behavior,
+  confirming the diagnosis.
+
+### U2. Local replay harness + deterministic tests
+
+- **Goal:** Run and iterate the executor off-box.
+- **Requirements:** KTD4.
+- **Dependencies:** U1.
+- **Files:**
+  - `pipeline/wgmesh_pipeline/langchain_agent/replay.py` (new entrypoint:
+    `python -m wgmesh_pipeline.langchain_agent.replay --spec <path> --repo <path>`)
+  - `pipeline/tests/test_langchain_agent_replay.py`
+- **Approach:** Build a `LangchainAgentRunner` against a given spec + checkout, run it, print the
+  agent trace + final result (ok, output, tree-dirty). Deterministic tests inject a **fake
+  tool-calling client** that scripts a known tool sequence (e.g. read_file→edit_file→stop) and
+  assert the runner drives it correctly. A real-LLM path is opt-in behind `ZAI_API_KEY` (skipped in
+  CI).
+- **Test scenarios:**
+  - Fake client that edits a file then stops → runner reports success with a dirty workspace.
+  - Fake client that only runs `run_bash` (the current bug) → runner reports **no real changes**
+    (post-KTD2), reproducing the live failure deterministically.
+  - Real-LLM test is `skipif` no `ZAI_API_KEY`.
+- **Verification:** `pytest test_langchain_agent_replay.py` green; `replay.py` runs locally and
+  prints a trace.
+
+### U3. Agent-native implement prompt
+
+- **Goal:** Drive real implementation, not diff-file production.
+- **Requirements:** KTD1.
+- **Dependencies:** U2 (to validate the prompt drives edits).
+- **Files:**
+  - new `pipeline/wgmesh_pipeline/langchain_agent/prompts.py` task template (or a new
+    `recipes/wgmesh-implementation-agent.md` consumed only by the langchain path)
+  - `langchain_agent/runner.py` (wire the implement stage to the agent prompt, not the goose recipe)
+  - `pipeline/tests/test_langchain_agent_prompts.py`
+- **Approach:** Author a system+task prompt that (a) names the deliverable as *edited source +
+  passing build*, (b) instructs read-spec → read-source → edit → verify → stop, (c) explicitly says
+  **do not** write a diff file or run packaging git commands — the pipeline derives the diff. Keep
+  the Go project context + "verify types exist before referencing." Route the implement stage to
+  this prompt; spec/triage stages unchanged.
+- **Test scenarios:**
+  - Rendered prompt contains edit-files instructions and **omits** the `diff_file` / "Run exactly"
+    git step.
+  - Required params resolve; missing params raise `PromptRenderError`.
+  - (Via U2 real run, creds-gated) the agent calls `read_file` + `edit_file`/`write_file`, not just
+    `run_bash`.
+- **Verification:** local replay with the new prompt shows the agent reading the spec and editing
+  files; token count rises from 844 into a real implementation range.
+
+### U4. Completion contract = real workspace changes
+
+- **Goal:** Success only when the agent actually changed code.
+- **Requirements:** KTD2.
+- **Dependencies:** U2, U3.
+- **Files:**
+  - `langchain_agent/runner.py` (implement-stage completion)
+  - `pipeline/tests/test_langchain_agent_runner.py`
+- **Approach:** For the implement stage, replace the `output_path.exists()/size>0` success signal
+  with a **git-dirty check** of the workspace (or hand back "agent finished" and let
+  `implement_node`'s existing `git diff --cached --quiet` guard be the sole authority — preferred,
+  fewer moving parts). Revisit the #1886 U2 finish-on-expected-output so it doesn't early-exit on a
+  diff artifact for this stage. Preserve all other failure semantics (timeout, max-iter,
+  prompt-render error, unknown tool).
+- **Test scenarios:**
+  - Agent edits a file then stops → success.
+  - Agent stops with no edits (clean workspace) → failure (`no changes implemented`), not success.
+  - Pre-existing stale diff file present but no real edits → **failure** (closes the existence-only
+    hole and the U2 stale-file regression flagged in #1886's risks).
+  - Timeout / max-iter / unknown-tool failures unchanged.
+- **Verification:** the deterministic "only run_bash, no edits" replay now returns failure (not the
+  silent ok→"no tree changes" path); a real edit returns success.
+
+### U5. Validation gate (local proof + shadow), then flip
+
+- **Goal:** Prove the agent executor produces real impl PRs before any production flip.
+- **Requirements:** KTD6.
+- **Dependencies:** U3, U4.
+- **Files:** none (process) — a documented run + a control-replay note in the plan/PR.
+- **Approach:** (1) Local replay against ≥1 real requeued spec (creds-gated) → assert real edits +
+  `go build ./...` clean. (2) Shadow/parallel on the box: run the agent executor on one issue
+  without flipping the global `EXECUTOR`, compare its diff to goose's. (3) Only then flip
+  `EXECUTOR=langchain` via set-box-env, watch the journal for a real `fix:` PR. Goose stays the
+  floor; revert on any regression.
+- **Test scenarios:** `Test expectation: none — validation/process unit.`
+- **Verification:** a real `fix: Issue #N` PR opened by the agent executor with a non-empty,
+  build-clean diff; tokens in a real range; trace shows read+edit calls.
+
+---
+
+## Risks & Dependencies
+
+- **R1 — Model capability.** GLM-4.7 (current implement model) may be too weak to drive an agentic
+  edit loop reliably even with a good prompt. Mitigation: the harness (U2) lets us A/B models
+  cheaply; route the implement stage to a stronger model if needed (see Open Questions). Don't
+  conclude "agent can't implement" until tested with a capable model + the new prompt.
+- **R2 — Verification cost/time.** `go build/test/vet` inside the agent loop is slow and
+  token-heavy; bounded tool output (#1886) helps. Cap verify iterations; the wall-clock limit
+  already exists.
+- **R3 — Don't disturb goose.** All iteration is local/shadow; the global `EXECUTOR` stays goose
+  until U5 passes. No box flip in this plan's main path.
+- **Dependency:** local real runs need `ZAI_API_KEY` (and possibly a stronger model's creds). If
+  unavailable locally, U3/U5 real-validation happens in a box shadow run instead — note the gap.
+
+## Open Questions (resolve during implementation)
+
+- **Which model drives the agent?** Keep GLM-4.7, or route implement to a more capable coding model
+  (DeepSeek / frontier via OpenRouter, per the model-routing layer)? Decide empirically with the U2
+  harness — this likely matters more than the prompt.
+- **New recipe file vs inline prompt?** A `recipes/wgmesh-implementation-agent.md` keeps prompts
+  editable without code changes; an inline template is simpler. Pick during U3.
+
+## Verification (end-to-end)
+
+1. Unit suites green (replay, prompts, runner).
+2. Local replay: agent reads spec + edits files + `go build` clean on a real spec.
+3. Box shadow run matches goose-quality diff.
+4. Flip `EXECUTOR=langchain` → real `fix:` PR opens; tokens in a real range; trace shows read+edit.
+5. Only after sustained green: retire goose (separate follow-up).

--- a/pipeline/tests/test_langchain_agent_prompts.py
+++ b/pipeline/tests/test_langchain_agent_prompts.py
@@ -6,6 +6,7 @@ import pytest
 
 from wgmesh_pipeline.langchain_agent.prompts import (
     PromptRenderError,
+    build_implement_prompt,
     render_recipe_prompt,
 )
 
@@ -44,6 +45,28 @@ def test_implementation_recipe_renders_required_params() -> None:
     assert "diff.patch" in rendered
     assert "{{" not in rendered
     assert "}}" not in rendered
+
+
+def test_build_implement_prompt_contains_agent_native_editing_instructions() -> None:
+    rendered = build_implement_prompt("specs/issue-5-spec.md")
+
+    assert "specs/issue-5-spec.md" in rendered
+    assert "IMPLEMENT by EDITING FILES" in rendered
+    assert "edit_file" in rendered
+    assert "write_file" in rendered
+    assert "go build ./..." in rendered
+    assert "go test ./..." in rendered
+    assert "go vet ./..." in rendered
+    assert "diff_file" not in rendered
+    assert "git add" not in rendered
+    assert "git diff" not in rendered
+    assert "Run exactly" not in rendered
+
+
+@pytest.mark.parametrize("spec_file", ["", None])
+def test_build_implement_prompt_requires_spec_file(spec_file) -> None:
+    with pytest.raises(PromptRenderError, match="spec_file"):
+        build_implement_prompt(spec_file)
 
 
 def test_missing_required_param_names_missing_key(tmp_path: Path) -> None:

--- a/pipeline/tests/test_langchain_agent_runner.py
+++ b/pipeline/tests/test_langchain_agent_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -60,6 +61,31 @@ def write_recipe(tmp_path: Path, body: str | None = None) -> Path:
         encoding="utf-8",
     )
     return recipe
+
+
+def init_git_repo(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "README.md").write_text("initial\n", encoding="utf-8")
+    (tmp_path / "spec.md").write_text("Implement the change.\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
 
 
 def test_bounded_under_budget_passthrough_and_pure() -> None:
@@ -171,7 +197,7 @@ def test_happy_path_writes_expected_output_and_sums_usage(tmp_path) -> None:
         workdir=tmp_path,
         params={"output_file": "out.txt"},
         expected_output="out.txt",
-        stage="implement",
+        stage="spec",
     )
 
     assert result.ok is True
@@ -183,10 +209,179 @@ def test_happy_path_writes_expected_output_and_sums_usage(tmp_path) -> None:
     assert result.model_key == "default"
 
 
+def test_implement_stage_agent_edits_file_then_stops_returns_ok_for_dirty_workspace(
+    tmp_path,
+) -> None:
+    recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="editing",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "implemented.txt", "content": "done\n"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "total_tokens": 13,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 4,
+                        "output_tokens": 2,
+                        "total_tokens": 6,
+                    },
+                ),
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+    )
+
+    assert result.ok is True
+    assert (tmp_path / "implemented.txt").read_text(encoding="utf-8") == "done\n"
+    assert result.usage == UsageTotals(
+        input_tokens=14, output_tokens=5, total_tokens=19, requests=2, skipped=0
+    )
+
+
+def test_implement_stage_agent_without_edits_returns_no_source_changes_error(
+    tmp_path,
+) -> None:
+    recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="checking",
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+    )
+
+    assert result.ok is False
+    assert "no source changes" in (result.error or "")
+
+
+def test_implement_stage_ignores_stale_diff_file_when_workspace_is_clean(
+    tmp_path,
+) -> None:
+    recipe = write_recipe(tmp_path)
+    (tmp_path / "diff.patch").write_text("stale diff\n", encoding="utf-8")
+    init_git_repo(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+    )
+
+    assert result.ok is False
+    assert "no source changes" in (result.error or "")
+
+
+def test_non_implement_stage_still_completes_from_expected_output(tmp_path) -> None:
+    recipe = write_recipe(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="writing",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "out.txt", "content": "done"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+        stage="spec",
+    )
+
+    assert result.ok is True
+
+
 def test_emit_generation_called_with_stage_model_and_usage(
     tmp_path, monkeypatch
 ) -> None:
     recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
     emitted: list[dict[str, Any]] = []
     monkeypatch.setattr(
         "wgmesh_pipeline.langchain_agent.runner.tracing.emit_generation",
@@ -226,8 +421,8 @@ def test_emit_generation_called_with_stage_model_and_usage(
     result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
         recipe=recipe,
         workdir=tmp_path,
-        params={"output_file": "out.txt"},
-        expected_output="out.txt",
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
         stage="implement",
         session_id="issue-1",
     )
@@ -239,7 +434,7 @@ def test_emit_generation_called_with_stage_model_and_usage(
             "stage": "implement",
             "model": cfg().goose_model,
             "usage": result.usage,
-            "output": "writing",
+            "output": "finished",
         }
     ]
 
@@ -506,6 +701,7 @@ def test_model_routing_passes_resolved_profile_to_client_factory(
     tmp_path, monkeypatch
 ) -> None:
     recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
     monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
     config = load_config(
         {
@@ -548,8 +744,8 @@ def test_model_routing_passes_resolved_profile_to_client_factory(
     result = LangchainAgentRunner(config, client_factory=client_factory).run_recipe(
         recipe=recipe,
         workdir=tmp_path,
-        params={"output_file": "out.txt"},
-        expected_output="out.txt",
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
         stage="implement",
     )
 

--- a/pipeline/wgmesh_pipeline/langchain_agent/prompts.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/prompts.py
@@ -13,6 +13,14 @@ class PromptRenderError(Exception):
     pass
 
 
+IMPLEMENT_SYSTEM_PROMPT = (
+    "You are an autonomous coding agent. Use the provided workspace tools to "
+    "inspect and modify files. For implementation tasks, finishing means the "
+    "approved spec has been implemented in the source tree and verified. It "
+    "does not mean an output artifact, diff file, or packaging command exists."
+)
+
+
 def load_recipe(recipe_path: str | Path) -> dict:
     try:
         data = yaml.safe_load(Path(recipe_path).read_text(encoding="utf-8"))
@@ -52,3 +60,41 @@ def render_recipe_prompt(
         )
 
     return _PLACEHOLDER_RE.sub(lambda match: str(params[match.group(1)]), prompt_text)
+
+
+def build_implement_prompt(spec_file: str | None) -> str:
+    if not spec_file:
+        raise PromptRenderError("missing required recipe params: spec_file")
+
+    return f"""Implement the approved wgmesh spec at {spec_file}.
+
+You are working in the wgmesh repository:
+- Go module: github.com/atvirokodosprendimai/wgmesh
+- Go version: 1.25
+- Prefer the Go standard library where it is sufficient.
+- Preserve existing project style and keep changes scoped to the spec.
+- Wrap errors with useful context when returning them.
+
+Required workflow:
+1. Read {spec_file} thoroughly.
+2. Read the real source files the spec touches. Verify referenced packages, types,
+   functions, methods, fields, and signatures exist before using or changing them.
+3. IMPLEMENT by EDITING FILES with edit_file or write_file.
+   File edits are the deliverable.
+4. Verify the implementation with run_bash:
+   - go build ./...
+   - go test ./...
+   - go vet ./...
+5. Run gofmt -w on changed Go files.
+6. If any verification command fails, inspect the failure, edit the source, and
+   repeat verification until the implementation is clean or you are blocked by a
+   real repository problem.
+
+Do not write a diff file.
+Do not run git staging commands.
+Do not run git comparison commands.
+Do not run packaging commands.
+The pipeline derives the diff from your file edits.
+
+Stop when the implementation is complete and the repository builds, tests, and vets cleanly.
+"""

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -106,6 +106,18 @@ class LangchainAgentRunner:
                 raw_log.append(f"assistant: {completion_text}")
 
                 tool_calls = list(getattr(ai_message, "tool_calls", None) or [])
+                # Agent-trace observability (non-goose executor build): the box
+                # journal was blind to what the ReAct agent actually does — this
+                # surfaces the per-iteration tool sequence so "no tree changes" /
+                # tiny-token runs are explainable (e.g. agent runs only run_bash,
+                # never read_file/edit_file → it skipped the implementation).
+                _LOGGER.info(
+                    "agent trace stage=%s iter=%d tools=%s text_len=%d",
+                    stage,
+                    iterations,
+                    [_tool_call_parts(call)[0] for call in tool_calls],
+                    len(completion_text or ""),
+                )
                 if not tool_calls:
                     break
 

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import time
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -51,10 +52,16 @@ class LangchainAgentRunner:
             root = Path(workdir).resolve()
             output_path = resolve_workspace_path(root, expected_output)
             profile = self._resolve_profile(stage, tier)
+            is_implement_stage = stage == "implement"
             try:
-                rendered_prompt = prompts.render_recipe_prompt(
-                    recipe, params, workdir=root
-                )
+                if is_implement_stage:
+                    rendered_prompt = prompts.build_implement_prompt(
+                        params.get("spec_file")
+                    )
+                else:
+                    rendered_prompt = prompts.render_recipe_prompt(
+                        recipe, params, workdir=root
+                    )
             except prompts.PromptRenderError as exc:
                 return _result(
                     ok=False,
@@ -72,10 +79,10 @@ class LangchainAgentRunner:
 
             HumanMessage, SystemMessage, ToolMessage = _message_classes()
             messages: list[Any] = [
-                SystemMessage(content=_system_prompt()),
+                SystemMessage(content=_system_prompt(is_implement_stage)),
                 HumanMessage(content=rendered_prompt),
             ]
-            raw_log.append(f"system: {_system_prompt()}")
+            raw_log.append(f"system: {_system_prompt(is_implement_stage)}")
             raw_log.append(f"human: {rendered_prompt}")
 
             iterations = 0
@@ -137,7 +144,11 @@ class LangchainAgentRunner:
                             name=name,
                         )
                     )
-                if output_path.exists() and output_path.stat().st_size > 0:
+                if (
+                    not is_implement_stage
+                    and output_path.exists()
+                    and output_path.stat().st_size > 0
+                ):
                     _emit_usage(
                         session_id=session_id,
                         stage=stage,
@@ -179,6 +190,26 @@ class LangchainAgentRunner:
                 usage=usage,
                 output=completion_text,
             )
+            if is_implement_stage:
+                if _workspace_is_dirty(root):
+                    return _result(
+                        ok=True,
+                        output_path=output_path,
+                        started=started,
+                        raw_log=raw_log,
+                        error=None,
+                        profile=profile,
+                        usage=usage,
+                    )
+                return _result(
+                    ok=False,
+                    output_path=output_path,
+                    started=started,
+                    raw_log=raw_log,
+                    error="agent made no source changes",
+                    profile=profile,
+                    usage=usage,
+                )
             if output_path.exists():
                 return _result(
                     ok=True,
@@ -274,12 +305,32 @@ def _message_classes() -> tuple[type[Any], type[Any], type[Any]]:
     return HumanMessage, SystemMessage, ToolMessage
 
 
-def _system_prompt() -> str:
+def _system_prompt(is_implement_stage: bool = False) -> str:
+    if is_implement_stage:
+        return prompts.IMPLEMENT_SYSTEM_PROMPT
     return (
         "You are an autonomous coding agent. Use the provided workspace tools to "
         "inspect and modify files. Keep all work inside the workspace, and write "
         "the requested expected output before finishing."
     )
+
+
+def _workspace_is_dirty(workdir: str | Path) -> bool:
+    root = Path(workdir)
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=root,
+        text=True,
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "could not inspect workspace git status: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    return bool(completed.stdout.strip())
 
 
 def _tool_call_parts(call: Any) -> tuple[str, dict[str, Any], str]:


### PR DESCRIPTION
## Why

Building the non-goose autobox (operator: goose=KTLO, all new work on the LangChain executor). Diagnosed why `EXECUTOR=langchain` does no work: it's handed the **goose recipe** (`wgmesh-implementation.yaml`), whose step 6 says *"Run exactly: `git add -A && … git diff --cached > diff_file`"*. The ReAct agent runs that literal command first, skips implementing, writes an empty diff — and the runner accepted it because completion was `output_path.exists()`. Live result: 844 tokens, no file reads, "no tree changes."

## What (langchain-only — goose untouched, KTLO-safe)

- **Agent-native implement prompt** (`build_implement_prompt`): read spec → read source → **edit files** with `edit_file`/`write_file` → `go build/test/vet` → stop. Explicitly forbids writing a diff file / `git add` / `git diff` / "Run exactly". The pipeline derives the diff from the edits.
- **Completion = real workspace changes**: for `stage=="implement"`, success iff `_workspace_is_dirty(root)`; no edits → `ok=False "agent made no source changes"`. The diff-file early-exit (#1886 U2) is gated to non-implement stages, closing the stale-diff hole.
- `runner.run_recipe` branches on `stage=="implement"`; all other stages unchanged.

This is slice 1 (executor core), model-agnostic. Next: a box-shadow harness to A/B the agent across **DeepSeek · MiniMax · GLM-5.2** (the likely real lever) without flipping the live `EXECUTOR`.

## Inert in production

`EXECUTOR=goose` on the box → this path isn't exercised yet. No behavior change until a deliberate shadow/flip after validation.

## Test plan
- `pytest test_langchain_agent_runner.py test_langchain_agent_prompts.py -q` → **28 passed** (verified locally, CI-parity). Covers: dirty-agent success, no-edit failure, stale-diff-no-success, non-implement regression, prompt content + missing-spec error.
- [ ] CI green.

Plan: `docs/plans/2026-06-20-004-feat-nongoose-agent-executor-plan.md` (slice 1 = U3+U4).