### PR TITLE
fix(infra): pin quackback to 0.12.0 (ghcr image lags git v0.12.4)

### DIFF
--- a/.github/workflows/provision-quackback.yml
+++ b/.github/workflows/provision-quackback.yml
@@ -109,7 +109,11 @@ jobs:
           ssh -o StrictHostKeyChecking=no -i "$RUNNER_TEMP/k" root@"$BOX_IP" bash -s -- "$BOX_IP" <<'REMOTE'
           set -euo pipefail
           IP="$1"
-          QB_TAG="v0.12.4"
+          # Git tag for the repo (postgres builds from its Dockerfile) AND the
+          # published ghcr image tag must agree. The ghcr image lags the git
+          # tags — it tops out at 0.12.0 (git has v0.12.4 with no matching
+          # image), so both are pinned to 0.12.0.
+          QB_TAG="v0.12.0"
           cd /opt/quackback
           if [ ! -d src ]; then
             git clone --branch "$QB_TAG" --depth 1 https://github.com/QuackbackIO/quackback.git src
@@ -117,12 +121,12 @@ jobs:
           cd src
           if [ ! -f .env ]; then
             # Docker reads .env literally: no quotes, no inline comments on values.
-            # NOTE: QUACKBACK_TAG is the ghcr IMAGE tag (no leading 'v'). If
-            # ghcr.io/quackbackio/quackback:0.12.4 does not exist, adjust this.
+            # QUACKBACK_TAG is the ghcr IMAGE tag (no leading 'v'); kept in sync
+            # with QB_TAG above (image lags git — 0.12.0 is the latest published).
             cat > .env <<EOF
           BASE_URL=http://$IP:3000
           SECRET_KEY=$(openssl rand -base64 32)
-          QUACKBACK_TAG=0.12.4
+          QUACKBACK_TAG=0.12.0
           APP_PORT=3000
           POSTGRES_USER=quackback
           POSTGRES_PASSWORD=$(openssl rand -base64 24)

--- a/docs/runbooks/quackback-cutover.md
+++ b/docs/runbooks/quackback-cutover.md
@@ -127,18 +127,30 @@ prior `*_LIVE` flags). The pipeline reads `QUACKBACK_URL` / `QUACKBACK_TOKEN`; s
 
 ## 2. API facts the adapter depends on
 
-Base: `<BASE_URL>/api/v1`, `Authorization: Bearer qb_…`.
+Base: `<BASE_URL>/api/v1`, `Authorization: Bearer qb_…`. **All rows below VERIFIED against
+the live instance `http://89.167.62.47:3000` on 2026-06-21** (status codes observed inline).
 
-| Need | Fact | Source / status |
+| Need | Fact | Status |
 |---|---|---|
-| Create Build Suggestion | `POST /api/v1/posts` | CONFIRMED |
-| Read one post (drift re-read, confirm) | `GET /api/v1/posts/{postId}` | CONFIRMED |
-| List accepted posts (ingest) | `GET /api/v1/posts?status=accepted_for_build&sort=newest&cursor=&limit=` | CONFIRMED; cursor pagination, `limit` max 100 |
-| Set status (Building/Ready/Shipped) | `PATCH /api/v1/posts/{postId}` | **VERIFY** full schema against instance — REST path is in the API index; MCP `triage_post` is the documented equivalent |
-| Comment | REST `POST /api/v1/posts/{postId}/comments` | **VERIFY** — MCP `comment_on_post` confirmed; REST schema not in fetched docs |
-| Post id | string TypeID `post_01h…` — **not numeric** | CONFIRMED → U4 maintains `quackback_post_id`↔int map (KTD6/OQ3 fallback) |
-| Idempotency / concurrency | only `updatedAt` (ISO 8601); **no** `status_version`/revision | CONFIRMED → KTD6 accept-transition timestamp fallback (OQ2 resolved) |
+| Create Build Suggestion | `POST /api/v1/posts` `{boardId, title, content, statusId?}` → **201** | VERIFIED |
+| Read one post (drift re-read, confirm) | `GET /api/v1/posts/{postId}` → **200** | VERIFIED |
+| List accepted posts (ingest) | `GET /api/v1/posts?status=accepted_for_build&cursor=&limit=` → **200** | VERIFIED — filter is by status **SLUG** |
+| **Filter gotcha** | `?status=<slug>` filters; **`?statusId=<id>` is IGNORED** (returns all) | VERIFIED — ingest MUST use the slug param |
+| Set status (Building/Ready/Shipped) | `PATCH /api/v1/posts/{postId}` `{"statusId":"<status TypeID>"}` → **200** | VERIFIED — body takes the status **id**, not slug; box maps slug→id via `GET /statuses` |
+| Comment | `POST /api/v1/posts/{postId}/comments` `{"content":"…"}` → **201** | VERIFIED |
+| Delete (probe cleanup) | `DELETE /api/v1/posts/{postId}` → **204** | VERIFIED |
+| Post id | string TypeID `post_01h…` — **not numeric** | VERIFIED → U4 maintains `quackback_post_id`↔int map (KTD6/OQ3) |
+| Idempotency / concurrency | post payload has **no** `version`/`revision`/`statusVersion`; only `createdAt`/`updatedAt` | VERIFIED → KTD6 accept-transition `updatedAt` marker (OQ2 resolved) |
+| `decided_by` (KTD10, PII-safe) | use `ownerPrincipalId` (opaque) — payload also exposes `authorEmail`/`authorName`; **never persist those** | VERIFIED |
+| Status object | `{id (status_…), name, slug, color, category(active\|complete\|closed), position, showOnRoadmap, isDefault}` | VERIFIED |
 | Post metadata | no custom-fields API | CONFIRMED → encode via tags + body |
+
+**Live instance state (2026-06-21):** workspace `wgmesh`; board **Build Suggestions**
+`board_01kvm80e4df69b5wf8t1v6x6xh` (slug `build-suggestions`); the 8 decision statuses
+created (slugs `open_for_vote`/`needs_refinement`/`accepted_for_build`/`building`/
+`ready_for_review`/`rejected`/`cancelled`/`shipped`); bot key `autobox` minted;
+`QUACKBACK_URL`/`QUACKBACK_TOKEN` set as repo secrets. (6 default statuses + 3 default
+boards from onboarding also present — harmless; the box targets `build-suggestions`.)
 
 Webhooks (deferred unit, when a public receiver exists): HMAC-SHA256 over
 `{timestamp}.{body}`, header **`X-Quackback-Signature`** (NOT `-256` as the plan guessed),
@@ -164,10 +176,11 @@ GitHub backlog was drained at cutover, reseed it. No code revert required.
 
 ---
 
-## 5. Open / VERIFY before depending units are proven
+## 5. VERIFY items — RESOLVED 2026-06-21 (probed against the live instance)
 
-- **VERIFY** `PATCH /api/v1/posts/{postId}` status-set request/response schema (U2/U3/U6).
-- **VERIFY** REST comment endpoint shape (U2/U5) — else route comments via MCP later.
-- **VERIFY** Postgres base version in `docker/postgres/Dockerfile` before pinning upgrades.
-- Probe a live post payload to confirm the `updatedAt` field name used for the
-  accept-transition idempotency marker (U2).
+- ✅ `PATCH /api/v1/posts/{postId}` `{"statusId":"<id>"}` → 200 (set-status; body takes id).
+- ✅ `POST /api/v1/posts/{postId}/comments` `{"content":"…"}` → 201.
+- ✅ Idempotency marker = `updatedAt` (no version/revision field on the post payload).
+- ✅ Ingest filter = `?status=<slug>` (the `?statusId=` param is ignored — see §2).
+- Still open: Postgres base version in `docker/postgres/Dockerfile` before pinning upgrades
+  (not blocking — the stack runs on the built image).


### PR DESCRIPTION
## What

`provision-quackback.yml` pinned `QUACKBACK_TAG=0.12.4` (latest git tag), but the **ghcr image lags** — `ghcr.io/quackbackio/quackback` tops out at `0.12.0`. The app image pull failed → app never started → `/api/health` dead for 10 min, port 3000 closed (the run still reported "success" because the health step only warns).

Aligns both pins to `0.12.0` (git `v0.12.0` for the postgres Dockerfile build + image `0.12.0`).

## Verification

Redeployed from this branch (run 27888944650) → `quackback up`, `http://89.167.62.47:3000/api/health` returns **200**, `/api/v1/*` returns 401 (auth gating live). Instance confirmed serving.

Learning captured: verify the deploy tag against the **registry** (`ghcr /v2/<repo>/tags/list`), not the git release tag.