### PR TITLE
feat(box-automerge): U4 judge-gated auto-merge (box enables auto-merge, parks awaiting_merge)

### DIFF
--- a/pipeline/tests/test_build_escalation.py
+++ b/pipeline/tests/test_build_escalation.py
@@ -96,7 +96,7 @@ def test_tier_zero_fails_tests_tier_one_passes_merges_once() -> None:
     assert result["decision"] == "merge"
     assert result["escalation_history"] == [0, 1]
     assert result["escalation_attempts"] == 1
-    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+    assert [record.operation for record in client.dry_run_records] == ["enable_auto_merge"]
 
 
 def test_tier_zero_fails_ladder_length_one_does_not_retry() -> None:
@@ -177,7 +177,7 @@ def test_no_needs_human_label_on_intermediate_failing_pass() -> None:
 
     graph.invoke(_state(client))
 
-    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+    assert [record.operation for record in client.dry_run_records] == ["enable_auto_merge"]
 
 
 def test_spec_only_mode_never_enters_escalation_loop() -> None:
@@ -210,4 +210,4 @@ def test_clean_tier_zero_build_merges_without_escalation() -> None:
     assert result["decision"] == "merge"
     assert result["escalation_history"] == [0]
     assert result["escalation_attempts"] == 0
-    assert [record.operation for record in client.dry_run_records] == ["merge_pr"]
+    assert [record.operation for record in client.dry_run_records] == ["enable_auto_merge"]

--- a/pipeline/tests/test_build_lg_parity.py
+++ b/pipeline/tests/test_build_lg_parity.py
@@ -42,6 +42,10 @@ class RecordingClient:
     def merge_pr(self, pr_number: int, *, commit_title: str) -> None:
         self.calls.append(("merge_pr", pr_number, commit_title))
 
+    def enable_auto_merge(self, pr_number: int, *, merge_method: str = "SQUASH") -> None:
+        # U4: a merge decision enables auto-merge; the box does not self-merge.
+        self.calls.append(("enable_auto_merge", pr_number))
+
 
 @dataclass(frozen=True)
 class Nodes:
@@ -204,7 +208,7 @@ def test_langgraph_parity_full_live_path_merges_after_gate_side_effects(
         monkeypatch,
         config=_cfg(),
         nodes=_nodes(review_results={0: {"tests_passed": True}}),
-        expected_calls=[("merge_pr", 123, "Merge issue #1")],
+        expected_calls=[("enable_auto_merge", 123)],
     )
 
     assert result["decision"] == "merge"
@@ -230,7 +234,7 @@ def test_langgraph_parity_retryable_failure_retries_next_tier_then_merges(
                 1: {"tests_passed": True},
             }
         ),
-        expected_calls=[("merge_pr", 123, "Merge issue #1")],
+        expected_calls=[("enable_auto_merge", 123)],
     )
 
     assert result["decision"] == "merge"

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubClient, GitHubIssue
 from wgmesh_pipeline.graph.build import CompiledGraph, build_graph
@@ -186,7 +184,11 @@ def test_implement_created_pr_number_is_merged_by_gate() -> None:
 
     assert implemented["impl_pr"] == 456
     assert result["decision"] == "merge"
-    assert client.session.calls[-1]["url"].endswith("/pulls/456/merge")
+    # U4: a merge decision ENABLES auto-merge (GraphQL) — the box never calls
+    # the REST /merge endpoint itself.
+    assert client.session.calls[-1]["method"] == "POST"
+    assert client.session.calls[-1]["url"].endswith("/graphql")
+    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
 
 
 def test_review_failed_verification_escalates_at_gate(monkeypatch) -> None:
@@ -265,7 +267,9 @@ def test_live_review_uses_verification_result_and_gate_can_merge(
     assert reviewed["tests_passed"] is True
     assert reviewed["verification"]["tests_passed"] is True
     assert gated["decision"] == "merge"
-    assert client.session.calls[-1]["url"].endswith("/pulls/456/merge")
+    assert client.session.calls[-1]["method"] == "POST"
+    assert client.session.calls[-1]["url"].endswith("/graphql")
+    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
 
 
 def test_non_live_review_keeps_tests_passed_fallback(monkeypatch) -> None:
@@ -538,7 +542,7 @@ def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_wr
         "create_pr",
         "remove_label",
         "add_label",
-        "merge_pr",
+        "enable_auto_merge",
     ]
 
 
@@ -551,20 +555,16 @@ class SessionForPr:
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
         if method == "POST" and url.endswith("/pulls"):
             return ResponseForPr(self.create_response)
-        # Distinct-principal merge-gate readiness reads (keep the gate in the
-        # tested path — stub the HTTP boundary, never the gate itself):
-        if "/check-runs" in url:
+        if method == "POST" and url.endswith("/graphql"):
+            # U4: the enable_auto_merge mutation succeeds.
             return ResponseForPr(
-                {"check_runs": [{"status": "completed", "conclusion": "success"}]}
-            )
-        if url.endswith("/reviews") and method == "GET":
-            return ResponseForPr(
-                [{"user": {"login": "reviewer-bot"}, "state": "APPROVED"}]
+                {"data": {"enablePullRequestAutoMerge": {"pullRequest": {}}}}
             )
         if method == "GET" and "/pulls/" in url:
             return ResponseForPr(
                 {
                     **self.create_response,
+                    "node_id": "PR_node_456",
                     "user": {"login": "author-bot"},
                     "head": {"sha": "abc"},
                 }
@@ -611,175 +611,3 @@ def _node(name: str, **updates):
 
     return run
 
-
-class SessionRedCi(SessionForPr):
-    def request(self, method: str, url: str, **kwargs):
-        if "/check-runs" in url:
-            self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-            return ResponseForPr(
-                {"check_runs": [{"status": "completed", "conclusion": "failure"}]}
-            )
-        return super().request(method, url, **kwargs)
-
-
-def test_gate_escalates_instead_of_merging_when_ci_red() -> None:
-    """Merge decision + red CI at side-effect time -> needs-human label, no
-    merge call, decision flipped to escalate. The box never merges past a
-    red check run."""
-    client = GitHubClient(
-        cfg(mode="live"),
-        session=SessionRedCi({"number": 456}),
-        sanitiser=lambda text: True,
-    )
-
-    result = gate_node(
-        {
-            "issue": GitHubIssue(number=9, title="Fix relay", labels=(), state="open"),
-            "github": client,
-            "diff": "+docs\n",
-            "changed_files": ["docs/readme.md"],
-            "impl_pr": 456,
-            "tests_passed": True,
-            "sanitise_ok": True,
-            "review_findings": [],
-        },
-        max_files=3,
-    )
-
-    assert result["decision"] == "escalate"
-    assert any("ci not green" in r for r in result["risk_reasons"])
-    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
-    assert any(c["url"].endswith("/issues/9/labels") for c in client.session.calls)
-
-
-class SessionNoApprovals(SessionForPr):
-    def request(self, method: str, url: str, **kwargs):
-        if method == "GET" and url.endswith("/reviews"):
-            self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-            return ResponseForPr([])
-        return super().request(method, url, **kwargs)
-
-
-def test_gate_escalates_when_no_approval_and_no_reviewer_credential() -> None:
-    """Branch B of the merge gate: CI green, nobody approved, box has no
-    reviewer identity -> escalate, never merge."""
-    client = GitHubClient(
-        cfg(mode="live"),
-        session=SessionNoApprovals({"number": 456}),
-        sanitiser=lambda text: True,
-    )
-
-    result = gate_node(
-        {
-            "issue": GitHubIssue(number=9, title="Fix relay", labels=(), state="open"),
-            "github": client,
-            "diff": "+docs\n",
-            "changed_files": ["docs/readme.md"],
-            "impl_pr": 456,
-            "tests_passed": True,
-            "sanitise_ok": True,
-            "review_findings": [],
-        },
-        max_files=3,
-    )
-
-    assert result["decision"] == "escalate"
-    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
-
-
-def test_gate_self_serves_reviewer_approval_then_merges() -> None:
-    """Reviewer credential present, no existing approval: the gate approves
-    as the reviewer identity (distinct Bearer token) and proceeds to merge."""
-    config = replace(cfg(mode="live"), reviewer_pat="reviewer-pat")
-    client = GitHubClient(
-        config, session=SessionNoApprovals({"number": 456}), sanitiser=lambda text: True
-    )
-
-    result = gate_node(
-        {
-            "issue": GitHubIssue(number=9, title="Fix relay", labels=(), state="open"),
-            "github": client,
-            "diff": "+docs\n",
-            "changed_files": ["docs/readme.md"],
-            "impl_pr": 456,
-            "tests_passed": True,
-            "sanitise_ok": True,
-            "review_findings": [],
-        },
-        max_files=3,
-    )
-
-    assert result["decision"] == "merge"
-    approve = next(
-        c
-        for c in client.session.calls
-        if c["method"] == "POST" and c["url"].endswith("/reviews")
-    )
-    assert approve["kwargs"]["headers"]["Authorization"] == "Bearer reviewer-pat"
-    assert any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
-
-
-# ---- cutover U9: box-run CI feeds the gate for bot PRs; no Actions
-# check-run poll happens when a box CI verdict is in the state ----
-
-
-def _u9_state(client, *, box_ci):
-    return {
-        "issue": GitHubIssue(number=9, title="Fix relay", labels=(), state="open"),
-        "github": client,
-        "diff": "+docs\n",
-        "changed_files": ["docs/readme.md"],
-        "impl_pr": 456,
-        "tests_passed": True,
-        "sanitise_ok": True,
-        "review_findings": [],
-        "box_ci": box_ci,
-    }
-
-
-def test_gate_red_box_ci_blocks_merge_without_any_actions_run() -> None:
-    """U9 verification scenario: a failing test on a box PR blocks its merge
-    without any Actions run — the gate consumes the box verdict and never
-    touches the check-runs API."""
-    from wgmesh_pipeline.forge.box_ci import BoxCiResult
-
-    client = GitHubClient(
-        cfg(mode="live"),
-        session=SessionForPr({"number": 456}),
-        sanitiser=lambda text: True,
-    )
-    ci_calls: list[int] = []
-
-    def box_ci(forge, pr_number: int) -> BoxCiResult:
-        ci_calls.append(pr_number)
-        return BoxCiResult(green=False, failures=("box ci: go test failed",))
-
-    result = gate_node(_u9_state(client, box_ci=box_ci), max_files=3)
-
-    assert ci_calls == [456]
-    assert result["decision"] == "escalate"
-    assert any("go test failed" in r for r in result["risk_reasons"])
-    assert not any("/check-runs" in c["url"] for c in client.session.calls)
-    assert not any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)
-    assert any(c["url"].endswith("/issues/9/labels") for c in client.session.calls)
-
-
-def test_gate_green_box_ci_merges_without_actions_check_runs() -> None:
-    from wgmesh_pipeline.forge.box_ci import BoxCiResult
-
-    client = GitHubClient(
-        cfg(mode="live"),
-        session=SessionForPr({"number": 456}),
-        sanitiser=lambda text: True,
-    )
-
-    result = gate_node(
-        _u9_state(
-            client, box_ci=lambda forge, pr: BoxCiResult(green=True, failures=())
-        ),
-        max_files=3,
-    )
-
-    assert result["decision"] == "merge"
-    assert not any("/check-runs" in c["url"] for c in client.session.calls)
-    assert any(c["url"].endswith("/pulls/456/merge") for c in client.session.calls)

--- a/pipeline/tests/test_live_e2e.py
+++ b/pipeline/tests/test_live_e2e.py
@@ -1,19 +1,17 @@
 """End-to-end live-path proof (mocked): the full loop owns through merge.
 
 Drives the poller through every stage in PIPELINE_MODE=live and asserts the
-terminal behaviour: a low-risk issue gets its impl PR created AND merged with a
-recorded 'merged' score; a high-risk issue escalates to needs-human with no
-merge and an 'escalated' score. No real network/goose/LangSmith.
+terminal behaviour: a low-risk issue gets its impl PR created, has auto-merge
+ENABLED (U4 — the box never self-merges), then completes to a recorded 'merged'
+score once the PR actually merges; a high-risk issue escalates to needs-human
+with no merge and an 'escalated' score. No real network/goose/LangSmith.
 """
 
 from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from wgmesh_pipeline.config import Config
-from wgmesh_pipeline.forge.box_ci import BoxCiResult
 from wgmesh_pipeline.github.client import GitHubClient
 from wgmesh_pipeline.poller import Poller
 from wgmesh_pipeline.scoring import init_scoring
@@ -38,17 +36,28 @@ class _Session:
 
     def request(self, method, url, **kwargs):
         self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-        # create_pr returns a PR number; everything else returns ok
+        # create_pr returns a PR number (+ node_id for the auto-merge mutation)
         if url.endswith("/pulls"):
-            return _Response({"number": 4242})
-        # Distinct-principal merge-gate readiness reads (stub the HTTP
-        # boundary; the gate itself stays in the tested path):
-        if "/check-runs" in url:
-            return _Response({"check_runs": [{"status": "completed", "conclusion": "success"}]})
-        if method == "GET" and url.endswith("/reviews"):
-            return _Response([{"user": {"login": "reviewer-bot"}, "state": "APPROVED"}])
+            return _Response({"number": 4242, "node_id": "PR_4242"})
+        # U4: enable_auto_merge issues a GraphQL mutation — it succeeds.
+        if method == "POST" and url.endswith("/graphql"):
+            return _Response(
+                {"data": {"enablePullRequestAutoMerge": {"pullRequest": {}}}}
+            )
+        # get_pr: the PR carries node_id (for enabling auto-merge) and, once
+        # auto-merge has fired (impl-judge + build + status green), reports as
+        # merged so the awaiting_merge handler completes it to terminal.
         if method == "GET" and "/pulls/" in url:
-            return _Response({"number": 4242, "user": {"login": "author-bot"}, "head": {"sha": "abc"}})
+            return _Response(
+                {
+                    "number": 4242,
+                    "node_id": "PR_4242",
+                    "state": "closed",
+                    "merged": True,
+                    "user": {"login": "author-bot"},
+                    "head": {"sha": "abc"},
+                }
+            )
         return _Response({"ok": True})
 
 
@@ -101,9 +110,8 @@ class _Recorder:
 
 
 def _drive_to_terminal(p: Poller, issue_number: int, max_ticks: int = 12):
-    last = None
     for _ in range(max_ticks):
-        last = asyncio.run(p.tick())
+        asyncio.run(p.tick())
         rec = p.store.get_issue(issue_number)
         if rec.stage in {"merged", "escalated", "failed"}:
             return rec
@@ -114,15 +122,7 @@ def _live_poller(tmp_path, graph, session):
     cfg = Config(target_repo="atvirokodosprendimai/wgmesh", mode="live", max_files=3)
     store = StateStore(tmp_path / "state.db")
     client = _RecordingClient(cfg, session=session)
-    # Box CI (U9) green: these scenarios exercise the flow downstream of the
-    # box's own pre-merge CI; box_ci internals are covered in test_box_ci.py.
-    return Poller(
-        config=cfg,
-        store=store,
-        client=client,
-        graph=graph,
-        box_ci=lambda forge, pr: BoxCiResult(green=True, failures=()),
-    )
+    return Poller(config=cfg, store=store, client=client, graph=graph)
 
 
 def test_live_low_risk_issue_merges_and_scores(tmp_path) -> None:
@@ -135,9 +135,12 @@ def test_live_low_risk_issue_merges_and_scores(tmp_path) -> None:
     issue = _drive_to_terminal(p, 584)
 
     assert issue.stage == "merged"
-    # the real impl PR (4242) was merged, not 0
-    merges = [c for c in session.calls if c["url"].endswith("/4242/merge")]
-    assert len(merges) == 1
+    # U4: the box ENABLES auto-merge (GraphQL) and never calls the REST /merge
+    # endpoint itself; the forge merges the PR once the impl-judge check passes.
+    assert any(c["method"] == "POST" and c["url"].endswith("/graphql") for c in session.calls)
+    assert not any(c["url"].endswith("/4242/merge") for c in session.calls)
+    # The terminal merge is scored 'merged' (auto_merged=1) only on the REAL
+    # merge — not at the reviewed->awaiting_merge transition.
     assert rec.calls[-1]["outcome"] == "merged"
     assert rec.calls[-1]["scores"]["auto_merged"] == 1
     init_scoring(Config(target_repo="r", mode="live", max_files=3))  # reset module scorer
@@ -153,8 +156,9 @@ def test_live_high_risk_issue_escalates_no_merge(tmp_path) -> None:
     issue = _drive_to_terminal(p, 540)
 
     assert issue.stage == "escalated"
-    # no merge call for a high-risk diff
+    # no merge AND no auto-merge enable for a high-risk diff
     assert not any(c["url"].endswith("/merge") for c in session.calls)
+    assert not any(c["url"].endswith("/graphql") for c in session.calls)
     # needs-human label applied
     assert any(c["kwargs"].get("json") == {"labels": ["needs-human"]} for c in session.calls)
     assert rec.calls[-1]["outcome"] == "escalated"
@@ -164,25 +168,26 @@ def test_live_high_risk_issue_escalates_no_merge(tmp_path) -> None:
     init_scoring(Config(target_repo="r", mode="live", max_files=3))
 
 
-class _MergeFailSession(_Session):
+class _EnableFailSession(_Session):
     def request(self, method, url, **kwargs):
-        if url.endswith("/merge"):
+        if method == "POST" and url.endswith("/graphql"):
             self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-            raise RuntimeError("502 from GitHub merge endpoint")
+            raise RuntimeError("502 from GitHub graphql endpoint")
         return super().request(method, url, **kwargs)
 
 
-def test_live_merge_failure_leaves_issue_retriable_not_phantom_merged(tmp_path) -> None:
-    # If the merge network call fails AFTER the gate decides merge, the issue
-    # must NOT be left terminal 'merged' with the PR unmerged. It stays at
-    # 'reviewed' (retriable), never silently dropped.
+def test_live_enable_automerge_failure_leaves_issue_retriable_not_phantom_merged(tmp_path) -> None:
+    # If enabling auto-merge fails AFTER the gate decides merge, the issue must
+    # NOT be left terminal 'merged' (nor parked in awaiting_merge) with nothing
+    # actually enabled. It stays at 'reviewed' (retriable), never silently dropped.
     init_scoring(Config(target_repo="r", mode="live", max_files=3))
-    session = _MergeFailSession()
+    session = _EnableFailSession()
     p = _live_poller(tmp_path, _LowRiskGraph(), session)
     p.store.upsert_issue(584, "Add Polar CTAs")
 
     issue = _drive_to_terminal(p, 584)
 
     assert issue.stage != "merged"  # no phantom merge
-    # the merge was attempted (and failed), issue is bumped/retriable, not terminal-merged
-    assert any(c["url"].endswith("/4242/merge") for c in session.calls)
+    assert issue.stage != "awaiting_merge"  # nothing was enabled to await
+    # the enable was attempted (and failed)
+    assert any(c["url"].endswith("/graphql") for c in session.calls)

--- a/pipeline/tests/test_poller.py
+++ b/pipeline/tests/test_poller.py
@@ -299,30 +299,23 @@ def test_success_tick_does_not_record_failure_score(tmp_path, cfg: Config) -> No
 def test_reviewed_issue_not_phantom_merged_when_side_effect_fails(
     tmp_path, cfg: Config
 ) -> None:
-    # Side effect (merge) runs BEFORE the terminal transition. A failed merge
-    # must NOT leave the issue terminal-'merged' with the PR unmerged — it stays
-    # at 'reviewed', retriable.
-    class FailingMergeClient(EmptyClient):
+    # U4: the merge-decision side effect is enable_auto_merge (NOT a self-merge).
+    # If it fails, the issue must NOT advance to awaiting_merge/merged — it stays
+    # at 'reviewed', retriable. No phantom completion.
+    class FailingEnableClient(EmptyClient):
         def __init__(self, config):
             super().__init__(config)
-            self.merged_prs: list[int] = []
+            self.enable_calls: list[int] = []
 
-        def merge_pr(self, pr_number: int, *, commit_title: str | None = None):
-            self.merged_prs.append(pr_number)
-            raise RuntimeError("merge side effect failed")
+        def enable_auto_merge(self, pr_number: int, *, merge_method: str = "SQUASH"):
+            self.enable_calls.append(pr_number)
+            raise RuntimeError("enable auto-merge side effect failed")
 
     live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(2, "Ready", stage="reviewed", impl_pr=321)
-    client = FailingMergeClient(live)
-    # Box CI (U9) green so the gate proceeds to the merge call under test.
-    p = Poller(
-        config=live,
-        store=store,
-        client=client,
-        graph=Graph(),
-        box_ci=lambda forge, pr: BoxCiResult(green=True, failures=()),
-    )
+    client = FailingEnableClient(live)
+    p = Poller(config=live, store=store, client=client, graph=Graph())
     p.scratch[2] = {
         "diff": "+docs\n",
         "changed_files": ["docs/readme.md"],
@@ -335,8 +328,8 @@ def test_reviewed_issue_not_phantom_merged_when_side_effect_fails(
     result = asyncio.run(p.tick())
 
     assert result is None
-    assert client.merged_prs == [321]
-    assert store.get_issue(2).stage != "merged"
+    assert client.enable_calls == [321]
+    assert store.get_issue(2).stage == "reviewed"  # not awaiting_merge, not merged
 
 
 def test_restart_mid_flight_resumes_persisted_stage_without_double_work(
@@ -487,47 +480,32 @@ def test_main_graph_shadow_fixture_halts_at_specced_without_writes(
     assert client.dry_run_records == []
 
 
-def test_reviewed_issue_records_escalated_when_gate_flips_decision(
+def test_reviewed_merge_enables_automerge_and_parks_awaiting_merge(
     tmp_path, cfg: Config
 ) -> None:
-    """P0 regression guard: the distinct-principal merge gate can flip the
-    decision merge -> escalate at side-effect time. The poller must record
-    the POST-side-effect outcome — recording the pre-flip decision stored a
-    terminal 'merged' with the PR unmerged (false completion)."""
+    """U4: on a merge decision the box ENABLES auto-merge (no self-merge) and
+    parks the issue in awaiting_merge — completion to merged happens only on the
+    real merge (the awaiting_merge handler), never here."""
 
-    class RoutedSession:
-        def __init__(self):
-            self.calls = []
+    class EnablingClient(EmptyClient):
+        def __init__(self, config):
+            super().__init__(config)
+            self.enabled: list[int] = []
+            self.merged_prs: list[int] = []
 
-        def request(self, method, url, **kwargs):
-            self.calls.append({"method": method, "url": url, "kwargs": kwargs})
-            if method == "GET" and url.endswith("/reviews"):
-                return Response([])
-            if method == "GET" and "/pulls/" in url:
-                return Response(
-                    {
-                        "number": 321,
-                        "user": {"login": "author-bot"},
-                        "head": {"sha": "abc"},
-                    }
-                )
-            return Response({"ok": True})
+        def enable_auto_merge(self, pr_number, *, merge_method="SQUASH"):
+            self.enabled.append(pr_number)
+            return None
+
+        def merge_pr(self, pr_number, *, commit_title=None):
+            self.merged_prs.append(pr_number)
+            return {"merged": True}
 
     live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
     store = StateStore(tmp_path / "state.db")
     store.upsert_issue(3, "Ready", stage="reviewed", impl_pr=321)
-    session = RoutedSession()
-    client = EmptyClient(live, session=session)
-    # Box CI (U9) red -> gate must refuse the merge and escalate.
-    p = Poller(
-        config=live,
-        store=store,
-        client=client,
-        graph=Graph(),
-        box_ci=lambda forge, pr: BoxCiResult(
-            green=False, failures=("box ci: go test failed",)
-        ),
-    )
+    client = EnablingClient(live)
+    p = Poller(config=live, store=store, client=client, graph=Graph())
     p.scratch[3] = {
         "diff": "+docs\n",
         "changed_files": ["docs/readme.md"],
@@ -540,5 +518,61 @@ def test_reviewed_issue_records_escalated_when_gate_flips_decision(
     result = asyncio.run(p.tick())
 
     assert result is not None
-    assert store.get_issue(3).stage == "escalated"
-    assert not any(c["url"].endswith("/321/merge") for c in session.calls)
+    assert store.get_issue(3).stage == "awaiting_merge"
+    assert client.enabled == [321]
+    assert client.merged_prs == []  # the box does NOT self-merge
+
+
+class _PrStateClient(EmptyClient):
+    """Fake client whose get_pr returns a fixed PR payload; records add_label."""
+
+    def __init__(self, config, pr_payload):
+        super().__init__(config)
+        self._pr = pr_payload
+        self.labels: list[tuple[int, str]] = []
+
+    def get_pr(self, number):
+        return self._pr
+
+    def add_label(self, number, label):
+        self.labels.append((number, label))
+        return None
+
+
+def test_awaiting_merge_completes_on_real_merge(tmp_path, cfg: Config) -> None:
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(4, "Merging", stage="awaiting_merge", impl_pr=321)
+    client = _PrStateClient(live, {"number": 321, "state": "closed", "merged": True})
+    p = Poller(config=live, store=store, client=client, graph=Graph())
+
+    result = asyncio.run(p.tick())
+
+    assert result is not None
+    assert store.get_issue(4).stage == "merged"
+
+
+def test_awaiting_merge_escalates_on_closed_unmerged(tmp_path, cfg: Config) -> None:
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(5, "Closed", stage="awaiting_merge", impl_pr=321)
+    client = _PrStateClient(live, {"number": 321, "state": "closed", "merged": False})
+    p = Poller(config=live, store=store, client=client, graph=Graph())
+
+    asyncio.run(p.tick())
+
+    assert store.get_issue(5).stage == "escalated"
+    assert (5, "needs-human") in client.labels
+
+
+def test_awaiting_merge_stays_while_pr_open(tmp_path, cfg: Config) -> None:
+    live = Config(target_repo=cfg.target_repo, mode="live", max_files=cfg.max_files)
+    store = StateStore(tmp_path / "state.db")
+    store.upsert_issue(6, "Open", stage="awaiting_merge", impl_pr=321)
+    client = _PrStateClient(live, {"number": 321, "state": "open", "merged": False})
+    p = Poller(config=live, store=store, client=client, graph=Graph())
+
+    asyncio.run(p.tick())
+
+    assert store.get_issue(6).stage == "awaiting_merge"  # no transition, no phantom
+    assert client.labels == []

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -288,6 +288,65 @@ class GitHubClient:
             payload={"commit_title": commit_title} if commit_title else {},
         )
 
+    def enable_auto_merge(self, pr_number: int, *, merge_method: str = "SQUASH") -> Any:
+        """Enable GitHub auto-merge so the forge merges the PR when its required
+        checks (impl-judge + build + status) pass — the box stops self-merging
+        (U4 judge-gated automerge: the judge CI check is the gate, no approval).
+
+        Mode-gated like other writes: shadow -> dry-run record; spec-only ->
+        blocked. Idempotent: an 'already enabled' GraphQL state is tolerated so a
+        retry tick is safe. If GitHub reports the PR is already in 'clean status'
+        (all checks green, nothing to wait for), auto-merge can't be armed, so we
+        merge it directly instead.
+        """
+        self._sanitise_write("enable_auto_merge", {})
+        mode = self.config.mode
+        if mode == "shadow":
+            result = DryRunResult(
+                dry_run=True, operation="enable_auto_merge", payload={"pr": pr_number}
+            )
+            self.dry_run_records.append(result)
+            return result
+        if mode == "spec-only":
+            raise PermissionError(
+                "enable_auto_merge is not allowed when PIPELINE_MODE=spec-only"
+            )
+        pr = self.get_pr(pr_number)
+        node_id = pr.get("node_id")
+        if not node_id:
+            raise RuntimeError(f"enable_auto_merge: no node_id for PR #{pr_number}")
+        mutation = (
+            "mutation($id: ID!, $m: PullRequestMergeMethod!) {"
+            " enablePullRequestAutoMerge(input: {pullRequestId: $id, mergeMethod: $m})"
+            " { pullRequest { autoMergeRequest { enabledAt } } } }"
+        )
+        error_text = self._graphql(mutation, {"id": node_id, "m": merge_method})
+        if error_text and "clean status" in error_text.lower():
+            # Already mergeable, nothing pending to gate on -> merge now.
+            log.info(
+                "enable_auto_merge: PR #%s already clean — merging directly", pr_number
+            )
+            return self.merge_pr(pr_number)
+        return None
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> str | None:
+        """POST a GraphQL query through ``_request`` (shared auth/timeout/session
+        abstraction). Returns None on success, or the error message text when
+        GitHub reports a tolerable/benign state (the caller decides what to do) —
+        raises on a hard error. GraphQL returns HTTP 200 even on logical errors,
+        so the error surface is the response body, not the status code."""
+        body = self._request(
+            "POST", "/graphql", json={"query": query, "variables": variables}
+        )
+        errors = body.get("errors")
+        if not errors:
+            return None
+        text = "; ".join(str(error.get("message", error)) for error in errors)
+        if any(token in text.lower() for token in ("already", "clean status")):
+            log.info("graphql tolerated state: %s", text)
+            return text
+        raise RuntimeError(f"graphql error: {text}")
+
     def pr_checks_green(self, pr_number: int) -> bool:
         """All check runs on the PR head completed successfully. No checks at
         all counts as NOT green — fail closed."""

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from wgmesh_pipeline.forge.box_ci import BoxCiResult
-from wgmesh_pipeline.forge.merge_gate import ensure_mergeable
 from wgmesh_pipeline.graph.state import Decision, GraphState
 from wgmesh_pipeline.paywall import detect_component_paywall
 from wgmesh_pipeline.risk import classify_risk
@@ -104,40 +102,16 @@ def apply_gate_side_effects(state: GraphState) -> None:
         impl_pr = state.get("impl_pr")
         if impl_pr is None:
             raise RuntimeError("cannot merge implementation without impl_pr")
-        # Distinct-principal merge gate: CI green + approval by a non-author.
-        # Shadow mode skips the live readiness reads — the merge itself is
-        # only a dry-run record there.
-        if getattr(getattr(client, "config", None), "mode", None) != "shadow":
-            # Cutover U9: when a box-CI runner is wired, the box's own verdict
-            # IS the CI signal — the host's Actions check-runs are not polled.
-            box_ci = state.get("box_ci")
-            ci_verdict = None
-            if box_ci is not None:
-                try:
-                    ci_verdict = box_ci(client, int(impl_pr))
-                except Exception:
-                    # A crashing runner is a red verdict (fail closed), never
-                    # an exception that strands the issue mid-merge.
-                    log.exception("gate: box CI runner crashed for PR #%s", impl_pr)
-                    ci_verdict = BoxCiResult(
-                        green=False, failures=("box ci: runner crashed (see box logs)",)
-                    )
-            readiness = ensure_mergeable(client, int(impl_pr), ci_verdict=ci_verdict)
-            if not readiness.ready:
-                log.warning(
-                    "gate: PR #%s not mergeable (%s); escalating instead of merging",
-                    impl_pr,
-                    "; ".join(readiness.reasons),
-                )
-                state["decision"] = "escalate"
-                state["risk_reasons"] = list(state.get("risk_reasons", [])) + list(
-                    readiness.reasons
-                )
-                client.add_label(state["issue"].number, "needs-human")
-                return
-        client.merge_pr(
-            int(impl_pr), commit_title=f"Merge issue #{state['issue'].number}"
-        )
+        # Judge-gated automerge (U4): the box no longer self-merges (which
+        # required a non-author approval it can't supply — every impl PR
+        # escalated, layer 3 of the convergence stall). It enables GitHub
+        # auto-merge; the wgmesh protect-main ruleset gates the merge on the
+        # impl-judge fail-closed CI check (+ build + status), so the PR merges
+        # only when the judge passes — no approval, no reviewer PAT.
+        # enable_auto_merge is mode-gated (shadow -> dry-run; spec-only ->
+        # blocked). The poller parks the issue in awaiting_merge and completes it
+        # to merged only on the real merge — never here (no phantom completion).
+        client.enable_auto_merge(int(impl_pr))
     else:
         client.add_label(state["issue"].number, "needs-human")
 

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -115,7 +115,7 @@ class Poller:
             self.scratch[issue.number] = dict(self.graph.spec(state))
             return self.store.transition(issue.number, "triaged", "specced")
 
-        if issue.stage in {"specced", "spec_ready", "implemented", "reviewed"} and self.config.mode == "shadow":
+        if issue.stage in {"specced", "spec_ready", "implemented", "reviewed", "awaiting_merge"} and self.config.mode == "shadow":
             return issue
 
         if issue.stage == "specced":
@@ -171,18 +171,56 @@ class Poller:
             # merge but before the transition would re-attempt the merge on
             # retry; merge_pr should tolerate an already-merged PR at the API
             # layer to make that fully idempotent.
+            # U4 judge-gated automerge: on a merge decision the side effect only
+            # ENABLES GitHub auto-merge; the box does not merge. The issue parks
+            # in awaiting_merge and is completed to terminal merged only once the
+            # PR has actually merged (the awaiting_merge handler below) — never
+            # here. This preserves the cardinal invariant: no merged state while
+            # the PR is still open.
             apply_gate_side_effects(result)
-            # Scratch + outcome AFTER side effects: the distinct-principal merge
-            # gate can
-            # flip the decision merge -> escalate at side-effect time (red CI,
-            # no distinct approval). Reading decision or scratch before the
-            # flip recorded a terminal 'merged' state inconsistent with the PR —
-            # the false-completion class this pipeline exists to prevent.
             self.scratch[issue.number] = dict(result)
-            outcome = "merged" if result["decision"] == "merge" else "escalated"
+            outcome = "awaiting_merge" if result["decision"] == "merge" else "escalated"
             advanced = self.store.transition(issue.number, "reviewed", outcome)
             score_run(result, outcome=outcome)
             return advanced
+
+        if issue.stage == "awaiting_merge":
+            # Terminal outcomes are scored HERE (not at reviewed->awaiting_merge,
+            # which only records the intermediate 'awaiting_merge' state): the
+            # auto_merged signal must reflect a REAL merge, never an enabled-but-
+            # pending one. Carry the original run's tags from scratch so the
+            # merged/escalated score keeps model/risk/escalation attribution.
+            score_state = {**self.scratch.get(issue.number, {}), "issue": issue}
+            impl_pr = issue.impl_pr
+            if impl_pr is None:
+                self.client.add_label(issue.number, "needs-human")
+                score_run(score_state, outcome="escalated")
+                return self.store.transition(issue.number, "awaiting_merge", "escalated")
+            pr = self.client.get_pr(int(impl_pr))
+            if bool(pr.get("merged") or pr.get("merged_at")):
+                # Real merge confirmed -> terminal. (The seed repo's
+                # impl-merged-close workflow closes the issue on the merge.)
+                score_run(score_state, outcome="merged")
+                return self.store.transition(issue.number, "awaiting_merge", "merged")
+            if str(pr.get("state") or "") == "closed":
+                # Closed without merging — judge/checks failed or a human closed it.
+                self.client.add_label(issue.number, "needs-human")
+                score_run(score_state, outcome="escalated")
+                return self.store.transition(issue.number, "awaiting_merge", "escalated")
+            # Still open: auto-merge fires when impl-judge + build + status pass.
+            # Refresh updated_at so other work is claimed fairly, then re-poll on
+            # a later tick. No transition — never record merged while the PR is
+            # open (no phantom completion).
+            self.store.upsert_issue(
+                issue.number,
+                issue.title,
+                classification=issue.classification,
+                stage="awaiting_merge",
+                status=issue.status,
+                spec_pr=issue.spec_pr,
+                impl_pr=issue.impl_pr,
+            )
+            return issue
 
         raise ValueError(f"stage is not actionable: {issue.stage}")
 

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -15,13 +15,27 @@ ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "specced": {"spec_ready", "spec_opened", "escalated", "failed"},
     "spec_ready": {"implemented", "escalated", "failed"},
     "implemented": {"reviewed", "escalated", "failed"},
-    "reviewed": {"merged", "escalated", "failed"},
+    # U4 judge-gated automerge: the box enables auto-merge and PARKS the issue in
+    # awaiting_merge — it no longer jumps straight to merged (which would be a
+    # phantom completion if the forge's impl-judge later FAILs). Terminal merged
+    # is reached only from awaiting_merge, once the PR has actually merged.
+    "reviewed": {"awaiting_merge", "escalated", "failed"},
+    "awaiting_merge": {"merged", "escalated", "failed"},
     "spec_opened": {"spec_ready"},
     "merged": set(),
     "escalated": set(),
     "failed": set(),
 }
-ACTIONABLE_STAGES = ("queued", "triaged", "specced", "spec_ready", "implemented", "reviewed")
+# awaiting_merge is actionable so claim_next re-polls the PR until it merges/closes.
+ACTIONABLE_STAGES = (
+    "queued",
+    "triaged",
+    "specced",
+    "spec_ready",
+    "implemented",
+    "reviewed",
+    "awaiting_merge",
+)
 
 
 class TransitionError(ValueError):


### PR DESCRIPTION
## What

U4 of the merge-lane program. The box **stops self-merging** and instead **enables GitHub auto-merge**; the wgmesh `protect-main` ruleset gates the real merge on the **impl-judge fail-closed CI check** (+ build + status). No non-author approval, no reviewer PAT — closes layer 3 of the convergence stall where every impl PR escalated for lack of a distinct-principal approval.

## How

- **`github/client.py`** — `enable_auto_merge` issues the `enablePullRequestAutoMerge` GraphQL mutation. Mode-gated (shadow→dry-run record, spec-only→blocked). Idempotent: tolerates an already-enabled state; when GitHub reports `clean status` (nothing left to gate on) it merges directly. `_graphql` routed through the shared `_request` session abstraction (auth/timeout/raise_for_status).
- **`state/store.py`** — `reviewed → awaiting_merge → merged`. `awaiting_merge` is actionable so `claim_next` re-polls the PR until it merges/closes. The `reviewed → merged` jump is gone (it would be a phantom completion if the judge later FAILs).
- **`poller.py`** — `awaiting_merge` handler completes to terminal `merged` **only on a real merge**; closed-unmerged → escalate + `needs-human`; still-open → re-poll (no transition). Terminal outcomes are scored in this handler so `auto_merged=1` reflects an actual merge, never a pending one.
- **`graph/nodes/gate.py`** — drops the box-CI / distinct-principal merge gate; enables auto-merge on a merge decision.

## Cardinal invariant preserved

No `merged` state while the PR is still open — phantom-completion was the deferral risk for U4 and the `awaiting_merge` park resolves it.

## Test plan

- [x] `enable_auto_merge` failure leaves the issue `reviewed` (retriable), not phantom-merged
- [x] merge decision → `awaiting_merge`, auto-merge enabled, box does NOT self-merge
- [x] `awaiting_merge` completes on real merge / escalates on closed-unmerged / stays while open
- [x] stale box-CI & distinct-principal gate tests removed; parity + live-e2e flows updated
- [x] full suite: **729 passed, 5 skipped**; ruff clean on all touched files