### PR TITLE
fix(impl-judge): stop truncating impl diffs mid-hunk into false-negatives

### DIFF
--- a/pipeline/evals/impl_judge.py
+++ b/pipeline/evals/impl_judge.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.request
 from dataclasses import dataclass, field
@@ -34,7 +35,14 @@ HttpCaller = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 JUDGE_MODEL = "deepseek/deepseek-chat"
-MAX_DIFF_CHARS = 16_000
+# Sized to the judge model's context, NOT a tiny cap. The old 16K cut a normal
+# 30KB multi-file impl mid-hunk, dropping the implementing file — the judge then
+# could not see the code, failed a faithful PR, and confabulated unrelated-change
+# reasons (false-negative merge block). deepseek-chat carries ~64K tokens; 200K
+# chars (~50K tokens) leaves ample room for spec + rubric while letting any
+# realistic impl diff through whole. Truncation (below) only engages for
+# genuinely huge diffs, and then only at file boundaries.
+MAX_DIFF_CHARS = 200_000
 _KEY_ENVS = ("OPENROUTER_API_KEY", "DEEPSEEK_API_KEY")
 _FALLBACK_REASON = "failed"
 
@@ -56,13 +64,64 @@ class Verdict:
     reasons: tuple[str, ...] = field(default_factory=tuple)
 
 
+_PARTIAL_MARKER = (
+    "\n...[truncated {files} more file(s) / {chars} chars — PARTIAL diff, "
+    "the judge could not see the full change]...\n"
+)
+
+
+def _split_diff_sections(text: str) -> list[str]:
+    """Split a unified diff into per-file sections, each starting at a
+    ``diff --git`` header (the boundary is preserved). Any preamble before the
+    first header is its own leading section. No header at all → one section."""
+    starts = [m.start() for m in re.finditer(r"(?m)^diff --git ", text)]
+    if not starts:
+        return [text]
+    sections: list[str] = []
+    if starts[0] > 0:
+        sections.append(text[: starts[0]])
+    for begin, end in zip(starts, starts[1:] + [len(text)]):
+        sections.append(text[begin:end])
+    return sections
+
+
 def _truncate(text: str, limit: int = MAX_DIFF_CHARS) -> str:
+    """Bound the diff to ``limit`` chars WITHOUT corrupting it mid-hunk.
+
+    A merge gate must never silently grade a fragment. The previous head+tail
+    char cut dropped whole implementing files and sliced others mid-line,
+    yielding an invalid diff the model "failed" while confabulating reasons. So:
+
+    - under the limit (the common case once the limit is sized to the model
+      context): return verbatim;
+    - over the limit: keep WHOLE ``diff --git`` file sections from the top until
+      the next would overflow, then append an explicit PARTIAL-diff marker naming
+      how many files/chars were dropped, so the model knows the diff is
+      incomplete instead of treating the fragment as the whole change;
+    - a single file section larger than the limit is cut at a LINE boundary
+      (never mid-line) with the same marker.
+    """
     if len(text) <= limit:
         return text
-    dropped = len(text) - limit
-    head = limit // 2
-    tail = limit - head
-    return f"{text[:head]}\n...[truncated {dropped} chars]...\n{text[-tail:]}"
+
+    sections = _split_diff_sections(text)
+    if len(sections) > 1:
+        kept: list[str] = []
+        used = 0
+        for i, section in enumerate(sections):
+            if kept and used + len(section) > limit:
+                dropped_chars = sum(len(s) for s in sections[i:])
+                kept.append(_PARTIAL_MARKER.format(files=len(sections) - i, chars=dropped_chars))
+                return "".join(kept)
+            kept.append(section)
+            used += len(section)
+        return "".join(kept)
+
+    # Single oversized section (or no file headers): cut at a line boundary.
+    head = text[:limit].rsplit("\n", 1)[0]
+    if not head:  # no newline within the limit — fall back to a hard char cut
+        head = text[:limit]
+    return head + _PARTIAL_MARKER.format(files=0, chars=len(text) - len(head))
 
 
 _UNTRUSTED = "UNTRUSTED_CONTENT_8f3a1c"  # fence boundary the model is told never appears in real content

--- a/pipeline/tests/test_impl_judge.py
+++ b/pipeline/tests/test_impl_judge.py
@@ -116,6 +116,62 @@ def test_oversized_diff_truncated_before_caller() -> None:
     assert big not in sent  # full untruncated diff never sent
 
 
+def _file_section(name: str, body_lines: int) -> str:
+    lines = "\n".join(f"+line {i} of {name}" for i in range(body_lines))
+    return f"diff --git a/{name} b/{name}\n--- a/{name}\n+++ b/{name}\n{lines}\n"
+
+
+def test_realistic_diff_under_raised_cap_is_not_truncated() -> None:
+    # The #793 bug: a faithful ~30KB multi-file impl was cut at 16K, dropping the
+    # implementing file (pkg/referral/code.go). With the cap sized to the model
+    # context, a normal impl passes through whole and every file survives.
+    diff = (
+        _file_section("main.go", 40)
+        + _file_section("pkg/referral/code.go", 400)   # the core implementation
+        + _file_section("pkg/referral/store.go", 300)
+        + _file_section("pkg/referral/tier.go", 200)
+    )
+    assert 16_000 < len(diff) < impl_judge.MAX_DIFF_CHARS  # over the OLD cap, under the new
+    out = impl_judge._truncate(diff)
+    assert out == diff                                   # verbatim — nothing dropped
+    assert "pkg/referral/code.go" in out                # implementing file survives
+
+
+def test_oversized_diff_truncates_at_file_boundaries_not_midhunk() -> None:
+    # Three whole file sections, each well-formed; force truncation with a small
+    # explicit limit. A kept file must be WHOLE; a dropped file must be ABSENT —
+    # never sliced mid-hunk (which corrupts the diff and makes the judge
+    # confabulate).
+    s1 = _file_section("a.go", 50)
+    s2 = _file_section("b.go", 50)
+    s3 = _file_section("c.go", 50)
+    diff = s1 + s2 + s3
+    limit = len(s1) + len(s2) + 5  # room for ~2 sections, not the 3rd
+    out = impl_judge._truncate(diff, limit=limit)
+
+    assert s1 in out and s2 in out          # kept files are intact
+    assert "diff --git a/c.go" not in out   # dropped file fully absent, not partial
+    assert "PARTIAL diff" in out            # model is told the diff is incomplete
+    assert "[truncated" in out
+    # No mid-line corruption: every non-marker line in the output is a real input line.
+    input_lines = set(diff.splitlines())
+    for line in out.splitlines():
+        if not line or "truncated" in line or "PARTIAL diff" in line:
+            continue  # skip the marker's own lines (incl. its boundary blank)
+        assert line in input_lines
+
+
+def test_single_oversized_file_cut_at_line_boundary() -> None:
+    # A lone file larger than the limit can't be kept whole — cut at a LINE
+    # boundary (never mid-line) and flag it partial.
+    big = _file_section("huge.go", 5000)
+    out = impl_judge._truncate(big, limit=2000)
+    assert "[truncated" in out
+    body = out.split("...[truncated", 1)[0]
+    # The kept portion ends on a complete line (no dangling partial line).
+    assert body.endswith("\n") or body.splitlines()[-1] in set(big.splitlines())
+
+
 def test_purity_same_inputs_same_verdict() -> None:
     caller = _caller(False, True, f_reason="x")
     assert judge(_DIFF, _SPEC, http_caller=caller) == judge(_DIFF, _SPEC, http_caller=caller)


### PR DESCRIPTION
## Problem

The `impl-judge` fail-closed merge gate was **rejecting faithful bot PRs with fabricated reasoning** — the real blocker on the first autonomous product merge. Surfaced via `/ce-debug` after the merge-lane heal (#1955) re-armed 11 stuck PRs and all returned `impl-judge=FAILURE`.

#793 (referral tracking) is a clean 10-file impl (`pkg/referral/{code,store,tier,types}.go` + tests, 30,314 chars). The judge's verdict — *"introduces unrelated changes (CI workflow files and exit-intent modal HTML/JS)... does not implement any of the specified referral tracking functionality"* — is **fabricated**: those strings are absent from the judge's actual input (verified by grep).

## Root cause

`MAX_DIFF_CHARS = 16_000` + a head/tail char cut in `_truncate`. A 30KB diff was sliced **mid-hunk** — the implementing file (`code.go`) dropped entirely, others cut mid-line. DeepSeek (temp 0) graded a mangled partial diff it couldn't verify → `faithfulness=FAIL` + confabulated reasons → fail-closed → systematic false-negative. Real multi-file impls routinely exceed 16K.

## Fix

- `MAX_DIFF_CHARS` 16_000 → **200_000** (sized to deepseek-chat's ~64K-token context — real impls pass through whole).
- `_truncate` keeps **whole `diff --git` file sections** until overflow, appends an explicit PARTIAL-diff marker (the model is told the diff is incomplete), and cuts a lone oversized file at a **line boundary** — never mid-hunk.

## Tests

4 new (`realistic_diff_under_raised_cap_is_not_truncated`, `truncates_at_file_boundaries_not_midhunk`, `single_oversized_file_cut_at_line_boundary`, back-compat oversized). Full pipeline suite: **813 passed, 0 failed**.

The judge runs in Actions (checks out the meta judge-tool fresh), so merge deploys the fix with no box redeploy.

Found via `/ce-debug`. Reinforces that an LLM merge-gate needs its *inputs* verified, not just its outputs.