### PR TITLE
feat(langchain): box-shadow replay harness (agent executor A/B)

### DIFF
--- a/.github/workflows/nongoose-shadow.yml
+++ b/.github/workflows/nongoose-shadow.yml
@@ -1,0 +1,129 @@
+name: Nongoose Shadow
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+      spec_ref:
+        description: 'Spec path in the wgmesh repo, e.g. specs/issue-783-spec.md'
+        required: true
+      model:
+        description: 'Implement model id'
+        default: 'GLM-5.2'
+
+permissions:
+  contents: read
+
+jobs:
+  shadow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
+          : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Validate inputs
+        env:
+          SERVER_NAME: ${{ github.event.inputs.server_name }}
+          SPEC_REF: ${{ github.event.inputs.spec_ref }}
+          MODEL: ${{ github.event.inputs.model }}
+        run: |
+          set -euo pipefail
+          [[ "$SERVER_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || {
+            echo "invalid server_name" >&2
+            exit 1
+          }
+          [[ "$MODEL" =~ ^[A-Za-z0-9._-]+$ ]] || {
+            echo "invalid model" >&2
+            exit 1
+          }
+          [[ "$SPEC_REF" =~ ^[A-Za-z0-9._/-]+$ ]] || {
+            echo "invalid spec_ref" >&2
+            exit 1
+          }
+          [[ "$SPEC_REF" != /* && "$SPEC_REF" != *..* ]] || {
+            echo "invalid spec_ref path" >&2
+            exit 1
+          }
+
+      - name: Resolve box IP
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SERVER_NAME: ${{ github.event.inputs.server_name }}
+        run: |
+          set -euo pipefail
+          IP=$(hcloud server ip "$SERVER_NAME")
+          echo "BOX_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Run shadow replay on box
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SPEC_REF: ${{ github.event.inputs.spec_ref }}
+          MODEL: ${{ github.event.inputs.model }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          SSH_SPEC_REF=$(printf '%q' "$SPEC_REF")
+          SSH_MODEL=$(printf '%q' "$MODEL")
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+              "SPEC_REF=$SSH_SPEC_REF MODEL=$SSH_MODEL bash -se" <<'REMOTE'
+          set -euo pipefail
+          . /etc/wgmesh-pipeline/env
+          : "${WGMESH_BOT_PAT:?WGMESH_BOT_PAT missing on box}"
+
+          temp_dir=$(mktemp -d)
+          cleanup() {
+            rm -rf "$temp_dir"
+          }
+          trap cleanup EXIT
+
+          git clone --depth 1 \
+            "https://x-access-token:${WGMESH_BOT_PAT}@github.com/atvirokodosprendimai/wgmesh.git" \
+            "$temp_dir"
+
+          if [ ! -f "$temp_dir/$SPEC_REF" ]; then
+            git -C "$temp_dir" fetch --depth 1 origin \
+              '+refs/heads/*:refs/remotes/origin/*' || true
+            found_ref=$(
+              git -C "$temp_dir" for-each-ref --format='%(refname:short)' \
+                refs/remotes/origin | while read -r ref; do
+                if git -C "$temp_dir" cat-file -e "$ref:$SPEC_REF" 2>/dev/null; then
+                  printf '%s\n' "$ref"
+                  break
+                fi
+              done
+            )
+            if [ -n "$found_ref" ]; then
+              git -C "$temp_dir" checkout --detach "$found_ref"
+            fi
+          fi
+
+          test -f "$temp_dir/$SPEC_REF"
+          . /etc/wgmesh-pipeline/env
+          cd /opt/wgmesh-pipeline
+          /opt/wgmesh-pipeline/.venv/bin/python \
+            -m wgmesh_pipeline.langchain_agent.replay \
+            --spec "$temp_dir/$SPEC_REF" \
+            --workdir "$temp_dir" \
+            --model "$MODEL"
+          REMOTE
+
+      - name: Cleanup
+        if: always()
+        run: rm -f "$RUNNER_TEMP/deploy_key"

--- a/pipeline/tests/test_langchain_agent_replay.py
+++ b/pipeline/tests/test_langchain_agent_replay.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import io
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.langchain_agent import replay
+from wgmesh_pipeline.models import ModelProfile
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class FakeAIMessage:
+    content: str
+    tool_calls: list[dict[str, Any]]
+    usage_metadata: dict[str, int]
+
+
+class FakeClient:
+    def __init__(self, messages: list[FakeAIMessage]):
+        self._messages = messages
+
+    def bind_tools(self, specs: list[object]) -> FakeClient:
+        return self
+
+    def invoke(self, messages: list[Any]) -> FakeAIMessage:
+        if len(self._messages) == 1:
+            return self._messages[0]
+        return self._messages.pop(0)
+
+
+def cfg() -> Config:
+    return Config(
+        target_repo="atvirokodosprendimai/wgmesh",
+        zai_api_key="zai",
+        anthropic_host="https://api.z.ai/api/anthropic",
+    )
+
+
+def init_git_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "README.md").write_text("initial\n", encoding="utf-8")
+    spec = tmp_path / "spec.md"
+    spec.write_text("Implement the change.\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return spec
+
+
+def test_replay_reports_ok_and_exits_zero_when_agent_edits_file(tmp_path: Path) -> None:
+    spec = init_git_repo(tmp_path)
+    stdout = io.StringIO()
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="editing",
+                    tool_calls=[
+                        {
+                            "name": "edit_file",
+                            "args": {
+                                "path": "README.md",
+                                "old": "initial\n",
+                                "new": "implemented\n",
+                            },
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "total_tokens": 13,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 4,
+                        "output_tokens": 2,
+                        "total_tokens": 6,
+                    },
+                ),
+            ]
+        )
+
+    code = replay.main(
+        ["--spec", str(spec), "--workdir", str(tmp_path)],
+        client_factory=client_factory,
+        config_loader=cfg,
+        stdout=stdout,
+    )
+
+    assert code == 0
+    report = stdout.getvalue()
+    assert "REPORT" in report
+    assert "ok: True" in report
+    assert "git_dirty: True" in report
+    assert "README.md" in report
+    assert "input_tokens=14" in report
+
+
+def test_replay_exits_one_when_agent_makes_no_edits(tmp_path: Path) -> None:
+    spec = init_git_repo(tmp_path)
+    stdout = io.StringIO()
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="checking",
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+            ]
+        )
+
+    code = replay.main(
+        ["--spec", str(spec), "--workdir", str(tmp_path)],
+        client_factory=client_factory,
+        config_loader=cfg,
+        stdout=stdout,
+    )
+
+    assert code == 1
+    report = stdout.getvalue()
+    assert "ok: False" in report
+    assert "git_dirty: False" in report
+    assert "no source changes" in report
+
+
+def test_replay_model_override_sets_goose_model_before_running(
+    tmp_path: Path,
+) -> None:
+    spec = init_git_repo(tmp_path)
+    stdout = io.StringIO()
+    seen_models: list[str] = []
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        seen_models.append(profile.model)
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="editing",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "implemented.txt", "content": "done\n"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+                FakeAIMessage(
+                    content="finished",
+                    tool_calls=[],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                ),
+            ]
+        )
+
+    code = replay.main(
+        ["--spec", str(spec), "--workdir", str(tmp_path), "--model", "X"],
+        client_factory=client_factory,
+        config_loader=cfg,
+        stdout=stdout,
+    )
+
+    assert code == 0
+    assert seen_models == ["X"]
+    assert "model: X" in stdout.getvalue()

--- a/pipeline/wgmesh_pipeline/langchain_agent/replay.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/replay.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable, TextIO
+
+from wgmesh_pipeline.config import Config, load_config
+from wgmesh_pipeline.langchain_agent.runner import (
+    ClientFactory,
+    LangchainAgentRunner,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_DIFF_LIMIT_CHARS = 8_000
+
+ConfigLoader = Callable[[], Config]
+RunnerFactory = Callable[[Config], LangchainAgentRunner]
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    client_factory: ClientFactory | None = None,
+    runner_factory: RunnerFactory | None = None,
+    config_loader: ConfigLoader = load_config,
+    stdout: TextIO | None = None,
+) -> int:
+    args = _parse_args(argv)
+    out = stdout or sys.stdout
+    workdir = Path(args.workdir).resolve()
+    spec_file = _spec_file_arg(Path(args.spec), workdir)
+
+    config = config_loader()
+    if args.model:
+        config = replace(
+            config,
+            goose_model=args.model,
+            model_registry={},
+            stage_routing={},
+        )
+
+    runner = (
+        runner_factory(config)
+        if runner_factory is not None
+        else LangchainAgentRunner(config, client_factory=client_factory)
+    )
+    result = runner.run_recipe(
+        recipe=Path(config.recipes_dir) / "wgmesh-implementation.yaml",
+        workdir=workdir,
+        params={
+            "spec_file": spec_file,
+            "diff_file": "pipeline-output/replay.diff",
+        },
+        expected_output="pipeline-output/replay.diff",
+        stage="implement",
+        tier=0,
+        session_id="replay",
+    )
+    dirty = _workspace_is_dirty(workdir)
+    diff = _bounded(_git_diff(workdir))
+    _print_report(
+        stdout=out,
+        model=config.goose_model,
+        ok=result.ok,
+        error=result.error,
+        dirty=dirty,
+        diff=diff,
+        usage=result.usage,
+    )
+    return 0 if result.ok and dirty else 1
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Replay the LangChain implementer.")
+    parser.add_argument("--spec", required=True, help="Spec file path.")
+    parser.add_argument("--workdir", required=True, help="Isolated git working tree.")
+    parser.add_argument("--model", help="Override the implement model id.")
+    return parser.parse_args(argv)
+
+
+def _spec_file_arg(spec_path: Path, workdir: Path) -> str:
+    if not spec_path.is_absolute():
+        spec_path = (Path.cwd() / spec_path).resolve()
+    else:
+        spec_path = spec_path.resolve()
+    try:
+        return spec_path.relative_to(workdir).as_posix()
+    except ValueError:
+        return str(spec_path)
+
+
+def _workspace_is_dirty(workdir: Path) -> bool:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workdir,
+        text=True,
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        _LOGGER.warning(
+            "could not inspect git status: %s",
+            completed.stderr.strip() or completed.stdout.strip(),
+        )
+        return False
+    return bool(completed.stdout.strip())
+
+
+def _git_diff(workdir: Path) -> str:
+    completed = subprocess.run(
+        ["git", "diff", "--"],
+        cwd=workdir,
+        text=True,
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return completed.stderr.strip() or completed.stdout.strip()
+    return completed.stdout
+
+
+def _bounded(text: str) -> str:
+    if len(text) <= _DIFF_LIMIT_CHARS:
+        return text
+    omitted = len(text) - _DIFF_LIMIT_CHARS
+    return f"{text[:_DIFF_LIMIT_CHARS]}\n...[truncated {omitted} chars]...\n"
+
+
+def _print_report(
+    *,
+    stdout: TextIO,
+    model: str,
+    ok: bool,
+    error: str | None,
+    dirty: bool,
+    diff: str,
+    usage: object,
+) -> None:
+    print("REPORT", file=stdout)
+    print(f"model: {model}", file=stdout)
+    print(f"ok: {ok}", file=stdout)
+    print(f"error: {error}", file=stdout)
+    print(f"git_dirty: {dirty}", file=stdout)
+    print(f"usage: {usage}", file=stdout)
+    print("diff:", file=stdout)
+    print(diff or "(empty)", file=stdout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why
Slice 2 of the non-goose executor. A box-shadow harness to run the LangChain implement executor against ONE real spec in isolation, WITHOUT flipping the live `EXECUTOR` (goose stays running) — so we can A/B the agent model. First experiment: **GLM-5.2** (config default; the box currently routes implement to the weaker **glm-4.7**, the likely cause of the 844-token / no-edit failures).

## What
- `langchain_agent/replay.py` — CLI: `--spec --workdir [--model]`. Runs `run_recipe(stage="implement")` in the given isolated workdir, prints a REPORT (model, ok, error, git_dirty, diff, tokens), exits 0 iff ok+dirty.
- `.github/workflows/nongoose-shadow.yml` — `workflow_dispatch(server_name, spec_ref, model=GLM-5.2)`. SSHes the box, clones wgmesh fresh into a `mktemp -d`, runs the replay there, cleans up. Scope-guarded inputs; does NOT touch `/opt/wgmesh-checkout` or the running service.
- `test_langchain_agent_replay.py` — 3 deterministic fake-client tests (dirty→ok exit0, no-edit→fail exit1, --model override).

## Inert in production — read-only shadow, no executor flip.

## Test plan
- `pytest test_langchain_agent_replay.py -q` → **3 passed** (local, CI-parity).
- [ ] CI green → merge → `update-pipeline-box` → dispatch `nongoose-shadow` with `model=GLM-5.2`.

Plan: `docs/plans/2026-06-20-004-...` (U2/U5).