### PR TITLE
fix(box-env): parse systemd EnvironmentFile, never bash-source it

### DIFF
--- a/.github/workflows/nongoose-shadow.yml
+++ b/.github/workflows/nongoose-shadow.yml
@@ -100,10 +100,14 @@ jobs:
               -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
               "SPEC_REF=$SSH_SPEC_REF MODEL=$SSH_MODEL ITERS=$SSH_ITERS bash -se" <<'REMOTE'
           set -euo pipefail
-          # set -a: /etc/wgmesh-pipeline/env is a systemd EnvironmentFile (bare
-          # KEY=VALUE, no `export`). Sourcing without auto-export leaves the vars
-          # unexported, so the python subprocess never sees TARGET_REPO etc.
-          set -a; . /etc/wgmesh-pipeline/env; set +a
+          # /etc/wgmesh-pipeline/env is a systemd EnvironmentFile (bare KEY=VALUE,
+          # values may contain spaces/JSON). Parse without sourcing: `. env`
+          # word-splits an unquoted-space value and runs a token as a command
+          # (see feedback_box_env_not_bash_sourceable). export VAR=VALUE as one
+          # arg sets it (and exports) without word-splitting or execution.
+          while IFS= read -r __envline; do
+            case "$__envline" in ''|'#'*) continue ;; *=*) export "$__envline" ;; esac
+          done < /etc/wgmesh-pipeline/env
           : "${WGMESH_BOT_PAT:?WGMESH_BOT_PAT missing on box}"
 
           temp_dir=$(mktemp -d)
@@ -134,7 +138,10 @@ jobs:
           fi
 
           test -f "$temp_dir/$SPEC_REF"
-          set -a; . /etc/wgmesh-pipeline/env; set +a
+          # re-load env (subshell above) — parse, never source (see above)
+          while IFS= read -r __envline; do
+            case "$__envline" in ''|'#'*) continue ;; *=*) export "$__envline" ;; esac
+          done < /etc/wgmesh-pipeline/env
           export LANGCHAIN_MAX_ITERATIONS="$ITERS"
           cd /opt/wgmesh-pipeline
           PYTHONUNBUFFERED=1 /opt/wgmesh-pipeline/.venv/bin/python \

--- a/.github/workflows/provision-pipeline-box.yml
+++ b/.github/workflows/provision-pipeline-box.yml
@@ -233,9 +233,13 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}.git"
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$RUNNER_TEMP/box_key" root@"$BOX_IP" \
             "set -euo pipefail
-             set -a
-             . /etc/wgmesh-pipeline/env
-             set +a
+             # systemd EnvironmentFile — parse KEY=VALUE, never source: a value
+             # with spaces/JSON would word-split and run as a command under \`.\`
+             # (see feedback_box_env_not_bash_sourceable). \$ escaped so the loop
+             # var resolves on the box, not the runner.
+             while IFS= read -r __envline; do
+               case \"\$__envline\" in ''|'#'*) continue ;; *=*) export \"\$__envline\" ;; esac
+             done < /etc/wgmesh-pipeline/env
              git clone --depth 1 '$REPO_URL' /opt/wgmesh-pipeline || (cd /opt/wgmesh-pipeline && git pull)
              if [ '${{ github.event.inputs.database_mode }}' = 'turso' ]; then EXTRA='[turso,trace]'; else EXTRA='[trace]'; fi
              python3 -m venv /opt/wgmesh-pipeline/.venv

--- a/.github/workflows/requeue-failed-issues.yml
+++ b/.github/workflows/requeue-failed-issues.yml
@@ -71,9 +71,16 @@ jobs:
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
               "ISSUES=$SSH_ISSUES TARGET_STAGE=$SSH_TARGET_STAGE bash -se" <<'REMOTE'
           set -euo pipefail
-          set -a
-          . /etc/wgmesh-pipeline/env
-          set +a
+          # /etc/wgmesh-pipeline/env is a systemd EnvironmentFile (values may
+          # contain spaces/JSON, e.g. STAGE_ROUTING). Parse KEY=VALUE WITHOUT
+          # sourcing — `. env` word-splits an unquoted-space value and runs a
+          # token as a command (see feedback_box_env_not_bash_sourceable).
+          while IFS= read -r __envline; do
+            case "$__envline" in
+              ''|'#'*) continue ;;
+              *=*) export "$__envline" ;;
+            esac
+          done < /etc/wgmesh-pipeline/env
           cd /opt/wgmesh-pipeline
           cmd=(/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main --requeue-failed)
           if [ -n "${ISSUES}" ]; then


### PR DESCRIPTION
## Problem

`/etc/wgmesh-pipeline/env` is a **systemd EnvironmentFile** — values may contain spaces/JSON (e.g. `STAGE_ROUTING`). Four workflow sites bash-source it (`set -a; . /etc/wgmesh-pipeline/env`), which word-splits an unquoted-space value and executes a token as a command.

Surfaced live while draining in-flight PRs: `requeue-failed-issues.yml --issues 752` failed:

```
/etc/wgmesh-pipeline/env: line 13: default:: command not found
##[error]Process completed with exit code 127
```

Line 13 = `STAGE_ROUTING`. The box **service** is unaffected (systemd parses EnvironmentFile tolerantly — it merged 8 PRs the same window); only bash-sourcing consumers break.

## Fix

Replace each `. env` with a parse-don't-execute loop:

```bash
while IFS= read -r __envline; do
  case "$__envline" in ''|'#'*) continue ;; *=*) export "$__envline" ;; esac
done < /etc/wgmesh-pipeline/env
```

`export "KEY=VALUE"` sets+exports one argument with no word-splitting or execution.

**Sites fixed:**
- `requeue-failed-issues.yml` (remote heredoc)
- `nongoose-shadow.yml` ×2 (remote heredoc)
- `provision-pipeline-box.yml` (`\$` escaped — runs inside a double-quoted ssh arg)

## Verification

Simulated against the exact failure: a JSON-with-spaces value crashes `. source` (`parse error`) but parses cleanly via the loop — all vars export correctly (incl. tokens with `==`, empty values, JSON `STAGE_ROUTING`). Zero behaviour change for well-formed vars. No box data change needed; the value is valid systemd/python content.

## Out of scope

`provision-langfuse.yml:153` sources `./.env` (different file/box, controlled content) — same anti-pattern, flagged for a follow-up.