### PR TITLE
feat(quackback): decision-layer foundation — config + provisioning (inert until cutover)

### DIFF
--- a/.github/workflows/provision-quackback.yml
+++ b/.github/workflows/provision-quackback.yml
@@ -1,0 +1,172 @@
+name: Provision Quackback
+
+# Self-hosted Quackback (AGPL feedback/decision board) on a Hetzner box via the
+# project's docker-compose.prod.yml (app + postgres[pg_cron] + dragonfly[redis] +
+# minio). Mirrors provision-langfuse.yml: a one-shot dispatch that creates the VM,
+# installs Docker via cloud-init, then deploys the stack OVER SSH with infra
+# secrets generated ON the box (never via cloud-init user-data, which lands in
+# Hetzner metadata/logs).
+#
+# Unlike Langfuse, Quackback has NO headless init env (no LANGFUSE_INIT_*
+# equivalent): after this run the stack is up and reachable, but the admin
+# account, the decision statuses, and the bot API key are created by hand in the
+# UI (see the Report step). The box's compose BUILDS postgres from a Dockerfile
+# in the repo, so the full repo (pinned to a release tag) is cloned on the box,
+# not just the compose file.
+#
+# Required secret: HCLOUD_TOKEN (org — Hetzner project to bill/host).
+# Optional: SSH_PUBKEY (operator key added alongside the ephemeral CI key).
+# Open the UI at http://<ip>:3000 and complete the setup wizard.
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        default: 'quackback'
+      server_type:
+        # postgres + dragonfly + minio + app — no clickhouse, so lighter than
+        # langfuse; cpx22 is enough. Bump to cpx32 if the box thrashes.
+        default: 'cpx22'
+      location:
+        default: 'hel1'
+
+permissions:
+  contents: read
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    env:
+      NAME: ${{ github.event.inputs.server_name }}
+    steps:
+      - name: Validate secrets
+        run: |
+          set -euo pipefail
+          : "${HCLOUD_TOKEN:?}"
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Ephemeral SSH key
+        run: ssh-keygen -t ed25519 -N '' -f "$RUNNER_TEMP/k" -C "qb-${{ github.run_id }}"
+
+      - name: Create server
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          SSH_PUBKEY: ${{ secrets.SSH_PUBKEY }}
+        run: |
+          set -euo pipefail
+          KEYNAME="qb-${{ github.run_id }}"
+          hcloud ssh-key create --name "$KEYNAME" --public-key-from-file "$RUNNER_TEMP/k.pub"
+          SSHKEYS="$KEYNAME"
+          if [ -n "${SSH_PUBKEY:-}" ]; then
+            printf '%s\n' "$SSH_PUBKEY" > "$RUNNER_TEMP/op.pub"
+            hcloud ssh-key describe op-persistent >/dev/null 2>&1 || \
+              hcloud ssh-key create --name op-persistent --public-key-from-file "$RUNNER_TEMP/op.pub"
+            SSHKEYS="$KEYNAME,op-persistent"
+          fi
+          cat > "$RUNNER_TEMP/ci.yml" <<'CLOUD'
+          #cloud-config
+          package_update: true
+          runcmd:
+            - curl -fsSL https://get.docker.com | sh
+            - command -v git || (apt-get update && apt-get install -y git)
+            - install -d -m 700 /opt/quackback
+            - touch /opt/quackback/.ci-done
+          CLOUD
+          hcloud server describe "$NAME" >/dev/null 2>&1 && hcloud server delete "$NAME" || true
+          hcloud server create --name "$NAME" --type "${{ github.event.inputs.server_type }}" \
+            --image ubuntu-24.04 --location "${{ github.event.inputs.location }}" \
+            --ssh-key "$SSHKEYS" --user-data-from-file "$RUNNER_TEMP/ci.yml"
+          echo "BOX_IP=$(hcloud server ip "$NAME")" >> "$GITHUB_ENV"
+          echo "KEYNAME=$KEYNAME" >> "$GITHUB_ENV"
+
+      - name: Wait for Docker
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 40); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -i "$RUNNER_TEMP/k" root@"$BOX_IP" \
+                 'cloud-init status --wait >/dev/null 2>&1; command -v docker && command -v git && test -f /opt/quackback/.ci-done'; then
+              echo ok; exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::docker not ready"; exit 1
+
+      - name: Deploy Quackback stack
+        run: |
+          set -euo pipefail
+          # Clone the repo pinned to a RELEASE TAG (postgres builds from a
+          # Dockerfile in the tree, so the whole repo is needed; main can change
+          # service shape between provisions with zero signal). Generate infra
+          # secrets ONCE on the box — keep an existing .env so SECRET_KEY /
+          # POSTGRES_PASSWORD stay stable across redeploys.
+          ssh -o StrictHostKeyChecking=no -i "$RUNNER_TEMP/k" root@"$BOX_IP" bash -s -- "$BOX_IP" <<'REMOTE'
+          set -euo pipefail
+          IP="$1"
+          QB_TAG="v0.12.4"
+          cd /opt/quackback
+          if [ ! -d src ]; then
+            git clone --branch "$QB_TAG" --depth 1 https://github.com/QuackbackIO/quackback.git src
+          fi
+          cd src
+          if [ ! -f .env ]; then
+            # Docker reads .env literally: no quotes, no inline comments on values.
+            # NOTE: QUACKBACK_TAG is the ghcr IMAGE tag (no leading 'v'). If
+            # ghcr.io/quackbackio/quackback:0.12.4 does not exist, adjust this.
+            cat > .env <<EOF
+          BASE_URL=http://$IP:3000
+          SECRET_KEY=$(openssl rand -base64 32)
+          QUACKBACK_TAG=0.12.4
+          APP_PORT=3000
+          POSTGRES_USER=quackback
+          POSTGRES_PASSWORD=$(openssl rand -base64 24)
+          POSTGRES_DB=quackback
+          MINIO_ROOT_USER=quackback
+          MINIO_ROOT_PASSWORD=$(openssl rand -base64 24)
+          S3_BUCKET=quackback
+          S3_REGION=us-east-1
+          EMAIL_SMTP_HOST=
+          EMAIL_SMTP_PORT=587
+          EMAIL_SMTP_USER=
+          EMAIL_SMTP_PASS=
+          EMAIL_FROM=Quackback <noreply@localhost>
+          EOF
+            chmod 600 .env
+          fi
+          docker compose -f docker-compose.prod.yml --env-file .env up -d
+          REMOTE
+
+      - name: Wait for Quackback web
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 40); do
+            if curl -fsS -o /dev/null "http://$BOX_IP:3000/api/health"; then echo "quackback up"; exit 0; fi
+            sleep 15
+          done
+          echo "::warning::health endpoint not green yet — stack may still be migrating"
+          ssh -o StrictHostKeyChecking=no -i "$RUNNER_TEMP/k" root@"$BOX_IP" \
+            'cd /opt/quackback/src && docker compose -f docker-compose.prod.yml ps' || true
+
+      - name: Cleanup ephemeral key
+        if: always()
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: hcloud ssh-key delete "${KEYNAME:-qb-${{ github.run_id }}}" || true
+
+      - name: Report
+        run: |
+          echo "Quackback at http://$BOX_IP:3000"
+          echo "Quackback has no headless init — finish setup by hand:"
+          echo "  1. Open http://$BOX_IP:3000 and complete the setup wizard (admin account + first board)."
+          echo "  2. Create the 8 decision statuses (Admin UI or POST /api/v1/statuses):"
+          echo "     Open for Vote, Needs Refinement, Accepted for Build, Building, Ready for Review (active);"
+          echo "     Rejected, Cancelled (closed); Shipped (complete). See docs/runbooks/quackback-cutover.md."
+          echo "  3. Mint a named API key: Admin -> Settings -> Developers (shown once; format qb_)."
+          echo "  4. Set repo secrets: QUACKBACK_URL=http://$BOX_IP:3000 and QUACKBACK_TOKEN=<qb_ key>,"
+          echo "     then propagate to the box env via set-box-env."

--- a/docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md
+++ b/docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md
@@ -1,0 +1,161 @@
+# Quackback as the Autonomous Pipeline's Decision Layer — Requirements
+
+**Date:** 2026-06-21
+**Status:** Requirements (ready for `/ce-plan`)
+**Scope:** Deep — product
+**Source:** Operator-supplied "Autonomous Build Suggestion Workflow with Quackback" spec, mapped onto the wgmesh autobox pipeline.
+
+---
+
+## Summary
+
+Replace GitHub Issues with a self-hosted **Quackback** board as the autonomous pipeline's decision and audit layer. The Observation Loop stops filing GitHub Issues and instead posts **Build Suggestions** to Quackback. Founders/co-founders vote and an authorized founder flips status to **Accepted for Build** — the only trigger that authorizes the box to spend build effort. The box then runs its existing spec → implement → PR pipeline, and the DeepSeek judge auto-merges as it does today. GitHub is touched only for branch, commits, and PR. Every human decision feeds a learning loop.
+
+**Core principle:** *Quackback decides what to build. GitHub stores the code. The judge decides what merges.*
+
+## Problem
+
+The pipeline was built for unattended convergence: the Observation Loop autonomously files GitHub Issues, the box implements them, and judge-gated auto-merge ships them with no human in the loop. That delivered autonomy but left founders without a single visible surface to **see, prioritize, and authorize** what the autonomous company proposes to build. GitHub Issues are a developer artifact, not a founder decision surface, and they conflate "the agent had an idea" with "we decided to build this." There is also no structured capture of human accept/reject judgments for the box to learn from.
+
+## Goals
+
+- Give founders/co-founders one private board to see every build proposal and authorize work.
+- Make human acceptance the gate on **what** gets built (prioritization), without re-adding a human gate at merge.
+- Move the work queue off GitHub Issues entirely; GitHub becomes code storage only.
+- Capture every decision as a durable, auditable, learnable signal.
+
+## Non-goals
+
+- A human merge gate. Judge-gated auto-merge stays the back-end authority (see Decisions).
+- A public/community-facing roadmap or voting (board is internal; community is a future option, not built now).
+- GitHub Projects / Linear / Jira integration; weighted voting schemes; auto-deploy.
+- Replacing the box's internal execution state machine — Quackback is the decision/audit layer, not the box's runtime store.
+
+## Primary actors
+
+- **Autonomous system (the box)** — proposes Build Suggestions, builds accepted ones, reports progress. Acts via a dedicated named Quackback API key (no human identity).
+- **Founders + co-founders** — vote, comment, request refinement, and hold sole `Accepted for Build` authority. Private internal board.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Front gate | Quackback `Accepted for Build` authorizes build | Human prioritization; the only build trigger |
+| Back gate (merge) | **Keep DeepSeek judge auto-merge** | Preserves shipped #1919/#1921 work; spec's "human PR review" step is dropped |
+| Rollout | **Hard replace day one** | Stop GitHub Issue generation, drain existing issues, Quackback becomes the only queue |
+| Authority | Founders + co-founders, private board | Matches co-founder decision model |
+| Learning loop | All four mechanisms (below) | Operator: "autonomous learning mode should see scores/evals" |
+| Hosting default | Self-host Quackback (Docker/Railway) | AGPL-3.0; aligns with no-component-paywall constitution; control |
+| Integration path | MCP server primary, REST fallback | 27-tool MCP server is purpose-built for agents |
+| Work discovery | Webhook (`Accepted for Build`) primary, poll fallback | Real-time, HMAC-verified |
+
+## The funnel (status machine)
+
+Quackback statuses, configured via the API:
+
+```
+Open for Vote → Needs Refinement → Open for Vote
+Open for Vote → Accepted for Build → Building → Ready for Review → Shipped
+Open for Vote → Rejected
+{Accepted for Build, Building, Ready for Review} → Cancelled
+```
+
+- **Open for Vote** — box created a suggestion; founders vote/comment.
+- **Needs Refinement** — founder wants more detail; box revises the *same* post (never a duplicate), returns it to Open for Vote.
+- **Accepted for Build** — authorized founder approved. The only status the box may act on.
+- **Building / Ready for Review / Shipped** — box-driven progress, mirrored from the real pipeline (Ready for Review ↔ PR open; Shipped ↔ judge auto-merge completed).
+- **Rejected** (reason required) / **Cancelled** — terminal; box ignores.
+
+The box may set `Building`, `Ready for Review`, `Shipped`. The box may **never** set `Accepted for Build`, `Rejected`, or vote.
+
+## How it maps onto the existing pipeline
+
+- **Observation Loop cron** (today: files GitHub Issues): now creates Build Suggestions in Quackback at `Open for Vote`, using the spec's Build Suggestion template (Summary / Problem / Suggested Build / Why Now / Value / Evidence / Complexity / Risk / Affected Areas / Acceptance Criteria / Non-goals / Alternatives / Open Questions / Stop-Rollback / Agent Confidence / Agent Notes). Required tags `agent-suggestion`, `build-candidate`.
+- **Work discovery** splits cleanly. The *issue* side (proposals, decisions, status) lives in Quackback via a new client. The *PR/code* side stays on the existing Forge/GitHub path. The box's stage machine reads `Accepted for Build` posts as its work queue instead of GitHub Issues.
+- **Two-layer state.** Quackback = source of truth for decisions + audit. The box keeps its own internal execution-state record keyed by `quackback_post_id` (current stage, branch, PR, agent run id) for idempotency. The two never merge.
+- **Bot identity.** A single named, least-privilege Quackback API key. This dissolves the prior `reviewer-PAT` distinct-identity (422) problem — Quackback attributes actions to the key name, no second human account needed.
+- **Judge auto-merge** is unchanged. When a PR auto-merges, the box flips the linked post to `Shipped`.
+
+## Decision & acceptance rules
+
+- Votes are **signal only**; they never trigger a build (MVP). An authorized founder's status change to `Accepted for Build` is the contract.
+- A suggestion may be accepted when: an authorized founder approves **and** no blocking objection is unresolved **and** the suggestion has enough detail to implement.
+- Rejection requires a reason comment. Refinement requires a comment naming what's missing; the box revises the same post.
+
+## Agent execution rule
+
+The box starts implementation only when **all** hold: board = Build Suggestions, status = `Accepted for Build`, tags include `agent-suggestion` + `build-candidate`, and idempotency check passes. On pickup it: verifies the conditions, marks the post `Building`, comments an implementation-start note, and begins. The box ignores every other status.
+
+## Idempotency
+
+Idempotency key = `quackback_post_id + accepted_for_build + status_version`. Stored in the box's execution-state record so the same acceptance never launches two build runs. Minimum record: `quackback_post_id`, `status_version`, `started_at`, `agent_run_id`, `current_state`, `linked_branch`, `linked_pr`.
+
+## Duplicate detection
+
+Before creating a new Build Suggestion the box searches existing posts across **all** statuses (Quackback's AI duplicate detection plus the box's own title/summary/problem/affected-areas comparison). On a match it comments on or revises the existing post rather than creating a duplicate. This replaces today's 5-keyword fuzzy GitHub-issue dedup.
+
+## GitHub touch policy
+
+Allowed: read repo files, create branch, push commits, open/update PR, read CI. Branch name `agent/qb-<post-id>-<short-title>`. Each commit footer `Quackback: <post-url>`. PR body links back to the Quackback post and copies its Acceptance Criteria. **Forbidden:** creating GitHub Issues, Projects, Discussions, or using GitHub labels/milestones as decision state.
+
+## Learning loop (all four mechanisms)
+
+1. **In-context proposal steering** — before proposing, the box reads recent accept/reject history + rejection reasons so it stops re-suggesting rejected shapes and leans toward accepted ones. Prompt-side, no training.
+2. **Langfuse scores** — each decision (accept / reject / refine + vote count) becomes a Langfuse score on the proposal's trace, giving a measurable acceptance-rate eval over time. Reuses the existing eval layer; written **after** the decision for measurement (not as an async gate).
+3. **Vote-weighted reranking** — among `Accepted for Build` posts, vote totals set build order. Demand drives the queue.
+4. **Decision dataset** — every decision persisted as a structured record (foundation for later analysis / eval-set / fine-tuning; not consumed live beyond the above).
+
+## Notifications & SLA (load-bearing, not polish)
+
+The loop was built for unattended convergence; under this design **build throughput is gated by founder attention.** The existing KPI "0 open items aged > 48h" now depends on humans voting, so notification is a first-class requirement, not an add-on:
+
+- Notify the founder channel on: new Build Suggestion, suggestion needs votes, needs refinement, accepted, rejected, build started, ready for review, shipped.
+- Surface aging `Open for Vote` posts against the 48h SLA (reuse the pulse open-age KPI, repointed from GitHub Issues to Quackback).
+- Notifications are notification-only (Slack/email); they are never a decision surface.
+
+## Failure handling
+
+- **Post creation fails** → log, retry with backoff, do not start building.
+- **Status read fails** → stop, do not build, retry later (fail-closed, matches pipeline convention).
+- **Accepted-suggestion processing fails before build starts** → leave status unchanged, comment the reason if safe, alert maintainers, do not touch GitHub.
+- **Implementation fails after start** → comment reason + suggested next step; do not mark Ready for Review; may move to Needs Refinement / Cancelled.
+- All Quackback writes that sit on the convergence path are best-effort with step-level timeouts (per the telemetry-writes lesson), but the **read** of acceptance state is fail-closed.
+
+## Security requirements
+
+Authenticated API access via a dedicated least-privilege named key; webhook HMAC-SHA256 signature + timestamp replay check (reject > 5 min); idempotency; rate limiting; audit logging. The box must be unable to: accept/reject its own suggestions, vote, change decision rules, delete objections, bypass `Accepted for Build`, force a merge, or deploy.
+
+## Success criteria
+
+- Observation Loop creates template-compliant Build Suggestions in Quackback; zero new GitHub Issues created by the pipeline.
+- Founders can vote/comment; an authorized founder can accept / reject / request refinement.
+- The box builds only after `Accepted for Build`, marks `Building`, runs the existing pipeline, and the judge auto-merges.
+- The later PR links back to the Quackback post; on merge the post goes `Shipped`.
+- Duplicate implementation starts are prevented.
+- Every decision is auditable in Quackback and emitted as a Langfuse score.
+- Aging `Open for Vote` posts are visible against the 48h SLA.
+
+## Dependencies & assumptions
+
+- **Quackback** (`github.com/QuackbackIO/quackback`), AGPL-3.0, self-hosted (Docker/Railway) — *default; cloud `app.quackback.io` is the fallback if self-host infra is deferred.* Requires Postgres + a Redis-compatible store (BullMQ).
+- REST API (`/api/v1`, `Authorization: Bearer qb_…`), HMAC-signed webhooks, and the 27-tool MCP server are all documented and confirmed. **MCP server is the primary integration path; REST is the fallback.**
+- **Unverified:** Quackback custom-fields API. Assumption — encode the spec's metadata (source, proposal_type, risk_level, complexity, agent_confidence, affected_areas) via **tags + structured Markdown body**, not custom fields, until custom fields are confirmed.
+- The Forge protocol's GitHub/Gitea-agnostic shape is assumed reusable as the seam for the Quackback work-queue adapter (confirmed agnostic by repo scan; the *issue* side, not PR side, is what moves).
+- Hard-replace requires an existing-GitHub-Issue drain step before cutover.
+
+## Outstanding questions (for `/ce-plan`)
+
+1. Self-host deployment target — own VM next to the box, Railway, or co-located? Postgres/Redis provisioning.
+2. MCP vs REST in practice — does the box's current langgraph/langchain runtime consume the MCP server cleanly, or is a thin REST client lower-friction for the first slice?
+3. Drain strategy for in-flight GitHub Issues at cutover — migrate to Quackback posts, or finish them on the old path and start Quackback clean?
+4. Exact Langfuse score schema for decisions (name, datatype, mapping) to fit the existing eval rules.
+5. Webhook endpoint hosting — where does the box receive `Accepted for Build` callbacks (the box is a VM, not a public service); poll fallback may be simpler for slice 1.
+6. Status-name canonicalization — create the spec's exact status set in Quackback, or map onto Quackback defaults.
+
+## Suggested slicing (rough, for planning)
+
+- **Slice 1** — Quackback self-host stood up; named bot key; statuses + Build Suggestions board created; box can create one template-compliant suggestion (shadow read, no build).
+- **Slice 2** — Acceptance discovery (poll first, webhook later) + execution rule + idempotency store; box builds one accepted post end-to-end through existing pipeline → judge merge → `Shipped`.
+- **Slice 3** — Observation Loop repointed to Quackback; GitHub Issue generation removed; existing issues drained (hard cutover).
+- **Slice 4** — Learning loop: Langfuse scores + in-context steering + vote reranking + decision dataset.
+- **Slice 5** — Notifications + 48h SLA repointed to Quackback; duplicate detection hardened.

--- a/docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md
+++ b/docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md
@@ -1,0 +1,391 @@
+---
+title: "feat: Quackback as the autonomous pipeline's decision layer"
+date: 2026-06-21
+type: feat
+depth: deep
+origin: docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md
+status: ready-for-work
+deepened: 2026-06-21
+---
+
+# feat: Quackback as the Autonomous Pipeline's Decision Layer
+
+**Origin:** `docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md`
+**Depth:** Deep (product) · **Output:** markdown
+**Package root:** `pipeline/wgmesh_pipeline/`
+
+> **Origin decisions revised at plan time.** Two of the origin's four "locked decisions" are deliberately reversed here after repo grounding: **transport REST (not MCP)** (KTD2) and **discovery poll-first (not webhook)** (KTD3). Treat this plan, not the origin's locked table, as authoritative for transport and discovery.
+
+---
+
+## Summary
+
+Replace GitHub Issues with a self-hosted **Quackback** board as the autonomous pipeline's decision and audit layer. The Observation Loop posts **Build Suggestions** to Quackback (`Open for Vote`) instead of creating GitHub Issues. A founder flips a post to `Accepted for Build` — the only trigger that lets the box ingest the item into its internal execution store and build it through the existing spec→implement→PR pipeline. The DeepSeek judge auto-merges as today; on real merge the box flips the post to `Shipped`. Human decisions are mirrored to Langfuse as audit scores and persisted to a decision table. GitHub is touched only for branch, commits, and PR.
+
+The integration plugs into the existing **Forge protocol** seam (`forge/protocol.py`) as a `QuackbackForge` **composition** adapter — it *holds* a `GitHubClient` (PR/branch/merge) and a `QuackbackClient` (issue/post ops), satisfying the `@runtime_checkable` `Forge` protocol structurally. Two-layer state: **Quackback** = decision/audit truth; the existing **SQLite store** (`state/store.py`) = execution stage.
+
+---
+
+## Problem Frame
+
+The pipeline was built for unattended convergence — the Observation Loop autonomously files GitHub Issues, the box implements them, and judge-gated auto-merge ships them with no human in the loop. Founders have no single surface to **see, prioritize, and authorize** what the autonomous company proposes, and there is no structured capture of accept/reject judgments. GitHub Issues conflate "the agent had an idea" with "we decided to build this," and are a developer artifact rather than a founder decision surface.
+
+This plan inserts a human prioritization gate at the **front** (Quackback `Accepted for Build`) while preserving autonomy at the **back** (judge auto-merge unchanged). The central consequence, accepted in the origin: build throughput now gates on founder attention. See **Open Questions OQ1** — whether that bottleneck is by-design or needs bounded auto-accept is a product decision left open for the operator; this plan ships the honest instrumentation either way (U8).
+
+---
+
+## Requirements Traceability
+
+Carried from origin (`see origin` for rationale):
+
+- **R1** Observation Loop creates template-compliant Build Suggestions in Quackback; pipeline creates zero GitHub Issues. → U5, U9
+- **R2** Founders vote/comment; authorized founder accepts/rejects/refines (Quackback-native, not built here). → external; U3 reads the result
+- **R3** Box builds only after `Accepted for Build`; marks `Building`; runs existing pipeline; judge auto-merges. → U3, U4, U6
+- **R4** PR links back to the post; on merge the post → `Shipped`. → U6
+- **R5** Duplicate implementation starts prevented (idempotency keyed by post id + accept transition). → U4
+- **R6** Every decision auditable in Quackback and emitted as a Langfuse **audit** score. → U7
+- **R7** Aging `Open for Vote` posts visible against the 48h SLA; founder-channel notifications across the funnel; **all-idle / zero-acceptance alarm**. → U8
+- **R8** Hard replace day one — GitHub Issue generation disabled, existing issues drained. → U9 *(the create path is flag-guarded, not deleted; deletion is a deferred follow-up — see Scope Boundaries)*
+- **R9** Keep DeepSeek judge auto-merge (back gate); drop the spec's human-PR-review step. → acceptance constraint, no unit; verify post-merge that merge stays judge-gated only (`impl_judge.py` unchanged).
+- **R10** Learning loop: Langfuse scores + decision dataset reframed as **audit/measurement** (R6), not live learning. The *live* learning loop (in-context steering) + vote reranking are deferred follow-ups (U10, U11) — nothing reads the dataset live in this plan. → U7 (audit); U10, U11 (deferred)
+- **R11** Self-host Quackback; named least-privilege bot key with **server-side** decision-status prohibition; gating read fail-closed, telemetry write best-effort. → U1, U2, U3, U7
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Composition, not subclass.** `QuackbackForge` (`forge/quackback.py`) **implements** the `Forge` protocol (`forge/protocol.py:30`, `@runtime_checkable`) by composition: it holds a `GitHubClient` for PR/branch/merge methods (`create_pr`, `update_pr_body`, `merge_pr`, `enable_auto_merge`, `get_pr`, `push_branch`, `has_merged_resolution_pr`) and a `QuackbackClient` for issue/post methods (`create_issue`, `get_issue`, `list_open_issues`, `comment`, `set_status`). It delegates each method to the correct backend explicitly. **Rationale (review F1/F6):** `GitHubClient` routes every call through a single `self.api_root` (`github/client.py:60,441`); the `GiteaForge` precedent retargets that one root to Gitea, so its inherited PR methods hit Gitea — a *single*-transport pattern. This integration needs *two* transports (issues→Quackback, PRs→GitHub) from one object, which subclassing cannot express. Composition gives two rooted clients and an explicit per-method split.
+  - Consequence: `QuackbackForge` needs **both** `QUACKBACK_*` and GitHub creds; each issue method that must never reach GitHub is implemented against `_qb` only, and PR methods against `_gh` only. The split is enforced by the conformance suite (U2), not by docstring.
+- **KTD2 — Transport: REST, not MCP.** The forge layer is plain `requests`/`urllib`; REST is the native fit and joins the existing conformance suite. The 27-tool MCP server is reserved for later interactive/agent-native use. *(Flips the origin's MCP-primary default after repo grounding.)*
+- **KTD3 — Discovery: idempotent poll via a dedicated ingest, webhook deferred.** The box is a VM with no public HTTP receiver, and bot-origin webhooks are silently suppressible (learning: `github-app-reviews-dont-trigger-workflows.md`). **Rationale (review F2):** the live poller ingests through `reconcile_issues` over `client.list_open_issues()` (`poller.py:41`, `reconcile.py:55`); nothing calls `list_needs_triage`, and `reconcile_issues` encodes GitHub-label semantics (`MERGED_LABELS`, `needs-human`, resolution-PR lookup) that misfire on Quackback posts. So a **dedicated `reconcile_quackback(client, store)`** ingest runs in `poller.tick` under `forge_kind == "quackback"` (in place of `reconcile_issues`), returning `Accepted for Build` posts and upserting them directly. Poll is idempotent and retried, never one-shot (learning: `loop-pr-automerge-timing-race.md`). *(Flips the origin's webhook-primary default.)*
+- **KTD4 — Two-layer state, with decision re-read for drift.** Quackback status = human decision/audit; the SQLite store (`state/store.py` `ALLOWED_TRANSITIONS`) = execution. Milestone mapping: store advances **past** `queued` (first real spec claim) → post `Building`; store `reviewed/awaiting_merge` → `Ready for Review`; store `merged` (real `pr.merged`) → `Shipped`. **Drift guard (review adversarial F2):** before claim, before PR open, and before the Shipped flip, the box does a cheap per-item `get_issue` decision-status read; if the post left `Accepted for Build`/`Building` (Cancelled / Needs Refinement), it aborts the run and does **not** flip status — the human's terminal decision is never overwritten. This is a bounded read, not a merge of the two state machines. `Building` is flipped only when work actually starts, not at ingest (review adversarial F3 — avoids false "in progress").
+- **KTD5 — Gating read fail-closed, telemetry write best-effort.** The `Accepted for Build` read is fail-closed and loud — on API error the box does **not** build and the failure surfaces (learning: `polar-checkout-404s`). The Langfuse score write is best-effort/non-blocking via the never-raise `score_run` guard (`scoring.py`).
+- **KTD6 — Idempotency + id mapping.** Idempotency key = `quackback_post_id + accept-transition marker`. **`status_version` is unverified** in Quackback's API (review adversarial F1) — U2 probes the live post payload for a monotonic version/`updatedAt`/revision field; if absent, the key falls back to the accept-transition timestamp (from the status-change or comment). Treat `409`/already-exists on create as success (learning: `feedback_create_endpoint_409_breaks_reapply`). Confirm accepted state with a direct per-item read, never inferred from absence in a capped list (learning: `feedback_absence_not_closed_paginated_list`). **Post-id→int mapping (review F3):** the store is `int`-keyed (`store.py:47,112`) and the int threads into spec paths, `bot/impl-{n}` branch names, and resolution-PR title matching. U4 defines the mapping (use Quackback's numeric post number if exposed; else a `quackback_post_id`↔`number` mapping column) and verifies it threads through branch naming and `has_merged_resolution_pr`.
+- **KTD7 — Client construction fail-closed.** `QuackbackClient` mirrors `impl_judge.py` raw-HTTP: `urllib` + `User-Agent: Mozilla/5.0` (Cloudflare-1010 guard), `os.environ` key resolution, assert on payload **shape** not HTTP 200, raise on missing `QUACKBACK_*` secret/endpoint (learning: `multi-model-routing.md`).
+- **KTD8 — Langfuse score = audit, not live learning.** Map the decision payload to the exact observation field the eval rule reads, on a real trace, and exclude the box's own generations (learning: `langfuse-evaluators-scored-empty-output.md`). Reuse `LangfuseScorer.record(...)`. Scores + the decision table are **audit/measurement only** (R6); no component reads them live in this plan (review product) — the live learning loop is deferred (U11).
+- **KTD9 — Decision-status authority is server-enforced.** The bot key must be **server-side** unable to set `Accepted for Build` / `Rejected` (review security F1/F2). The local allowlist in the adapter is defense-in-depth only. U1/U2 require: provision a least-privilege Quackback key whose scopes permit create/read/update/comment/status→{Building, Ready for Review, Shipped} but **not** decision statuses; U2 conformance asserts a forbidden status write returns server **non-2xx**, not just a local raise. Key stored as a CI/box secret (`QUACKBACK_TOKEN`), rotation on personnel change or suspected exposure (runbook, U9).
+- **KTD10 — Untrusted post content is fenced before it enters any LLM prompt.** Build Suggestion bodies and rejection reasons are human/agent-authored and flow into spec/implement and (deferred) steering prompts (review security F5, adversarial F2). Ingest bounds the fields injected into prompts (title + summary, not all 16 sections) and wraps them in a nonce-fence / DATA-not-instructions envelope (pattern: `feedback_llm_judge_gate_failopen_classes`). `decided_by` is stored as an **opaque Quackback user id**, never an email/name, to keep PII out of the public-repo SQLite/Langfuse/logs (review security F3; learning `feedback_public_repo_third_party_pii`).
+
+---
+
+## High-Level Technical Design
+
+### Component / data flow
+
+```mermaid
+flowchart LR
+  OL[Observation Loop<br/>cron + observation.py] -->|create_issue → Build Suggestion| QB[(Quackback<br/>self-host)]
+  Founders[Founders / co-founders] -->|vote / Accept for Build| QB
+  QB -->|poll: reconcile_quackback<br/>Accepted for Build| QF[QuackbackForge<br/>composition adapter]
+  QF -->|upsert post-id→int| ST[(SQLite store<br/>state/store.py)]
+  ST --> P[poller.py]
+  P -->|first spec claim → set_status Building| QF
+  P -->|spec → implement| EX[control_loop/executor + goose/langchain]
+  EX -->|create_pr / push via _gh| GH[(GitHub<br/>code + PR)]
+  P -->|reviewed| J[impl_judge<br/>DeepSeek]
+  J -->|enable_auto_merge via _gh| GH
+  GH -->|pr.merged| P
+  P -->|drift re-read: still Accepted?| QF
+  P -->|flip Shipped| QF
+  QF -->|Building / Ready for Review / Shipped| QB
+  P -->|decision audit| LF[LangfuseScorer.record]
+  QF -.PR/merge via held GitHubClient.-> GH
+  QF -.issues/status via held QuackbackClient.-> QB
+```
+
+### Two-layer state mapping (decision ↔ execution) with drift guard
+
+```mermaid
+flowchart TB
+  subgraph Quackback["Quackback — decision/audit (human)"]
+    OFV[Open for Vote] --> NR[Needs Refinement] --> OFV
+    OFV --> AFB[Accepted for Build]
+    OFV --> REJ[Rejected]
+    AFB --> BLD[Building] --> RFR[Ready for Review] --> SHP[Shipped]
+    AFB --> CAN[Cancelled]
+    BLD --> CAN
+  end
+  subgraph Store["SQLite store — execution (box)"]
+    Q[queued] --> TR[triaged] --> SP[specced] --> SR[spec_ready]
+    SR --> IM[implemented] --> RV[reviewed] --> AM[awaiting_merge] --> MG[merged]
+    Q -. drift: post Cancelled .-> AB[aborted/escalated]
+  end
+  AFB -. ingest upsert .-> Q
+  TR -. first claim → mirror .-> BLD
+  RV -. mirror .-> RFR
+  MG -. mirror on real pr.merged + re-read .-> SHP
+  CAN -. drift re-read aborts run .-> AB
+```
+
+### Accept → Shipped sequence (with drift re-read)
+
+```mermaid
+sequenceDiagram
+  participant F as Founder
+  participant QB as Quackback
+  participant QF as QuackbackForge
+  participant ST as store
+  participant P as poller
+  participant GH as GitHub
+  participant J as judge
+  F->>QB: status → Accepted for Build
+  QF->>QB: reconcile_quackback poll (idempotent)
+  QF->>ST: upsert at queued (post-id→int, dedup key)
+  P->>ST: claim_next → first spec
+  P->>QB: re-read status (still Accepted?) → set_status Building
+  P->>GH: create_pr via _gh (links Quackback post)
+  P->>QB: re-read status → set_status Ready for Review
+  P->>J: judge diff (fail-closed)
+  J->>GH: enable_auto_merge via _gh
+  GH-->>P: pr.merged
+  P->>QB: re-read status; if still active → set_status Shipped
+  P->>QB: (best-effort) Langfuse audit score
+```
+
+---
+
+## Output Structure
+
+New files (created), package root `pipeline/wgmesh_pipeline/` — `quackback/` subpackage folded into `forge/` per review (matches the single-file `forge/gitea.py` precedent):
+
+```
+pipeline/wgmesh_pipeline/
+  forge/
+    quackback.py            # QuackbackForge (composition: holds _gh + _qb) (U2)
+    quackback_client.py     # QuackbackClient — raw urllib REST, fail-closed (U2)
+    quackback_status.py     # status ↔ milestone map + allowlist constant (U3)
+  github/
+    reconcile.py            # + reconcile_quackback() ingest (U4)
+pipeline/tests/
+  test_quackback_client.py        # (U2)
+  test_quackback_forge.py         # (U2, U3)
+  test_quackback_discovery.py     # (U4)
+  test_quackback_drift.py         # (U12)
+  test_quackback_lifecycle.py     # (U6)
+  test_quackback_audit.py         # (U7)
+docs/runbooks/
+  quackback-cutover.md            # drain + cutover + key-provisioning + rollback (U9)
+```
+
+Modified: `config.py`, `forge/factory.py`, `forge/protocol.py` (add `set_status`), `poller.py`, `observation.py` / `control_loop/executor.py`, `state/migrations/` (decision table + id-map column), `tests/conformance/test_forge_conformance.py`, `.github/workflows/observation-loop.yml`, notification/pulse workflow(s).
+
+---
+
+## Implementation Units
+
+Grouped into phases. Land in order; each unit is one atomic commit.
+
+### Phase 1 — Adapter foundation
+
+### U1. Config + bot-key provisioning (least-privilege, server-enforced)
+
+**Goal:** Add `quackback_url`/`quackback_token` config (fail-closed) and document provisioning a least-privilege bot key that the Quackback server forbids from setting decision statuses.
+**Requirements:** R11. **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/config.py`, `pipeline/tests/test_config.py`, `docs/runbooks/quackback-cutover.md` (provisioning section)
+**Approach:** Add `quackback_url`/`quackback_token` next to `gitea_url` (~`config.py:102`), from `QUACKBACK_URL`/`QUACKBACK_TOKEN`. When `forge_kind == "quackback"` and either is unset → raise at construction (KTD7). Runbook documents required key scopes (create/read/update/comment/status→{Building, Ready for Review, Shipped}; **not** Accepted/Rejected), storage as box/CI secret, rotation trigger (KTD9).
+**Patterns to follow:** `config.py:33–36,102` env reads; retired `WGMESH_REVIEWER_PAT` secret-wiring shape.
+**Test scenarios:**
+- Happy: `forge_kind=quackback` + both env set → config exposes url/token.
+- Error: `forge_kind=quackback` + missing token → raises clearly.
+- Edge: `forge_kind=github` + Quackback vars unset → no error.
+**Verification:** selecting Quackback without creds fails loudly; runbook names key scopes + rotation.
+
+### U2. QuackbackClient + QuackbackForge (composition) + factory + conformance
+
+**Goal:** A fail-closed REST `QuackbackClient` and a `QuackbackForge` that composes it with a `GitHubClient`, wired into the factory and the conformance suite, with the issue/PR backend split asserted.
+**Requirements:** R1, R3, R11. **Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback_client.py`, `pipeline/wgmesh_pipeline/forge/quackback.py`, `pipeline/wgmesh_pipeline/forge/factory.py`, `pipeline/wgmesh_pipeline/forge/protocol.py` (add `set_status`), `pipeline/tests/test_quackback_client.py`, `pipeline/tests/test_quackback_forge.py`, `pipeline/tests/conformance/test_forge_conformance.py`
+**Approach:** `quackback_client.py` = raw urllib per `impl_judge.py` (Mozilla UA, `QUACKBACK_*` keys, assert payload shape, never silent-200; KTD7). `QuackbackForge` (KTD1 composition) holds `_gh: GitHubClient` + `_qb: QuackbackClient`, implements the `Forge` protocol structurally: issue/post methods → `_qb` (`create_issue` → Build Suggestion `Open for Vote`, tags `agent-suggestion`+`build-candidate`, keep `_sanitise_write` wall; `get_issue`, `list_open_issues`, `comment`, new `set_status`), PR methods → `_gh`. Probe the live post payload for a `status_version`/`updatedAt` field (KTD6); record which field is used. Factory `make_forge` gains `kind == "quackback"`. Conformance (`test_forge_conformance.py:73`) adds a `QUACKBACK` case asserting issue methods hit `_qb` and **PR methods delegate to `_gh`**.
+**Execution note:** Start with a failing conformance assertion that a forbidden `set_status(Accepted for Build)` returns server non-2xx (KTD9).
+**Patterns to follow:** `impl_judge.py:128` UA, `forge/gitea.py` `_sanitise_write`, `tests/conformance/test_forge_conformance.py` RoutingSession.
+**Test scenarios:**
+- Covers R1. Happy: `create_issue` → POST Build Suggestion with both required tags; returns post id.
+- Split: a PR method call routes to `_gh` (GitHub stub), an issue method routes to `_qb` (Quackback stub) — asserted explicitly.
+- Server authority (KTD9): `set_status(post, "Accepted for Build")` → server non-2xx, surfaced (not just local raise).
+- Idempotency: duplicate-title create → `409` treated as success, returns existing id.
+- Fail-closed: HTTP 200 with malformed payload → raises (KTD7).
+- Sanitise: each new Build-Suggestion field (`Evidence`, `Open Questions`, `Agent Notes`) carrying a synthetic secret → blocked (review security F3).
+**Verification:** conformance green for all forge kinds; backend split + server-side status authority proven.
+
+### Phase 2 — Discovery and lifecycle
+
+### U3. Status map + fail-closed Accepted-for-Build read
+
+**Goal:** Map statuses ↔ milestones, expose the box-settable allowlist, and provide a fail-closed read of `Accepted for Build` posts.
+**Requirements:** R2, R3, R11. **Dependencies:** U2.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback_status.py`, `pipeline/wgmesh_pipeline/forge/quackback.py`, `pipeline/tests/test_quackback_forge.py`
+**Approach:** `quackback_status.py` holds the KTD4 milestone→status map + the box-settable set ({Building, Ready for Review, Shipped}). `list_open_issues` (the ingest read, per KTD3) returns only `Accepted for Build` posts and is **fail-closed**: API error propagates, never empty-looks-healthy (KTD5). Per-item `get_issue` confirms accepted state (KTD6).
+**Patterns to follow:** `forge/protocol.py` method shape; `state/store.py:ALLOWED_TRANSITIONS` discipline.
+**Test scenarios:**
+- Covers R3. Happy: mixed board → returns only `Accepted for Build`.
+- Fail-closed: API 5xx on list → raises; not treated as "no work".
+- Guard: `set_status(post, "Rejected")` rejected locally (defense-in-depth atop KTD9 server enforcement).
+- Per-item confirm: post absent from a capped page but `get_issue` shows accepted → treated accepted.
+**Verification:** gating read raises on failure; box cannot author decision statuses.
+
+### U4. `reconcile_quackback` ingest: discovery → store with id mapping + idempotency
+
+**Goal:** A dedicated idempotent ingest that upserts `Accepted for Build` posts into the store with a post-id→int mapping, replacing `reconcile_issues` under `forge_kind=quackback`.
+**Requirements:** R3, R5. **Dependencies:** U3.
+**Files:** `pipeline/wgmesh_pipeline/github/reconcile.py` (`reconcile_quackback`), `pipeline/wgmesh_pipeline/poller.py` (tick branch), `pipeline/wgmesh_pipeline/state/migrations/` (id-map column), `pipeline/tests/test_quackback_discovery.py`
+**Approach:** Add `reconcile_quackback(client, store)` (no GitHub-label semantics) and branch `poller.tick`: under `forge_kind=quackback` call it instead of `reconcile_issues` (KTD3, review F2). For each accepted post: resolve/allocate the int `number` from the post id (KTD6 mapping; new `quackback_post_id` column), compute the dedup key, and if unseen `store.upsert_issue` at `queued` (no `Building` flip yet — KTD4). Idempotent + retried, never one-shot. The fields carried into the store for later prompting are bounded + fenced (KTD10).
+**Execution note:** Start with a failing test asserting a second poll of the same accepted post launches no second run.
+**Patterns to follow:** `reconcile.py:55` ingest shape (minus label branches), `state/store.py` `upsert_issue`/`claim_next` (206), `poller.py:41` tick.
+**Test scenarios:**
+- Covers R5. Happy: new accepted post → upserted at `queued` with mapped int; no premature `Building`.
+- Idempotency: same post polled twice → one row, one run.
+- Id mapping: non-int `qb_…` post id → stable int allocated; threads into a `bot/impl-{n}` branch name (asserted).
+- Re-accept after cancel: accept-transition marker changes → new key → new run allowed (uses KTD6 fallback if no `status_version`).
+- Resilience: transient API error mid-poll → retried next tick, no partial double-ingest.
+- Fencing: ingested body stored bounded (title+summary), fenced (KTD10).
+**Verification:** double-poll launches one build; ids thread correctly; `reconcile_issues` label logic never runs on posts.
+
+### U5. Repoint Observation Loop create → Quackback Build Suggestion
+
+**Goal:** Observation Loop emits template-compliant Build Suggestions to Quackback instead of `gh issue create`.
+**Requirements:** R1. **Dependencies:** U2.
+**Files:** `.github/workflows/observation-loop.yml`, `pipeline/wgmesh_pipeline/observation.py`, `pipeline/wgmesh_pipeline/control_loop/executor.py`, `pipeline/tests/test_observation.py`
+**Approach:** Route creation through `control_loop/executor._h_create_issue` (~line 87) with a Quackback-kind forge so `plan_actions`/`ObservationPlan` need no change (KTD1). Body uses the origin's 16-section template; metadata via tags + body (custom-fields API unverified — origin assumption). Behind `forge_kind=quackback`, the workflow path at `observation-loop.yml:735` routes to the adapter (flag-guarded, not deleted — see U9), under the same `sanitise.sh` gate and `OBSERVATION_LIVE`. **Cross-status proposal dedup** (review product): give it explicit ownership here — compare against existing posts across all statuses (Quackback AI dedup + the box's own title/summary/affected-areas comparison); on match, comment/update rather than create.
+**Patterns to follow:** `control_loop/executor.py:87`, `observation.py` `plan_actions`, `company/scripts/sanitise.sh`, learning `observation-loop-creates-bogus-issues`.
+**Test scenarios:**
+- Covers R1. Happy: `create_issue` action → Build Suggestion `Open for Vote`, both tags, all template sections.
+- Dedup: near-duplicate of an existing post (any status) → comments/updates existing, no new post.
+- Sanitise: body with secret → blocked before POST.
+- Gating: `OBSERVATION_LIVE` unset → shadow, no write.
+**Verification:** observation run creates a template post, not a GitHub issue; dedup spans non-open statuses.
+
+### U6. Lifecycle mirroring + flip-to-Shipped (with drift re-read)
+
+**Goal:** Mirror execution milestones to Quackback; flip `Shipped` only on real PR merge *and* only if the post is still active.
+**Requirements:** R3, R4. **Dependencies:** U3, U4.
+**Files:** `pipeline/wgmesh_pipeline/poller.py`, `pipeline/tests/test_quackback_lifecycle.py`
+**Approach:** First spec claim (store past `queued`) → `set_status(Building)` (KTD4). PR open → `set_status(Ready for Review)`; `create_pr` (via `_gh`) links the post URL (R4). In the `awaiting_merge→merged` branch (`poller.py:197`, terminal only on real `pr.merged` confirmed via `_gh.get_pr` at `poller.py:192`), do the drift re-read (U12) then `set_status(Shipped)` beside `score_run(outcome="merged")`. All flips best-effort, logged, never block the merge path.
+**Patterns to follow:** `poller.py:156,180,192,197` handlers, `github/client.py:291` `enable_auto_merge`.
+**Test scenarios:**
+- Covers R4. Happy: PR merges → post `Shipped`, `score_run` once.
+- Negative: `awaiting_merge` but not yet merged → no `Shipped` flip.
+- Drift: post Cancelled before merge → no `Shipped` flip (U12), run aborted, human decision intact.
+- Link: created PR body contains the Quackback post URL.
+- Best-effort: `set_status` errors → merge still recorded, logged, no exception into loop.
+**Verification:** Shipped only on real merge + still-active post; PR links post; status errors non-fatal.
+
+### U12. Cancel / refine drift guard
+
+**Goal:** Honor a founder Cancel/Refine that lands mid-build — abort the run instead of overwriting the terminal human decision.
+**Requirements:** R3. **Dependencies:** U3, U4.
+**Files:** `pipeline/wgmesh_pipeline/poller.py`, `pipeline/tests/test_quackback_drift.py`
+**Approach:** Add a cheap per-item `get_issue` decision-status read at three points (KTD4, review adversarial F2): at claim, before PR open, before the Shipped flip. If the post left `Accepted for Build`/`Building` (Cancelled / Needs Refinement), transition the store row to `escalated`/aborted, stop work, and do **not** flip Quackback status. Bounded read; does not merge the two state machines.
+**Execution note:** Start with a failing test that a Cancel between claim and PR-open aborts before any PR is created.
+**Patterns to follow:** `poller.py` stage handlers; `forge.get_issue` per-item read.
+**Test scenarios:**
+- Happy: post stays Accepted/Building through merge → no abort.
+- Cancel at claim → no spec/PR; store aborted; post untouched.
+- Cancel after PR open, before merge → no Shipped flip; store aborted.
+- Needs Refinement mid-build → same abort path.
+**Verification:** a mid-build Cancel never produces a Shipped flip or further work.
+
+### Phase 3 — Decision audit + notifications
+
+### U7. Decision → Langfuse audit score + decision table
+
+**Goal:** Emit a best-effort Langfuse **audit** score per human decision and persist a decision row. (Audit/measurement only — nothing reads it live; KTD8.)
+**Requirements:** R6. **Dependencies:** U3.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback.py` (decision read), `pipeline/wgmesh_pipeline/scoring.py`, `pipeline/wgmesh_pipeline/state/migrations/` (decision table), `pipeline/tests/test_quackback_audit.py`, `pipeline/tests/test_scoring.py`
+**Approach:** When discovery/drift observes a decision transition, call `LangfuseScorer.record(issue=number, outcome="accepted"|"rejected"|"refined", scores={"votes": n}, session_id=f"issue-{number}")` — best-effort via `score_run` (KTD5). Map the payload to the exact field the eval rule reads, on a real trace, excluding the box's own generations (KTD8). Persist a `quackback_decisions` row (number, quackback_post_id, status, accept_marker, votes, **decided_by = opaque user id**, decided_at, rejection_reason). `decided_by` never an email/name (KTD10, review security F3).
+**Patterns to follow:** `scoring.py:67` `LangfuseScorer.record` (stable `score_id`, never raises); `state/migrations/` style.
+**Test scenarios:**
+- Covers R6. Happy: accept decision → `record(outcome="accepted")` with votes; row persisted.
+- Idempotency: same decision twice → one score (stable `score_id`), one row.
+- Best-effort: Langfuse down → no exception into loop; row still persisted.
+- Mapping: score lands on the field the rule reads (not empty `{{output}}`); box generations excluded.
+- PII: `decided_by` stored as opaque id; a name/email in the payload is not persisted verbatim.
+**Verification:** decisions produce audit scores + rows; Langfuse failure non-blocking; no PII persisted.
+
+### U8. Notifications + SLA + all-idle alarm
+
+**Goal:** Founder-channel notifications across the funnel, a 48h `Open for Vote` SLA, and a board-level zero-acceptance alarm — all repointed to Quackback.
+**Requirements:** R7. **Dependencies:** U2.
+**Files:** the pulse/open-age KPI workflow under `.github/workflows/`, pulse module if Python-side, `pipeline/tests/` matching test
+**Approach:** Repoint the existing open-age KPI (origin `project_pulse_open_age_kpi`, 48h, target 0) to count Quackback `Open for Vote` posts by `createdAt`. Add a **board-level alarm** (review adversarial F5): "zero `Accepted for Build` transitions in N hours" → founder alert, distinct from per-post aging, since an absent founder produces a legitimately-empty (fail-closed-correct) read with no other signal. Emit founder-channel notifications on each funnel transition (new / needs votes / needs refinement / accepted / rejected / build started / ready for review / shipped), reusing the MentisDB/Slack/email best-effort `continue-on-error` pattern — **and monitor notifier delivery** (a silently-dropping notifier is the gate's single point of failure). Notification-only, never a decision surface.
+**Patterns to follow:** existing pulse KPI workflow; `observation-loop.yml` MentisDB/Polar `continue-on-error` blocks.
+**Test scenarios:**
+- Covers R7. Happy: a post aged >48h in `Open for Vote` → SLA breach.
+- Boundary: post aged exactly 48h → matches existing KPI inclusivity.
+- Idle alarm: zero accept transitions in N hours → founder alert fires.
+- Notify: each transition emits one message; delivery failure is detected (not silent).
+**Verification:** SLA + idle alarm count Quackback; notifications fire per transition and surface delivery failure.
+
+### Phase 4 — Cutover
+
+### U9. Cutover: disable GitHub issue generation (flag-guarded), drain, runbook
+
+**Goal:** Make Quackback the only queue by flipping `forge_kind`, with the GitHub create path **flag-guarded (not deleted)** so rollback is a real config flip.
+**Requirements:** R1, R8. **Dependencies:** U2–U8, U12 landed and proven in shadow against a real Quackback instance.
+**Files:** `.github/workflows/observation-loop.yml`, `pipeline/wgmesh_pipeline/config.py` (default `forge_kind`), `docs/runbooks/quackback-cutover.md`
+**Approach:** Drain in-flight GitHub issues on the old path (origin OQ3 — finish-clean). Flip default `forge_kind=quackback` (or box env). Keep `gh issue create` **behind the `forge_kind` flag** (review adversarial F4 / product) — deletion is a deferred follow-up after N days proven. Runbook: drain checklist, key provisioning (KTD9), **true rollback** (flip `forge_kind=github` re-enables the still-present create path; if backlog was drained, reseed), verification (zero new GitHub issues; end-to-end accept→build→merge→Shipped).
+**Execution note:** Cutover only after Phase 1–3 + U12 green in shadow against a real instance.
+**Test scenarios:**
+- Covers R8. Happy: post-cutover observation run creates a Quackback post, zero GitHub issues.
+- Rollback: `forge_kind=github` → GitHub create path active again (flag-guarded, not a code revert).
+- Assert: under `forge_kind=quackback`, the `gh issue create` path is not invoked.
+**Verification:** end-to-end on the real instance; rollback is a genuine config flip.
+
+---
+
+## Scope Boundaries
+
+### In scope
+The composition forge adapter + fail-closed REST client, server-enforced decision-status authority, dedicated poll ingest with id mapping + idempotency, observation-loop repoint with cross-status dedup, lifecycle mirroring + flip-to-Shipped, cancel/refine drift guard, decision **audit** score + table (PII-safe), notifications + SLA + idle alarm, and the flag-guarded cutover.
+
+### Deferred to follow-up work
+- **U10 — vote-weighted build-order reranking.** A pure sort over the accepted-post list in `reconcile_quackback`; post-cutover fast-follow (origin slicing; review scope-guardian). Not needed for end-to-end correctness.
+- **U11 — in-context proposal steering.** Inject recent decisions into the proposal prompt (mirrors `project_capabilities_grounding_redo_prevention`); requires U7's table to be non-empty first, so it lands after the first production decision cycle (review scope-guardian/product). This is the *only* mechanism that closes a live learning loop — until it ships, U7 is audit-only.
+- **Delete the `gh issue create` path** — separate unit after Quackback is proven in production for N days (review adversarial F4).
+- **HMAC webhook receiver** — real-time discovery once a public receiver exists; **when implemented it must validate `X-Quackback-Signature-256` and reject timestamp delta > 5 min** (review security F4; origin security requirement).
+- **MCP-server client** — if the box adopts MCP as primary transport later (KTD2).
+- **Promote four memory-only learnings into `docs/solutions/`** via `/ce-compound` after this lands (409-idempotency, absence≠closed, conflicting-PR rebase, LLM-judge fail-open classes).
+- **Quackback custom-fields metadata** — adopt if/when that API is confirmed; until then tags + body.
+
+### Outside this product's identity (from origin)
+- A human merge gate (back stays judge auto-merge).
+- Public/community-facing roadmap or voting (board is internal).
+- GitHub Projects/Linear/Jira integration; weighted-voting schemes; auto-deploy.
+- Replacing the box's internal execution state machine.
+
+---
+
+## Open Questions
+
+- **OQ1 (product, for operator).** Build throughput now hard-stops on founder attention (an absent founder = idle company, with U9 the GitHub path is flag-guarded off). Is the founder the bottleneck **by design**, or should a bounded class (e.g. high-vote + low-risk + low-complexity) **auto-accept** so the box degrades gracefully? This plan ships the honest instrumentation (U8 idle alarm) either way; auto-accept would be a new follow-up unit. *Resolve before relying on the box for steady throughput.*
+- **OQ2 (implementation, U2).** Does Quackback's REST post payload expose a monotonic `status_version`/revision? U2 probes it; if absent, KTD6 falls back to the accept-transition timestamp. Confirms the idempotency key shape.
+- **OQ3 (implementation, U2/U6).** Does Quackback expose a numeric post number, or must the box maintain a `quackback_post_id`↔`number` map? Decides the U4 id-mapping mechanism.
+
+---
+
+## Risks & Dependencies
+
+- **Dependency: a running self-hosted Quackback** (Docker/Railway; Postgres + Redis-compatible) with statuses created and a **least-privilege** bot key that the server forbids from decision statuses (KTD9). U2+ cannot be proven without it. *(origin OQ1,6.)*
+- **Risk: gating read masks failure.** Mitigation: KTD5 fail-closed + U3 raise-on-error tests.
+- **Risk: throughput gates on founder attention.** Mitigation: U8 SLA + idle alarm + monitored notifier; product decision OQ1.
+- **Risk: client-side-only decision-status guard bypassable.** Mitigation: KTD9 server enforcement + U2 conformance asserting server non-2xx.
+- **Risk: prompt-injection from post bodies.** Mitigation: KTD10 fencing + bounded fields; U4 test.
+- **Risk: PII in public-repo decision table.** Mitigation: KTD10 opaque `decided_by`; U7 test.
+- **Risk: drift overwrites human Cancel.** Mitigation: U12 drift guard.
+- **Risk: cutover irreversible.** Mitigation: U9 flag-guards the create path (rollback = config flip); deletion deferred.
+- **Risk: Langfuse empty-score regression.** Mitigation: KTD8 + U7 real-trace mapping test.
+
+---
+
+## Verified Execution (AGENTS.md §95–99)
+
+No completion claim without test/source evidence. Every new input-producing module gets a test; the Quackback adapter joins `tests/conformance/test_forge_conformance.py` and the suite asserts the issue/PR backend split + server-side status authority. All forge writes pass the `sanitise.sh`/`_sanitise_write` wall (public repo — never commit secrets/PII/exact revenue). Conventional commits; branch off `main`.
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md`
+- Quackback feasibility (web research): `github.com/QuackbackIO/quackback` — AGPL-3.0, REST `/api/v1` (`Bearer qb_`), HMAC-SHA256 webhooks, 27-tool MCP server, OAuth 2.1, self-host Docker/Railway. Named API key per agent (dissolves the prior reviewer-PAT distinct-identity 422). *Unconfirmed: per-post `status_version` field, numeric post id, custom-fields API (OQ2/OQ3).*
+- Repo grounding (file:line): `forge/protocol.py:30`, `forge/gitea.py:65`, `forge/factory.py`, `github/client.py:60,270,287,291,441`, `github/reconcile.py:55`, `state/store.py:47,112`, `poller.py:41,192,197`, `observation.py`, `control_loop/executor.py:87`, `pipeline/evals/impl_judge.py:128`, `scoring.py:67`, `tests/conformance/test_forge_conformance.py:73`.
+- Learnings: `docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md`, `integration-issues/github-app-reviews-dont-trigger-workflows.md`, `integration-issues/loop-pr-automerge-timing-race.md`, `integration-issues/polar-checkout-404s-from-stale-config-2026-05-08.md`, `design-decisions/multi-model-routing.md`; memory: `feedback_create_endpoint_409_breaks_reapply`, `feedback_absence_not_closed_paginated_list`, `feedback_llm_judge_gate_failopen_classes`, `feedback_telemetry_writes_must_be_best_effort`, `feedback_public_repo_third_party_pii`.
+- Plan deepened 2026-06-21 via ce-doc-review (6 personas): composition over subclass (F1/F6), dedicated `reconcile_quackback` ingest (F2), post-id→int mapping (F3), cancel/refine drift guard (adversarial F2 → U12), flag-guarded cutover (adversarial F4), server-side status authority + key scopes (security F1/F2 → KTD9), prompt-injection fencing + PII-safe `decided_by` (security F5/F3 → KTD10), audit-not-learning reframe of U7 (product), fold `quackback/` subpackage into `forge/` + defer U10/U11 (scope-guardian).

--- a/docs/runbooks/quackback-cutover.md
+++ b/docs/runbooks/quackback-cutover.md
@@ -1,0 +1,173 @@
+# Runbook — Quackback decision layer: provision, cut over, roll back
+
+Operational companion to `docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md`.
+All facts below are sourced from the live QuackbackIO/quackback repo + quackback.io
+docs (research 2026-06-21). Items marked **VERIFY** were not fully confirmed in docs and
+must be checked against the running instance before the depending unit is proven.
+
+---
+
+## 0. Security posture (KTD9 — revised after grounding)
+
+**Quackback API keys are all-or-nothing.** Every `qb_` key carries all seven scopes
+(`read/write:feedback`, `read/write:changelog`, `read/write:help-center`,
+`read/write:chat`). A key with `write:feedback` can call `triage_post` and set **any**
+status — including `Accepted for Build` and `Rejected`.
+
+> *"API keys get all seven scopes. OAuth tokens get only the scopes the user approved."*
+> — quackback.io/docs/mcp
+
+Consequence: the plan's KTD9 (server-enforced prohibition on the bot setting decision
+statuses) **is not achievable**. Decision-status authority is enforced **client-side
+only** — the adapter allowlist (`forge/quackback_status.py`, box-settable =
+{Building, Ready for Review, Shipped}) plus the fact that box code never targets a
+decision status.
+
+**Accepted risk (operator decision 2026-06-21): the board is used only by trusted
+cofounders.** Under that threat model the residual exposure — a leaked or buggy bot key
+forging a founder decision — is acceptable. The bot key's blast radius already includes
+GitHub write. Mitigations that remain mandatory:
+
+- Box code MUST never call `set_status` with a decision status; the adapter allowlist
+  raises locally if it does (defense-in-depth; asserted by U2 conformance via a **local**
+  raise — the non-2xx server assertion in the plan's U2 execution note is dropped as
+  infeasible).
+- Rotate `QUACKBACK_TOKEN` on cofounder personnel change or any suspected exposure.
+- Keep the board private (internal cofounders only) — never public/community.
+
+---
+
+## 1. Provision a self-hosted Quackback instance
+
+### 1.1 Deploy (production single-host stack)
+
+```bash
+git clone https://github.com/QuackbackIO/quackback.git && cd quackback
+cp .env.prod.example .env        # fill EVERY value — stack refuses to start half-configured
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Migrations run automatically on app startup. Upgrade later with:
+
+```bash
+git pull && docker compose -f docker-compose.prod.yml pull \
+  && docker compose -f docker-compose.prod.yml up -d
+```
+
+Services in the prod stack:
+
+| Service | Image | Notes |
+|---|---|---|
+| app | `ghcr.io/quackbackio/quackback:latest` | only host-published port (`${APP_PORT:-3000}:3000`); health `GET /api/health` |
+| postgres | custom build (`docker/postgres/Dockerfile`) | requires `pg_cron`; **VERIFY** base PG version before pinning upgrades |
+| dragonfly | `dragonflydb/dragonfly:v1.27.1` | Redis-compatible; BullMQ queue backend |
+| minio + minio-init | `minio/minio`, `minio/mc` | optional S3 store (changelog image uploads); omit if unused |
+
+Required env (`.env.example`):
+
+```
+DATABASE_URL=postgresql://postgres:password@host:5432/quackback
+BASE_URL=https://feedback.<your-domain>
+PORT=3000
+SECRET_KEY=<>=32 chars>     # openssl rand -base64 32
+REDIS_URL=redis://dragonfly:6379
+```
+
+> **Gotcha (`.env.example`):** do NOT wrap values in quotes and do NOT put inline comments
+> on a value line — Docker `--env-file` reads everything after `=` literally. A quoted
+> `DATABASE_URL="postgresql://..."` fails with `ERR_INVALID_URL`.
+
+> Railway: no `railway.json` in the repo — there is no one-click template. Deploy on
+> Railway by wiring `docker-compose.prod.yml` to Railway-managed Postgres + a
+> Redis-compatible service manually.
+
+### 1.2 First-run admin setup
+
+Open `BASE_URL` → setup wizard: create the admin account, set the workspace name, create
+the first board (the internal decision board). If you seeded demo data (`bun run db:seed`),
+login is `demo@example.com` / `password` — do not seed a production instance.
+
+### 1.3 Create the decision statuses
+
+Create these eight statuses (Admin UI, or `POST /api/v1/statuses`). Category drives
+roadmap/closed semantics:
+
+| Status | slug | category |
+|---|---|---|
+| Open for Vote | `open_for_vote` | active |
+| Needs Refinement | `needs_refinement` | active |
+| Accepted for Build | `accepted_for_build` | active |
+| Building | `building` | active |
+| Ready for Review | `ready_for_review` | active |
+| Rejected | `rejected` | closed |
+| Cancelled | `cancelled` | closed |
+| Shipped | `shipped` | complete |
+
+API shape (confirmed): `POST /api/v1/statuses` `{name, slug, color, category, position,
+showOnRoadmap, isDefault}`. Record each returned `statusId` (TypeID) — the adapter maps
+slug→statusId for `set_status`.
+
+### 1.4 Mint the bot key
+
+Admin → Settings → Developers → create a named key (e.g. `autobox`). Shown **once** —
+copy immediately. Format `qb_…`, all seven scopes (see §0).
+
+### 1.5 Wire secrets to the box / CI
+
+```bash
+gh secret set QUACKBACK_URL   --body "https://feedback.<your-domain>"   # == BASE_URL
+gh secret set QUACKBACK_TOKEN --body "qb_…"
+```
+
+Then propagate to the box env via the provision/`set-box-env` path (same mechanism as
+prior `*_LIVE` flags). The pipeline reads `QUACKBACK_URL` / `QUACKBACK_TOKEN`; selecting
+`forge_kind=quackback` with either unset fails loudly at config construction (U1).
+
+---
+
+## 2. API facts the adapter depends on
+
+Base: `<BASE_URL>/api/v1`, `Authorization: Bearer qb_…`.
+
+| Need | Fact | Source / status |
+|---|---|---|
+| Create Build Suggestion | `POST /api/v1/posts` | CONFIRMED |
+| Read one post (drift re-read, confirm) | `GET /api/v1/posts/{postId}` | CONFIRMED |
+| List accepted posts (ingest) | `GET /api/v1/posts?status=accepted_for_build&sort=newest&cursor=&limit=` | CONFIRMED; cursor pagination, `limit` max 100 |
+| Set status (Building/Ready/Shipped) | `PATCH /api/v1/posts/{postId}` | **VERIFY** full schema against instance — REST path is in the API index; MCP `triage_post` is the documented equivalent |
+| Comment | REST `POST /api/v1/posts/{postId}/comments` | **VERIFY** — MCP `comment_on_post` confirmed; REST schema not in fetched docs |
+| Post id | string TypeID `post_01h…` — **not numeric** | CONFIRMED → U4 maintains `quackback_post_id`↔int map (KTD6/OQ3 fallback) |
+| Idempotency / concurrency | only `updatedAt` (ISO 8601); **no** `status_version`/revision | CONFIRMED → KTD6 accept-transition timestamp fallback (OQ2 resolved) |
+| Post metadata | no custom-fields API | CONFIRMED → encode via tags + body |
+
+Webhooks (deferred unit, when a public receiver exists): HMAC-SHA256 over
+`{timestamp}.{body}`, header **`X-Quackback-Signature`** (NOT `-256` as the plan guessed),
+timestamp header `X-Quackback-Timestamp`, consumer enforces ≤5-min replay window. Secret
+rotation `POST /api/v1/webhooks/{id}/rotate`.
+
+---
+
+## 3. Cutover (U9 — fill at cutover time)
+
+Prerequisite: Phase 1–3 + U12 green in shadow against this real instance.
+
+1. Drain in-flight GitHub issues on the old path (finish-clean).
+2. Flip default `forge_kind=quackback` (config default or box env).
+3. `gh issue create` path stays **flag-guarded, not deleted** — rollback is a config flip.
+4. Verify: post-cutover observation run creates a Quackback post and **zero** GitHub
+   issues; one end-to-end accept→build→merge→Shipped cycle completes.
+
+## 4. Rollback (true config flip)
+
+Set `forge_kind=github` → the still-present `gh issue create` path reactivates. If the
+GitHub backlog was drained at cutover, reseed it. No code revert required.
+
+---
+
+## 5. Open / VERIFY before depending units are proven
+
+- **VERIFY** `PATCH /api/v1/posts/{postId}` status-set request/response schema (U2/U3/U6).
+- **VERIFY** REST comment endpoint shape (U2/U5) — else route comments via MCP later.
+- **VERIFY** Postgres base version in `docker/postgres/Dockerfile` before pinning upgrades.
+- Probe a live post payload to confirm the `updatedAt` field name used for the
+  accept-transition idempotency marker (U2).

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -345,3 +345,46 @@ def test_committed_box_config_is_valid_and_allowlisted() -> None:
     for k in cfg:
         if k.endswith("_SECONDS") or k == "MAX_FILES":
             assert int(cfg[k]) > 0
+
+
+# --- Quackback config tests ---
+
+_MINIMAL_ENV = {
+    "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+    "DATABASE_MODE": "local",
+}
+
+
+def test_quackback_forge_with_creds_loads_successfully() -> None:
+    cfg = load_config(
+        {
+            **_MINIMAL_ENV,
+            "FORGE_KIND": "quackback",
+            "QUACKBACK_URL": "https://quackback.example.com",
+            "QUACKBACK_TOKEN": "secret-token",
+        }
+    )
+    assert cfg.quackback_url == "https://quackback.example.com"
+    assert cfg.quackback_token == "secret-token"
+
+
+def test_quackback_forge_missing_token_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="QUACKBACK"):
+        load_config(
+            {
+                **_MINIMAL_ENV,
+                "FORGE_KIND": "quackback",
+                "QUACKBACK_URL": "https://quackback.example.com",
+                # QUACKBACK_TOKEN intentionally absent
+            }
+        )
+
+
+def test_github_forge_without_quackback_vars_is_fine() -> None:
+    cfg = load_config(
+        {
+            **_MINIMAL_ENV,
+            # FORGE_KIND defaults to github; no Quackback vars set
+        }
+    )
+    assert cfg.quackback_url is None

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -100,6 +100,8 @@ class Config:
     goose_model: str = DEFAULT_GOOSE_MODEL
     forge_kind: str = "github"
     gitea_url: str | None = None
+    quackback_url: str | None = None
+    quackback_token: str | None = None
     database_mode: str = "local"
     database_path: str = "pipeline/state.db"
     turso_url: str | None = None
@@ -174,6 +176,14 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
     if db_mode == "turso" and not turso_url:
         raise ValueError("DATABASE_MODE=turso requires TURSO_DATABASE_URL")
 
+    forge_kind = _get_nonempty(source, "FORGE_KIND") or "github"
+    quackback_url = _get_nonempty(source, "QUACKBACK_URL")
+    quackback_token = _get_nonempty(source, "QUACKBACK_TOKEN")
+    if forge_kind == "quackback" and not (quackback_url and quackback_token):
+        raise ValueError(
+            "forge_kind=quackback requires QUACKBACK_URL and QUACKBACK_TOKEN"
+        )
+
     control_loop_mode = (
         _get_nonempty(source, "CONTROL_LOOP_MODE") or DEFAULT_CONTROL_LOOP_MODE
     ).lower()
@@ -200,8 +210,10 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         zai_api_key=_get_nonempty(source, "ZAI_API_KEY"),
         anthropic_host=anthropic_host,
         langsmith_api_key=_get_nonempty(source, "LANGSMITH_API_KEY"),
-        forge_kind=_get_nonempty(source, "FORGE_KIND") or "github",
+        forge_kind=forge_kind,
         gitea_url=_get_nonempty(source, "GITEA_URL"),
+        quackback_url=quackback_url,
+        quackback_token=quackback_token,
         poll_interval_seconds=_get_int(
             source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS
         ),


### PR DESCRIPTION
## What

Foundation for the Quackback decision-layer feature (plan: `docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md`). **Inert until cutover** — `forge_kind` defaults to `github`; nothing here activates Quackback. Landed early so `provision-quackback.yml` is dispatchable from `main` (workflow_dispatch only registers from the default branch).

## Commits

- **U1 config** (`858be31`) — `quackback_url`/`quackback_token` from `QUACKBACK_URL`/`QUACKBACK_TOKEN`; fail-closed at load when `forge_kind=quackback` and either unset. 3 tests, 28 green.
- **Plan + brainstorm docs** (`b01f5c6`).
- **Provisioning runbook** (`1f7ed5f`) — `docs/runbooks/quackback-cutover.md`: deploy stack, 8-status set, secret wiring, revised KTD9 posture, VERIFY list.
- **Provision workflow** (`49df5bc`) — `.github/workflows/provision-quackback.yml`: Hetzner VM + `docker-compose.prod.yml` over SSH, mirroring `provision-langfuse.yml`. Pins Quackback `v0.12.4`; secrets generated on box; reports the post-boot wizard/key-mint steps.

## Key decisions captured

- **KTD9 (server-enforced decision-status authority) is infeasible** — Quackback API keys are all-or-nothing (all 7 scopes). Enforcement is client-side only (adapter allowlist). Accepted under the trusted-cofounder-only threat model. Runbook documents the residual risk.
- Transport REST, discovery poll-first (KTD2/KTD3). Composition adapter, not subclass (KTD1).

## Test plan

- [x] `pytest pipeline/tests/test_config.py` — 28 green (happy / missing-token-raises / github-default-inert).
- [x] `provision-quackback.yml` YAML validates; heredoc indentation verified (column-0 after YAML block-strip).
- [ ] Dispatch `provision-quackback.yml` from main → Hetzner box up, `http://<ip>:3000/api/health` green. *(operator, post-merge)*
- [ ] Post-boot: setup wizard → 8 statuses → mint `qb_` key → set `QUACKBACK_URL`/`QUACKBACK_TOKEN`. *(operator)*

## Not in this PR

U2–U9, U12 (the adapter, ingest, lifecycle, drift guard, cutover) land on the feature branch after a live instance exists.