### PR TITLE
fix(deploy): auto-deploy via git-reset (Update Pipeline Box), not docker

### DIFF
--- a/.github/workflows/auto-deploy-on-merge.yml
+++ b/.github/workflows/auto-deploy-on-merge.yml
@@ -1,29 +1,32 @@
 name: Auto Deploy on Merge
 
-# Restores the merge≠deploy KTLO fix (originally #1928, backed out in the
-# Actions-retirement churn): on a green "Build Pipeline Image" for main, deploy
-# that exact image to the box. CD-on-merge stays in Actions per the
-# Actions=CI/CD-only direction (CD is the explicitly-kept piece). Box-CODE merges
-# (graph nodes, observation routing) only take effect once the image is deployed;
-# without this, every such merge silently needs a manual Deploy Pipeline Box.
+# Closes the merge≠deploy lag for box CODE. The box runs the pipeline from a
+# git checkout under systemd (NOT a container — it has no docker), so the deploy
+# is a git-reset, not a docker pull. On a push to main that touches pipeline code,
+# git-reset the box to origin/main and restart. CD-on-merge stays in Actions per
+# the Actions=CI/CD-only direction.
+#
+# (The earlier #1928 chain pointed at the docker Deploy Pipeline Box; that path
+# can't run on this box — docker is absent — so this targets Update Pipeline Box,
+# the git-checkout deploy that actually works.)
 
 on:
-  workflow_run:
-    workflows: ["Build Pipeline Image"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths:
+      - 'pipeline/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: deploy-pipeline-box
+  group: update-pipeline-box
   cancel-in-progress: true
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
-    uses: ./.github/workflows/deploy-pipeline-box.yml
+    uses: ./.github/workflows/update-pipeline-box.yml
     with:
-      sha: ${{ github.event.workflow_run.head_sha }}
       server_name: wgmesh-pipeline
     secrets: inherit

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -74,6 +74,16 @@ jobs:
               "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -lse" <<'REMOTE'
           set -euo pipefail
 
+          # docker lives outside the minimal non-interactive SSH PATH on this box
+          # (login shell alone didn't surface it). Augment with the common install
+          # dirs; if still missing, print where it actually is for a precise fix.
+          export PATH="/usr/local/sbin:/usr/local/bin:/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+          if ! command -v docker >/dev/null 2>&1; then
+            echo "::error::docker not on PATH after augment. PATH=$PATH"
+            ls -la /usr/local/bin/docker /usr/bin/docker /snap/bin/docker /opt/bin/docker 2>&1 || true
+            exit 1
+          fi
+
           docker pull "${IMAGE}:${SHA}"
 
           # First containerized deploy has no prior SHA — empty means "no

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -56,13 +56,13 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          IP=$(hcloud server ip "${{ inputs.server_name }}")
+          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
           echo "BOX_IP=$IP" >> "$GITHUB_ENV"
 
       - name: Deploy image
         env:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          SHA: ${{ inputs.sha }}
+          SHA: ${{ github.event.inputs.sha }}
         run: |
           set -euo pipefail
           umask 077
@@ -71,18 +71,8 @@ jobs:
           SSH_IMAGE=$(printf '%q' "$IMAGE")
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
-              "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -lse" <<'REMOTE'
+              "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -se" <<'REMOTE'
           set -euo pipefail
-
-          # docker lives outside the minimal non-interactive SSH PATH on this box
-          # (login shell alone didn't surface it). Augment with the common install
-          # dirs; if still missing, print where it actually is for a precise fix.
-          export PATH="/usr/local/sbin:/usr/local/bin:/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
-          if ! command -v docker >/dev/null 2>&1; then
-            echo "::error::docker not on PATH after augment. PATH=$PATH"
-            ls -la /usr/local/bin/docker /usr/bin/docker /snap/bin/docker /opt/bin/docker 2>&1 || true
-            exit 1
-          fi
 
           docker pull "${IMAGE}:${SHA}"
 
@@ -116,4 +106,4 @@ jobs:
           REMOTE
 
       - name: Report
-        run: echo "Box $BOX_IP deployed image tag '${{ inputs.sha }}'."
+        run: echo "Box $BOX_IP deployed image tag '${{ github.event.inputs.sha }}'."

--- a/.github/workflows/deploy-pipeline-box.yml
+++ b/.github/workflows/deploy-pipeline-box.yml
@@ -56,13 +56,13 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          IP=$(hcloud server ip "${{ inputs.server_name }}")
           echo "BOX_IP=$IP" >> "$GITHUB_ENV"
 
       - name: Deploy image
         env:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          SHA: ${{ github.event.inputs.sha }}
+          SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
           umask 077
@@ -71,7 +71,7 @@ jobs:
           SSH_IMAGE=$(printf '%q' "$IMAGE")
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
-              "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -se" <<'REMOTE'
+              "SHA=$SSH_SHA IMAGE=$SSH_IMAGE bash -lse" <<'REMOTE'
           set -euo pipefail
 
           docker pull "${IMAGE}:${SHA}"
@@ -106,4 +106,4 @@ jobs:
           REMOTE
 
       - name: Report
-        run: echo "Box $BOX_IP deployed image tag '${{ github.event.inputs.sha }}'."
+        run: echo "Box $BOX_IP deployed image tag '${{ inputs.sha }}'."

--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -16,6 +16,13 @@ on:
       server_name:
         description: 'Hetzner server name'
         default: 'wgmesh-pipeline'
+  # Reusable so Auto Deploy on Merge can git-reset the box to a green main.
+  workflow_call:
+    inputs:
+      server_name:
+        description: 'Hetzner server name'
+        default: 'wgmesh-pipeline'
+        type: string
 
 permissions:
   contents: read
@@ -45,7 +52,7 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
         run: |
           set -euo pipefail
-          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          IP=$(hcloud server ip "${{ inputs.server_name }}")
           echo "BOX_IP=$IP" >> "$GITHUB_ENV"
 
       - name: Update + restart


### PR DESCRIPTION
## Problem

#1961 restored auto-deploy pointing at the **docker** Deploy Pipeline Box. But this box has **no docker** — it runs the pipeline from a git checkout under systemd. Verified: `docker` is absent from `/usr/bin`, `/usr/local/bin`, `/snap/bin` (the docker deploy fails `docker: command not found`, exit 127, even with a login shell). So the #1961 chain (Build → docker Deploy) can never run here.

## Fix

Repoint **Auto Deploy on Merge** at **Update Pipeline Box** — the git-reset deploy that actually works (`git reset --hard origin/main` + `pip install` + `systemctl restart`). Trigger on push to `main` touching `pipeline/**` (no image/Build dependency). Make `update-pipeline-box.yml` reusable (`workflow_call`) and `inputs.*`-compatible.

## Verified

- Manual `Update Pipeline Box` dispatch deployed the pending spec gate (#1959) + surface gate (#1960) to the box — git-reset, green. **Both gates are now live.**
- `Auto Deploy on Merge` dispatched from this branch → calls `Update Pipeline Box` via `workflow_call` → green. The reusable chain works.

Operator: *"if merge green - autoredeploy."* Now future `pipeline/**` merges to main auto-git-reset the box.