### PR TITLE
feat(spec): reject malformed transcript/truncated specs before implement

### DIFF
--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.github.client import GitHubIssue
-from wgmesh_pipeline.graph.nodes.spec import spec_node
+from wgmesh_pipeline.graph.nodes.spec import _spec_malformed_reason, spec_node
 from wgmesh_pipeline.goose.runner import GooseResult
 
 
@@ -96,8 +98,86 @@ def test_spec_node_no_runner_has_no_spec_content(tmp_path: Path) -> None:
     result = spec_node(
         {
             "issue": GitHubIssue(number=18, title="x", labels=(), state="open"),
-            "repo_path": tmp_path,
             "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+            "repo_path": tmp_path,
         }
     )
     assert "spec_content" not in result  # no-op path writes no file
+
+
+# ---- malformed-spec gate (issue #783: goose dumped a 3672-line transcript with a
+# truncated write-tool call as the "spec"; result.ok only checks the file is
+# non-empty, so the garbage spec advanced to implement and produced off-spec code) --
+
+# The exact markers seen on the #783 transcript-spec; absent from clean specs (#779).
+_TRANSCRIPT_SPEC = (
+    "   __( O)>  ● new session · anthropic glm-4.6\n"
+    " \\____)    goose is ready\n"
+    "I'll create an implementation specification. Let me explore.\n"
+    "  ▸ tree\n"
+    "...3000 lines of exploration...\n"
+    "-32602: Could not parse tool arguments: the response may have been truncated.\n"
+)
+
+
+@dataclass
+class MalformedRunner:
+    content: str
+
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, session_id=None):
+        output = Path(workdir) / expected_output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(self.content)
+        return GooseResult(ok=True, output_path=output, duration_seconds=0.01, raw_log="ok")
+
+
+def test_spec_node_rejects_transcript_spec(tmp_path: Path) -> None:
+    # result.ok is True (file exists, non-empty) but the content is a goose
+    # transcript with a truncated write — must fail like any other spec failure
+    # so it never advances to implement.
+    runner = MalformedRunner(content=_TRANSCRIPT_SPEC)
+    with pytest.raises(RuntimeError, match="malformed spec"):
+        spec_node(
+            {
+                "issue": GitHubIssue(number=783, title="Add onboarding checklist widget", labels=(), state="open"),
+                "goose_runner": runner,
+                "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+                "repo_path": tmp_path,
+            }
+        )
+
+
+def test_spec_node_accepts_clean_spec(tmp_path: Path) -> None:
+    # The default FakeRunner writes a clean structured spec — must pass.
+    runner = FakeRunner(calls=[])
+    result = spec_node(
+        {
+            "issue": GitHubIssue(number=17, title="Fix mesh discovery", labels=(), state="open"),
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+            "repo_path": tmp_path,
+        }
+    )
+    assert result["spec_path"].endswith("issue-17-spec.md")
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "goose is ready",
+        "● new session ·",
+        "Could not parse tool arguments",
+        "the response may have been truncated",
+        "-32602",
+    ],
+)
+def test_spec_malformed_reason_flags_each_marker(marker: str) -> None:
+    assert _spec_malformed_reason(f"# Spec\n\n## Classification\nfeature\n{marker}\n") is not None
+
+
+def test_spec_malformed_reason_passes_clean_spec() -> None:
+    clean = (
+        "# Issue #779: Implement Trial Signup Analytics Funnel\n\n"
+        "## Classification\nfeature\n\n## Problem Analysis\nThe flow lacks visibility.\n"
+    )
+    assert _spec_malformed_reason(clean) is None

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -52,6 +52,17 @@ def spec_node(state: GraphState) -> GraphState:
             issue.number, result.error, recipe_path, repo_path, len(raw), head, tail,
         )
         raise RuntimeError(result.error or "goose spec failed")
+    # Content gate: result.ok only proves the spec file exists and is non-empty.
+    # On #783, goose dumped a 3672-line session transcript whose final write-tool
+    # call was truncated ("-32602: Could not parse tool arguments") — a malformed
+    # "spec" that passed result.ok, advanced to implement, and produced off-spec
+    # code the judge then rejected. Reject a transcript/truncated spec here so it
+    # fails like any other spec failure (retry/escalate) instead of poisoning the
+    # downstream impl.
+    reason = _spec_malformed_reason(_read_full(result.output_path))
+    if reason:
+        log.error("malformed spec for #%s: %s", issue.number, reason)
+        raise RuntimeError(f"malformed spec: {reason}")
     next_state["spec_path"] = str(result.output_path)
     if result.model_key is not None:
         next_state["spec_model_key"] = result.model_key
@@ -64,6 +75,42 @@ def spec_node(state: GraphState) -> GraphState:
 
 
 _SPEC_EXCERPT_LIMIT = 6000
+# Capacious enough to scan a bloated transcript head+tail without reading an
+# unbounded file; the discriminating markers appear at the start (goose banner)
+# and end (truncated-write error) of a transcript-spec.
+_SPEC_SCAN_LIMIT = 500_000
+
+# Markers that appear in a goose session TRANSCRIPT or a truncated write-tool
+# call, and never in a clean authored spec (verified: #783 has all of these,
+# clean spec #779 has none). Their presence means the spec write failed and the
+# file captured the raw session instead of a structured spec.
+_MALFORMED_MARKERS = (
+    "goose is ready",
+    "● new session ·",
+    "Could not parse tool arguments",
+    "the response may have been truncated",
+    "-32602",
+)
+
+
+def _spec_malformed_reason(content: str) -> str | None:
+    """Return a reason string if the spec content is a goose transcript or a
+    truncated write rather than a clean spec, else None."""
+    for marker in _MALFORMED_MARKERS:
+        if marker in content:
+            return (
+                f"spec file contains goose-transcript/error marker {marker!r} — "
+                "the spec write likely truncated, leaving a raw session instead "
+                "of a structured spec"
+            )
+    return None
+
+
+def _read_full(path) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")[:_SPEC_SCAN_LIMIT]
+    except Exception:
+        return ""
 
 
 def _read_excerpt(path) -> str:


### PR DESCRIPTION
## Problem

The bot built **off-spec** code (#785: `pkg/daemon/*.go` VPN code for an "onboarding checklist widget" spec) — a wasted spec + impl + judge cycle. Root cause via `/ce-debug`:

`spec_node`'s `result.ok` only proves the spec file **exists and is non-empty**. On issue #783, goose over-produced a spec (full inline Go for `pkg/onboard/*`) and its write-tool call **truncated** — `-32602: Could not parse tool arguments — the response may have been truncated`. So `specs/issue-783-spec.md` captured the raw **3672-line session transcript** (goose banner, `▸ tree` dumps) instead of a structured spec. `result.ok` passed it → it advanced to implement → the impl drifted into off-spec daemon code → the judge correctly rejected it.

(Clean spec #779 was 184 structured lines and wrote fine — this is a per-issue over-production failure, not systemic.)

## Fix

Content gate in `spec_node`, after `result.ok`: scan the spec for goose-transcript / truncated-write markers (`goose is ready`, `● new session ·`, `Could not parse tool arguments`, `the response may have been truncated`, `-32602`). On a hit → `raise RuntimeError("malformed spec: ...")` — the **same failure path** as a goose error, so the box retries/escalates and a garbage spec never reaches implement.

Markers verified **present on #783, absent from clean #779**; gate proven on both real files (rejects #783, accepts #779). The existing `.github/scripts/validate-spec.sh` + `spec-validation.yml` are advisory ("does not gate the pipeline") — this closes the gap at generation time.

This is the tactical fail-fast. The strategic root — #783 is a **cloudroof** (managed-service) feature misfiled into the **wgmesh** (product) pipeline — is a separate product/service-split brainstorm.

## Tests

8 new (`spec_node` rejects transcript spec / accepts clean; `_spec_malformed_reason` per-marker + clean-pass). All 12 `test_spec_node.py` green.

> Note: ~21 unrelated local suite failures are a **host git commit-hook API-quota** issue (`no more API calls available`) that fails clean `origin/main` identically — not from this change. CI runs in a clean env.

Found via `/ce-debug`.