### PR TITLE
feat(ci): auto-deploy box on green Build Pipeline Image (close merge≠deploy lag)

### DIFF
--- a/.github/workflows/auto-deploy-on-merge.yml
+++ b/.github/workflows/auto-deploy-on-merge.yml
@@ -1,0 +1,22 @@
+name: Auto Deploy on Merge
+
+on:
+  workflow_run:
+    workflows: ["Build Pipeline Image"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pipeline-box
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    uses: ./.github/workflows/deploy-pipeline-box.yml
+    with:
+      sha: ${{ github.event.workflow_run.head_sha }}
+      server_name: wgmesh-pipeline
+    secrets: inherit

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -6,9 +6,21 @@ on:
       server_name:
         description: 'Hetzner server name'
         default: 'wgmesh-pipeline'
+        type: string
       sha:
         description: 'Image tag to deploy'
         default: 'latest'
+        type: string
+  workflow_call:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+        type: string
+      sha:
+        description: 'Image tag to deploy'
+        default: 'latest'
+        type: string
 
 permissions:
   contents: read
@@ -44,13 +56,13 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          IP=$(hcloud server ip "${{ inputs.server_name }}")
           echo "BOX_IP=$IP" >> "$GITHUB_ENV"
 
       - name: Deploy image
         env:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          SHA: ${{ github.event.inputs.sha }}
+          SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
           umask 077
@@ -94,4 +106,4 @@ jobs:
           REMOTE
 
       - name: Report
-        run: echo "Box $BOX_IP deployed image tag '${{ github.event.inputs.sha }}'."
+        run: echo "Box $BOX_IP deployed image tag '${{ inputs.sha }}'."


### PR DESCRIPTION
## What

Auto-redeploy the pipeline box on every green `Build Pipeline Image`, closing the **merge ≠ deploy** lag. Until now `Deploy Pipeline Box` was `workflow_dispatch`-only, so merged code ran on the box only after a manual dispatch — e.g. eval-enrichment #1866 merged 06-19 but the box kept old code for ~2 days, leaving Langfuse NUMERIC evals scoring empty `{{output}}` as degenerate integers until a manual redeploy.

## How

- **`deploy-pipeline-box.yml`**: add a `workflow_call` trigger beside the existing `workflow_dispatch` (same `server_name`/`sha` inputs); swap step refs `github.event.inputs.*` → `inputs.*` so both paths resolve. SSH → `docker pull` → `systemctl restart` → journalctl-tick health gate are unchanged.
- **`auto-deploy-on-merge.yml`** (new): fires on `workflow_run` of `Build Pipeline Image` (completed); guards `conclusion == success && head_branch == main`; calls the reusable deploy with `sha: head_sha`, `secrets: inherit`, `concurrency: deploy-pipeline-box / cancel-in-progress`.

### Why this shape
- `workflow_run` (not raw `push`) → image is guaranteed built + pytest + eval-gated + pushed before deploy, and **Build's `paths:` filter is inherited** (heal/chore/docs/supervisor-rank merges don't build → don't redeploy → no restart thrash).
- Deploy the build's exact `head_sha`, not `latest` → auditable, immune to a racing newer push.
- `cancel-in-progress` collapses a burst of merges to one deploy of the newest.
- No new secrets; manual `workflow_dispatch` Deploy stays as override/rollback.

## Activation note
Takes effect only once merged to `main` (workflow_run + the new file must live on the default branch). After merge: pipeline-code merge → Build → green → auto-deploy.

## Test plan
- [x] `actionlint` clean on both workflow files
- [x] `pytest pipeline/tests/` → 763 passed / 5 skipped (YAML-only change, no python delta)
- [x] YAML parses; no stray `github.event.inputs` left in deploy
- [ ] Post-merge: confirm a pipeline-code merge triggers Build → Auto Deploy on Merge → box on new SHA (journalctl tick)

## Rollback
Delete `auto-deploy-on-merge.yml`; manual Deploy untouched.
