### PR TITLE
ci: restore auto-deploy box on green main Build (merge→deploy)

### DIFF
--- a/.github/workflows/auto-deploy-on-merge.yml
+++ b/.github/workflows/auto-deploy-on-merge.yml
@@ -1,0 +1,29 @@
+name: Auto Deploy on Merge
+
+# Restores the merge≠deploy KTLO fix (originally #1928, backed out in the
+# Actions-retirement churn): on a green "Build Pipeline Image" for main, deploy
+# that exact image to the box. CD-on-merge stays in Actions per the
+# Actions=CI/CD-only direction (CD is the explicitly-kept piece). Box-CODE merges
+# (graph nodes, observation routing) only take effect once the image is deployed;
+# without this, every such merge silently needs a manual Deploy Pipeline Box.
+
+on:
+  workflow_run:
+    workflows: ["Build Pipeline Image"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pipeline-box
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    uses: ./.github/workflows/deploy-pipeline-box.yml
+    with:
+      sha: ${{ github.event.workflow_run.head_sha }}
+      server_name: wgmesh-pipeline
+    secrets: inherit

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -9,6 +9,18 @@ on:
       sha:
         description: 'Image tag to deploy'
         default: 'latest'
+  # Reusable so Auto Deploy on Merge can deploy the just-built image on a green
+  # main build (restores the #1928 merge→deploy chain).
+  workflow_call:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+        type: string
+      sha:
+        description: 'Image tag to deploy'
+        default: 'latest'
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`auto-deploy-on-merge.yml` (the #1928 KTLO fix) and `deploy-pipeline-box.yml`'s `workflow_call` were **backed out** during the Actions-retirement churn. So box-**code** merges (graph nodes, observation routing) silently stopped deploying — a merged change builds an image but never ships it to the box.

Caught after merging the surface gate (#1960): `Build Pipeline Image` succeeded for the merge sha, **zero deploy fired**, and the box still runs the old image. Two box-code merges this session (#1959 spec-malformed gate, #1960 surface gate) are merged but not live.

## Fix

Restores the merge→deploy chain:
- `auto-deploy-on-merge.yml` — `workflow_run` of "Build Pipeline Image" → if `success` && `head_branch == main` → call the reusable deploy with `sha = head_sha`. Concurrency `cancel-in-progress`.
- `deploy-pipeline-box.yml` — re-add `workflow_call` (mirroring the current `workflow_dispatch` inputs `server_name`/`sha`) so the auto-deploy can invoke it.

CD-on-merge **stays in Actions** per the Actions=CI/CD-only direction — CD is the explicitly-kept piece, not the substrate being retired.

## Note

Merging this also deploys the currently-pending box code (spec gate #1959 + surface gate #1960): the merge fires its own `Build Pipeline Image`, which the restored auto-deploy then ships.

Operator directive: *"if merge green - autoredeploy."*