### PR TITLE
feat(graph): surface gate — keep service/unclassified issues out of the wgmesh builder

### DIFF
--- a/docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md
+++ b/docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md
@@ -1,0 +1,69 @@
+# Requirements: Gate + route cloudroof (service) issues out of the wgmesh builder
+
+**Date:** 2026-06-21
+**Scope tier:** Deep — feature (extends the #1931 product/service split)
+**Origin:** `/ce-debug` session — issue #783 ("onboarding checklist widget on cloudroof dashboard") was filed in wgmesh, the spec agent reinterpreted it as a wgmesh terminal/daemon feature, the impl built off-spec `pkg/daemon` code, and the judge rejected it — a wasted spec+impl+judge cycle.
+
+---
+
+## Problem Frame
+
+PR #1931 shipped the product/service split machinery — `surface:product`/`surface:service` labels, routing constants (`SURFACE_REPO = {"product": wgmesh, "service": cloudroof-eu}`), and `_route_lane_and_repo()` (`pipeline/wgmesh_pipeline/observation.py:48–256`). But that routing fires **only inside the observation loop** (LLM-ideated issues). Three entry points bypass it, so service issues still reach the wgmesh impl builder:
+
+1. **Manually-filed issues** — `observation.py` only processes LLM assessments; an issue filed directly on GitHub (like #783: `fn:dev`, `copilot-triaging`, **no surface label**) never hits `_route_lane_and_repo`.
+2. **No builder-entry gate** — `triage.py` classifies `wont-do | needs-info | feature | fix` only; it does not check surface. A service issue in wgmesh proceeds to spec→impl unfiltered.
+3. **No fail-safe on unknown surface at the builder** — an unclassified issue with `fn:dev` advances and gets built in wgmesh.
+
+The result is wasted autonomous cycles and off-spec code. The judge catches the output, but the cost (spec + impl + judge) is already spent.
+
+## Goal
+
+A surface-aware **gate + router** at the builder entry that makes it structurally impossible for a service-scoped (or unclassified) issue to be built in the wgmesh pipeline, and routes detected service issues toward cloudroof-eu through a cofounder decision gate.
+
+## Requirements
+
+- **R1 — Classify surface on every issue entering the builder.** Every issue that reaches the build pipeline carries a `surface:product` or `surface:service` classification, including manually-filed issues that bypass the observation loop today. Reuse the surface-classification prompt already used by the LLM gather (`observation_gather.py:290–301`).
+- **R2 — Load-bearing builder gate (the fail-safe).** A `surface:service` issue NEVER advances to spec→impl in the wgmesh pipeline. An **unknown/unclassified** surface BLOCKS spec→impl until surface is assigned (classify inline, else hold) — it does not default to product. This is the gate that directly prevents the #783 path.
+- **R3 — Route detected service issues to cloudroof-eu + the cofounder decision gate.** A detected service issue is relocated toward `cloudroof-eu` (reuse `_route_lane_and_repo`) AND surfaced in Quackback's **gtm-decision stream** so a cofounder decides whether it is worth building before it consumes build effort. High-confidence service → route; low/ambiguous confidence → human queue.
+- **R4 — Fail-safe by default.** Any ambiguity (unknown surface, low classification confidence) resolves to the human queue (`needs-human` / Quackback), never to a silent wgmesh build.
+- **R5 — Reuse, don't duplicate.** Build on the existing #1931 surface labels, `SURFACE_REPO`, and `_route_lane_and_repo`; the deliverable is wiring them at the **triage/builder entry** and covering the **manual-issue** path, not new routing primitives.
+
+## Key Decisions
+
+- **KD1 — The gate lives at the builder entry (triage/poller), not only at observation routing.** Manual issues bypass the observation loop, so a builder-entry gate is the only place that catches all entry paths. This is the root-cause fix for #783.
+- **KD2 — Unknown surface blocks; it does not default to product.** #783 had no surface label and was built anyway. Defaulting unknown→product re-opens that exact leak.
+- **KD3 — Disposition flows through Quackback's gtm-decision stream, not pure auto-build.** Operator: *"either way we need this quack something to make sure co-founders want to spend time on those things."* Service/GTM work needs human judgment on whether it is worth doing — a cofounder accept-gate (the existing Quackback front gate / two-stream contract) sits in front of cloudroof build effort.
+
+## Scope Boundaries
+
+### In scope
+- Surface classification at triage for all builder-bound issues (incl. manual).
+- Builder-entry gate: refuse `surface:service`; block unknown-surface until classified.
+- Route detected service issues to cloudroof-eu + surface them in the Quackback gtm-decision stream.
+
+### Deferred to follow-up
+- The cloudroof-eu **autonomous builder** (a pipeline pointed at cloudroof-eu). cloudroof-eu exists but is nascent (tiny Cloudflare site, 0 issues).
+- goal-sprint **dual-surface emission** (#1931 U4 — still hardcoded to `pulse_seed_product_repo` = wgmesh).
+- cloudroof **GTM/content terminal** (non-code service work).
+- **Backfill** — reclassifying the existing aged wgmesh backlog of service-scoped issues (e.g. #786, #789) — candidate one-shot sweep, separate from the standing gate.
+
+### Outside this product's identity
+- Monetizing or gating wgmesh (product) itself — revenue lives only at the cloudroof (service) layer per CONSTITUTION.md. This effort enforces that boundary; it does not move it.
+
+## Success Criteria
+
+- A `surface:service` or unclassified issue filed directly in wgmesh does **not** reach spec→impl (would have stopped #783).
+- Detected service issues appear in cloudroof-eu and in the Quackback gtm-decision stream for cofounder triage.
+- Zero off-spec "service-feature-built-in-wgmesh" impl PRs after rollout (the #783 class goes to zero).
+
+## Dependencies & Assumptions
+
+- **cloudroof-eu repo exists** (verified — nascent Cloudflare Workers site). Valid routing target; its builder is out of scope.
+- **Quackback gtm-decision stream** (`docs/quackback-decision-streams.md`, #1931 U7) is assumed usable as the cofounder gate. **Unverified whether it is live/wired** — if not, service issues park via `needs-human` until it is (see Open Questions).
+- **Surface classifier reuse** — the triage-time classifier reuses the observation gather's surface prompt; assumes it classifies a bare manual issue (title + body) as reliably as an ideated one.
+
+## Open Questions
+
+- Is the Quackback gtm-decision stream actually live and wired, or still spec? Determines whether R3 routes to Quackback now or falls back to `needs-human` until it lands.
+- Backfill: reclassify the existing aged wgmesh backlog of service issues in this effort, or as a separate follow-up sweep?
+- Cross-repo relocation mechanism (GitHub issue transfer vs recreate-with-pointer) — defer to ce-plan.

--- a/docs/plans/2026-06-21-008-feat-surface-gate-builder-entry-plan.md
+++ b/docs/plans/2026-06-21-008-feat-surface-gate-builder-entry-plan.md
@@ -1,0 +1,165 @@
+---
+title: "feat: surface gate at the builder entry — keep service issues out of the wgmesh impl pipeline"
+date: 2026-06-21
+type: feat
+status: planned
+depth: standard
+origin: docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md
+---
+
+# feat: Surface gate at the builder entry
+
+**Target repo:** ai-pipeline-template (box code; gates the wgmesh impl pipeline)
+
+## Summary
+
+A surface-aware gate between triage and spec that makes it structurally impossible for a cloudroof (service) or unclassified issue to be built in the wgmesh impl pipeline. It classifies the issue's surface (reading the label, else an LLM call), and for service / unresolvable-unknown surfaces it blocks the spec→impl path and parks the issue for human decision via labels — which is exactly the input the Quackback gtm-decision stream keys on. Directly prevents the #783 class: a manually-filed cloudroof issue (`fn:dev`, no surface label) that reached the wgmesh builder, was respecced as a daemon feature, built off-spec, and rejected by the judge.
+
+## Problem Frame
+
+PR #1931 shipped surface routing (`observation.py:48–256`, `_route_lane_and_repo` → `cloudroof-eu`) but it fires **only inside the observation loop** (LLM-ideated issues). Three entry paths bypass it: manually-filed issues never hit routing (`observation.py` processes only LLM assessments — #783's path), `triage.py` has no surface check, and there is no fail-safe on unknown surface at the builder. So service/unclassified issues still flow triage → spec → implement in the wgmesh pipeline. The judge catches the output, but the spec+impl+judge cost is already spent.
+
+The graph runs linearly per issue (`graph/build.py::CompiledGraph.invoke` and `graph/build_lg.py` for langgraph): `triage → spec → spec_pr → implement-ladder → gate`. There is already one pre-spec escape — `classification in {wont-do, needs-info} → escalate(needs-human), return`. The surface gate is a second escape on the same seam.
+
+## Requirements (origin)
+
+- **R1** — Classify surface on every issue entering the builder, including manual/unlabeled ones (reuse the gather surface prompt).
+- **R2** — Load-bearing builder gate: `surface:service` never reaches spec→impl; unknown surface blocks until classified (does not default to product).
+- **R3** — Route detected service issues toward the cofounder decision gate (Quackback gtm-decision stream).
+- **R4** — Fail-safe by default: any ambiguity resolves to the human queue, never a silent wgmesh build.
+- **R5** — Reuse #1931 surface infra (`_resolve_surface`, labels), don't duplicate.
+
+## Key Technical Decisions
+
+- **KTD1 — Gate is a new step on the triage→spec seam, wired into BOTH graph impls.** Mirror the existing `wont-do/needs-info → escalate, return` escape in `CompiledGraph.invoke`, and add the equivalent branch to `build_lg.py::route_after_triage` (+ a node). Wiring both paths is load-bearing — a gate in only one impl is bypassable by `config.graph_impl`.
+- **KTD2 — Surface resolution reuses `observation._resolve_surface(labels)`; unlabeled → LLM-classify.** No new classifier primitive. An issue with no `surface:*` label is classified from title+body using the gather surface prompt (`observation_gather.py:290–301`), and the resolved `surface:*` label is **applied** (persisted) so the decision is idempotent and visible to the contract.
+- **KTD3 — Disposition is park-in-place, not GitHub relocation.** A blocked service issue gets `surface:service` + `needs-human` and stays where it is; no `gh issue transfer`. This honors the "moving out of GitHub" direction — the box-side gate is substrate-agnostic, and re-homing to cloudroof-eu is the cutover/Quackback layer's job, not this gate's.
+- **KTD4 — Quackback gtm-decision wiring needs no separate emit.** Per `docs/quackback-decision-streams.md`, the stream is a **label-keyed view**: `surface:service` + `needs-human` → gtm-decision; `surface:product` + `needs-human` → product-decision; missing surface + `needs-human` → product-decision (fail-safe) + log. Producing those labels IS the wiring; the decision layer (feat/quackback-decision-layer) consumes them.
+- **KTD5 — "Block unknown" governs building, not review routing.** An unresolvable-unknown issue is blocked from the wgmesh builder (never specs) AND parked via `needs-human` (no surface → product-decision fail-safe per contract). "Don't default to product" (R2) is about not *building* it as product, not about which review stream a human sees it in.
+
+## High-Level Technical Design
+
+Per-issue flow with the gate inserted (both graph impls):
+
+```
+triage ──▶ classification in {wont-do, needs-info}? ──yes──▶ escalate(needs-human) ▶ return
+   │                                                              (existing escape)
+   no
+   ▼
+SURFACE GATE (new)
+   resolve surface: _resolve_surface(issue.labels)
+     └─ None? → LLM classify(title, body) → (surface, confidence); apply surface:* label
+   decide:
+     product (confident)        → proceed to spec  (the only build path)
+     service                    → apply surface:service + needs-human ▶ escalate ▶ return
+     unknown / low-confidence   → apply needs-human (no surface) + log ▶ escalate ▶ return
+   ▼ (product only)
+spec ──▶ spec_pr ──▶ implement-ladder ──▶ gate
+```
+
+The block branches reuse the existing escalate/return shape: set `decision="escalate"`, add the labels, append `visited`, return — the issue never reaches `self.spec()`. The gtm-decision / product-decision stream a human sees is then derived from the labels by the Quackback layer (KTD4), no extra call.
+
+## Implementation Units
+
+### U1. Surface resolution + classification
+
+**Goal:** Given an issue, resolve its surface (product|service|unknown) from labels, classifying via LLM when no `surface:*` label is present, and apply the resolved label.
+**Requirements:** R1, R5.
+**Dependencies:** none.
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py` (new)
+- `pipeline/tests/test_surface_gate.py` (new)
+**Approach:** Export `resolve_issue_surface(issue, *, classifier_fn=None) -> SurfaceResolution` (surface: `"product"|"service"|"unknown"`, confidence, source: `"label"|"classified"`). Read labels via the existing `observation._resolve_surface`. When it returns None, call the injected `classifier_fn(title, body)` (the LLM surface classifier reusing the gather surface prompt; injected so tests run without a model). Low/zero confidence → `"unknown"`. Caller applies the `surface:*` label when source is `"classified"` (via forge `add_label`, mode-gated like other writes).
+**Patterns to follow:** `observation.py::_resolve_surface` (label read), `observation_gather.py:290–301` (surface prompt), the injected-callable test idiom in `company/scripts/conflict-heal/run.py`.
+**Test scenarios:**
+- Issue with `surface:service` label → `("service", high, "label")`, no classifier call.
+- Issue with `surface:product` label → `("product", …, "label")`.
+- Issue with NO surface label, classifier returns service → `("service", …, "classified")`.
+- No surface label, classifier returns product → `("product", …, "classified")`.
+- No surface label, classifier low/zero confidence or error → `("unknown", …)`; classifier exception surfaces as unknown, never silently product.
+- Both `surface:product` and `surface:service` present (contradiction) → service wins (gated), matching `_resolve_surface` precedence.
+
+### U2. Gate decision (pure)
+
+**Goal:** Map a resolved surface to a gate verdict the graph acts on.
+**Requirements:** R2, R4.
+**Dependencies:** U1.
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py` (modify)
+- `pipeline/tests/test_surface_gate.py` (modify)
+**Approach:** Export pure `decide_surface_gate(resolution) -> verdict` where verdict ∈ `{"build", "block_service", "block_unknown"}`. product+confident → `build`; service → `block_service`; unknown/low-confidence → `block_unknown`. No I/O. The graph wiring (U3) maps verdicts to label-application + escalate.
+**Test scenarios:**
+- product/high → `build`.
+- service (label or classified) → `block_service`.
+- unknown → `block_unknown`.
+- product but low confidence → `block_unknown` (fail-safe: don't build on a shaky product guess).
+- Determinism: same resolution → same verdict.
+
+### U3. Wire the gate into both graph impls + block disposition
+
+**Goal:** Run the surface gate between triage and spec in both execution paths; block_service / block_unknown apply the parking labels and escalate without reaching spec.
+**Requirements:** R2, R3, R4 (KTD1, KTD3, KTD4).
+**Dependencies:** U1, U2.
+**Files:**
+- `pipeline/wgmesh_pipeline/graph/build.py` (modify — `CompiledGraph.invoke`, after the wont-do/needs-info escape, before `self.spec`)
+- `pipeline/wgmesh_pipeline/graph/build_lg.py` (modify — `route_after_triage` + a surface-gate node)
+- `pipeline/tests/test_graph.py` and/or `pipeline/tests/test_build_lg_parity.py` (modify)
+**Approach:** Insert the gate call after triage. On `block_service`: apply `surface:service` (if not already labeled) + `needs-human`, set `decision="escalate"`, append `visited`, return — never call `self.spec`. On `block_unknown`: apply `needs-human` (no surface label) and log the missing-surface case (contract fail-safe → product-decision), escalate, return. On `build`: proceed to spec unchanged. In `build_lg.py`, `route_after_triage` returns a new `"surface_gate"` route (or folds into `"escalate"`) so the langgraph path blocks identically. Reuse the forge `add_label` already used by the existing escalate. Mode-gated writes (shadow → dry-run, spec-only → blocked) inherited from the forge.
+**Patterns to follow:** the existing `wont-do/needs-info` escape in `build.py::invoke`; `build_lg.py::route_after_triage` / `escalate`.
+**Test scenarios:**
+- `surface:service` issue → does NOT reach spec (assert `spec` not in `visited`); ends with `surface:service` + `needs-human`; `decision == "escalate"`. (Legacy AND langgraph.)
+- Manual issue, no surface label, classifier→service → classified, blocked, labeled, no spec.
+- Unknown/low-confidence issue → blocked, `needs-human` applied, missing-surface logged, no spec.
+- `surface:product` issue → proceeds to spec (assert `spec` in `visited`).
+- Parity: legacy `CompiledGraph` and langgraph `build_lg` produce the same block/proceed decision for the same issue.
+- wont-do/needs-info still escapes first (gate doesn't change the existing pre-spec escape).
+
+### U4. gtm-decision stream conformance + observability
+
+**Goal:** Prove the gate's output satisfies the Quackback decision-stream contract and surfaces the missing-surface signal.
+**Requirements:** R3 (KTD4), R4.
+**Dependencies:** U3.
+**Files:**
+- `pipeline/tests/test_surface_gate.py` (modify) or a small `pipeline/tests/test_gtm_stream_conformance.py` (new)
+**Approach:** Assert the contract conformance examples from `docs/quackback-decision-streams.md`: a gate-blocked service issue carries `surface:service` + `needs-human` (→ gtm-decision stream); an unresolvable-unknown carries `needs-human` with no surface (→ product-decision fail-safe) and the missing-surface case is logged. No new emit code — this unit verifies the label output is contract-correct, since the stream is a label-keyed view.
+**Test scenarios:**
+- Covers contract example 1: `surface:service` + `needs-human` present → routes gtm-decision, not product-decision.
+- Covers contract example 2: `needs-human` + no surface → product-decision fail-safe AND missing-surface logged.
+- A built (product) issue carries no `needs-human` (it went to spec, not the decision queue).
+
+## Scope Boundaries
+
+### In scope
+- Surface classification at the builder entry (incl. manual/unlabeled issues).
+- The gate in both graph impls; block service + unknown before spec.
+- Park-in-place disposition (`surface:service`/`needs-human`) feeding the Quackback gtm-decision stream by label.
+
+### Deferred to follow-up
+- The cloudroof-eu autonomous builder (a pipeline pointed at cloudroof-eu).
+- goal-sprint dual-surface emission (#1931 U4).
+- Backfilling/reclassifying the existing aged wgmesh backlog of service issues.
+- Active relocation of issues to cloudroof-eu (left to the cutover/Quackback re-home layer).
+
+### Outside this product's identity
+- Monetizing or gating wgmesh itself — revenue lives only at the cloudroof layer (CONSTITUTION.md). This gate enforces the boundary; it does not move it.
+
+## Risks & Dependencies
+
+- **Classifier reliability** — an LLM mis-classifying a real product issue as service would wrongly block it. Mitigated by R4 fail-safe (low confidence → block_unknown → human, never silent), and the human can re-label. The cost of a false service-classification is a human review, not a bad merge.
+- **Both-graph drift** — if the gate lands in only one graph impl, the other path leaks service issues. U3 parity test is load-bearing.
+- **Quackback liveness** — the gtm-decision stream is a contract/label-view; if the decision layer (feat/quackback-decision-layer) is not yet consuming labels, blocked service issues still park safely via `needs-human` (no regression — they simply wait in the human queue). No hard dependency.
+- **Reuse dependency** — `observation._resolve_surface` and the gather surface prompt are the reused primitives; no new secrets or external calls beyond the existing LLM classifier path.
+
+## Open Questions (execution-time)
+
+- Exact LLM call wiring for the unlabeled-classification path — reuse the gather model/client factory; resolve concrete client wiring during implementation.
+- Whether `route_after_triage` should return a distinct `"surface_gate"` route or fold the block into the existing `"escalate"` route in langgraph — decide when touching `build_lg.py` (both yield the same no-spec outcome).
+
+## Sources & Research
+
+- Origin: `docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md`.
+- Surface infra (reuse): `pipeline/wgmesh_pipeline/observation.py:48–58, 203–256`; `observation_gather.py:290–301`.
+- Graph seams: `pipeline/wgmesh_pipeline/graph/build.py::CompiledGraph.invoke` (wont-do/needs-info escape), `graph/build_lg.py::route_after_triage`, `graph/nodes/triage.py`.
+- Decision-stream contract: `docs/quackback-decision-streams.md` (#1931 U7 — label-keyed streams, conformance examples).
+- Forge label/status surface: `pipeline/wgmesh_pipeline/forge/quackback.py`, `forge/quackback_status.py`.
+- Root incident: `[[feedback_offspec_impl_malformed_transcript_spec]]`, `[[project_product_service_split]]`.

--- a/pipeline/tests/test_build_escalation.py
+++ b/pipeline/tests/test_build_escalation.py
@@ -78,7 +78,7 @@ def _review_by_tier(results: dict[int, dict]):
 
 def _state(client: GitHubClient | None = None):
     return {
-        "issue": GitHubIssue(number=1, title="Fix docs", labels=("needs-triage",), state="open"),
+        "issue": GitHubIssue(number=1, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"),
         "github": client,
     }
 
@@ -193,7 +193,7 @@ def test_spec_only_mode_never_enters_escalation_loop() -> None:
     result = graph.invoke(_state(GitHubClient(config)))
 
     assert calls == []
-    assert result["visited"] == ["triage", "spec", "spec_pr"]
+    assert result["visited"] == ["triage", "surface_gate", "spec", "spec_pr"]
     assert "escalation_history" not in result
 
 

--- a/pipeline/tests/test_build_lg_parity.py
+++ b/pipeline/tests/test_build_lg_parity.py
@@ -118,7 +118,7 @@ def _state(client: RecordingClient) -> GraphState:
         "issue": GitHubIssue(
             number=1,
             title="Fix docs",
-            labels=("needs-triage",),
+            labels=("needs-triage", "surface:product"),
             state="open",
         ),
         "github": client,
@@ -196,7 +196,7 @@ def test_langgraph_parity_spec_only_stops_after_spec_pr(monkeypatch) -> None:
         expected_calls=[],
     )
 
-    assert result["visited"] == ["triage", "spec", "spec_pr"]
+    assert result["visited"] == ["triage", "surface_gate", "spec", "spec_pr"]
     assert "decision" not in result
     assert "escalation_history" not in result
 
@@ -214,6 +214,7 @@ def test_langgraph_parity_full_live_path_merges_after_gate_side_effects(
     assert result["decision"] == "merge"
     assert result["visited"] == [
         "triage",
+        "surface_gate",
         "spec",
         "spec_pr",
         "implement",
@@ -307,3 +308,62 @@ def test_build_graph_langgraph_flag_dispatches_and_exposes_poller_nodes() -> Non
     assert graph.config is config
     for name in ("triage", "spec", "spec_pr", "implement", "review", "gate"):
         assert hasattr(graph, name)
+
+
+# ---- U3: surface gate parity (service/unknown blocked before spec, both impls) ----
+
+def _state_with_labels(client: RecordingClient, labels: tuple[str, ...]) -> GraphState:
+    return {
+        "issue": GitHubIssue(number=1, title="Add widget", labels=labels, state="open"),
+        "github": client,
+    }
+
+
+def _run_both(monkeypatch, *, labels: tuple[str, ...]) -> tuple[GraphState, GraphState, list, list]:
+    nodes = _nodes(classification="fix")
+    monkeypatch.setattr(build_lg, "triage_node", nodes.triage)
+    monkeypatch.setattr(build_lg, "spec_node", nodes.spec)
+    monkeypatch.setattr(build_lg, "spec_pr_node", nodes.spec_pr)
+    monkeypatch.setattr(build_lg, "implement_node", nodes.implement)
+    monkeypatch.setattr(build_lg, "review_node", nodes.review)
+    cfg = _cfg()
+    lc, gc = RecordingClient(cfg), RecordingClient(cfg)
+    legacy = CompiledGraph(
+        config=cfg, triage=nodes.triage, spec=nodes.spec, spec_pr=nodes.spec_pr,
+        implement=nodes.implement, review=nodes.review, gate=gate_node,
+    )
+    langgraph = build_lg.build_state_graph(cfg)
+    lr = legacy.invoke(_state_with_labels(lc, labels))
+    gr = langgraph.invoke(_state_with_labels(gc, labels))
+    return lr, gr, lc.calls, gc.calls
+
+
+def test_surface_gate_service_issue_blocked_before_spec_both_impls(monkeypatch) -> None:
+    lr, gr, lc, gc = _run_both(monkeypatch, labels=("fn:dev", "surface:service"))
+    for r in (lr, gr):
+        assert r["surface_verdict"] == "block_service"
+        assert "spec" not in r["visited"]          # never reached the builder
+        assert r["visited"] == ["triage", "surface_gate", "escalate"]
+        assert r["decision"] == "escalate"
+    # parked via needs-human → surface:service + needs-human = gtm-decision stream
+    assert ("add_label", 1, "needs-human") in lc and ("add_label", 1, "needs-human") in gc
+    assert lc == gc  # parity
+
+
+def test_surface_gate_unknown_issue_blocked_no_surface_label_both_impls(monkeypatch) -> None:
+    # No surface label, no classifier wired → unknown → block, needs-human, NO surface
+    # label applied (contract fail-safe → product-decision).
+    lr, gr, lc, gc = _run_both(monkeypatch, labels=("fn:dev",))
+    for r in (lr, gr):
+        assert r["surface_verdict"] == "block_unknown"
+        assert "spec" not in r["visited"]
+    assert ("add_label", 1, "needs-human") in lc
+    assert ("add_label", 1, "surface:service") not in lc  # no surface forced
+    assert lc == gc
+
+
+def test_surface_gate_product_issue_builds_both_impls(monkeypatch) -> None:
+    lr, gr, lc, gc = _run_both(monkeypatch, labels=("fn:dev", "surface:product"))
+    for r in (lr, gr):
+        assert r["surface_verdict"] == "build"
+        assert "spec" in r["visited"]              # reached the builder

--- a/pipeline/tests/test_gate.py
+++ b/pipeline/tests/test_gate.py
@@ -123,7 +123,7 @@ def test_implement_derives_changed_files_from_existing_diff_for_gate() -> None:
     result = implement_node(
         {
             "issue": GitHubIssue(
-                number=7, title="Fix keys", labels=("needs-triage",), state="open"
+                number=7, title="Fix keys", labels=("needs-triage", "surface:product"), state="open"
             ),
             "diff": """diff --git a/internal/crypto/key.go b/internal/crypto/key.go
 --- a/internal/crypto/key.go
@@ -155,7 +155,7 @@ def test_implement_created_pr_number_is_merged_by_gate() -> None:
     implemented = implement_node(
         {
             "issue": GitHubIssue(
-                number=9, title="Fix relay", labels=("needs-triage",), state="open"
+                number=9, title="Fix relay", labels=("needs-triage", "surface:product"), state="open"
             ),
             "github": client,
             "diff": """diff --git a/docs/readme.md b/docs/readme.md
@@ -169,7 +169,7 @@ def test_implement_created_pr_number_is_merged_by_gate() -> None:
     result = gate_node(
         {
             "issue": GitHubIssue(
-                number=9, title="Fix relay", labels=("needs-triage",), state="open"
+                number=9, title="Fix relay", labels=("needs-triage", "surface:product"), state="open"
             ),
             "github": client,
             "diff": implemented["diff"],
@@ -199,7 +199,7 @@ def test_review_failed_verification_escalates_at_gate(monkeypatch) -> None:
     reviewed = review_node(
         {
             "issue": GitHubIssue(
-                number=8, title="Fix docs", labels=("needs-triage",), state="open"
+                number=8, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"
             ),
             "diff": "+docs\n",
             "changed_files": ["docs/readme.md"],
@@ -250,7 +250,7 @@ def test_live_review_uses_verification_result_and_gate_can_merge(
     reviewed = review_node(
         {
             "issue": GitHubIssue(
-                number=11, title="Fix docs", labels=("needs-triage",), state="open"
+                number=11, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"
             ),
             "github": client,
             "goose_runner": object(),
@@ -280,7 +280,7 @@ def test_non_live_review_keeps_tests_passed_fallback(monkeypatch) -> None:
     reviewed = review_node(
         {
             "issue": GitHubIssue(
-                number=12, title="Fix docs", labels=("needs-triage",), state="open"
+                number=12, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"
             ),
             "goose_runner": object(),
             "diff": "+docs\n",
@@ -346,7 +346,7 @@ def test_gate_node_blocks_component_paywall_and_labels_needs_human() -> None:
     result = gate_node(
         {
             "issue": GitHubIssue(
-                number=766, title="Add trial expiry", labels=(), state="open"
+                number=766, title="Add trial expiry", labels=("surface:product",), state="open"
             ),
             "github": client,
             "diff": """diff --git a/internal/trial/api.go b/internal/trial/api.go
@@ -378,7 +378,7 @@ def test_gate_node_clean_managed_layer_change_does_not_add_paywall_reason() -> N
     result = gate_node(
         {
             "issue": GitHubIssue(
-                number=767, title="Add billing docs", labels=(), state="open"
+                number=767, title="Add billing docs", labels=("surface:product",), state="open"
             ),
             "diff": """diff --git a/docs/cloudroof-signup.md b/docs/cloudroof-signup.md
 --- a/docs/cloudroof-signup.md
@@ -408,7 +408,7 @@ def test_gate_node_paywall_detection_exception_fails_closed(monkeypatch) -> None
     )
     result = gate_node(
         {
-            "issue": GitHubIssue(number=768, title="Fix docs", labels=(), state="open"),
+            "issue": GitHubIssue(number=768, title="Fix docs", labels=("surface:product",), state="open"),
             "diff": "+docs\n",
             "changed_files": ["docs/readme.md"],
             "tests_passed": True,
@@ -452,7 +452,7 @@ def test_component_paywall_does_not_retry_model_ladder() -> None:
     result = graph.invoke(
         {
             "issue": GitHubIssue(
-                number=766, title="Add trial expiry", labels=(), state="open"
+                number=766, title="Add trial expiry", labels=("surface:product",), state="open"
             ),
             "github": client,
         }
@@ -468,7 +468,7 @@ def test_gate_node_surfaces_retryable_in_state() -> None:
     result = gate_node(
         {
             "issue": GitHubIssue(
-                number=10, title="Fix docs", labels=("needs-triage",), state="open"
+                number=10, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"
             ),
             "diff": "+docs\n",
             "changed_files": ["docs/readme.md"],
@@ -493,7 +493,7 @@ def test_graph_wont_do_routes_to_escalate_and_skips_spec_implement() -> None:
             "issue": GitHubIssue(
                 number=5,
                 title="wont fix old path",
-                labels=("needs-triage",),
+                labels=("needs-triage", "surface:product"),
                 state="open",
             ),
             "github": client,
@@ -517,7 +517,7 @@ def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_wr
     result = graph.invoke(
         {
             "issue": GitHubIssue(
-                number=6, title="Fix docs", labels=("needs-triage",), state="open"
+                number=6, title="Fix docs", labels=("needs-triage", "surface:product"), state="open"
             ),
             "github": client,
             "diff": "+docs only\n",
@@ -529,6 +529,7 @@ def test_graph_full_fix_path_reaches_gate_with_diff_and_shadow_has_no_network_wr
 
     assert result["visited"] == [
         "triage",
+        "surface_gate",
         "spec",
         "spec_pr",
         "implement",

--- a/pipeline/tests/test_spec_pr.py
+++ b/pipeline/tests/test_spec_pr.py
@@ -48,7 +48,7 @@ def cfg() -> Config:
 
 
 def issue() -> GitHubIssue:
-    return GitHubIssue(number=17, title="Fix mesh discovery", labels=("needs-triage",), state="open")
+    return GitHubIssue(number=17, title="Fix mesh discovery", labels=("needs-triage", "surface:product"), state="open")
 
 
 def test_spec_pr_node_creates_exact_spec_title_and_swaps_labels(tmp_path: Path, cfg: Config) -> None:
@@ -307,7 +307,7 @@ def test_spec_pr_idempotent_reuses_existing_pr_on_422(tmp_path: Path) -> None:
 
     client = Reraiser(cfg)
     state = {
-        "issue": GitHubIssue(number=652, title="Fix CI", labels=(), state="open"),
+        "issue": GitHubIssue(number=652, title="Fix CI", labels=("surface:product",), state="open"),
         "github": client,
         "repo_path": str(tmp_path),
         "spec_path": "specs/issue-652-spec.md",

--- a/pipeline/tests/test_surface_gate.py
+++ b/pipeline/tests/test_surface_gate.py
@@ -1,0 +1,154 @@
+"""U1/U2/U4 — surface gate logic (graph/nodes/surface_gate.py).
+
+Pure resolution + decision + the node's label disposition. Graph-integration
+(both-impl wiring) is covered in the parity tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.graph.nodes.surface_gate import (
+    decide_surface_gate,
+    resolve_issue_surface,
+    run_surface_gate,
+    surface_gate_blocks,
+)
+
+
+def _issue(number=783, title="Add widget", labels=(), body=""):
+    return GitHubIssue(number=number, title=title, labels=tuple(labels), state="open", body=body) \
+        if "body" in GitHubIssue.__dataclass_fields__ \
+        else GitHubIssue(number=number, title=title, labels=tuple(labels), state="open")
+
+
+@dataclass
+class FakeForge:
+    calls: list = field(default_factory=list)
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        self.calls.append((issue_number, label))
+
+
+# ---- U1: resolve_issue_surface --------------------------------------------
+
+def test_resolve_reads_service_label_no_classifier_call() -> None:
+    called = []
+    res = resolve_issue_surface(
+        _issue(labels=("surface:service", "fn:dev")),
+        classifier_fn=lambda t, b: called.append(1) or ("product", 1.0),
+    )
+    assert (res.surface, res.source) == ("service", "label")
+    assert called == []  # labelled → classifier never runs
+
+
+def test_resolve_reads_product_label() -> None:
+    res = resolve_issue_surface(_issue(labels=("surface:product",)))
+    assert (res.surface, res.source) == ("product", "label")
+
+
+def test_resolve_classifies_unlabelled_service() -> None:
+    res = resolve_issue_surface(_issue(labels=("fn:dev",)), classifier_fn=lambda t, b: ("service", 0.9))
+    assert (res.surface, res.source) == ("service", "classified")
+
+
+def test_resolve_classifies_unlabelled_product() -> None:
+    res = resolve_issue_surface(_issue(labels=()), classifier_fn=lambda t, b: ("product", 0.8))
+    assert (res.surface, res.source) == ("product", "classified")
+
+
+def test_resolve_no_classifier_is_unknown_never_product() -> None:
+    res = resolve_issue_surface(_issue(labels=("fn:dev",)), classifier_fn=None)
+    assert (res.surface, res.source) == ("unknown", "none")
+
+
+def test_resolve_classifier_failure_is_unknown_not_product() -> None:
+    def boom(t, b):
+        raise RuntimeError("provider down")
+    res = resolve_issue_surface(_issue(), classifier_fn=boom)
+    assert res.surface == "unknown"
+
+
+def test_resolve_invalid_classifier_output_is_unknown() -> None:
+    res = resolve_issue_surface(_issue(), classifier_fn=lambda t, b: ("banana", 0.99))
+    assert res.surface == "unknown"
+
+
+def test_resolve_both_surface_labels_service_wins() -> None:
+    res = resolve_issue_surface(_issue(labels=("surface:product", "surface:service")))
+    assert res.surface == "service"  # mirrors _resolve_surface precedence
+
+
+# ---- U2: decide_surface_gate ----------------------------------------------
+
+def test_decide_product_label_builds() -> None:
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    assert decide_surface_gate(SurfaceResolution("product", 1.0, "label")) == "build"
+
+
+def test_decide_service_blocks() -> None:
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    assert decide_surface_gate(SurfaceResolution("service", 1.0, "label")) == "block_service"
+    assert decide_surface_gate(SurfaceResolution("service", 0.6, "classified")) == "block_service"
+
+
+def test_decide_unknown_blocks() -> None:
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    assert decide_surface_gate(SurfaceResolution("unknown", 0.0, "none")) == "block_unknown"
+
+
+def test_decide_low_confidence_product_blocks() -> None:
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    assert decide_surface_gate(SurfaceResolution("product", 0.3, "classified")) == "block_unknown"
+
+
+# ---- run_surface_gate node + U4 contract conformance ----------------------
+
+def test_node_product_label_builds_no_writes() -> None:
+    forge = FakeForge()
+    out = run_surface_gate({"issue": _issue(labels=("surface:product",)), "github": forge})
+    assert out["surface_verdict"] == "build"
+    assert surface_gate_blocks(out) is False
+    assert forge.calls == []  # no label churn for an already-labelled product issue
+
+
+def test_node_service_label_blocks() -> None:
+    forge = FakeForge()
+    out = run_surface_gate({"issue": _issue(labels=("surface:service",)), "github": forge})
+    assert out["surface_verdict"] == "block_service"
+    assert surface_gate_blocks(out) is True
+
+
+def test_node_classified_service_persists_label() -> None:
+    # U4 contract: a classified service issue ends with surface:service present
+    # (+ needs-human from the escalate wiring) → gtm-decision stream.
+    forge = FakeForge()
+    out = run_surface_gate({
+        "issue": _issue(labels=("fn:dev",)),
+        "github": forge,
+        "surface_classifier": lambda t, b: ("service", 0.9),
+    })
+    assert out["surface_verdict"] == "block_service"
+    assert (783, "surface:service") in forge.calls  # persisted for the contract
+
+
+def test_node_unknown_no_classifier_blocks_no_surface_label() -> None:
+    # U4 contract fail-safe: needs-human with NO surface → product-decision.
+    forge = FakeForge()
+    out = run_surface_gate({"issue": _issue(labels=("fn:dev",)), "github": forge})
+    assert out["surface_verdict"] == "block_unknown"
+    assert forge.calls == []  # no surface label applied → product-decision fail-safe
+
+
+def test_node_classified_product_persists_and_builds() -> None:
+    forge = FakeForge()
+    out = run_surface_gate({
+        "issue": _issue(labels=()),
+        "github": forge,
+        "surface_classifier": lambda t, b: ("product", 0.8),
+    })
+    assert out["surface_verdict"] == "build"
+    assert (783, "surface:product") in forge.calls

--- a/pipeline/wgmesh_pipeline/graph/build.py
+++ b/pipeline/wgmesh_pipeline/graph/build.py
@@ -10,6 +10,7 @@ from wgmesh_pipeline.graph.nodes.implement import implement_node
 from wgmesh_pipeline.graph.nodes.review import review_node
 from wgmesh_pipeline.graph.nodes.spec import spec_node
 from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
+from wgmesh_pipeline.graph.nodes.surface_gate import run_surface_gate, surface_gate_blocks
 from wgmesh_pipeline.graph.nodes.triage import triage_node
 from wgmesh_pipeline.graph.state import GraphState
 from wgmesh_pipeline.models import ladder_length_for
@@ -29,6 +30,18 @@ class CompiledGraph:
     def invoke(self, state: GraphState) -> GraphState:
         current = self.triage(state)
         if current.get("classification") in {"wont-do", "needs-info"}:
+            current = dict(current)
+            current["decision"] = "escalate"
+            if current.get("github") is not None:
+                current["github"].add_label(current["issue"].number, "needs-human")
+            current.setdefault("visited", []).append("escalate")
+            return current
+
+        # Surface gate (R2): a service or unclassified issue never reaches spec in
+        # the wgmesh pipeline. Mirrors the wont-do/needs-info escape above —
+        # park via needs-human (+ the persisted surface label) instead of building.
+        current = run_surface_gate(current)
+        if surface_gate_blocks(current):
             current = dict(current)
             current["decision"] = "escalate"
             if current.get("github") is not None:

--- a/pipeline/wgmesh_pipeline/graph/build_lg.py
+++ b/pipeline/wgmesh_pipeline/graph/build_lg.py
@@ -11,6 +11,7 @@ from wgmesh_pipeline.graph.nodes.implement import implement_node
 from wgmesh_pipeline.graph.nodes.review import review_node
 from wgmesh_pipeline.graph.nodes.spec import spec_node
 from wgmesh_pipeline.graph.nodes.spec_pr import spec_pr_node
+from wgmesh_pipeline.graph.nodes.surface_gate import run_surface_gate
 from wgmesh_pipeline.graph.nodes.triage import triage_node
 from wgmesh_pipeline.graph.state import GraphState
 from wgmesh_pipeline.models import ladder_length_for
@@ -126,7 +127,12 @@ class StateGraphWrapper:
     def route_after_triage(self, state: GraphState) -> str:
         if state.get("classification") in {"wont-do", "needs-info"}:
             return "escalate"
-        return "spec"
+        return "surface_gate"
+
+    def route_after_surface_gate(self, state: GraphState) -> str:
+        # A non-build verdict parks the issue (escalate adds needs-human); only a
+        # product issue reaches spec. Parity with the legacy CompiledGraph.invoke.
+        return "spec" if state.get("surface_verdict") == "build" else "escalate"
 
     def route_after_spec_pr(self, state: GraphState) -> str:
         if self.config.mode == "spec-only":
@@ -190,6 +196,7 @@ def build_state_graph(config: Config) -> StateGraphWrapper:
     graph = StateGraph(GraphState)
     graph.add_node("triage", triage_node)
     graph.add_node("escalate", wrapper.escalate)
+    graph.add_node("surface_gate", run_surface_gate)
     graph.add_node("spec", spec_node)
     graph.add_node("spec_pr", spec_pr_node)
     graph.add_node("ladder_prep", wrapper.ladder_prep)
@@ -203,6 +210,11 @@ def build_state_graph(config: Config) -> StateGraphWrapper:
     graph.add_conditional_edges(
         "triage",
         wrapper.route_after_triage,
+        {"escalate": "escalate", "surface_gate": "surface_gate"},
+    )
+    graph.add_conditional_edges(
+        "surface_gate",
+        wrapper.route_after_surface_gate,
         {"escalate": "escalate", "spec": "spec"},
     )
     graph.add_edge("escalate", END)

--- a/pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py
@@ -1,0 +1,123 @@
+"""Surface gate — keep service (cloudroof) and unclassified issues out of the
+wgmesh impl pipeline.
+
+Runs on the triage→spec seam (both graph impls). It resolves the issue's surface
+(reading the ``surface:*`` label, else classifying title+body via an injected
+LLM callable), then decides:
+
+  - ``product`` (confident)      → ``build``         (the only path to spec→impl)
+  - ``service``                  → ``block_service`` (park; never built in wgmesh)
+  - unknown / low-confidence     → ``block_unknown`` (fail-safe: park, never build)
+
+Blocked issues are parked via labels: a classified surface is persisted, and the
+block path (the graph's existing ``escalate``) adds ``needs-human``. Those labels
+ARE the Quackback decision-stream input — ``surface:service`` + ``needs-human`` →
+``gtm-decision``; ``needs-human`` with no surface → ``product-decision`` fail-safe
+(see ``docs/quackback-decision-streams.md``). No separate emit.
+
+Reuses ``observation._resolve_surface`` and the surface label constants (R5).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.observation import _resolve_surface
+
+log = logging.getLogger("wgmesh_pipeline.surface_gate")
+
+# Below this, a classifier verdict is not trusted enough to build on — fail safe
+# to block_unknown rather than spec→impl a shaky guess.
+MIN_CONFIDENCE = 0.5
+
+# (title, body) -> (surface, confidence). Injected so tests and the graph wire a
+# real LLM classifier without this module importing a model client.
+SurfaceClassifier = Callable[[str, str], "tuple[str, float]"]
+
+
+@dataclass(frozen=True)
+class SurfaceResolution:
+    surface: str  # "product" | "service" | "unknown"
+    confidence: float
+    source: str  # "label" | "classified" | "none"
+
+
+def resolve_issue_surface(
+    issue: Any, *, classifier_fn: SurfaceClassifier | None = None
+) -> SurfaceResolution:
+    """Resolve an issue's surface from its labels, classifying title+body when no
+    ``surface:*`` label is present. Never silently assumes product: an absent
+    label with no classifier, or a failed/invalid classification, is ``unknown``."""
+    labels = tuple(getattr(issue, "labels", ()) or ())
+    labeled = _resolve_surface(labels)
+    if labeled is not None:
+        return SurfaceResolution(labeled, 1.0, "label")
+    if classifier_fn is None:
+        return SurfaceResolution("unknown", 0.0, "none")
+    try:
+        surface, confidence = classifier_fn(
+            getattr(issue, "title", "") or "", getattr(issue, "body", "") or ""
+        )
+    except Exception:  # noqa: BLE001 — a classifier failure must fail safe, never build
+        log.warning("surface classifier failed for #%s; treating as unknown", getattr(issue, "number", "?"))
+        return SurfaceResolution("unknown", 0.0, "classified")
+    if surface not in ("product", "service"):
+        return SurfaceResolution("unknown", float(confidence), "classified")
+    return SurfaceResolution(surface, float(confidence), "classified")
+
+
+def decide_surface_gate(resolution: SurfaceResolution) -> str:
+    """Map a resolved surface to a gate verdict: ``build`` | ``block_service`` |
+    ``block_unknown``. Policy (confidence gating) lives here, not in resolution."""
+    if resolution.surface == "service":
+        return "block_service"
+    if resolution.surface == "product" and resolution.confidence >= MIN_CONFIDENCE:
+        return "build"
+    return "block_unknown"
+
+
+def run_surface_gate(state: GraphState) -> GraphState:
+    """Graph node: resolve + decide, persist a classified surface label, and
+    record the verdict in state. Does NOT itself escalate — the graph wiring maps
+    a non-``build`` verdict to the existing ``escalate`` path (which adds
+    ``needs-human``), so both graph impls share one disposition."""
+    next_state = dict(state)
+    next_state.setdefault("visited", []).append("surface_gate")
+    issue = next_state["issue"]
+    classifier = next_state.get("surface_classifier")
+    resolution = resolve_issue_surface(issue, classifier_fn=classifier)
+    verdict = decide_surface_gate(resolution)
+    next_state["surface"] = resolution.surface
+    next_state["surface_verdict"] = verdict
+
+    forge = next_state.get("github")
+    # Persist a classified surface so the decision is idempotent and visible to
+    # the decision-stream contract (a labelled issue routes deterministically).
+    if (
+        resolution.source == "classified"
+        and resolution.surface in ("product", "service")
+        and forge is not None
+    ):
+        forge.add_label(issue.number, f"surface:{resolution.surface}")
+        # block_service via classification: surface:service is now present, so a
+        # service issue ends with surface:service + needs-human → gtm-decision.
+
+    if verdict == "block_unknown":
+        # Contract fail-safe: needs-human with no surface → product-decision
+        # stream. Log so the upstream classifier can be corrected.
+        log.warning(
+            "surface-gate: issue #%s has no resolvable surface — blocking spec→impl "
+            "and parking to needs-human (product-decision fail-safe)",
+            getattr(issue, "number", "?"),
+        )
+
+    return next_state
+
+
+def surface_gate_blocks(state: GraphState) -> bool:
+    """True when the gate's verdict is anything but ``build`` (used by the legacy
+    invoke path to mirror the wont-do/needs-info escape)."""
+    return state.get("surface_verdict") != "build"

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -36,3 +36,10 @@ class GraphState(TypedDict, total=False):
     goose_runner: Any
     impl_pr: int
     config: Config
+    # Surface gate (keeps service/unclassified issues out of the wgmesh builder).
+    # Declared so the langgraph StateGraph propagates them between nodes — an
+    # undeclared channel is silently dropped, which would make route_after_surface_gate
+    # see no verdict and escalate every issue.
+    surface: str
+    surface_verdict: str
+    surface_classifier: Any


### PR DESCRIPTION
## Problem

A cloudroof (service) issue filed in wgmesh — e.g. #783 *"onboarding checklist widget on cloudroof dashboard"* — flowed `triage → spec → implement`, was respecced as a wgmesh daemon feature, built off-spec, and rejected by the judge. Wasted spec+impl+judge cycle. PR #1931 added surface routing but **only inside the observation loop**; manually-filed issues bypassed it.

## What this does

A surface gate on the `triage → spec` seam, in **both** graph impls, so a service or unclassified issue never reaches spec→impl in the wgmesh pipeline.

- `graph/nodes/surface_gate.py` — resolve surface (reuse `observation._resolve_surface`, else an injected classifier, else `unknown`); decide `build` / `block_service` / `block_unknown`; block routes to the existing escalate path (`needs-human`) and persists a classified surface label.
- `build.py` (`CompiledGraph.invoke`) + `build_lg.py` (`route_after_triage` + `surface_gate` node + `route_after_surface_gate`) — wired in both impls so it can't be bypassed by `config.graph_impl`.
- `state.py` — declare `surface` / `surface_verdict` / `surface_classifier` channels (langgraph's `StateGraph` drops undeclared channels, which silently escalated every issue — caught by the parity tests).

## Key decisions (from the brainstorm/plan)

- **Park-in-place, not GitHub transfer.** Block + `surface:service` + `needs-human`, leave the issue where it is — aligns with the off-GitHub direction.
- **No separate Quackback emit.** The gtm-decision stream is a label-keyed view (`docs/quackback-decision-streams.md`): `surface:service` + `needs-human` → gtm-decision. Producing those labels *is* the wiring.
- **Unknown blocks** (does not default to product) — the fail-safe that closes the #783 leak.
- **LLM auto-classifier deferred** — `surface_classifier` is an injected seam (default off). Unlabeled issues park to `needs-human` for human labeling; auto-classification is a clean follow-up.

## Rollout note

The gate makes a surface label (or a wired classifier) a prerequisite to building. Build-path test fixtures updated to carry `surface:product`, reflecting production reality (the observation gather already labels buildable issues).

## Tests

17 gate-logic tests + 3 both-impl parity tests, all green.

> 21 unrelated suite failures locally are the host git commit-hook API-quota issue (`no more API calls available`) — same set as on clean `origin/main`; CI's clean env passes.

Plan: `docs/plans/2026-06-21-008-feat-surface-gate-builder-entry-plan.md` · Brainstorm: `docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md`