### PR TITLE
feat(merge-lane-heal): re-arm MERGEABLE bot fix PRs whose required impl-judge check never ran

### DIFF
--- a/.github/workflows/conflict-heal.yml
+++ b/.github/workflows/conflict-heal.yml
@@ -1,10 +1,18 @@
 name: Conflict Heal
 
-# Autonomous rebase of CONFLICTING bot PRs across both repos (meta + seed).
-# A bot PR goes CONFLICTING when main moves under it; such a PR fires no
-# pull_request workflows, so the judge never runs and it dead-ends. This rebases
-# it onto main (--force-with-lease, bot-branches only), re-arming the merge lane;
-# a genuinely unresolvable conflict escalates to a human after two attempts.
+# Bot-PR merge-lane heal across both repos (meta + seed). Two passes:
+#
+#   Pass A (rebase) — a bot PR goes CONFLICTING when main moves under it; such a
+#   PR fires no pull_request workflows, so the judge never runs and it dead-ends.
+#   Rebase onto main (--force-with-lease, bot-branches only) re-arms the lane; a
+#   genuinely unresolvable conflict escalates to a human after two attempts.
+#
+#   Pass B (re-arm) — a MERGEABLE bot `fix:` PR can be stuck because its required
+#   `impl-judge` check was never produced (it predates the judge workflow, so no
+#   pull_request event ever fired it — an absent required check is permanently
+#   pending, not red). Enable auto-merge + push an empty commit to fire the judge.
+#   Pass B runs AFTER Pass A, so a PR the rebase already re-armed (force-push fires
+#   the judge) is no longer a Pass-B candidate.
 #
 # Cron offset to 01/07/13/19 so it never overlaps pr-disposition's 0 */6.
 
@@ -86,7 +94,7 @@ jobs:
           echo "::add-mask::$token"
           echo "GH_TOKEN=$token" >> "$GITHUB_ENV"
 
-      - name: Run conflict-heal
+      - name: Run conflict-heal (Pass A — rebase CONFLICTING)
         env:
           TARGET_REPO: ${{ matrix.target_repo }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
@@ -99,35 +107,51 @@ jobs:
           fi
           python company/scripts/conflict-heal/run.py "${args[@]}"
 
+      - name: Run check-rearm (Pass B — re-arm MERGEABLE unjudged)
+        env:
+          TARGET_REPO: ${{ matrix.target_repo }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          CHECK_REARM_STATE: company/check-rearm-state-${{ matrix.repo_label }}.json
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python company/scripts/check-rearm/run.py "${args[@]}"
+
       - name: Commit state
         if: ${{ (github.event.inputs.dry_run || 'false') != 'true' }}
         env:
-          STATE_FILE: company/conflict-heal-state-${{ matrix.repo_label }}.json
+          STATE_FILES: >-
+            company/conflict-heal-state-${{ matrix.repo_label }}.json
+            company/check-rearm-state-${{ matrix.repo_label }}.json
         run: |
           set -euo pipefail
 
-          state_content="$(cat "$STATE_FILE")"
-          if ! printf '%s' "$state_content" | bash company/scripts/sanitise.sh > /dev/null; then
-            echo "::error::sanitise.sh rejected $STATE_FILE"
-            exit 1
-          fi
+          for f in $STATE_FILES; do
+            if ! cat "$f" | bash company/scripts/sanitise.sh > /dev/null; then
+              echo "::error::sanitise.sh rejected $f"
+              exit 1
+            fi
+          done
 
           git config user.name "pupabobas[bot]"
           git config user.email "pupabobas[bot]@users.noreply.github.com"
-          git add "$STATE_FILE"
+          git add $STATE_FILES
           git diff --cached --quiet && echo "No state changes to commit" && exit 0
 
           today=$(date -u '+%Y-%m-%d')
           branch="conflict-heal/${{ matrix.repo_label }}-${today}-${GITHUB_RUN_ID}"
           git checkout -b "$branch" origin/main
-          git add "$STATE_FILE"
-          git commit -m "chore(conflict-heal): update ${{ matrix.repo_label }} state $today"
+          git add $STATE_FILES
+          git commit -m "chore(merge-lane-heal): update ${{ matrix.repo_label }} state $today"
           git push -u origin "$branch"
 
           pr_url=$(gh pr create \
             --repo "${{ github.repository }}" \
-            --title "chore(conflict-heal): update ${{ matrix.repo_label }} state $today" \
-            --body "Automated conflict-heal retry-tracker update." \
+            --title "chore(merge-lane-heal): update ${{ matrix.repo_label }} state $today" \
+            --body "Automated conflict-heal + check-rearm retry-tracker update." \
             --base main \
             --head "$branch")
           echo "Opened state PR: $pr_url"

--- a/company/check-rearm-state-meta.json
+++ b/company/check-rearm-state-meta.json
@@ -1,0 +1,3 @@
+{
+  "retry_tracker": {}
+}

--- a/company/check-rearm-state-seed.json
+++ b/company/check-rearm-state-seed.json
@@ -1,0 +1,3 @@
+{
+  "retry_tracker": {}
+}

--- a/company/scripts/check-rearm/rearm.sh
+++ b/company/scripts/check-rearm/rearm.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Re-arm ONE bot PR by pushing an empty commit to its head branch, firing
+# `pull_request: synchronize` so the absent required judge check finally runs.
+#
+# Usage: rearm.sh <repo-slug> <pr-number> <head-branch>     (e.g. owner/name)
+# Auth:  GH_TOKEN env (a bot-push app token with contents:write on the repo).
+# Emits exactly one structured result line for the orchestrator to parse:
+#   OUTCOME=rearmed|skipped|error REASON=<slug>
+#
+# Safety invariants (mirror conflict-heal/rebase.sh):
+#   - bot/* branches ONLY (R3) — a non-bot branch returns BEFORE any git call.
+#   - an EMPTY commit + a NORMAL push (R2/KTD1) — it is a new commit, never a
+#     history rewrite, so no --force is used or needed. A non-fast-forward push
+#     (branch moved under us) surfaces as OUTCOME=error and is retried next tick.
+# The runner is ephemeral and the clone is a temp dir removed on return, so
+# there is no box-state risk.
+set -euo pipefail
+
+rearm_pr() {
+  local repo="${1:-}" pr_number="${2:-}" branch="${3:-}"
+
+  if [[ -z "$repo" || -z "$pr_number" || -z "$branch" ]]; then
+    echo "OUTCOME=skipped REASON=missing-args"
+    return 0
+  fi
+
+  # LOAD-BEARING GUARD (R3): never touch a non-bot branch. This MUST precede
+  # every git invocation so a human PR can never reach a clone/push line.
+  case "$branch" in
+    bot/*) ;;
+    *)
+      echo "OUTCOME=skipped REASON=non-bot-branch"
+      return 0
+      ;;
+  esac
+
+  local workdir
+  workdir="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand workdir now, on trap registration
+  trap "rm -rf '$workdir'" RETURN
+
+  git clone --quiet \
+    "https://x-access-token:${GH_TOKEN:-}@github.com/${repo}.git" "$workdir"
+  git -C "$workdir" checkout "$branch"
+
+  # Identity for the empty commit (the box's bot identity).
+  git -C "$workdir" config user.name "pupabobas[bot]"
+  git -C "$workdir" config user.email "pupabobas[bot]@users.noreply.github.com"
+
+  git -C "$workdir" commit --allow-empty \
+    -m "chore: re-arm impl-judge (merge-lane heal)"
+
+  if ! git -C "$workdir" push origin "$branch"; then
+    echo "OUTCOME=error REASON=push-failed"
+    return 0
+  fi
+  echo "OUTCOME=rearmed REASON=empty-commit-pushed"
+  return 0
+}
+
+# Execute only when run directly; sourcing (tests) exposes rearm_pr without
+# running it.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  rearm_pr "$@"
+fi

--- a/company/scripts/check-rearm/run.py
+++ b/company/scripts/check-rearm/run.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Check-rearm orchestrator: planner → enable-auto-merge + re-arm → escalate.
+
+The MERGEABLE-but-unjudged sibling of ``conflict-heal/run.py``. A bot ``fix:``
+PR can sit MERGEABLE + all-produced-checks-green yet blocked forever because the
+required ``impl-judge`` check was never produced (the PR predates the judge
+workflow, so no ``pull_request`` event ever fired it — an absent required check
+is permanently pending, not red). This loop, per repo:
+
+  1. lists open PRs via ``gh`` (number, headRefName, mergeable, title, isDraft,
+     statusCheckRollup) — one call, cross-repo via ``--repo`` (no per-PR fetch);
+  2. resolves each PR's present check/status contexts from the rollup;
+  3. plans re-arm/escalate via the pure ``plan_check_rearm``;
+  4. for each re-arm: ENABLES AUTO-MERGE FIRST (the standing backlog has
+     ``autoMergeRequest: null`` — it predates the box's gate.py auto-merge
+     wiring, so re-arming the check alone would leave a green-but-idle PR), THEN
+     pushes an empty commit (``rearm.sh``) to fire the judge. Once the judge +
+     build + status are green, GitHub merges — no approval, no reviewer PAT.
+
+Side effects (listing, enabling auto-merge, running the re-arm script, escalate
+mutations) are injected, so tests drive the whole loop with fakes. The planner
+is pure; the git mutation lives in ``rearm.sh`` (bot-branch guard + empty commit
++ normal push); escalation reuses the ``needs-human`` + comment shape.
+
+NOTE (plan U2 deviation): the plan proposed a ``client.list_pr_check_contexts``
+Python method, but this orchestrator follows the conflict-heal idiom (``gh`` CLI,
+no Python client), so present contexts come from ``gh``'s ``statusCheckRollup``
+in the single list call instead — one code path, parity with the sibling, no
+per-PR round trips. ``gh --json`` failing raises (``check=True``), so an absent
+check is never masked as present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PIPELINE_SRC = REPO_ROOT / "pipeline"
+if str(PIPELINE_SRC) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_SRC))
+
+from wgmesh_pipeline.selfheal import (  # noqa: E402
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_CHECK_REARM,
+    REARM_RECHECK_COOLDOWN_HOURS,
+    plan_check_rearm,
+)
+from wgmesh_pipeline.selfheal.models import shift  # noqa: E402
+from wgmesh_pipeline.selfheal.rearm import DEFAULT_REQUIRED_CONTEXT  # noqa: E402
+
+REARM_SCRIPT = Path(__file__).resolve().parent / "rearm.sh"
+
+# Injectable side effects -------------------------------------------------------
+GhRun = Callable[[Sequence[str]], str]            # read-only gh, returns stdout
+RearmFn = Callable[[str, int, str], str]          # (repo, number, branch) -> OUTCOME line
+EnableAutoMergeFn = Callable[[str, int], None]    # (repo, number) -> enable auto-merge
+GhMutate = Callable[[Sequence[str]], None]        # write gh (edit/comment)
+
+
+def _real_gh_run(args: Sequence[str]) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _real_gh_mutate(args: Sequence[str]) -> None:
+    subprocess.run(["gh", *args], check=True)
+
+
+def _real_enable_automerge(repo: str, number: int) -> None:
+    # gh-native equivalent of client.enable_auto_merge: arms GitHub auto-merge so
+    # the PR merges once required checks pass. Idempotent (an already-enabled PR
+    # is a benign no-op). Squash to match the box's merge method.
+    subprocess.run(
+        ["gh", "pr", "merge", str(number), "--repo", repo, "--auto", "--squash"],
+        check=True,
+    )
+
+
+def _real_rearm(repo: str, number: int, branch: str) -> str:
+    out = subprocess.run(
+        ["bash", str(REARM_SCRIPT), repo, str(number), branch],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    return out.strip().splitlines()[-1] if out.strip() else ""
+
+
+# Pure helpers ------------------------------------------------------------------
+
+def normalize_mergeable(value: Any) -> str | None:
+    """gh reports MERGEABLE / CONFLICTING / UNKNOWN; map UNKNOWN (and anything
+    not yet computed) to None so the planner skips it this cycle."""
+    return value if value in ("MERGEABLE", "CONFLICTING") else None
+
+
+def present_contexts(rollup: Any) -> frozenset[str]:
+    """Set of check/status context names present on a PR head, parsed from gh's
+    ``statusCheckRollup``. A check-run carries ``name``; a commit status carries
+    ``context`` — take whichever is present. An absent rollup is an empty set
+    (no checks ran), which is exactly the re-arm signal."""
+    names: set[str] = set()
+    for item in rollup or []:
+        if not isinstance(item, Mapping):
+            continue
+        name = item.get("name") or item.get("context")
+        if name:
+            names.add(str(name))
+    return frozenset(names)
+
+
+def list_open_prs(target_repo: str, gh_run: GhRun) -> list[dict[str, Any]]:
+    """Open PRs as planner-ready dicts: number, headRefName, title, isDraft,
+    mergeable (tri), present_contexts (frozenset)."""
+    raw = gh_run([
+        "pr", "list", "--repo", target_repo, "--state", "open",
+        "--limit", "200",
+        "--json", "number,headRefName,mergeable,title,isDraft,statusCheckRollup",
+    ])
+    prs = json.loads(raw) if raw.strip() else []
+    return [
+        {
+            "number": int(pr["number"]),
+            "headRefName": pr.get("headRefName") or "",
+            "title": pr.get("title") or "",
+            "isDraft": bool(pr.get("isDraft")),
+            "mergeable": normalize_mergeable(pr.get("mergeable")),
+            "present_contexts": present_contexts(pr.get("statusCheckRollup")),
+        }
+        for pr in prs
+    ]
+
+
+def parse_outcome(line: str) -> str:
+    """Extract OUTCOME=<slug> from a rearm.sh result line."""
+    for token in line.split():
+        if token.startswith("OUTCOME="):
+            return token.split("=", 1)[1]
+    return "unknown"
+
+
+def _escalate(
+    number: int,
+    comment: str,
+    *,
+    gh_mutate: GhMutate,
+    target_repo: str,
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        print(f"DRY_RUN escalate PR #{number}: would add needs-human + comment")
+        return
+    gh_mutate(["pr", "edit", str(number), "--repo", target_repo, "--add-label", "needs-human"])
+    gh_mutate(["pr", "comment", str(number), "--repo", target_repo, "--body", comment])
+
+
+# Orchestration -----------------------------------------------------------------
+
+def run_check_rearm(
+    target_repo: str,
+    state: Mapping[str, Any],
+    now: str,
+    *,
+    dry_run: bool,
+    gh_run: GhRun,
+    enable_automerge_fn: EnableAutoMergeFn,
+    rearm_fn: RearmFn,
+    gh_mutate: GhMutate,
+    required_context: str = DEFAULT_REQUIRED_CONTEXT,
+    escalate_cooldown_hours: float = CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    recheck_cooldown_hours: float = REARM_RECHECK_COOLDOWN_HOURS,
+) -> dict[str, Any]:
+    """Plan + execute one check-rearm cycle, returning the new state dict.
+
+    For each re-arm action: enable auto-merge FIRST (KTD2 — the backlog predates
+    the box's auto-merge wiring), THEN push the empty commit. A re-arm sets a
+    short recheck cooldown so the next tick doesn't re-push while the judge runs;
+    repeated failures increment toward the cap and escalate. dry_run makes zero
+    mutations and is surfaced by the caller to skip the state write.
+    """
+    prs = list_open_prs(target_repo, gh_run)
+    tracker_in: Mapping[str, Any] = dict(state.get("retry_tracker") or {})
+    plan = plan_check_rearm(
+        prs, tracker_in, now,
+        required_context=required_context,
+        dry_run=dry_run, escalate_cooldown_hours=escalate_cooldown_hours,
+    )
+    branch_by_number = {pr["number"]: pr["headRefName"] for pr in prs}
+    tracker: dict[str, Any] = dict(plan.tracker)
+
+    for action in plan.actions:
+        number = int(action.number)  # type: ignore[arg-type]
+        key = f"pr-{number}"
+        if action.kind == "escalate":
+            # Planner already set the cooldown in plan.tracker; just publish.
+            _escalate(
+                number, action.comment or "Merge-lane heal escalation.",
+                gh_mutate=gh_mutate, target_repo=target_repo, dry_run=dry_run,
+            )
+            continue
+        if action.kind != HEAL_KIND_CHECK_REARM:
+            continue
+        branch = branch_by_number.get(number, "")
+        if dry_run:
+            print(f"DRY_RUN re-arm PR #{number} ({branch}): would enable auto-merge + push empty commit")
+            continue
+        # KTD2: enable auto-merge BEFORE pushing the re-arm commit. A repo with
+        # auto-merge disabled (OQ2) makes this raise — warn and still re-arm so
+        # the check at least posts, rather than aborting the whole cycle.
+        try:
+            enable_automerge_fn(target_repo, number)
+        except Exception as exc:  # noqa: BLE001 — resilience: never abort the cycle
+            print(f"::warning::enable auto-merge failed for PR #{number}: {exc}")
+        outcome = parse_outcome(rearm_fn(target_repo, number, branch))
+        entry = dict(tracker.get(key) or {})
+        if outcome == "rearmed":
+            retries = int(entry.get("retries") or 0) + 1
+            tracker[key] = {
+                **entry, "retries": retries, "last_retry": now,
+                "action": HEAL_KIND_CHECK_REARM,
+                "cooldown_until": shift(now, hours=recheck_cooldown_hours),
+            }
+        elif outcome == "error":
+            retries = int(entry.get("retries") or 0) + 1
+            tracker[key] = {
+                **entry, "retries": retries, "last_retry": now,
+                "action": HEAL_KIND_CHECK_REARM,
+                "cooldown_until": shift(now, hours=recheck_cooldown_hours),
+            }
+        else:  # skipped / non-bot / unknown — leave tracker untouched, log loudly
+            print(f"::warning::re-arm PR #{number} returned OUTCOME={outcome}; no tracker change")
+
+    # NB: deliberately no timestamp in the persisted state — the commit gate is a
+    # byte diff, so an unchanged tracker must produce an identical file.
+    return {**state, "retry_tracker": tracker}
+
+
+def _write_state(path: Path, state: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check-rearm orchestrator")
+    parser.add_argument("--target-repo", default=os.environ.get("TARGET_REPO", ""))
+    parser.add_argument("--state-file", default=os.environ.get(
+        "CHECK_REARM_STATE", "company/check-rearm-state.json"))
+    parser.add_argument("--now", default=os.environ.get("NOW", ""))
+    parser.add_argument("--required-context", default=os.environ.get(
+        "REQUIRED_CONTEXT", DEFAULT_REQUIRED_CONTEXT))
+    parser.add_argument("--dry-run", action="store_true",
+                        default=os.environ.get("DRY_RUN", "false") == "true")
+    args = parser.parse_args(argv)
+
+    if not args.target_repo:
+        parser.error("TARGET_REPO (or --target-repo) is required")
+    now = args.now
+    if not now:
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    state_path = Path(args.state_file)
+    state = json.loads(state_path.read_text()) if state_path.exists() else {"retry_tracker": {}}
+
+    new_state = run_check_rearm(
+        args.target_repo, state, now,
+        dry_run=args.dry_run,
+        gh_run=_real_gh_run,
+        enable_automerge_fn=_real_enable_automerge,
+        rearm_fn=_real_rearm,
+        gh_mutate=_real_gh_mutate,
+        required_context=args.required_context,
+    )
+
+    if args.dry_run:
+        print("DRY_RUN: no state written.")
+    else:
+        _write_state(state_path, new_state)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/company/scripts/check-rearm/test-rearm.sh
+++ b/company/scripts/check-rearm/test-rearm.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Tests for check-rearm/rearm.sh
+# Run: bash company/scripts/check-rearm/test-rearm.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+ORIG_PATH="$PATH"
+
+cleanup() {
+  PATH="$ORIG_PATH"
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+REAL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_LOG="$TMPDIR/git.log"
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  FAIL: $desc (should NOT contain '$needle')"; FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  fi
+}
+
+# ── Mock git ──────────────────────────────────────────────────────
+# Logs every invocation to GIT_LOG and simulates outcomes via env:
+#   PUSH_EXIT (default 0): exit code of `git push origin <branch>`
+mkdir -p "$TMPDIR/bin"
+cat > "$TMPDIR/bin/git" <<'GIT'
+#!/usr/bin/env bash
+echo "$@" >> "$GIT_LOG"
+# Strip a leading "-C <dir>" so the real subcommand is $1.
+if [[ "${1:-}" == "-C" ]]; then shift 2; fi
+case "${1:-}" in
+  clone) exit 0 ;;
+  checkout) exit 0 ;;
+  config) exit 0 ;;
+  commit) exit 0 ;;
+  push) exit "${PUSH_EXIT:-0}" ;;
+  *) exit 0 ;;
+esac
+GIT
+chmod +x "$TMPDIR/bin/git"
+export GIT_LOG
+
+run_rearm() {
+  : > "$GIT_LOG"
+  PATH="$TMPDIR/bin:$ORIG_PATH" \
+    PUSH_EXIT="${PUSH_EXIT:-0}" \
+    bash "$REAL_SCRIPT_DIR/rearm.sh" "$@"
+}
+
+echo "── check-rearm/rearm.sh ──"
+
+# 1. bot branch, push ok → rearmed; empty commit + normal push, NO force
+out=$(PUSH_EXIT=0 run_rearm wgmesh 782 bot/impl-782)
+assert_contains "bot branch push ok → rearmed" "OUTCOME=rearmed" "$out"
+git_log=$(cat "$GIT_LOG")
+assert_contains "creates an empty commit" "commit --allow-empty" "$git_log"
+assert_contains "pushes the branch" "push origin bot/impl-782" "$git_log"
+assert_not_contains "never force-pushes" "--force" "$git_log"
+
+# 2. bot branch, push fails (non-fast-forward) → error, no crash
+out=$(PUSH_EXIT=1 run_rearm wgmesh 782 bot/impl-782)
+assert_contains "push failure → error" "OUTCOME=error REASON=push-failed" "$out"
+
+# 3. non-bot branch → skipped, NO git invoked at all (R3 — load-bearing guard)
+out=$(run_rearm wgmesh 9 feature/human-9)
+assert_contains "non-bot branch → skipped" "OUTCOME=skipped REASON=non-bot-branch" "$out"
+git_log=$(cat "$GIT_LOG")
+assert_eq "non-bot branch reaches ZERO git calls" "" "$git_log"
+
+# 4. missing args → skipped
+out=$(run_rearm wgmesh)
+assert_contains "missing args → skipped" "OUTCOME=skipped REASON=missing-args" "$out"
+
+# ── Summary ───────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/docs/plans/2026-06-21-007-feat-rearm-stuck-bot-pr-merge-lane-plan.md
+++ b/docs/plans/2026-06-21-007-feat-rearm-stuck-bot-pr-merge-lane-plan.md
@@ -1,0 +1,312 @@
+---
+title: "feat: re-arm stuck bot PRs whose required check never ran (merge-lane heal)"
+date: 2026-06-21
+type: feat
+status: planned
+depth: standard
+target_repo: ai-pipeline-template (runs against meta + seed wgmesh)
+---
+
+# feat: Re-arm stuck bot PRs whose required check never ran (merge-lane heal)
+
+## Summary
+
+A class of bot PRs is permanently stuck: MERGEABLE, all produced checks green, not draft —
+but blocked forever because a **required** status check (`impl-judge`) was never produced, so
+it sits *permanently pending* (absent ≠ red). GitHub auto-merge waits for a check that will
+never post; the box never enabled auto-merge on these (they predate the U4 wiring). Result on
+2026-06-21: **0 autonomous product merges** despite judge gate, box auto-merge, and the
+required-check ruleset all being live.
+
+This plan adds a durable self-heal that detects these stuck PRs and re-arms them — enables
+auto-merge **and** pushes a trivial commit to fire the `impl-judge` workflow — so the gate runs
+and the box's product PRs auto-merge. It mirrors the existing `conflict-heal` machinery exactly
+and runs cross-repo (meta + seed). Its first scheduled run drains the standing seed backlog
+(#782–#793 et al).
+
+## Problem Frame
+
+Seed `protect-main` ruleset (id `12831947`, active) requires three checks: **`impl-judge`**,
+`status-check`, `build-and-push`. The `impl-judge.yml` workflow first fired
+**2026-06-20T21:32Z**. Bot PRs opened *before* that (e.g. `fix: Issue #779` = #782, opened
+2026-06-19) never received a `pull_request` event for the judge → the `impl-judge` check is
+**absent** on them. A required check that is absent is *permanently pending*, not failing — so:
+
+- GitHub auto-merge can never complete (waits on a check that won't post).
+- These PRs also show `autoMergeRequest: null` — the box that created them predated `gate.py`'s
+  `enable_auto_merge` call (U4, #1919), so auto-merge was never even requested.
+
+Both must be fixed for a PR to merge: the check must be produced **and** auto-merge must be
+enabled. Posting the check alone leaves a green-but-idle PR; enabling auto-merge alone leaves a
+PR waiting on an absent required check.
+
+This is the same family as conflict-heal's root cause (a stuck bot PR that "fires no
+`pull_request` workflows → the judge never runs → dead-ends") and the documented
+required-check-skipped-blocks-merge gotcha. conflict-heal already rescues the **CONFLICTING**
+subset (its force-push re-arms the judge as a side effect); this plan rescues the
+**MERGEABLE-but-unjudged** subset it skips.
+
+## Requirements
+
+- **R1** — Detect bot PRs that are stuck on an absent required check: open, not draft,
+  `mergeable == MERGEABLE`, bot-authored (`bot/` head branch, mirroring conflict-heal's scope
+  guard), title `fix: Issue #…` (the judge's own applicability predicate), and the required
+  `impl-judge` check is **absent** from the PR's check set.
+- **R2** — Re-arm each such PR: (a) enable auto-merge (idempotent), (b) push a trivial commit to
+  the PR head branch to fire `pull_request: synchronize`, producing the `impl-judge` check.
+- **R3** — Never touch human PRs (non-`bot/` head branches) — hard scope guard, identical to
+  conflict-heal R1/R4.
+- **R4** — Idempotent and non-thrashing: a PR re-armed once is not re-pushed every cycle. Track
+  per-PR re-arm attempts + cooldown; only re-arm again if the check is still absent after the
+  cooldown. Escalate to a human (`needs-human` + comment) after N failed re-arms.
+- **R5** — Cross-repo: run against both the meta-repo and the seed repo
+  (`pulse_seed_product_repo` → `TARGET_REPO`), exactly as conflict-heal does.
+- **R6** — Pure planner / impure executor split: the decision is a pure, unit-tested function;
+  git/GitHub mutations live in shell + thin orchestrator, mirroring
+  `selfheal/conflict.py` ↔ `company/scripts/conflict-heal/`.
+- **R7** — Mode-gated writes: `shadow` → dry-run, `spec-only` → blocked, matching
+  `gate.py`'s `enable_auto_merge` mode-gating and the sanitise write-gate.
+
+## Scope Boundaries
+
+**In scope:** detecting and re-arming MERGEABLE bot `fix:` PRs whose `impl-judge` required check
+is absent; enabling auto-merge on them; cross-repo; escalation after N attempts; draining the
+current backlog as the first run.
+
+**Out of scope (true non-goals):**
+- Changing the `protect-main` ruleset or which checks are required.
+- Changing the judge logic / rubric (`impl_judge.py`).
+- Conflict resolution — `conflict-heal` (#1930) owns CONFLICTING PRs.
+- Any change to merge *policy* (still judge-gated, fail-closed, no reviewer PAT).
+
+### Deferred to Follow-Up Work
+- **spec-PR orphan (facet B).** The judge job is gated `if: startsWith(title,'fix: Issue #')`,
+  so `spec:` PRs skip the job and the `impl-judge` required check reports *skipped*. Whether a
+  skipped job satisfies or blocks the seed ruleset is an execution-time unknown (see Open
+  Questions). If it blocks, the fix — emit a passing neutral `impl-judge` check for non-`fix:`
+  PR types so the required context is always satisfiable — is a separate change to the judge
+  workflow, tracked as follow-up. This plan targets the product-merge KPI (`fix:` PRs) only.
+
+## Key Technical Decisions
+
+- **KTD1 — Re-arm by trivial commit, not close→reopen.** Push an empty commit
+  (`git commit --allow-empty`) to fire `pull_request: synchronize` (a listed judge trigger:
+  `types: [opened, synchronize, reopened]`). Gentler than close→reopen (preserves PR state and
+  history), and it is a *new* commit so it needs only a normal push — no force, unlike
+  conflict-heal's `--force-with-lease` rebase. _(Confirmed against seed `impl-judge.yml`.)_
+- **KTD2 — Re-arm must enable auto-merge too.** Because the standing backlog shows
+  `autoMergeRequest: null`, the heal step calls `client.enable_auto_merge(pr)` (reusing the
+  exact method `gate.py` uses) in addition to firing the check. Order: enable auto-merge first
+  (idempotent, no-op if already set), then push the commit; once `impl-judge` + `build-and-push`
+  + `status-check` are green, GitHub merges with no approval.
+- **KTD3 — Sibling of conflict-heal, sharing its workflow.** Add a second pass to
+  `conflict-heal.yml` that runs **after** the rebase pass: rebase handles CONFLICTING (and
+  re-arms them as a side effect of force-push), then the re-arm pass handles the remaining
+  MERGEABLE-but-unjudged PRs. One bot-PR-merge-lane-heal workflow, shared cron
+  (`0 1,7,13,19`), shared escalation idiom, separate state files. Avoids a second overlapping
+  cron and a second permissions surface.
+- **KTD4 — "Required check absent" detection.** Reuse the check-runs API already wrapped in the
+  client. Add a thin method returning the set of check **contexts present** on the PR head SHA;
+  a PR is a re-arm candidate when the required `impl-judge` context is **not** in that set.
+  (Distinct from `pr_checks_green`, which only inspects checks that *did* run and would wrongly
+  call an unjudged PR "green".)
+- **KTD5 — Required-check list is config, not hardcoded.** The required context to look for
+  (`impl-judge`) is read from config/env so the planner stays host-neutral and the same code
+  works if the required set changes.
+
+## High-Level Technical Design
+
+Merge-lane heal, per cycle, per repo (meta + seed):
+
+```
+list open PRs (gh, --repo TARGET_REPO)
+  │
+  ├─ PASS A  rebase  ──▶ conflict.py: CONFLICTING bot PRs → rebase.sh (--force-with-lease)
+  │                       (force-push fires synchronize → judge re-arms as side effect)
+  │
+  └─ PASS B  re-arm  ──▶ rearm.py (pure): for each PR, candidate iff
+                          open ∧ ¬draft ∧ MERGEABLE ∧ head startswith "bot/"
+                          ∧ title startswith "fix: Issue #"
+                          ∧ "impl-judge" ∉ present_check_contexts(headSha)
+                          ∧ not in cooldown
+                        decision = rearm | escalate(after N) | skip
+                          │
+                          ├─ rearm:    enable_auto_merge(pr)  then  rearm.sh(empty commit + push)
+                          ├─ escalate: add needs-human + comment (after N failed attempts)
+                          └─ skip:     already armed / cooling down / human PR
+  │
+  └─ write check-rearm-state-{meta,seed}.json (retry_tracker + cooldown), unless dry_run
+```
+
+Pass B is intentionally downstream of Pass A: a PR that Pass A rebased is no longer MERGEABLE-
+unjudged-without-a-running-judge (its force-push already fired the judge), so Pass B skips it.
+
+## Implementation Units
+
+### U1. Pure re-arm planner
+
+**Goal:** Decide, per PR, whether to re-arm, escalate, or skip — with zero side effects.
+**Requirements:** R1, R3, R4, R6.
+**Dependencies:** none.
+**Files:**
+- `pipeline/wgmesh_pipeline/selfheal/rearm.py` (new)
+- `pipeline/tests/test_rearm.py` (new)
+**Approach:** Mirror `selfheal/conflict.py`'s shape. Export
+`plan_check_rearm(prs, present_contexts_by_pr, state, *, required_context, max_retries, cooldown_hours, now)`
+returning an ordered list of actions (`kind="rearm" | "escalate" | "skip"`, pr number, head
+branch, reason). Candidate predicate per R1. Reuse `selfheal/models.py` constants
+(`MAX_RETRIES_BEFORE_ESCALATE`) and the `retry_tracker` cooldown idiom. `mergeable is None`
+(GitHub still computing) → skip, never act (same as conflict.py).
+**Patterns to follow:** `selfheal/conflict.py::plan_conflict_heal`; `selfheal/retry_policy.py`.
+**Test scenarios:**
+- MERGEABLE `fix:` bot PR with `impl-judge` absent, no prior attempts → `rearm`.
+- Same PR with `impl-judge` present (any conclusion) → `skip` (already armed).
+- `spec:` bot PR (title not `fix: Issue #`) → `skip` (out of judge predicate).
+- Human PR (head not `bot/`) → `skip` (R3 scope guard), even if otherwise eligible.
+- Draft / `CONFLICTING` / `mergeable is None` → `skip`.
+- PR with prior attempt inside cooldown → `skip`; cooldown elapsed + still absent → `rearm`.
+- PR at `max_retries` failed attempts → `escalate` exactly once (cooldown-guarded, no re-escalate).
+- Empty input → empty action list.
+- Determinism: same inputs → identical ordered output.
+
+### U2. Client: present-check-contexts query (+ reuse enable_auto_merge)
+
+**Goal:** Let the orchestrator learn which check contexts exist on a PR, to detect the absent
+required one.
+**Requirements:** R1, R2 (KTD2/KTD4).
+**Dependencies:** none (parallel to U1).
+**Files:**
+- `pipeline/wgmesh_pipeline/github/client.py` (modify — add `list_pr_check_contexts`)
+- `pipeline/wgmesh_pipeline/forge/protocol.py` (modify — add to Forge protocol if the planner
+  path needs it; else orchestrator-only)
+- `pipeline/tests/test_client.py` (modify) — or the existing client test module
+**Approach:** Add `list_pr_check_contexts(pr_number) -> set[str]` returning the set of check-run
+names (and, where present, commit-status contexts) on the PR head SHA, via the existing
+`/commits/{sha}/check-runs` call already used by `pr_checks_green`. Do **not** alter
+`pr_checks_green`. `enable_auto_merge` already exists (`client.py:322`) — reuse as-is.
+**Patterns to follow:** `GitHubClient.pr_checks_green` (`client.py`), `get_pr_mergeable`
+(`client.py:126`).
+**Test scenarios:**
+- Head SHA with check-runs `[Analyze, build-and-push, status-check]` → set excludes `impl-judge`.
+- Head SHA that also has `impl-judge` → set includes it.
+- No check-runs yet → empty set.
+- Pagination: contexts spanning multiple API pages are all included.
+- Network/HTTP error surfaces (no silent empty-set masking an absent check as "present").
+
+### U3. Re-arm executor (shell)
+
+**Goal:** Push a trivial commit to a bot PR's head branch to fire the judge.
+**Requirements:** R2, R3, R7.
+**Dependencies:** none (parallel to U1/U2).
+**Files:**
+- `company/scripts/check-rearm/rearm.sh` (new)
+- `company/scripts/check-rearm/test-rearm.sh` (new)
+**Approach:** Mirror `company/scripts/conflict-heal/rebase.sh`. Args `(repo, number, branch)`.
+**Hard bot-branch guard** (refuse any head not `bot/`-prefixed) before any git write. Clone/
+fetch the PR head, `git commit --allow-empty -m "chore: re-arm impl-judge (merge-lane heal)"`,
+normal `git push` (new commit — no force). Emit a single `OUTCOME=<slug>` result line
+(`rearmed` / `noop` / `error` / `refused-non-bot`) for the orchestrator to parse. Route writes
+through the sanitise gate per R7.
+**Patterns to follow:** `conflict-heal/rebase.sh` (guard + OUTCOME line + parse idiom).
+**Test scenarios (shell harness):**
+- `bot/impl-foo` branch → empty commit created, push invoked, `OUTCOME=rearmed`.
+- Non-`bot/` branch → `OUTCOME=refused-non-bot`, **no git write**.
+- Push failure (simulated) → `OUTCOME=error`, non-zero, no partial state.
+**Test expectation:** behavioral shell test mirroring `test-rebase.sh`.
+
+### U4. Orchestrator (cross-repo, stateful)
+
+**Goal:** Run one re-arm cycle for a repo: list PRs → plan → enable auto-merge + execute →
+escalate → persist state.
+**Requirements:** R2, R4, R5, R7.
+**Dependencies:** U1, U2, U3.
+**Files:**
+- `company/scripts/check-rearm/run.py` (new)
+- `company/check-rearm-state-meta.json` (new, seed `{}`)
+- `company/check-rearm-state-seed.json` (new, seed `{}`)
+- `pipeline/tests/test_check_rearm_run.py` (new)
+**Approach:** Mirror `company/scripts/conflict-heal/run.py`. `run_check_rearm(target_repo,
+state, *, gh_run, gh_mutate, rearm_fn, enable_auto_merge_fn, list_contexts_fn, dry_run, now,
+required_context, cooldown_hours)`. List open PRs via `gh pr list --repo TARGET_REPO`
+(number + headRefName + mergeable + title + isDraft), fetch present contexts per candidate
+(U2), call `plan_check_rearm` (U1). For each `rearm` action: call `enable_auto_merge` (KTD2),
+then `rearm.sh` (U3); a successful re-arm resets/advances the PR's tracker entry; a failure
+increments toward the cap. For each `escalate`: add `needs-human` + comment (reuse conflict-
+heal's `_escalate`). `dry_run` makes zero mutations and skips the state write. Injected side-
+effect callables keep the orchestrator unit-testable (no live GitHub in tests).
+**Patterns to follow:** `conflict-heal/run.py::run_conflict_heal`, `_escalate`,
+`normalize_mergeable`, `list_open_prs`.
+**Test scenarios:**
+- One eligible PR → `enable_auto_merge` called once **and** `rearm_fn` called once; tracker
+  records the attempt.
+- `enable_auto_merge` is called before `rearm_fn` (KTD2 ordering) — assert call order.
+- Re-arm failure → tracker increments; at cap → escalate path fires, `needs-human` added.
+- `dry_run=True` → zero mutations, state unchanged, intentions printed.
+- Two repos run independently writing their own `-meta` / `-seed` state file.
+- Idempotency: a PR already showing `impl-judge` present → planner skips → no
+  `enable_auto_merge`, no push.
+- A PR re-armed last cycle, still within cooldown → skipped this cycle.
+
+### U5. Wire the re-arm pass into the workflow
+
+**Goal:** Schedule the re-arm pass cross-repo, after the rebase pass, with the right
+permissions; drain the backlog on first run.
+**Requirements:** R5, R7.
+**Dependencies:** U4.
+**Files:**
+- `.github/workflows/conflict-heal.yml` (modify — add Pass B step/job invoking
+  `company/scripts/check-rearm/run.py` for meta and seed, after the rebase step) **or**
+  `.github/workflows/check-rearm.yml` (new) if a separate workflow reads cleaner during review.
+**Approach:** Extend `conflict-heal.yml` (already `contents: write`, `pull-requests: write`,
+`issues: write`; cron `0 1,7,13,19`; App-token auth; `TARGET_REPO` per repo). Add a step that
+runs the re-arm orchestrator for each repo after the rebase step, committing the
+`check-rearm-state-*.json` updates the same way conflict-heal commits its state. Honor
+`dry_run` input. Backlog drain needs no separate one-shot — a manual `workflow_dispatch`
+immediately after merge runs Pass B over the standing PRs.
+**Patterns to follow:** existing `conflict-heal.yml` job/steps, state-commit, and App-token
+generation.
+**Test scenarios:** `Test expectation: none — CI/workflow wiring`; validated by a
+`workflow_dispatch` dry-run showing intended re-arms for the current backlog, then a live run.
+**Verification:** dry-run dispatch lists the stuck `fix:` PRs as `rearm` intentions; live run
+produces the `impl-judge` check on a previously-absent PR and the PR auto-merges once green.
+
+## Open Questions
+
+- **OQ1 (blocking the spec-PR follow-up, not this plan): does a skipped `impl-judge` job satisfy
+  or block the seed required check?** The judge job is `if: startsWith(title,'fix: Issue #')`,
+  so `spec:` PRs skip it. Verify empirically on an open seed `spec:` PR (e.g. #784): does the
+  `impl-judge` required context show satisfied-by-skip or expected-and-pending? If pending →
+  spec PRs are also permanently blocked and the follow-up (emit a passing neutral check for
+  non-`fix:` PR types) is required for full convergence. **Resolve by observation before
+  starting the follow-up; does not block U1–U5.**
+- **OQ2 (execution-time): is `enable_auto_merge` sufficient on a repo where auto-merge may be
+  disabled at the repo level?** If GitHub repo settings have auto-merge off, `enable_auto_merge`
+  errors. Confirm auto-merge is enabled on both repos; if not, that is a one-time repo-settings
+  prerequisite, surfaced at first live run rather than guessed here.
+
+## Risks & Dependencies
+
+- **Thrash risk** — re-pushing every cycle would spam CI and PR timelines. Mitigated by R4
+  cooldown + tracker; U4 tests assert no re-push within cooldown and skip-when-present.
+- **Wrong-PR write risk** — pushing to a human branch would be a serious breach. Mitigated by
+  the double bot-branch guard (planner R3 + executor refuse-non-bot in U3), mirroring conflict-
+  heal's proven guard.
+- **Stale-context false negative** — if `list_pr_check_contexts` silently returned empty on
+  error, every PR would look "absent" and get re-armed. U2 requires errors to surface, not mask.
+- **Dependency:** reuses live `client.enable_auto_merge` (gate.py path) and the conflict-heal
+  workflow/auth surface — no new secrets or identities.
+
+## Sources & Research
+
+- Live diagnosis (2026-06-21 pulse): seed ruleset `12831947` requires `impl-judge`; judge first
+  ran 2026-06-20T21:32Z; backlog PRs #782–#793 show `impl-judge` absent + `autoMergeRequest:
+  null`. Memory: `project_zero_autonomous_merges_judge_required_check_orphan`.
+- `gate.py:97-114` — `apply_gate_side_effects` → `client.enable_auto_merge(impl_pr)`; ruleset
+  gates merge on `impl-judge` + build + status; mode-gated; poller parks `awaiting_merge`.
+- Sibling pattern: `selfheal/conflict.py`, `company/scripts/conflict-heal/{run.py,rebase.sh}`,
+  `conflict-heal-state-{meta,seed}.json`, `.github/workflows/conflict-heal.yml`
+  (docs/plans/2026-06-21-002-feat-conflict-heal-plan.md).
+- Seed `impl-judge.yml`: `on.pull_request.types=[opened,synchronize,reopened]`, job
+  `if: startsWith(title,'fix: Issue #')`.
+- Related learnings: `feedback_backlog_predating_lane_is_orphaned`,
+  `feedback_conflicting_pr_runs_no_workflows`, `feedback_required_check_path_filter_blocks_merge`.

--- a/pipeline/tests/test_check_rearm_run.py
+++ b/pipeline/tests/test_check_rearm_run.py
@@ -1,0 +1,203 @@
+"""U4 — check-rearm orchestrator (run.py): planner → enable-auto-merge + re-arm
+→ escalate.
+
+Loads the script module by path (it lives under company/scripts/, not the
+package) and drives the loop with fakes for gh listing, auto-merge enabling, the
+re-arm script, and gh mutations — zero real subprocess calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_PY = REPO_ROOT / "company" / "scripts" / "check-rearm" / "run.py"
+
+spec = importlib.util.spec_from_file_location("check_rearm_run", RUN_PY)
+assert spec and spec.loader
+run = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(run)
+
+NOW = "2026-06-21T12:00:00Z"
+REPO = "atvirokodosprendimai/wgmesh"
+
+
+class FakeGh:
+    """Records read-only gh list calls; returns a canned PR list (gh --json)."""
+
+    def __init__(self, prs):
+        self._prs = prs
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+        return json.dumps(self._prs)
+
+
+class CallLog:
+    """Shared ordered log so we can assert enable-auto-merge precedes re-arm."""
+
+    def __init__(self):
+        self.events: list[tuple] = []
+
+
+class FakeEnable:
+    def __init__(self, log, *, raises=False):
+        self._log = log
+        self._raises = raises
+        self.calls: list[tuple] = []
+
+    def __call__(self, repo, number):
+        self.calls.append((repo, number))
+        self._log.events.append(("enable", repo, number))
+        if self._raises:
+            raise RuntimeError("auto-merge disabled on repo")
+
+
+class FakeRearm:
+    def __init__(self, log, outcome):
+        self._log = log
+        self._outcome = outcome
+        self.calls: list[tuple] = []
+
+    def __call__(self, repo, number, branch):
+        self.calls.append((repo, number, branch))
+        self._log.events.append(("rearm", repo, number))
+        return f"OUTCOME={self._outcome} REASON=test"
+
+
+class FakeMutate:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+
+
+def _pr(number, head, *, title="fix: Issue #1 - thing", mergeable="MERGEABLE",
+        is_draft=False, rollup=None):
+    return {
+        "number": number,
+        "headRefName": head,
+        "title": title,
+        "isDraft": is_draft,
+        "mergeable": mergeable,
+        "statusCheckRollup": rollup if rollup is not None
+        else [{"name": "build-and-push"}, {"name": "status-check"}],
+    }
+
+
+def _run(prs, state, *, outcome="rearmed", dry_run=False, enable_raises=False):
+    log = CallLog()
+    gh = FakeGh(prs)
+    enable = FakeEnable(log, raises=enable_raises)
+    rb = FakeRearm(log, outcome)
+    mut = FakeMutate()
+    new_state = run.run_check_rearm(
+        REPO, state, NOW, dry_run=dry_run,
+        gh_run=gh, enable_automerge_fn=enable, rearm_fn=rb, gh_mutate=mut,
+    )
+    return new_state, log, gh, enable, rb, mut
+
+
+def test_eligible_pr_enables_automerge_then_rearms() -> None:
+    new_state, log, gh, enable, rb, mut = _run(
+        [_pr(782, "bot/impl-782")], {"retry_tracker": {}}
+    )
+
+    assert enable.calls == [(REPO, 782)]
+    assert rb.calls == [(REPO, 782, "bot/impl-782")]
+    # KTD2: enable auto-merge BEFORE the re-arm push.
+    assert log.events == [("enable", REPO, 782), ("rearm", REPO, 782)]
+    assert mut.calls == []  # no escalation
+    # listing scoped to the target repo and requests the rollup
+    assert "--repo" in gh.calls[0] and REPO in gh.calls[0]
+    assert any("statusCheckRollup" in tok for tok in gh.calls[0])
+    # re-arm recorded with a recheck cooldown so the next tick won't thrash
+    entry = new_state["retry_tracker"]["pr-782"]
+    assert entry["retries"] == 1 and entry["cooldown_until"] > NOW
+
+
+def test_check_already_present_skips_everything() -> None:
+    new_state, _, _, enable, rb, mut = _run(
+        [_pr(782, "bot/impl-782", rollup=[{"name": "impl-judge"}, {"name": "build-and-push"}])],
+        {"retry_tracker": {}},
+    )
+    assert enable.calls == [] and rb.calls == [] and mut.calls == []
+    assert new_state["retry_tracker"] == {}
+
+
+def test_enable_failure_does_not_abort_rearm() -> None:
+    # OQ2: a repo with auto-merge disabled makes enable raise — we still re-arm.
+    new_state, log, _, enable, rb, _ = _run(
+        [_pr(782, "bot/impl-782")], {"retry_tracker": {}}, enable_raises=True
+    )
+    assert enable.calls == [(REPO, 782)]
+    assert rb.calls == [(REPO, 782, "bot/impl-782")]
+    assert new_state["retry_tracker"]["pr-782"]["retries"] == 1
+
+
+def test_rearm_error_increments_toward_cap() -> None:
+    new_state, _, _, _, rb, mut = _run(
+        [_pr(782, "bot/impl-782")],
+        {"retry_tracker": {"pr-782": {"retries": 1, "cooldown_until": "2026-06-21T06:00:00Z"}}},
+        outcome="error",
+    )
+    assert rb.calls == [(REPO, 782, "bot/impl-782")]
+    assert new_state["retry_tracker"]["pr-782"]["retries"] == 2
+    assert mut.calls == []  # escalation is next cycle, by the planner
+
+
+def test_at_cap_escalates_without_enabling_or_rearming() -> None:
+    new_state, _, _, enable, rb, mut = _run(
+        [_pr(782, "bot/impl-782")],
+        {"retry_tracker": {"pr-782": {"retries": 2}}},
+    )
+    assert enable.calls == [] and rb.calls == []  # planner escalated
+    labels = [c for c in mut.calls if "--add-label" in c]
+    comments = [c for c in mut.calls if "comment" in c]
+    assert len(labels) == 1 and "needs-human" in labels[0]
+    assert len(comments) == 1
+    assert "cooldown_until" in new_state["retry_tracker"]["pr-782"]
+
+
+def test_dry_run_makes_zero_mutations() -> None:
+    new_state, _, _, enable, rb, mut = _run(
+        [_pr(782, "bot/impl-782")], {"retry_tracker": {}}, dry_run=True
+    )
+    assert enable.calls == [] and rb.calls == [] and mut.calls == []
+    assert new_state["retry_tracker"] == {}
+
+
+def test_idempotent_no_change_no_churn() -> None:
+    # An armed PR (judge present) → planner skips → state identical (no churn commit).
+    state = {"retry_tracker": {}}
+    new_state, *_ = _run(
+        [_pr(782, "bot/impl-782", rollup=[{"name": "impl-judge"}])], state
+    )
+    assert json.dumps(new_state, sort_keys=True) == json.dumps(state, sort_keys=True)
+
+
+def test_present_contexts_parses_names_and_status_contexts() -> None:
+    rollup = [
+        {"name": "impl-judge"},          # check run
+        {"context": "ci/legacy"},        # commit status
+        {"unrelated": "x"},              # ignored
+    ]
+    assert run.present_contexts(rollup) == frozenset({"impl-judge", "ci/legacy"})
+    assert run.present_contexts(None) == frozenset()
+
+
+def test_normalize_mergeable() -> None:
+    assert run.normalize_mergeable("UNKNOWN") is None
+    assert run.normalize_mergeable("MERGEABLE") == "MERGEABLE"
+    assert run.normalize_mergeable("CONFLICTING") == "CONFLICTING"
+    assert run.normalize_mergeable(None) is None
+
+
+def test_parse_outcome() -> None:
+    assert run.parse_outcome("OUTCOME=rearmed REASON=empty-commit-pushed") == "rearmed"
+    assert run.parse_outcome("OUTCOME=error REASON=push-failed") == "error"
+    assert run.parse_outcome("garbage") == "unknown"

--- a/pipeline/tests/test_rearm.py
+++ b/pipeline/tests/test_rearm.py
@@ -1,0 +1,102 @@
+"""U1 — check-rearm planner (rearm.py): pure decision for MERGEABLE bot fix PRs
+whose required judge check is absent.
+
+No I/O: the planner is fed plain dicts (the orchestrator resolves mergeable +
+present contexts via gh) and a tracker, and returns planned actions + the
+tracker to persist.
+"""
+
+from __future__ import annotations
+
+from wgmesh_pipeline.selfheal import (
+    HEAL_KIND_CHECK_REARM,
+    MAX_RETRIES_BEFORE_ESCALATE,
+    plan_check_rearm,
+)
+
+NOW = "2026-06-21T12:00:00Z"
+REQUIRED = "impl-judge"
+
+
+def _pr(number, head, *, title="fix: Issue #1 - do a thing", mergeable="MERGEABLE",
+        is_draft=False, present=()):
+    return {
+        "number": number,
+        "headRefName": head,
+        "title": title,
+        "isDraft": is_draft,
+        "mergeable": mergeable,
+        "present_contexts": frozenset(present),
+    }
+
+
+def _plan(prs, tracker=None, **kw):
+    return plan_check_rearm(prs, tracker or {}, NOW, required_context=REQUIRED, **kw)
+
+
+def test_mergeable_fix_pr_absent_check_is_rearmed() -> None:
+    plan = _plan([_pr(782, "bot/impl-782", present=["build-and-push", "status-check"])])
+    assert [a.kind for a in plan.actions] == [HEAL_KIND_CHECK_REARM]
+    assert plan.actions[0].number == 782
+    assert plan.actions[0].target == "pr"
+
+
+def test_check_already_present_is_skipped() -> None:
+    # judge ran (PASS or FAIL) — present means armed; not ours to re-fire.
+    plan = _plan([_pr(782, "bot/impl-782", present=["impl-judge", "build-and-push"])])
+    assert plan.actions == ()
+
+
+def test_spec_pr_is_skipped() -> None:
+    plan = _plan([_pr(784, "bot/spec-784", title="spec: Issue #783 - add widget")])
+    assert plan.actions == ()
+
+
+def test_human_pr_is_never_touched() -> None:
+    # Eligible in every other way, but the head is not bot/* — R3 scope guard.
+    plan = _plan([_pr(9, "feature/human-9", present=[])])
+    assert plan.actions == ()
+
+
+def test_draft_conflicting_and_unknown_mergeable_are_skipped() -> None:
+    prs = [
+        _pr(1, "bot/impl-1", is_draft=True),
+        _pr(2, "bot/impl-2", mergeable="CONFLICTING"),
+        _pr(3, "bot/impl-3", mergeable=None),
+    ]
+    assert _plan(prs).actions == ()
+
+
+def test_cooldown_blocks_then_elapses() -> None:
+    cooling = {"pr-782": {"retries": 1, "cooldown_until": "2026-06-21T18:00:00Z"}}
+    assert _plan([_pr(782, "bot/impl-782")], cooling).actions == ()  # now < cooldown
+
+    elapsed = {"pr-782": {"retries": 1, "cooldown_until": "2026-06-21T06:00:00Z"}}
+    plan = _plan([_pr(782, "bot/impl-782")], elapsed)  # now > cooldown, below cap
+    assert [a.kind for a in plan.actions] == [HEAL_KIND_CHECK_REARM]
+
+
+def test_at_cap_escalates_once() -> None:
+    at_cap = {"pr-782": {"retries": MAX_RETRIES_BEFORE_ESCALATE}}
+    plan = _plan([_pr(782, "bot/impl-782")], at_cap)
+    assert [a.kind for a in plan.actions] == ["escalate"]
+    action = plan.actions[0]
+    assert action.add_label == "needs-human"
+    assert "impl-judge" in (action.comment or "")
+    assert plan.tracker["pr-782"]["cooldown_until"] is not None
+
+
+def test_empty_input_is_empty_plan() -> None:
+    assert _plan([]).actions == ()
+
+
+def test_order_preserved_and_deterministic() -> None:
+    prs = [
+        _pr(3, "bot/impl-3", present=["build-and-push"]),
+        _pr(1, "bot/impl-1", present=["build-and-push"]),
+        _pr(2, "bot/impl-2", present=["build-and-push"]),
+    ]
+    first = _plan(prs)
+    second = _plan(prs)
+    assert [a.number for a in first.actions] == [3, 1, 2]
+    assert [a.number for a in first.actions] == [a.number for a in second.actions]

--- a/pipeline/wgmesh_pipeline/selfheal/__init__.py
+++ b/pipeline/wgmesh_pipeline/selfheal/__init__.py
@@ -38,16 +38,20 @@ from wgmesh_pipeline.selfheal.models import (
     CIRCUIT_MAX_ERRORS,
     CONFLICT_ESCALATE_COOLDOWN_HOURS,
     ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_CHECK_REARM,
     HEAL_KIND_CONFLICT_REBASE,
     IDLE_DISPATCH_COOLDOWN_SECONDS,
     MAX_RETRIES_BEFORE_ESCALATE,
+    REARM_RECHECK_COOLDOWN_HOURS,
     SUPERVISOR_DEAD_TITLE,
+    CheckRearmPlan,
     ConflictHealPlan,
     HealAction,
     SelfHealInputs,
     SelfHealRun,
     SweepOutcome,
 )
+from wgmesh_pipeline.selfheal.rearm import plan_check_rearm
 from wgmesh_pipeline.selfheal.retry_policy import Decision, apply_retry_gate
 from wgmesh_pipeline.selfheal.runner import needs_human_from_forge, run_self_heal
 from wgmesh_pipeline.selfheal.signals import (
@@ -73,10 +77,13 @@ __all__ = [
     "CIRCUIT_MAX_ERRORS",
     "CONFLICT_ESCALATE_COOLDOWN_HOURS",
     "ESCALATE_COOLDOWN_HOURS",
+    "HEAL_KIND_CHECK_REARM",
     "HEAL_KIND_CONFLICT_REBASE",
     "IDLE_DISPATCH_COOLDOWN_SECONDS",
     "MAX_RETRIES_BEFORE_ESCALATE",
+    "REARM_RECHECK_COOLDOWN_HOURS",
     "SUPERVISOR_DEAD_TITLE",
+    "CheckRearmPlan",
     "ConflictHealPlan",
     "Decision",
     "HealAction",
@@ -92,6 +99,7 @@ __all__ = [
     "circuit_breaker_tripped",
     "decide_idle_dispatch",
     "needs_human_from_forge",
+    "plan_check_rearm",
     "plan_conflict_heal",
     "run_self_heal",
     "sweep_needs_human",

--- a/pipeline/wgmesh_pipeline/selfheal/models.py
+++ b/pipeline/wgmesh_pipeline/selfheal/models.py
@@ -20,6 +20,15 @@ ESCALATE_COOLDOWN_HOURS = 24
 # stale sweeps'. The retry cap is shared (MAX_RETRIES_BEFORE_ESCALATE).
 CONFLICT_ESCALATE_COOLDOWN_HOURS = 72
 HEAL_KIND_CONFLICT_REBASE = "conflict_rebase"
+# Check-rearm: a MERGEABLE bot PR whose required judge check never ran (it
+# predates the lane, so no pull_request event ever fired it) is permanently
+# pending, never red. We re-arm it (enable auto-merge + push an empty commit to
+# fire the judge). After a re-arm we wait one cron cycle before re-checking, so
+# a single tick can't thrash a branch while the judge runs. The retry cap is
+# shared (MAX_RETRIES_BEFORE_ESCALATE); the escalate cooldown reuses the
+# conflict value (a PR that can't be armed in 2 tries needs a human).
+HEAL_KIND_CHECK_REARM = "check_rearm"
+REARM_RECHECK_COOLDOWN_HOURS = 6
 IDLE_DISPATCH_COOLDOWN_SECONDS = 6 * 60 * 60
 CHECK_INTERVAL_HOURS = 0.5
 ACTIVE_PIPELINE_LABELS = (
@@ -111,6 +120,18 @@ class ConflictHealPlan:
     / ``escalate`` actions plus the retry tracker the executor persists. The
     planner does NOT increment a rebase attempt — the executor reports the
     outcome and the *next* cycle's tracker reflects it (R5)."""
+
+    actions: tuple[HealAction, ...] = ()
+    tracker: dict[str, Any] = field(default_factory=dict)
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class CheckRearmPlan:
+    """Result of the pure check-rearm planner: the planned ``check_rearm`` /
+    ``escalate`` actions plus the retry tracker the executor persists. Like the
+    conflict planner, it does NOT record the re-arm attempt — the executor
+    reports the outcome and the next cycle's tracker reflects it."""
 
     actions: tuple[HealAction, ...] = ()
     tracker: dict[str, Any] = field(default_factory=dict)

--- a/pipeline/wgmesh_pipeline/selfheal/rearm.py
+++ b/pipeline/wgmesh_pipeline/selfheal/rearm.py
@@ -1,0 +1,117 @@
+"""Check-rearm planner — pure decision for stuck-on-absent-required-check bot PRs.
+
+A bot ``fix: Issue #N`` PR can go MERGEABLE + all-produced-checks-green yet be
+blocked forever because a *required* status check (``impl-judge``) was never
+produced: the PR predates the judge workflow, so no ``pull_request`` event ever
+fired it. A required check that is **absent** is permanently pending — not red —
+so GitHub auto-merge waits on a check that will never post and the PR dead-ends.
+
+This planner decides, per PR, whether to re-arm (the executor enables auto-merge
+and pushes an empty commit to fire ``pull_request: synchronize`` → the judge
+runs → the required check posts) or, after repeated failures, to escalate. It is
+the MERGEABLE-but-unjudged sibling of ``selfheal/conflict.py`` (which rescues the
+CONFLICTING subset; its force-push re-arms the judge as a side effect, so this
+planner only ever sees the PRs conflict-heal leaves behind).
+
+Scope guard (R3): only ``bot/``-prefixed head branches are ever considered;
+human PRs are never touched. ``mergeable`` anything but ``"MERGEABLE"`` (including
+``None`` while GitHub computes) is a skip. A PR whose required check is already
+present (PASS *or* FAIL) is skipped — a failing judge is a real impl problem, not
+ours to re-fire.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from wgmesh_pipeline.selfheal.models import (
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_CHECK_REARM,
+    MAX_RETRIES_BEFORE_ESCALATE,
+    CheckRearmPlan,
+    HealAction,
+    tracker_entry,
+)
+from wgmesh_pipeline.selfheal.retry_policy import apply_retry_gate
+
+BOT_BRANCH_PREFIX = "bot/"
+FIX_TITLE_PREFIX = "fix: Issue #"
+MERGEABLE = "MERGEABLE"
+DEFAULT_REQUIRED_CONTEXT = "impl-judge"
+
+
+def plan_check_rearm(
+    prs: Sequence[Mapping[str, Any]],
+    tracker: Mapping[str, Any],
+    now: str,
+    *,
+    required_context: str = DEFAULT_REQUIRED_CONTEXT,
+    dry_run: bool = False,
+    max_retries: int = MAX_RETRIES_BEFORE_ESCALATE,
+    escalate_cooldown_hours: float = CONFLICT_ESCALATE_COOLDOWN_HOURS,
+) -> CheckRearmPlan:
+    """Plan re-arm/escalate actions for MERGEABLE bot ``fix:`` PRs whose required
+    check is absent.
+
+    ``prs`` are plain dicts carrying ``number``, ``headRefName``, ``title``,
+    ``isDraft``, the tri-state ``mergeable`` and ``present_contexts`` (the set of
+    check/status context names already on the PR head) the orchestrator resolved
+    — the planner stays pure. Input order is preserved. Returns the planned
+    actions plus the tracker the executor persists; ``dry_run`` is surfaced for
+    the executor to honor (the plan is identical either way).
+    """
+    out_tracker: dict[str, Any] = dict(tracker)
+    actions: list[HealAction] = []
+
+    for pr in prs:
+        head = str(pr.get("headRefName") or "")
+        if not head.startswith(BOT_BRANCH_PREFIX):
+            continue  # R3: never touch human PRs
+        if pr.get("isDraft"):
+            continue
+        if pr.get("mergeable") != MERGEABLE:
+            continue  # CONFLICTING (conflict-heal owns it) / None (computing) → skip
+        title = str(pr.get("title") or "")
+        if not title.startswith(FIX_TITLE_PREFIX):
+            continue  # only the judge's own predicate (product impl PRs)
+        present = pr.get("present_contexts") or frozenset()
+        if required_context in present:
+            continue  # already armed — judge ran (PASS or FAIL); not ours to re-fire
+
+        number = int(pr["number"])
+        key = f"pr-{number}"
+        entry = tracker_entry(out_tracker, key)
+        decision = apply_retry_gate(
+            entry,
+            now,
+            max_retries=max_retries,
+            escalate_cooldown_hours=escalate_cooldown_hours,
+        )
+        if decision.kind == "skip":
+            continue
+        if decision.kind == "escalate":
+            actions.append(HealAction(
+                kind="escalate",
+                number=number,
+                target="pr",
+                add_label="needs-human",
+                comment=(
+                    f"Merge-lane heal could not arm the required `{required_context}` "
+                    f"check after {decision.retries} attempts. A human needs to look — "
+                    f"the judge may be failing to run on this PR."
+                ),
+                reason=f"{max_retries} consecutive re-arm attempts without the check posting",
+            ))
+            out_tracker[key] = {**entry, "cooldown_until": decision.cooldown_until}
+            continue
+        # decision.kind == "act": below the cap → attempt a re-arm. The planner
+        # does NOT record the attempt; the executor reports the outcome and the
+        # next cycle's tracker reflects it. Preserve the entry for the executor.
+        actions.append(HealAction(
+            kind=HEAL_KIND_CHECK_REARM,
+            number=number,
+            target="pr",
+            reason=f"MERGEABLE bot fix PR — required `{required_context}` check absent",
+        ))
+
+    return CheckRearmPlan(actions=tuple(actions), tracker=out_tracker, dry_run=dry_run)


### PR DESCRIPTION
## Problem

The 2026-06-21 pulse flagged **0 autonomous product merges** despite judge gate (#796), box auto-merge (#1919), and the required-check ruleset all live. Root cause: a *required* status check (`impl-judge`) that was never produced is **permanently pending, not red**. Bot `fix: Issue #N` PRs opened before the judge workflow landed (2026-06-20T21:32Z) never got a `pull_request` event → the `impl-judge` check is **absent** → GitHub auto-merge waits forever. The standing backlog also shows `autoMergeRequest: null` (predates `gate.py`'s `enable_auto_merge` wiring).

Same family as conflict-heal (a stuck bot PR fires no `pull_request` workflows → judge never runs → dead-ends). conflict-heal rescues the CONFLICTING subset; this rescues the **MERGEABLE-but-unjudged** subset it skips.

## What this does

A durable self-heal — the MERGEABLE-but-unjudged sibling of conflict-heal, sharing its workflow as a second pass:

- **U1** `selfheal/rearm.py` — pure planner: `bot/` head ∧ `fix: Issue #` title ∧ `MERGEABLE` ∧ required check **absent** ∧ not cooling down → re-arm; escalate after N.
- **U3** `company/scripts/check-rearm/rearm.sh` — empty commit + normal push (fires `pull_request: synchronize` → judge runs). Hard bot-branch guard.
- **U4** `company/scripts/check-rearm/run.py` — cross-repo orchestrator. **Enables auto-merge BEFORE pushing** (re-arming the check alone won't merge — `autoMergeRequest: null`). Escalate-after-N, separate state files.
- **U5** `conflict-heal.yml` — Pass B (re-arm) after Pass A (rebase), both repos. A PR the rebase already re-armed is no longer a Pass-B candidate.

## Plan deviation (U2)

The plan proposed `client.list_pr_check_contexts`. Delivered instead via `gh pr list --json …,statusCheckRollup` + a pure `present_contexts` parser — `pr_checks_green` was purged in #1921 (nothing to mirror) and the orchestrator uses `gh`, not the Python client. One code path, parity with conflict-heal, no per-PR round-trips. `gh --json` failing raises, so an absent check is never masked as present.

## Deferred (OQ1)

`spec:` PRs skip the judge job (`if: title startsWith 'fix: Issue #'`) → required check reports skipped; whether that blocks the ruleset is verified separately. This PR targets the product-merge KPI (`fix:` PRs).

## Tests

19 new Python + 8 shell = 27 new tests. Full `pipeline/tests/` suite: **810 passed, 5 skipped, 0 failed**.

Plan: `docs/plans/2026-06-21-007-feat-rearm-stuck-bot-pr-merge-lane-plan.md`