### PR TITLE
feat(langchain): history compaction + max-iter harvest + replay logging (non-goose converge)

### DIFF
--- a/pipeline/tests/test_langchain_agent_replay.py
+++ b/pipeline/tests/test_langchain_agent_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -220,3 +221,39 @@ def test_replay_model_override_sets_goose_model_before_running(
     assert code == 0
     assert seen_models == ["X"]
     assert "model: X" in stdout.getvalue()
+
+
+def test_replay_configures_logging_to_stdout(monkeypatch, tmp_path: Path) -> None:
+    spec = init_git_repo(tmp_path)
+    calls: list[dict[str, Any]] = []
+
+    def fake_basic_config(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    class FakeRunner:
+        def __init__(self, config: Config) -> None:
+            self.config = config
+
+        def run_recipe(self, **kwargs: Any) -> Any:
+            return type(
+                "Result",
+                (),
+                {
+                    "ok": False,
+                    "error": "agent made no source changes",
+                    "usage": object(),
+                },
+            )()
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    replay.main(
+        ["--spec", str(spec), "--workdir", str(tmp_path)],
+        runner_factory=FakeRunner,
+        config_loader=cfg,
+        stdout=io.StringIO(),
+    )
+
+    assert calls[0]["level"] == logging.INFO
+    assert calls[0]["stream"] is replay.sys.stdout
+    assert calls[0]["force"] is True

--- a/pipeline/tests/test_langchain_agent_runner.py
+++ b/pipeline/tests/test_langchain_agent_runner.py
@@ -10,9 +10,11 @@ import pytest
 from wgmesh_pipeline.config import Config, load_config
 from wgmesh_pipeline.goose.usage import UsageTotals
 from wgmesh_pipeline.langchain_agent.runner import (
+    MAX_CONTEXT_CHARS,
     MAX_TOOL_OUTPUT_CHARS,
     LangchainAgentRunner,
     _bounded,
+    _compact_messages,
 )
 from wgmesh_pipeline.models import ModelProfile
 
@@ -106,6 +108,191 @@ def test_bounded_over_budget_keeps_head_tail_and_marker() -> None:
     assert f"[truncated {dropped} chars]" in bounded
 
 
+def test_compact_messages_under_budget_returns_messages_unchanged() -> None:
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    messages = [
+        SystemMessage(content="system"),
+        HumanMessage(content="task"),
+        AIMessage(content="done", tool_calls=[]),
+    ]
+
+    assert _compact_messages(messages, 1_000) == messages
+
+
+def test_compact_messages_over_budget_preserves_prefix_and_pairs() -> None:
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    from langchain_core.messages import ToolMessage
+
+    messages = [
+        SystemMessage(content="system"),
+        HumanMessage(content="task"),
+        AIMessage(
+            content="old ai " + ("x" * 50),
+            tool_calls=[
+                {
+                    "name": "read_file",
+                    "args": {"path": "old.txt"},
+                    "id": "old-call",
+                }
+            ],
+        ),
+        ToolMessage(content="old tool " + ("x" * 50), tool_call_id="old-call"),
+        AIMessage(
+            content="middle ai " + ("x" * 50),
+            tool_calls=[
+                {
+                    "name": "read_file",
+                    "args": {"path": "middle.txt"},
+                    "id": "middle-call",
+                }
+            ],
+        ),
+        ToolMessage(
+            content="middle tool " + ("x" * 50), tool_call_id="middle-call"
+        ),
+        AIMessage(
+            content="last ai",
+            tool_calls=[
+                {
+                    "name": "read_file",
+                    "args": {"path": "last.txt"},
+                    "id": "last-call",
+                }
+            ],
+        ),
+        ToolMessage(content="last tool", tool_call_id="last-call"),
+    ]
+
+    compacted = _compact_messages(messages, 100)
+
+    assert compacted[0] == messages[0]
+    assert compacted[1] == messages[1]
+    assert messages[2] not in compacted
+    assert messages[3] not in compacted
+    assert messages[4] not in compacted
+    assert messages[5] not in compacted
+    assert messages[6:] == compacted[2:]
+    compacted_size = sum(
+        len(str(getattr(message, "content", ""))) for message in compacted
+    )
+    assert compacted_size <= 100
+    _assert_no_orphaned_tool_pairs(compacted)
+
+
+def test_compact_messages_preserves_pairing_integrity_across_rounds() -> None:
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    from langchain_core.messages import ToolMessage
+
+    messages = [
+        SystemMessage(content="system"),
+        HumanMessage(content="task"),
+        AIMessage(
+            content="old no tools " + ("x" * 40),
+            tool_calls=[],
+        ),
+        AIMessage(
+            content="middle tools " + ("x" * 40),
+            tool_calls=[
+                {"name": "read_file", "args": {"path": "a.txt"}, "id": "middle-a"},
+                {"name": "read_file", "args": {"path": "b.txt"}, "id": "middle-b"},
+            ],
+        ),
+        ToolMessage(content="middle result a " + ("x" * 40), tool_call_id="middle-a"),
+        ToolMessage(content="middle result b " + ("x" * 40), tool_call_id="middle-b"),
+        AIMessage(
+            content="last tools",
+            tool_calls=[
+                {"name": "read_file", "args": {"path": "c.txt"}, "id": "last-a"},
+                {"name": "read_file", "args": {"path": "d.txt"}, "id": "last-b"},
+            ],
+        ),
+        ToolMessage(content="last result a", tool_call_id="last-a"),
+        ToolMessage(content="last result b", tool_call_id="last-b"),
+    ]
+
+    compacted = _compact_messages(messages, 90)
+
+    assert compacted[:2] == messages[:2]
+    assert messages[2] not in compacted
+    assert messages[3] not in compacted
+    assert messages[4] not in compacted
+    assert messages[5] not in compacted
+    assert messages[6:] == compacted[2:]
+    _assert_no_orphaned_tool_pairs(compacted)
+
+
+def test_compact_messages_keeps_last_round_when_last_round_exceeds_budget() -> None:
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+    from langchain_core.messages import ToolMessage
+
+    messages = [
+        SystemMessage(content="system"),
+        HumanMessage(content="task"),
+        AIMessage(content="old", tool_calls=[]),
+        AIMessage(
+            content="last ai " + ("x" * 80),
+            tool_calls=[
+                {"name": "read_file", "args": {"path": "last.txt"}, "id": "last"}
+            ],
+        ),
+        ToolMessage(content="last tool " + ("x" * 80), tool_call_id="last"),
+    ]
+
+    compacted = _compact_messages(messages, 40)
+
+    assert compacted == messages[:2] + messages[3:]
+    _assert_no_orphaned_tool_pairs(compacted)
+
+
+def test_agent_compacts_history_before_each_llm_invoke(tmp_path: Path) -> None:
+    recipe = write_recipe(tmp_path)
+    fake_client: FakeClient | None = None
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        nonlocal fake_client
+        fake_client = FakeClient(
+            [
+                FakeAIMessage(
+                    content="x" * (MAX_CONTEXT_CHARS + 1),
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-1",
+                        }
+                    ],
+                    usage_metadata={},
+                ),
+                FakeAIMessage(
+                    content="small follow-up",
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-2",
+                        }
+                    ],
+                    usage_metadata={},
+                ),
+                FakeAIMessage(content="finished", tool_calls=[], usage_metadata={}),
+            ]
+        )
+        return fake_client
+
+    LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+    )
+
+    assert fake_client is not None
+    assert len(fake_client.invocations) == 3
+    assert len(fake_client.invocations[2]) == 4
+    assert fake_client.invocations[2][2].content == "small follow-up"
+
+
 def test_tool_output_is_bounded_but_raw_log_keeps_full_output(tmp_path) -> None:
     recipe = write_recipe(tmp_path)
     large_output = "head" + ("x" * MAX_TOOL_OUTPUT_CHARS) + "tail"
@@ -157,6 +344,19 @@ def test_tool_output_is_bounded_but_raw_log_keeps_full_output(tmp_path) -> None:
     tool_message = fake_client.invocations[1][-1]
     assert tool_message.content == _bounded(large_output)
     assert tool_message.content != large_output
+
+
+def _assert_no_orphaned_tool_pairs(messages: list[Any]) -> None:
+    ai_call_ids: set[str] = set()
+    tool_call_ids: set[str] = set()
+    for message in messages:
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            ai_call_ids.add(str(tool_call["id"]))
+        tool_call_id = getattr(message, "tool_call_id", None)
+        if tool_call_id is not None:
+            tool_call_ids.add(str(tool_call_id))
+
+    assert ai_call_ids == tool_call_ids
 
 
 def test_happy_path_writes_expected_output_and_sums_usage(tmp_path) -> None:
@@ -544,6 +744,127 @@ def test_max_iterations_env_override_reports_actual_cap(
     assert "max iterations (3)" in (result.error or "")
     assert result.usage is not None
     assert result.usage.requests == 3
+
+
+def test_implement_stage_at_max_iterations_harvests_dirty_workspace(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "3")
+    recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="still working",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"path": "README.md", "content": "changed\n"},
+                            "id": "call-loop",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+    )
+
+    assert result.ok is True
+    assert result.error == "harvested at max iterations (3) — workspace had changes"
+    assert result.usage.requests == 3
+
+
+def test_implement_stage_at_max_iterations_clean_workspace_still_fails(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "3")
+    recipe = write_recipe(tmp_path)
+    init_git_repo(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="still checking",
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-loop",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"spec_file": "spec.md"},
+        expected_output="diff.patch",
+        stage="implement",
+    )
+
+    assert result.ok is False
+    assert result.error == "langchain agent reached max iterations (3)"
+    assert "harvested" not in (result.error or "")
+
+
+def test_non_implement_stage_at_max_iterations_still_fails(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LANGCHAIN_MAX_ITERATIONS", "3")
+    recipe = write_recipe(tmp_path)
+
+    def client_factory(profile: ModelProfile, config: Config) -> FakeClient:
+        return FakeClient(
+            [
+                FakeAIMessage(
+                    content="still working",
+                    tool_calls=[
+                        {
+                            "name": "run_bash",
+                            "args": {"command": "true"},
+                            "id": "call-loop",
+                        }
+                    ],
+                    usage_metadata={
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                )
+            ]
+        )
+
+    result = LangchainAgentRunner(cfg(), client_factory=client_factory).run_recipe(
+        recipe=recipe,
+        workdir=tmp_path,
+        params={"output_file": "out.txt"},
+        expected_output="out.txt",
+        stage="spec",
+    )
+
+    assert result.ok is False
+    assert result.error == "langchain agent reached max iterations (3)"
 
 
 def test_max_iterations_invalid_env_falls_back_to_default(

--- a/pipeline/wgmesh_pipeline/langchain_agent/replay.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/replay.py
@@ -29,6 +29,7 @@ def main(
     config_loader: ConfigLoader = load_config,
     stdout: TextIO | None = None,
 ) -> int:
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout, force=True)
     args = _parse_args(argv)
     out = stdout or sys.stdout
     workdir = Path(args.workdir).resolve()

--- a/pipeline/wgmesh_pipeline/langchain_agent/runner.py
+++ b/pipeline/wgmesh_pipeline/langchain_agent/runner.py
@@ -22,6 +22,7 @@ from wgmesh_pipeline.models import (
 ClientFactory = Callable[[ModelProfile, Config], Any]
 MAX_ITERATIONS = 40
 MAX_TOOL_OUTPUT_CHARS = 16_000
+MAX_CONTEXT_CHARS = 120_000
 WALL_CLOCK_LIMIT_SECONDS = 1800
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,11 +102,15 @@ class LangchainAgentRunner:
                         output_path=output_path,
                         started=started,
                         raw_log=raw_log,
-                        error=f"langchain agent timed out after {WALL_CLOCK_LIMIT_SECONDS}s",
+                        error=(
+                            "langchain agent timed out after "
+                            f"{WALL_CLOCK_LIMIT_SECONDS}s"
+                        ),
                         profile=profile,
                         usage=usage,
                     )
                 iterations += 1
+                messages = _compact_messages(messages)
                 ai_message = llm.invoke(messages)
                 messages.append(ai_message)
                 usage = _add_usage(usage, getattr(ai_message, "usage_metadata", None))
@@ -173,6 +178,19 @@ class LangchainAgentRunner:
                     usage=usage,
                     output=completion_text,
                 )
+                if is_implement_stage and _workspace_is_dirty(root):
+                    return _result(
+                        ok=True,
+                        output_path=output_path,
+                        started=started,
+                        raw_log=raw_log,
+                        error=(
+                            "harvested at max iterations "
+                            f"({max_iterations}) — workspace had changes"
+                        ),
+                        profile=profile,
+                        usage=usage,
+                    )
                 return _result(
                     ok=False,
                     output_path=output_path,
@@ -297,6 +315,82 @@ def _bounded(text: str) -> str:
     dropped_chars = len(text) - MAX_TOOL_OUTPUT_CHARS
     marker = f"\n...[truncated {dropped_chars} chars]...\n"
     return f"{text[:head_chars]}{marker}{text[-tail_chars:]}"
+
+
+def _compact_messages(
+    messages: list[Any], max_chars: int = MAX_CONTEXT_CHARS
+) -> list[Any]:
+    """Drop oldest middle rounds when total content chars exceed max_chars.
+
+    Always keep messages[0] (SystemMessage) and messages[1] (initial HumanMessage).
+    Drop whole rounds: an AIMessage with tool_calls and its following
+    ToolMessage(s) form one round. Size is based on message content.
+    """
+    if len(messages) <= 2 or _messages_size(messages) <= max_chars:
+        return messages
+
+    prefix = messages[:2]
+    rounds = _message_rounds(messages[2:])
+    kept_rounds = list(rounds)
+    while len(kept_rounds) > 1 and (
+        _messages_size(prefix + _flatten_rounds(kept_rounds)) > max_chars
+    ):
+        kept_rounds.pop(0)
+    return prefix + _flatten_rounds(kept_rounds)
+
+
+def _messages_size(messages: list[Any]) -> int:
+    return sum(len(str(getattr(message, "content", ""))) for message in messages)
+
+
+def _message_rounds(messages: list[Any]) -> list[list[Any]]:
+    rounds: list[list[Any]] = []
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        round_messages = [message]
+        index += 1
+        tool_call_ids = _tool_call_ids(message)
+        if tool_call_ids:
+            while (
+                index < len(messages)
+                and _tool_message_call_id(messages[index]) in tool_call_ids
+            ):
+                round_messages.append(messages[index])
+                index += 1
+        rounds.append(round_messages)
+    return rounds
+
+
+def _flatten_rounds(rounds: list[list[Any]]) -> list[Any]:
+    return [message for round_messages in rounds for message in round_messages]
+
+
+def _tool_call_ids(message: Any) -> set[str]:
+    tool_calls = getattr(message, "tool_calls", None) or []
+    ids: set[str] = set()
+    for call in tool_calls:
+        if isinstance(call, dict):
+            raw_id = call.get("id") or call.get("tool_call_id")
+        else:
+            raw_id = getattr(call, "id", None) or getattr(call, "tool_call_id", None)
+        if raw_id is not None:
+            ids.add(str(raw_id))
+    return ids
+
+
+def _is_tool_message(message: Any) -> bool:
+    return (
+        hasattr(message, "tool_call_id")
+        or message.__class__.__name__ == "ToolMessage"
+    )
+
+
+def _tool_message_call_id(message: Any) -> str | None:
+    if not _is_tool_message(message):
+        return None
+    raw_id = getattr(message, "tool_call_id", None)
+    return str(raw_id) if raw_id is not None else None
 
 
 def _message_classes() -> tuple[type[Any], type[Any], type[Any]]:


### PR DESCRIPTION
## Why
GLM-5.2 box-shadow PROVED the LangChain implementer works — real `main.go` edits, `git_dirty=True` — but hit `max iterations (40)` at **1,489,134 input tokens** without terminating, and the real edits were discarded (`ok=False`). The model is capable; the executor just doesn't converge and throws away work.

## What (langchain-only — goose untouched)
- **History compaction** (`_compact_messages`, `MAX_CONTEXT_CHARS=120_000`): before every `llm.invoke`, when content exceeds budget, drop the OLDEST complete tool-rounds — preserving the system message, the initial task, recent rounds, and **tool_use/tool_result pairing**. Kills the runaway the per-tool 16KB cap (#1886) couldn't.
- **Harvest at max-iter** (implement stage): max-iter **with a dirty workspace** → `ok=True` (`error="harvested at max iterations …"`) instead of discarding real edits. Clean workspace → `ok=False`. Non-implement unchanged. Downstream box_ci/build + judge gate quality.
- **Replay logging**: `basicConfig(stdout)` so the agent trace (`agent trace stage=… tools=…`) finally prints.

## Test plan
- `pytest test_langchain_agent_runner.py test_langchain_agent_replay.py -q` → **30 passed** (local, CI-parity). Covers: compaction under/over budget + pairing integrity + invoke-time call; harvest dirty/clean; non-implement regression; replay basicConfig.
- [ ] CI green → merge → `update-pipeline-box` → re-run `nongoose-shadow` GLM-5.2 → expect converge-under-cap OR harvested `main.go` diff, with the agent trace now visible.

Inert in prod (EXECUTOR=goose). Plan `docs/plans/2026-06-20-004-...` (U6/U7/U8).