### PR TITLE
feat(set-box-env): allow clearing a key (empty value) without provision

### DIFF
--- a/.github/workflows/set-box-env.yml
+++ b/.github/workflows/set-box-env.yml
@@ -81,7 +81,11 @@ jobs:
             if ! printf '%s' "$key" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
               echo "::error::illegal key (charset)"; exit 2
             fi
-            if ! printf '%s' "$val" | grep -Eq '^[A-Za-z0-9_./:-]+$'; then
+            # '*' (not '+'): an EMPTY value is allowed so a key can be CLEARED
+            # in place (e.g. MODEL_REGISTRY=/STAGE_ROUTING= → zero-config single
+            # default model) without a full server-recreating provision. Non-empty
+            # values still must be flag-charset (no JSON/secrets).
+            if ! printf '%s' "$val" | grep -Eq '^[A-Za-z0-9_./:-]*$'; then
               echo "::error::illegal value for ${key} (flags only — JSON/secret goes through provision)"; exit 2
             fi
             if grep -q "^${key}=" "$ENV_FILE"; then


### PR DESCRIPTION
Relax the value guard `+`→`*` so an empty value clears a key in place. Needed for the non-goose cutover: clear MODEL_REGISTRY/STAGE_ROUTING (→ zero-config single GLM-5.2 default for all stages) without a server-recreating provision. Non-empty values still flag-charset only.