### PR TITLE
feat: #1599 Phase D — bot-PR CI on the box + ci/guards required check (U9, U10)

### DIFF
--- a/.github/workflows/external-pr-ci.yml
+++ b/.github/workflows/external-pr-ci.yml
@@ -18,8 +18,16 @@ name: External PR CI
 #   - Author/event filter scopes the jobs to external / non-bot PRs (bot PRs
 #     are CI'd on the box; this avoids double-gating).
 #
-# NOT in this workflow (owned by cutover Phase D): disabling the three
-# standalone workflows, and making this a required check on main.
+# Phase D: this workflow now emits the shared `ci/guards` required-check name
+# (the `ci-guards` aggregation job below) for the EXTERNAL path. The box posts
+# a commit status of the same name for bot PRs — one required context, two
+# producers, so neither PR class orphans. The aggregation is a JOB (its own
+# pass/fail is the check-run) rather than a `gh api` commit-status POST, because
+# a fork `pull_request` GITHUB_TOKEN is forced read-only and cannot write a
+# status — keeping the secretless guarantee intact.
+#
+# NOT in this workflow (owned by cutover Phase D): the protect-main ruleset swap
+# to require `ci/guards`, and disabling the three standalone workflows.
 
 on:
   pull_request:
@@ -125,3 +133,31 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash scripts/lint/check-pii-policy.sh
+
+  # Aggregate the three guard jobs into the single `ci/guards` required check
+  # (#1599 Phase D, KTD1). This job's own conclusion IS the check-run — no
+  # `gh api` status POST, so it needs no `statuses: write` and works under the
+  # read-only fork token. On bot PRs the `if` is false → the job is skipped →
+  # the `ci/guards` check-run reports skipped (= success for branch protection),
+  # while the box posts the real `ci/guards` commit status that actually gates
+  # the bot PR. So the required context exists for every PR class.
+  ci-guards:
+    name: ci/guards
+    if: ${{ always() && !startsWith(github.event.pull_request.head.ref, 'bot/') }}
+    needs: [pytest, sanitise, pii-policy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate guard results
+        run: |
+          set -euo pipefail
+          echo "pytest=${{ needs.pytest.result }} sanitise=${{ needs.sanitise.result }} pii=${{ needs.pii-policy.result }}"
+          for result in \
+            "${{ needs.pytest.result }}" \
+            "${{ needs.sanitise.result }}" \
+            "${{ needs.pii-policy.result }}"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::a guard job concluded '$result' — ci/guards fails"; exit 1 ;;
+            esac
+          done
+          echo "external-pr guards green"

--- a/pipeline/tests/test_create_commit_status.py
+++ b/pipeline/tests/test_create_commit_status.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.config import CI_GUARDS_CONTEXT, Config
+from wgmesh_pipeline.github.client import DryRunResult, GitHubClient
+
+
+class Response:
+    def __init__(self, data: Any = None) -> None:
+        self._data = data
+        self.text = "" if data is None else "json"
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._data
+
+
+class Session:
+    def __init__(self, response: Response) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Response:
+        self.calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return self.response
+
+
+def cfg(mode: str = "live") -> Config:
+    return Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode=mode, wgmesh_bot_pat="pat"
+    )
+
+
+def test_create_commit_status_posts_to_statuses_endpoint() -> None:
+    session = Session(Response({}))
+    client = GitHubClient(cfg(), session=session)
+
+    client.create_commit_status(
+        "abc123", context=CI_GUARDS_CONTEXT, state="success", description="all green"
+    )
+
+    call = session.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"].endswith("/repos/atvirokodosprendimai/wgmesh/statuses/abc123")
+    assert call["kwargs"]["json"]["state"] == "success"
+    assert call["kwargs"]["json"]["context"] == "ci/guards"
+
+
+def test_create_commit_status_failure_state_carries_description() -> None:
+    session = Session(Response({}))
+    client = GitHubClient(cfg(), session=session)
+
+    client.create_commit_status(
+        "abc", context=CI_GUARDS_CONTEXT, state="failure", description="blocked: pii"
+    )
+
+    payload = session.calls[0]["kwargs"]["json"]
+    assert payload["state"] == "failure"
+    assert payload["description"] == "blocked: pii"
+
+
+def test_create_commit_status_shadow_dry_runs_with_no_network() -> None:
+    session = Session(Response({}))
+    client = GitHubClient(cfg(mode="shadow"), session=session)
+
+    result = client.create_commit_status("abc", context=CI_GUARDS_CONTEXT, state="success")
+
+    assert isinstance(result, DryRunResult)
+    assert session.calls == []
+
+
+def test_create_commit_status_spec_only_is_blocked() -> None:
+    session = Session(Response({}))
+    client = GitHubClient(cfg(mode="spec-only"), session=session)
+
+    with pytest.raises(PermissionError):
+        client.create_commit_status("abc", context=CI_GUARDS_CONTEXT, state="success")
+
+    assert session.calls == []

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -42,6 +42,53 @@ def test_gate_tests_failed_only_low_risk_is_retryable() -> None:
     assert decision.retryable is True
 
 
+def test_gate_pii_failure_escalates_and_is_not_retryable() -> None:
+    # #1599 Phase D: a PII guard failure is a leak guard, not a flaky test —
+    # escalate to a human, never auto-retry.
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+        pii_ok=False,
+    )
+
+    assert decision.decision == "escalate"
+    assert "PII check failed" in decision.reasons
+    assert decision.retryable is False
+
+
+def test_gate_emit_sanitise_failure_escalates() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+        emit_sanitise_ok=False,
+    )
+
+    assert decision.decision == "escalate"
+    assert "emit-sanitise failed" in decision.reasons
+    assert decision.retryable is False
+
+
+def test_gate_pii_emit_default_true_preserves_backward_compat() -> None:
+    decision = decide_gate(
+        changed_files=["docs/readme.md"],
+        diff="+docs\n",
+        max_files=3,
+        tests_passed=True,
+        sanitise_ok=True,
+        review_findings=[],
+    )
+
+    assert decision.decision == "merge"
+
+
 def test_gate_blocking_review_finding_only_low_risk_is_retryable() -> None:
     decision = decide_gate(
         changed_files=["docs/readme.md"],

--- a/pipeline/tests/test_guards_node.py
+++ b/pipeline/tests/test_guards_node.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import subprocess
+import types
+from typing import Any
+
+from wgmesh_pipeline.graph.nodes.guards import guards_node
+
+
+class FakeClient:
+    def __init__(self, pr: dict[str, Any]) -> None:
+        self._pr = pr
+        self.statuses: list[dict[str, Any]] = []
+
+    def get_pr(self, number: int) -> dict[str, Any]:
+        return self._pr
+
+    def create_commit_status(
+        self, sha: str, *, context: str, state: str, description: str = "", target_url=None
+    ) -> None:
+        self.statuses.append(
+            {"sha": sha, "context": context, "state": state, "description": description}
+        )
+
+
+PR = {"base": {"sha": "base000"}, "head": {"sha": "head111"}}
+
+
+def make_runner(*, pii_rc: int = 0, emit_rc: int = 0, raise_on: str | None = None):
+    def runner(cmd: list[str], **kwargs: Any):
+        script = cmd[1]
+        if raise_on and raise_on in script:
+            raise subprocess.TimeoutExpired(cmd, 1)
+        rc = pii_rc if "check-pii-policy" in script else emit_rc
+        return types.SimpleNamespace(returncode=rc, stdout="", stderr="")
+
+    return runner
+
+
+def base_state(client: FakeClient, **over: Any) -> dict[str, Any]:
+    state = {
+        "repo_path": ".",
+        "github": client,
+        "goose_runner": object(),  # live-path sentinel (mirrors review_node)
+        "impl_pr": 5,
+        "tests_passed": True,
+        "sanitise_ok": True,
+    }
+    state.update(over)
+    return state
+
+
+def test_synthetic_path_skips_guards_and_passes() -> None:
+    # No goose_runner -> synthetic/shadow path: guards pass without running the
+    # subprocess scans or posting a status (mirrors review_node's fallback).
+    client = FakeClient(PR)
+    out = guards_node(
+        {"repo_path": ".", "github": client, "impl_pr": 5}, runner=make_runner(pii_rc=1)
+    )
+
+    assert out["pii_ok"] is True
+    assert out["emit_sanitise_ok"] is True
+    assert client.statuses == []
+
+
+def test_clean_guards_post_success() -> None:
+    client = FakeClient(PR)
+    out = guards_node(base_state(client), runner=make_runner())
+
+    assert out["pii_ok"] is True
+    assert out["emit_sanitise_ok"] is True
+    status = client.statuses[-1]
+    assert status["state"] == "success"
+    assert status["context"] == "ci/guards"
+    assert status["sha"] == "head111"
+
+
+def test_pii_failure_blocks_and_posts_failure() -> None:
+    client = FakeClient(PR)
+    out = guards_node(base_state(client), runner=make_runner(pii_rc=1))
+
+    assert out["pii_ok"] is False
+    assert client.statuses[-1]["state"] == "failure"
+    assert "pii" in client.statuses[-1]["description"]
+
+
+def test_emit_sanitise_failure_blocks() -> None:
+    client = FakeClient(PR)
+    out = guards_node(base_state(client), runner=make_runner(emit_rc=1))
+
+    assert out["emit_sanitise_ok"] is False
+    assert client.statuses[-1]["state"] == "failure"
+    assert "emit-sanitise" in client.statuses[-1]["description"]
+
+
+def test_guard_timeout_fails_closed() -> None:
+    client = FakeClient(PR)
+    out = guards_node(base_state(client), runner=make_runner(raise_on="check-pii-policy"))
+
+    assert out["pii_ok"] is False
+    assert client.statuses[-1]["state"] == "failure"
+
+
+def test_missing_head_sha_fails_pii_closed_and_skips_post() -> None:
+    client = FakeClient({"base": {}, "head": {}})
+    out = guards_node(base_state(client), runner=make_runner())
+
+    assert out["pii_ok"] is False
+    assert client.statuses == []  # no head sha -> no status posted
+
+
+def test_status_description_never_contains_email() -> None:
+    client = FakeClient(PR)
+    guards_node(base_state(client), runner=make_runner(pii_rc=1))
+
+    assert "@" not in client.statuses[-1]["description"]
+
+
+def test_upstream_tests_failed_yields_failure_status() -> None:
+    client = FakeClient(PR)
+    out = guards_node(base_state(client, tests_passed=False), runner=make_runner())
+
+    assert out["pii_ok"] is True  # the guards themselves are green
+    assert client.statuses[-1]["state"] == "failure"  # aggregate includes tests
+    assert "tests" in client.statuses[-1]["description"]
+
+
+def test_status_post_error_does_not_crash() -> None:
+    class BoomClient(FakeClient):
+        def create_commit_status(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+    client = BoomClient(PR)
+    out = guards_node(base_state(client), runner=make_runner())
+
+    assert out["pii_ok"] is True  # the node still returns; the post error is swallowed

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -63,6 +63,11 @@ def _read_box_config(path: Path = BOX_CONFIG_PATH) -> dict[str, str]:
 
 VALID_MODES = frozenset({"shadow", "spec-only", "live"})
 VALID_DB_MODES = frozenset({"local", "turso"})
+# The single required CI status context the protect-main ruleset gates on
+# (#1599 Phase D). Posted by the box for bot PRs and by external-pr-ci.yml for
+# external PRs — one name, two producers, so neither PR class orphans. A shared
+# constant keeps the posted name and the ruleset-required name from drifting.
+CI_GUARDS_CONTEXT = "ci/guards"
 DEFAULT_ANTHROPIC_HOST = "https://api.z.ai/api/anthropic"
 DEFAULT_TARGET_REPO = "atvirokodosprendimai/wgmesh"
 DEFAULT_POLL_INTERVAL_SECONDS = 300

--- a/pipeline/wgmesh_pipeline/forge/protocol.py
+++ b/pipeline/wgmesh_pipeline/forge/protocol.py
@@ -76,6 +76,16 @@ class Forge(Protocol):
 
     def merge_pr(self, pr_number: int, *, commit_title: str | None = None) -> Any: ...
 
+    def create_commit_status(
+        self,
+        sha: str,
+        *,
+        context: str,
+        state: str,
+        description: str = "",
+        target_url: str | None = None,
+    ) -> Any: ...
+
     def push_branch(
         self, clone_path: str, branch: str, *, spec_pr: bool = False
     ) -> Any: ...

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -254,6 +254,25 @@ class QuackbackForge:
     def merge_pr(self, pr_number: int, *, commit_title: str | None = None) -> Any:
         return self._gh.merge_pr(pr_number, commit_title=commit_title)
 
+    def create_commit_status(
+        self,
+        sha: str,
+        *,
+        context: str,
+        state: str,
+        description: str = "",
+        target_url: str | None = None,
+    ) -> Any:
+        # CI status is a GitHub commit concern → _gh (the code backend), not the
+        # decision board.
+        return self._gh.create_commit_status(
+            sha,
+            context=context,
+            state=state,
+            description=description,
+            target_url=target_url,
+        )
+
     def enable_auto_merge(self, pr_number: int, *, merge_method: str = "SQUASH") -> Any:
         return self._gh.enable_auto_merge(pr_number, merge_method=merge_method)
 

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -319,6 +319,36 @@ class GitHubClient:
             payload={"commit_title": commit_title} if commit_title else {},
         )
 
+    def create_commit_status(
+        self,
+        sha: str,
+        *,
+        context: str,
+        state: str,
+        description: str = "",
+        target_url: str | None = None,
+    ) -> Any:
+        """Post a commit status (``POST /repos/{owner}/{repo}/statuses/{sha}``)
+        so GitHub branch protection can require it (#1599 Phase D ``ci/guards``).
+
+        ``state`` is one of ``success`` / ``failure`` / ``pending`` / ``error``.
+        Mode-gated via ``_write`` like other writes (shadow -> dry-run record;
+        spec-only -> PermissionError, which the guards node tolerates). The
+        ``description`` must carry NO PII/secret value — it is posted to a public
+        status surface; keep it to a static guard summary.
+        """
+        payload: dict[str, Any] = {"state": state, "context": context}
+        if description:
+            payload["description"] = description[:140]
+        if target_url:
+            payload["target_url"] = target_url
+        return self._write(
+            "create_commit_status",
+            "POST",
+            f"/repos/{self.config.owner}/{self.config.repo}/statuses/{sha}",
+            payload=payload,
+        )
+
     def enable_auto_merge(self, pr_number: int, *, merge_method: str = "SQUASH") -> Any:
         """Enable GitHub auto-merge so the forge merges the PR when its required
         checks (impl-judge + build + status) pass — the box stops self-merging

--- a/pipeline/wgmesh_pipeline/graph/nodes/gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/gate.py
@@ -27,6 +27,8 @@ def decide_gate(
     sanitise_ok: bool,
     review_findings: list[dict],
     paywall_ok: bool = True,
+    pii_ok: bool = True,
+    emit_sanitise_ok: bool = True,
 ) -> GateDecision:
     risk = classify_risk(changed_files, diff, max_files=max_files)
     reasons = list(risk.reasons)
@@ -34,6 +36,10 @@ def decide_gate(
         reasons.append("tests failed")
     if not sanitise_ok:
         reasons.append("sanitise failed")
+    if not pii_ok:
+        reasons.append("PII check failed")
+    if not emit_sanitise_ok:
+        reasons.append("emit-sanitise failed")
     if not paywall_ok:
         reasons.append("component paywall")
     if any(finding.get("blocking", False) for finding in review_findings):
@@ -83,6 +89,12 @@ def gate_node(
         sanitise_ok=bool(next_state.get("sanitise_ok", False)),
         paywall_ok=paywall_ok,
         review_findings=list(next_state.get("review_findings", [])),
+        # The guards node (#1599 Phase D) is the always-on producer of these on
+        # the live reviewed path and sets explicit booleans (False on any guard
+        # failure). Default True covers shadow/synthetic paths where guards did
+        # not run, so it never blocks them spuriously.
+        pii_ok=bool(next_state.get("pii_ok", True)),
+        emit_sanitise_ok=bool(next_state.get("emit_sanitise_ok", True)),
     )
     next_state["decision"] = decision.decision
     next_state["risk_tier"] = decision.risk_tier

--- a/pipeline/wgmesh_pipeline/graph/nodes/guards.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/guards.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from wgmesh_pipeline.config import CI_GUARDS_CONTEXT
+from wgmesh_pipeline.graph.state import GraphState
+
+log = logging.getLogger(__name__)
+
+# Repo root: .../pipeline/wgmesh_pipeline/graph/nodes/guards.py -> parents[4].
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+PII_SCRIPT = _REPO_ROOT / "scripts" / "lint" / "check-pii-policy.sh"
+EMIT_SANITISE_SCRIPT = _REPO_ROOT / "scripts" / "lint" / "check-llm-emit-sanitise.sh"
+GUARD_TIMEOUT_SECONDS = 120
+
+
+def guards_node(state: GraphState, *, runner=subprocess.run) -> GraphState:
+    """#1599 Phase D bot-PR CI: run the path-scoped PII guard and the static
+    emit-sanitise guard the standalone Actions workflows skip for ``bot/*`` heads,
+    expose ``pii_ok`` / ``emit_sanitise_ok`` to the gate, and post the shared
+    ``ci/guards`` required status on the PR head.
+
+    Fail-closed: any guard that errors, times out, or exits non-zero leaves its
+    flag ``False`` (never a silent pass), so the gate escalates and the posted
+    status is ``failure``.
+    """
+    next_state = dict(state)
+    _visit(next_state, "guards")
+
+    # Mirror review_node's two-path split: the guards run their real subprocess
+    # scans + status post only on the live path (a real goose runner AND a real
+    # github client). On the synthetic/shadow path there is no PR range to scan,
+    # so the guards pass (like review_node deriving tests_passed instead of
+    # running go test) — this keeps integration harnesses that drive the merge
+    # flow without a live PR from being blocked by a guard that has nothing real
+    # to check.
+    real_path = (
+        next_state.get("goose_runner") is not None
+        and next_state.get("github") is not None
+    )
+    if not real_path:
+        next_state["pii_ok"] = True
+        next_state["emit_sanitise_ok"] = True
+        return next_state
+
+    repo_path = Path(next_state.get("repo_path", "."))
+    client = next_state.get("github")
+    impl_pr = next_state.get("impl_pr")
+
+    base_sha, head_sha = _resolve_range(client, impl_pr)
+
+    if base_sha and head_sha:
+        env = {**os.environ, "BASE_SHA": str(base_sha), "HEAD_SHA": str(head_sha)}
+        pii_ok = _run_guard(
+            ["bash", str(PII_SCRIPT)], cwd=repo_path, env=env, runner=runner
+        )
+    else:
+        log.error("guards: missing base/head SHA — PII check fails closed")
+        pii_ok = False
+
+    emit_sanitise_ok = _run_guard(
+        ["bash", str(EMIT_SANITISE_SCRIPT), str(repo_path)],
+        cwd=repo_path,
+        runner=runner,
+    )
+
+    next_state["pii_ok"] = pii_ok
+    next_state["emit_sanitise_ok"] = emit_sanitise_ok
+    _post_guards_status(next_state, head_sha)
+    return next_state
+
+
+def _resolve_range(client, impl_pr) -> tuple[str | None, str | None]:
+    if client is None or impl_pr is None:
+        return None, None
+    try:
+        pr = client.get_pr(int(impl_pr))
+    except Exception:
+        log.exception("guards: could not resolve PR base/head SHA")
+        return None, None
+    base_sha = (pr.get("base") or {}).get("sha")
+    head_sha = (pr.get("head") or {}).get("sha")
+    return base_sha, head_sha
+
+
+def _run_guard(cmd: list[str], *, cwd: Path, env=None, runner=subprocess.run) -> bool:
+    try:
+        completed = runner(
+            cmd,
+            cwd=cwd,
+            env=env,
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=GUARD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        log.error("guards: %s timed out — fails closed", cmd[1] if len(cmd) > 1 else cmd)
+        return False
+    except Exception:
+        log.exception("guards: %s errored — fails closed", cmd)
+        return False
+    if completed.returncode != 0:
+        log.warning("guards: %s exited %s", cmd, completed.returncode)
+    return completed.returncode == 0
+
+
+def _post_guards_status(state: GraphState, head_sha: str | None) -> None:
+    client = state.get("github")
+    if client is None or not head_sha:
+        return
+    all_ok = (
+        bool(state.get("tests_passed"))
+        and bool(state.get("sanitise_ok"))
+        and bool(state.get("pii_ok"))
+        and bool(state.get("emit_sanitise_ok"))
+    )
+    gh_state = "success" if all_ok else "failure"
+    # Static description only — never echo a matched email/secret value to the
+    # public status surface.
+    description = (
+        "all guards green"
+        if all_ok
+        else f"blocked: {_failed_guards(state)}"
+    )
+    try:
+        client.create_commit_status(
+            head_sha,
+            context=CI_GUARDS_CONTEXT,
+            state=gh_state,
+            description=description,
+        )
+    except PermissionError:
+        # spec-only mode disallows the write; the gate still enforces internally.
+        log.info("guards: ci/guards status post skipped (mode restricts writes)")
+    except Exception:
+        # A failed post leaves the required check absent → the PR cannot merge,
+        # which is the safe direction. Surface it loudly.
+        log.exception("guards: ci/guards status post failed")
+
+
+def _failed_guards(state: GraphState) -> str:
+    failed = []
+    if not state.get("tests_passed"):
+        failed.append("tests")
+    if not state.get("sanitise_ok"):
+        failed.append("sanitise")
+    if not state.get("pii_ok"):
+        failed.append("pii")
+    if not state.get("emit_sanitise_ok"):
+        failed.append("emit-sanitise")
+    return ",".join(failed) or "unknown"
+
+
+def _visit(state: dict, node: str) -> None:
+    state.setdefault("visited", []).append(node)

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -26,6 +26,8 @@ class GraphState(TypedDict, total=False):
     review_findings: list[dict[str, Any]]
     tests_passed: bool
     sanitise_ok: bool
+    pii_ok: bool
+    emit_sanitise_ok: bool
     decision: Decision
     escalation_tier: int
     escalation_attempts: int

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -11,6 +11,7 @@ from wgmesh_pipeline.forge.protocol import Forge, ForgeIssue as GitHubIssue
 from wgmesh_pipeline.forge.quackback_status import is_active_lane, status_for_stage
 from wgmesh_pipeline.github.reconcile import reconcile_issues, reconcile_quackback
 from wgmesh_pipeline.graph.nodes.gate import apply_gate_side_effects, gate_node
+from wgmesh_pipeline.graph.nodes.guards import guards_node
 from wgmesh_pipeline.scoring import score_run
 from wgmesh_pipeline.state.store import ACTIONABLE_STAGES, IssueRecord, StateStore
 
@@ -183,6 +184,12 @@ class Poller:
             return self.store.transition(issue.number, "implemented", "reviewed")
 
         if issue.stage == "reviewed":
+            # #1599 Phase D: run the bot-PR leak guards (PII + emit-sanitise that
+            # the standalone Actions workflows skip for bot/* heads) and post the
+            # shared ci/guards required status BEFORE the gate decides, so the
+            # gate sees pii_ok/emit_sanitise_ok and GitHub auto-merge has the
+            # required check to wait on. Fail-closed inside guards_node.
+            state = guards_node(state)
             result = gate_node(state, max_files=self.config.max_files, apply_side_effects=False)
             # Side-effect BEFORE the terminal transition: if the merge/label
             # network call fails it raises here, the issue stays at 'reviewed'

--- a/scripts/ruleset/apply-protect-main-required-checks.sh
+++ b/scripts/ruleset/apply-protect-main-required-checks.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# #1599 Phase D — swap the protect-main ruleset's required status checks:
+# ADD `ci/guards` (the single shared CI gate, posted by the box for bot PRs and
+# by external-pr-ci.yml for external PRs) and REMOVE the three standalone
+# workflow contexts (pipeline-ci / sanitise-wall / pii-policy-check) once the
+# box + external producers are proven green.
+#
+# SAFETY:
+#   * Dry-run by DEFAULT — prints the current and proposed required-check sets
+#     and exits without mutating. Pass --apply to PUT the updated ruleset.
+#   * Idempotent — re-running after a successful apply is a no-op (ci/guards
+#     already present, the three already removed).
+#   * Drain gate — refuses to apply while any OPEN bot PR is CONFLICTING: such a
+#     PR fires no workflows / gets no box status, so a newly required `ci/guards`
+#     would be ABSENT (not red) and the PR would dead-end. Conflict-heal (#1930)
+#     drains these; this is the KTD5 precondition.
+#
+# Edits the repo RULESET (not classic branch protection) — the protect-main
+# ruleset is the real gate. Requires `gh` (admin on the repo) and `jq`.
+set -euo pipefail
+
+REPO="${REPO:-atvirokodosprendimai/ai-pipeline-template}"
+RULESET_ID="${RULESET_ID:-13925617}"
+CI_GUARDS_CONTEXT="${CI_GUARDS_CONTEXT:-ci/guards}"
+# Contexts retired by Phase D once ci/guards carries the guards on both paths.
+REMOVE_JSON='["pipeline-ci","sanitise-wall","pii-policy-check"]'
+
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
+
+echo "Repo:    $REPO"
+echo "Ruleset: $RULESET_ID (protect-main)"
+echo "Add:     $CI_GUARDS_CONTEXT"
+echo "Remove:  $REMOVE_JSON"
+echo
+
+ruleset_json="$(gh api "repos/${REPO}/rulesets/${RULESET_ID}")"
+
+echo "Current required checks:"
+printf '%s' "$ruleset_json" | jq -r '
+  (.rules[] | select(.type=="required_status_checks")
+   | .parameters.required_status_checks[].context)
+  // empty' | sed 's/^/  - /' || echo "  (none / unreadable)"
+echo
+
+# Drain gate: any OPEN bot PR that is CONFLICTING blocks the swap.
+conflicting="$(
+  gh pr list --repo "$REPO" --state open --json number,headRefName,mergeable \
+    --jq '[.[] | select(.headRefName|startswith("bot/")) | select(.mergeable=="CONFLICTING") | .number] | join(",")' \
+    2>/dev/null || true
+)"
+if [ -n "$conflicting" ]; then
+  echo "REFUSING: open CONFLICTING bot PR(s): #${conflicting}."
+  echo "A required ci/guards would be ABSENT on these and dead-end them."
+  echo "Let conflict-heal (#1930) rebase them to zero first (KTD5), then re-run."
+  exit 2
+fi
+echo "Drain gate: no open CONFLICTING bot PRs."
+echo
+
+# New ruleset with the required_status_checks list swapped (every other rule,
+# parameter, condition, and bypass actor preserved verbatim).
+new_ruleset="$(
+  printf '%s' "$ruleset_json" | jq \
+    --arg add "$CI_GUARDS_CONTEXT" \
+    --argjson remove "$REMOVE_JSON" '
+    .rules |= map(
+      if .type=="required_status_checks" then
+        .parameters.required_status_checks =
+          ( ( [.parameters.required_status_checks[]
+               | select(.context as $c | ($remove | index($c)) | not)]
+              + [{context:$add, integration_id:null}] )
+            | unique_by(.context) )
+      else . end
+    )
+  '
+)"
+
+echo "New required checks:"
+printf '%s' "$new_ruleset" | jq -r '
+  .rules[] | select(.type=="required_status_checks")
+  | .parameters.required_status_checks[].context' | sed 's/^/  - /'
+echo
+
+if [ "$APPLY" -ne 1 ]; then
+  echo "DRY RUN — pass --apply to PUT the ruleset. No changes made."
+  exit 0
+fi
+
+# PUT the full ruleset back (name/target/enforcement/conditions/bypass_actors
+# preserved from the fetched object; only rules changed).
+printf '%s' "$new_ruleset" \
+  | jq '{name, target, enforcement, bypass_actors, conditions, rules}' \
+  | gh api -X PUT "repos/${REPO}/rulesets/${RULESET_ID}" --input -
+
+echo
+echo "Applied. Verify:"
+echo "  gh api repos/${REPO}/rulesets/${RULESET_ID} --jq '.rules[]|select(.type==\"required_status_checks\").parameters.required_status_checks[].context'"


### PR DESCRIPTION
## Summary

Completes the CI phase of the #1599 Actions→box cutover. The external-PR side (U10) shipped in #1934; this PR delivers the **bot-PR side (U9)** and the shared required-check plumbing.

Today the box's bot-authored PRs merge gated only by the LLM `impl-judge` check plus the box's *internal* deterministic decision. The three standalone Actions guards (`pipeline-ci`, `sanitise-wall`, `pii-policy-check`) **skip `bot/*` heads**, so bot PRs currently get **no path-scoped PII scan and no static emit-sanitise scan at all** — a real leak-guard gap on a public repo. This closes it.

Plan: `docs/plans/2026-06-21-005-refactor-1599-phase-d-bot-ci-plan.md`

## What changed

- **U1+U2 — box-side guards + status** (`e0b5739`)
  - New `graph/nodes/guards.py`: runs `check-pii-policy.sh` (over the bot PR's `BASE..HEAD`) and `check-llm-emit-sanitise.sh`, threads `pii_ok`/`emit_sanitise_ok` into the gate, and posts the shared `ci/guards` commit status on the PR head **before** `enable_auto_merge`. **Fail-closed**: any guard error/timeout/non-zero → flag `False`, status `failure`, gate escalates (non-retryable — a leak guard, not a flaky test).
  - Runs real work only on the **live path** (`goose_runner` + `github` present), mirroring `review_node`'s two-path split — synthetic/shadow paths pass without a real PR to scan.
  - `client.create_commit_status` (`POST /statuses/{sha}`), mode-gated via `_write`; delegated by `QuackbackForge`, inherited by `GiteaForge`.
  - `config.CI_GUARDS_CONTEXT = "ci/guards"` — one shared name so the posted and required names can't drift.
- **U3 — external producer of the same check** (`db32488`)
  - `external-pr-ci.yml` gains a `ci-guards` aggregation job (`name: ci/guards`) that `needs` the pytest/sanitise/pii-policy jobs. The job's own pass/fail **is** the check-run — no `gh api` status POST, because a fork `pull_request` `GITHUB_TOKEN` is forced read-only. Stays fully secretless (no `statuses: write`, no `pull_request_target`).
- **U4 — ruleset-swap script** (`ea4d7a7`)
  - `scripts/ruleset/apply-protect-main-required-checks.sh` — dry-run by default, idempotent, refuses to apply while any open bot PR is `CONFLICTING`. **Not executed by this PR.**

## Design: one required context, two producers (KTD1)

`ci/guards` is the lone CI gate in the `protect-main` ruleset. The **box** posts it (commit status) for bot PRs; **external-pr-ci** emits it (aggregation job) for external PRs. Exactly one producer fires per PR class, same name → branch protection is satisfiable for both without orphaning either. A box-posted-only required check would have orphaned external PRs (the box never touches forks); a fork-Actions-posted status is impossible (read-only token) — hence the two-producer split.

## Test plan

- [x] Box unit tests: `test_guards_node` (clean→success, PII/emit fail→failure, timeout→fail-closed, missing head SHA→fail-closed + no post, status value never contains an email, upstream tests-failed→failure, post-error doesn't crash, synthetic path skips), `test_create_commit_status` (endpoint/payload, shadow dry-run, spec-only blocked), `test_gate` (PII/emit-sanitise escalate + non-retryable, defaults preserve merge).
- [x] Full suite: 806 passed (1 pre-existing flaky `test_implement_no_changes_fails_loudly` — passes isolated + whole-file 9/9; unrelated to this change).
- [x] `external-pr-ci.yml` valid YAML, still zero `secrets.`/`pull_request_target`, `contents: read`.
- [ ] **Bake** `ci/guards` green on a real bot PR (box producer) and a real external PR (Actions producer).
- [ ] **Canary**: confirm GitHub branch protection unifies a commit-status context and a check-run name both called `ci/guards` (plan Open Question #3).

## Deferred (KTD4 — operator, after bake)

- **U4 execution** — run `apply-protect-main-required-checks.sh --apply` (drain CONFLICTING bot PRs first).
- **U5** — disable `pipeline-ci` / `sanitise-wall` / `pii-policy-check` (keep files; deletion is #1599 U13).
- The single-PAT `ci/guards` status is **not forgery-resistant** (KTD6); the off-box/scope-split hardening stays on #1599's identity risk.