### PR TITLE
fix(set-box-env): empty-value clear (grep-on-empty never matches)

### DIFF
--- a/.github/workflows/set-box-env.yml
+++ b/.github/workflows/set-box-env.yml
@@ -81,11 +81,13 @@ jobs:
             if ! printf '%s' "$key" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
               echo "::error::illegal key (charset)"; exit 2
             fi
-            # '*' (not '+'): an EMPTY value is allowed so a key can be CLEARED
-            # in place (e.g. MODEL_REGISTRY=/STAGE_ROUTING= → zero-config single
-            # default model) without a full server-recreating provision. Non-empty
-            # values still must be flag-charset (no JSON/secrets).
-            if ! printf '%s' "$val" | grep -Eq '^[A-Za-z0-9_./:-]*$'; then
+            # An EMPTY value is allowed so a key can be CLEARED in place
+            # (e.g. MODEL_REGISTRY=/STAGE_ROUTING= → zero-config single default
+            # model) without a full server-recreating provision. The charset check
+            # only runs for NON-empty values — `printf '' | grep` matches no lines
+            # (empty input → grep exit 1), so it must be skipped for empties, not
+            # just loosened to '*'. Non-empty values still must be flag-charset.
+            if [ -n "$val" ] && ! printf '%s' "$val" | grep -Eq '^[A-Za-z0-9_./:-]+$'; then
               echo "::error::illegal value for ${key} (flags only — JSON/secret goes through provision)"; exit 2
             fi
             if grep -q "^${key}=" "$ENV_FILE"; then


### PR DESCRIPTION
The `*` relaxation (#1910) didn't work: `printf '' | grep -q` matches NO lines (empty input → exit 1), so empty values still failed. Correct fix: skip the charset check when value is empty (`[ -n "$val" ] && ...`). Enables clearing MODEL_REGISTRY/STAGE_ROUTING for the non-goose cutover.