### PR TITLE
chore(ci): U4/U5 — ci.yml is the required gate (meta); disable standalone

### DIFF
--- a/docs/actions-cicd-only-end-state.md
+++ b/docs/actions-cicd-only-end-state.md
@@ -39,9 +39,9 @@ CD does, on merge, like for any developer. `build-pipeline-image.yml` (push) +
 Strangler throughout — disable an Actions workflow only after its box equivalent
 bakes. Each step maps to a #1599 phase.
 
-1. **CI invariant + Phase-D reversal** — *done in this change*: ci.yml is the CI; external-pr-ci + box ci/guards removed.
-2. **Make ci.yml the required gate** (follow-up, governance) — point the `protect-main` ruleset's required status checks at ci.yml's job names (`pipeline-tests`, `sanitise-wall`, `pii-policy-check`); then disable the legacy standalone `pipeline-ci` / `sanitise-wall` / `pii-policy-check` workflows. Drain CONFLICTING bot PRs first.
-3. **Seed repo CI** — give `wgmesh` its own `ci.yml` (go build/test + leak guards + `impl-judge` **as a CI job**, not a box gate) for all authors; secretless fork lane.
+1. **CI invariant + Phase-D reversal** — *done* (#1948): ci.yml is the CI; external-pr-ci + box ci/guards removed.
+2. **Make ci.yml the required gate** — *meta done*: `protect-main` (13925617) now requires `pipeline-tests` / `sanitise-wall` / `pii-policy-check` (ci.yml jobs); the standalone `pipeline-ci` / `sanitise-wall` / `pii-policy-check` workflows are disabled. Reusable: `scripts/ruleset/apply-required-checks.sh`. **wgmesh deferred** — its `protect-main` (12831947) already requires `impl-judge` / `status-check` / `build-and-push`; **add** `build-test` to that set (don't replace), and only after conflict-heal drains its CONFLICTING bot PRs (#755, #744 at time of writing).
+3. **Seed repo CI** — *done* (`wgmesh#798`): `ci.yml` runs go build/test/vet for all authors, secretless. `impl-judge` stays its own secret-bearing, same-repo-gated workflow (folding it into the secretless lane would expose its LLM-judge key to forks). wgmesh has no `docs/outreach`/`docs/customers`, so the meta path-scoped PII guard is N/A there; impl-judge's safety axis covers PII/secret on bot PRs.
 4. **Loop → box** (#1599 Phase B): goal-sprint, observation, supervisor, strategy, conflict-heal, heartbeat-automerge, requeue, nongoose-shadow.
 5. **Monitoring → box** (#1599 Phase C): health, error-rate, diagnose, checkout-monitor, langfuse ×3, mentisdb, control-replay.
 6. **Provisioning → box/off-box** (#1599 Phase E): provision box/langfuse/quackback, set-box-env, terraform.

--- a/scripts/ruleset/apply-required-checks.sh
+++ b/scripts/ruleset/apply-required-checks.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Set a repo ruleset's required status checks to exactly the given contexts
+# (#1599 retarget U4: require the ci.yml job checks so the autobox's PRs gate on
+# the same CI a human's do). CREATE-IF-ABSENT: appends a required_status_checks
+# rule when the ruleset has none (today's state on both repos).
+#
+# SAFETY: dry-run by default (prints current → proposed, exits); --apply to PUT.
+# Idempotent. Refuses to apply while any open bot PR is CONFLICTING (a missing
+# required check dead-ends it). Edits the ruleset, not classic branch protection.
+#
+# Usage: REPO=owner/name RULESET_ID=123 CHECKS="a,b,c" apply-required-checks.sh [--apply]
+set -euo pipefail
+
+: "${REPO:?REPO=owner/name required}"
+: "${RULESET_ID:?RULESET_ID required}"
+: "${CHECKS:?CHECKS=comma,separated required}"
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+echo "Repo:    $REPO"
+echo "Ruleset: $RULESET_ID"
+echo "Require: $CHECKS"
+echo
+
+ruleset_json="$(gh api "repos/${REPO}/rulesets/${RULESET_ID}")"
+echo "Current required checks:"
+printf '%s' "$ruleset_json" | jq -r '
+  (.rules[]? | select(.type=="required_status_checks")
+   | .parameters.required_status_checks[]?.context) // empty' \
+  | sed 's/^/  - /' || true
+echo
+
+conflicting="$(
+  gh pr list --repo "$REPO" --state open --json number,headRefName,mergeable \
+    --jq '[.[]|select(.headRefName|startswith("bot/"))|select(.mergeable=="CONFLICTING")|.number]|join(",")' \
+    2>/dev/null || true)"
+if [ -n "$conflicting" ]; then
+  echo "REFUSING: open CONFLICTING bot PR(s): #${conflicting} — a new required check"
+  echo "would be ABSENT on them and dead-end them. Drain (conflict-heal) first."
+  exit 2
+fi
+echo "Drain gate: no open CONFLICTING bot PRs."
+echo
+
+# checks array from CHECKS; create-if-absent the required_status_checks rule.
+checks_json="$(printf '%s' "$CHECKS" | jq -R 'split(",") | map({context: .})')"
+new_ruleset="$(
+  printf '%s' "$ruleset_json" | jq --argjson checks "$checks_json" '
+    if ([.rules[]|select(.type=="required_status_checks")]|length) > 0
+    then .rules |= map(if .type=="required_status_checks"
+                       then .parameters.required_status_checks = $checks else . end)
+    else .rules += [{type:"required_status_checks",
+                     parameters:{strict_required_status_checks_policy:false,
+                                 required_status_checks:$checks}}]
+    end')"
+
+echo "Proposed required checks:"
+printf '%s' "$new_ruleset" | jq -r '
+  .rules[]|select(.type=="required_status_checks")
+  |.parameters.required_status_checks[].context' | sed 's/^/  - /'
+echo
+
+if [ "$APPLY" -ne 1 ]; then
+  echo "DRY RUN — pass --apply to PUT. No changes made."
+  exit 0
+fi
+
+printf '%s' "$new_ruleset" \
+  | jq '{name, target, enforcement, bypass_actors, conditions, rules}' \
+  | gh api -X PUT "repos/${REPO}/rulesets/${RULESET_ID}" --input -
+echo "Applied."


### PR DESCRIPTION
Completes U4/U5 of the #1599 retarget for the **meta** repo.

- **U4** — `protect-main` (13925617) now requires the ci.yml job checks: `pipeline-tests` / `sanitise-wall` / `pii-policy-check`. Applied via the new reusable `scripts/ruleset/apply-required-checks.sh` (create-if-absent, dry-run default, refuses to apply while any bot PR is CONFLICTING). The ruleset previously had **no** required_status_checks rule.
- **U5** — disabled the redundant standalone `sanitise-wall` + `pii-policy-check` workflows (`pipeline-ci` already was). ci.yml produces the same check contexts, so nothing orphans.

This PR itself is now gated by the new required checks (good dogfood).

**wgmesh deferred** — its `protect-main` (12831947) already requires `impl-judge`/`status-check`/`build-and-push`; **add** `build-test` to that set (don't replace), and only after conflict-heal drains its CONFLICTING bot PRs (#755, #744).

Note: `pipeline-tests` is now a required gate on the autonomous loop — the known-flaky `test_implement_no_changes_fails_loudly` should be fixed so a flake can't stall a bot PR. Rollback if needed: re-empty the required_status_checks rule.