### PR TITLE
feat(selfheal): stale-base-heal lane — rebase MERGEABLE stale-base-broken bot PRs

### DIFF
--- a/.github/workflows/conflict-heal.yml
+++ b/.github/workflows/conflict-heal.yml
@@ -1,6 +1,6 @@
 name: Conflict Heal
 
-# Bot-PR merge-lane heal across both repos (meta + seed). Two passes:
+# Bot-PR merge-lane heal across both repos (meta + seed). Three passes:
 #
 #   Pass A (rebase) — a bot PR goes CONFLICTING when main moves under it; such a
 #   PR fires no pull_request workflows, so the judge never runs and it dead-ends.
@@ -13,6 +13,13 @@ name: Conflict Heal
 #   pending, not red). Enable auto-merge + push an empty commit to fire the judge.
 #   Pass B runs AFTER Pass A, so a PR the rebase already re-armed (force-push fires
 #   the judge) is no longer a Pass-B candidate.
+#
+#   Pass C (stale-base rebase) — a MERGEABLE bot PR (no conflict) can still be RED
+#   because its branch predates a since-merged fix to main: the failing check is
+#   already resolved on current main. Rebase such PRs (behind main AND failing —
+#   green/current PRs are never force-pushed) onto main so checks re-run against
+#   the fixed tree; reuses Pass A's rebase.sh. Still red after two rebases ⇒ the
+#   failure is in the PR's own diff ⇒ escalate to a human.
 #
 # Cron offset to 01/07/13/19 so it never overlaps pr-disposition's 0 */6.
 
@@ -120,12 +127,26 @@ jobs:
           fi
           python company/scripts/check-rearm/run.py "${args[@]}"
 
+      - name: Run stale-base-heal (Pass C — rebase MERGEABLE stale-base-broken)
+        env:
+          TARGET_REPO: ${{ matrix.target_repo }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          STALE_BASE_HEAL_STATE: company/stale-base-heal-state-${{ matrix.repo_label }}.json
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python company/scripts/stale-base-heal/run.py "${args[@]}"
+
       - name: Commit state
         if: ${{ (github.event.inputs.dry_run || 'false') != 'true' }}
         env:
           STATE_FILES: >-
             company/conflict-heal-state-${{ matrix.repo_label }}.json
             company/check-rearm-state-${{ matrix.repo_label }}.json
+            company/stale-base-heal-state-${{ matrix.repo_label }}.json
         run: |
           set -euo pipefail
 
@@ -151,7 +172,7 @@ jobs:
           pr_url=$(gh pr create \
             --repo "${{ github.repository }}" \
             --title "chore(merge-lane-heal): update ${{ matrix.repo_label }} state $today" \
-            --body "Automated conflict-heal + check-rearm retry-tracker update." \
+            --body "Automated conflict-heal + check-rearm + stale-base-heal retry-tracker update." \
             --base main \
             --head "$branch")
           echo "Opened state PR: $pr_url"

--- a/company/scripts/stale-base-heal/run.py
+++ b/company/scripts/stale-base-heal/run.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Stale-base-heal orchestrator: planner → rebase executor → escalate.
+
+Sibling of ``company/scripts/conflict-heal/run.py`` (mirrors its structure). A
+bot PR can be ``MERGEABLE`` yet RED because its branch predates a since-merged
+fix to ``main`` — the failing check is already resolved on current main. This
+lane rebases such PRs onto main (REUSING ``conflict-heal/rebase.sh`` —
+bot-branch guard + ``--force-with-lease`` + empty-after-rebase detection) so
+their checks re-run against the fixed tree.
+
+Side effects (listing PRs, resolving behind-by + failing-check, running the
+rebase script, mutating GitHub labels/comments) are injected, so tests drive the
+loop with fakes. The planner is pure (``plan_stale_base_heal``). Per-PR
+resolution of ``behindBy`` (``gh api .../compare/main...<branch>``) and
+``hasFailingCheck`` (``gh pr view --json statusCheckRollup``) runs ONLY for
+``bot/*`` MERGEABLE PRs — non-candidates cost no extra gh calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PIPELINE_SRC = REPO_ROOT / "pipeline"
+if str(PIPELINE_SRC) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_SRC))
+
+from wgmesh_pipeline.selfheal import (  # noqa: E402
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_STALE_BASE_REBASE,
+    plan_stale_base_heal,
+)
+from wgmesh_pipeline.selfheal.models import shift  # noqa: E402
+
+# Reuse the conflict-heal rebase executor verbatim (bot guard + force-with-lease
+# + empty-after-rebase). One rebase implementation for both lanes — no drift.
+REBASE_SCRIPT = (
+    Path(__file__).resolve().parents[1] / "conflict-heal" / "rebase.sh"
+)
+
+BOT_BRANCH_PREFIX = "bot/"
+
+# Injectable side effects -------------------------------------------------------
+GhRun = Callable[[Sequence[str]], str]       # read-only gh, returns stdout
+RebaseFn = Callable[[str, int, str], str]    # (repo, number, branch) -> OUTCOME line
+GhMutate = Callable[[Sequence[str]], None]   # write gh (edit/comment)
+
+
+def _real_gh_run(args: Sequence[str]) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _real_gh_mutate(args: Sequence[str]) -> None:
+    subprocess.run(["gh", *args], check=True)
+
+
+def _real_rebase(repo: str, number: int, branch: str) -> str:
+    out = subprocess.run(
+        ["bash", str(REBASE_SCRIPT), repo, str(number), branch],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    return out.strip().splitlines()[-1] if out.strip() else ""
+
+
+# Pure helpers ------------------------------------------------------------------
+
+def normalize_mergeable(value: Any) -> str | None:
+    """gh reports MERGEABLE / CONFLICTING / UNKNOWN; map UNKNOWN (and anything
+    not yet computed) to None so the planner skips it this cycle."""
+    return value if value in ("MERGEABLE", "CONFLICTING") else None
+
+
+def _resolve_behind_by(target_repo: str, branch: str, gh_run: GhRun) -> int:
+    """Commits ``branch`` is behind ``origin/main`` (compare base...head). Any
+    error (deleted branch, 404, non-numeric) resolves to 0 → not a candidate."""
+    try:
+        raw = gh_run([
+            "api", f"repos/{target_repo}/compare/main...{branch}",
+            "--jq", ".behind_by",
+        ])
+    except Exception:
+        return 0
+    try:
+        return int(raw.strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+def _resolve_has_failing_check(
+    target_repo: str, number: int, gh_run: GhRun
+) -> bool:
+    """True iff any check on the PR has conclusion FAILURE."""
+    try:
+        raw = gh_run([
+            "pr", "view", str(number), "--repo", target_repo,
+            "--json", "statusCheckRollup",
+        ])
+    except Exception:
+        return False
+    if not raw.strip():
+        return False
+    rollup = (json.loads(raw) or {}).get("statusCheckRollup") or []
+    return any(
+        str(check.get("conclusion") or "").upper() == "FAILURE"
+        for check in rollup
+    )
+
+
+def list_stale_candidate_prs(
+    target_repo: str, gh_run: GhRun
+) -> list[dict[str, Any]]:
+    """Open PRs as planner-ready dicts. ``behindBy`` + ``hasFailingCheck`` are
+    resolved ONLY for ``bot/*`` MERGEABLE PRs (the planner's other guards would
+    skip the rest anyway — bounds the per-PR gh calls)."""
+    raw = gh_run([
+        "pr", "list", "--repo", target_repo, "--state", "open",
+        "--limit", "200",
+        "--json", "number,headRefName,mergeable",
+    ])
+    prs = json.loads(raw) if raw.strip() else []
+    out: list[dict[str, Any]] = []
+    for pr in prs:
+        number = int(pr["number"])
+        head = pr.get("headRefName") or ""
+        mergeable = normalize_mergeable(pr.get("mergeable"))
+        behind_by = 0
+        failing = False
+        if head.startswith(BOT_BRANCH_PREFIX) and mergeable == "MERGEABLE":
+            behind_by = _resolve_behind_by(target_repo, head, gh_run)
+            if behind_by > 0:
+                failing = _resolve_has_failing_check(target_repo, number, gh_run)
+        out.append({
+            "number": number,
+            "headRefName": head,
+            "mergeable": mergeable,
+            "behindBy": behind_by,
+            "hasFailingCheck": failing,
+        })
+    return out
+
+
+def parse_outcome(line: str) -> str:
+    """Extract OUTCOME=<slug> from a rebase.sh result line."""
+    for token in line.split():
+        if token.startswith("OUTCOME="):
+            return token.split("=", 1)[1]
+    return "unknown"
+
+
+def _escalate(
+    number: int,
+    comment: str,
+    *,
+    gh_mutate: GhMutate,
+    target_repo: str,
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        print(f"DRY_RUN escalate PR #{number}: would add needs-human + comment")
+        return
+    gh_mutate(["pr", "edit", str(number), "--repo", target_repo, "--add-label", "needs-human"])
+    gh_mutate(["pr", "comment", str(number), "--repo", target_repo, "--body", comment])
+
+
+# Orchestration -----------------------------------------------------------------
+
+def run_stale_base_heal(
+    target_repo: str,
+    state: Mapping[str, Any],
+    now: str,
+    *,
+    dry_run: bool,
+    gh_run: GhRun,
+    rebase_fn: RebaseFn,
+    gh_mutate: GhMutate,
+    escalate_cooldown_hours: float = CONFLICT_ESCALATE_COOLDOWN_HOURS,
+) -> dict[str, Any]:
+    """Plan + execute one stale-base-heal cycle, returning the new state dict.
+
+    R5: a clean rebase RESETS the PR's retry entry; only rebase *failures*
+    increment toward the cap (after the cap the planner escalates: the failure
+    is in the PR's own diff, not a stale base). An empty-after-rebase PR
+    escalates (content already in main) instead of pushing. dry_run makes zero
+    mutations and is surfaced by the caller to skip the state write.
+    """
+    prs = list_stale_candidate_prs(target_repo, gh_run)
+    tracker_in: Mapping[str, Any] = dict(state.get("retry_tracker") or {})
+    plan = plan_stale_base_heal(
+        prs, tracker_in, now,
+        dry_run=dry_run, escalate_cooldown_hours=escalate_cooldown_hours,
+    )
+    branch_by_number = {pr["number"]: pr["headRefName"] for pr in prs}
+    tracker: dict[str, Any] = dict(plan.tracker)
+
+    for action in plan.actions:
+        number = int(action.number)  # type: ignore[arg-type]
+        key = f"pr-{number}"
+        if action.kind == "escalate":
+            # Planner already set the cooldown in plan.tracker; just publish.
+            _escalate(
+                number, action.comment or "Stale-base-heal escalation.",
+                gh_mutate=gh_mutate, target_repo=target_repo, dry_run=dry_run,
+            )
+            continue
+        if action.kind != HEAL_KIND_STALE_BASE_REBASE:
+            continue
+        branch = branch_by_number.get(number, "")
+        if dry_run:
+            print(f"DRY_RUN rebase PR #{number} ({branch}): would rebase onto main")
+            continue
+        outcome = parse_outcome(rebase_fn(target_repo, number, branch))
+        entry = dict(tracker.get(key) or {})
+        if outcome == "rebased":
+            tracker.pop(key, None)  # R5: clean reset
+        elif outcome == "empty":
+            _escalate(
+                number,
+                "Stale-base-heal: this PR's content already merged to main "
+                "(empty after rebase). A human should close it.",
+                gh_mutate=gh_mutate, target_repo=target_repo, dry_run=dry_run,
+            )
+            tracker[key] = {**entry, "cooldown_until": shift(now, hours=escalate_cooldown_hours)}
+        elif outcome == "conflict":
+            # MERGEABLE shouldn't conflict on rebase, but defensively treat it
+            # as a failed attempt feeding the retry gate.
+            retries = int(entry.get("retries") or 0) + 1
+            tracker[key] = {**entry, "retries": retries, "last_retry": now,
+                            "action": HEAL_KIND_STALE_BASE_REBASE}
+        else:  # skipped / unknown — leave tracker untouched, log loudly
+            print(f"::warning::rebase PR #{number} returned OUTCOME={outcome}; no tracker change")
+
+    # NB: deliberately no timestamp in the persisted state — the commit gate is
+    # a byte diff, so an unchanged tracker must produce an identical file.
+    return {**state, "retry_tracker": tracker}
+
+
+def _write_state(path: Path, state: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Stale-base-heal orchestrator")
+    parser.add_argument("--target-repo", default=os.environ.get("TARGET_REPO", ""))
+    parser.add_argument("--state-file", default=os.environ.get(
+        "STALE_BASE_HEAL_STATE", "company/stale-base-heal-state.json"))
+    parser.add_argument("--now", default=os.environ.get("NOW", ""))
+    parser.add_argument("--dry-run", action="store_true",
+                        default=os.environ.get("DRY_RUN", "false") == "true")
+    args = parser.parse_args(argv)
+
+    if not args.target_repo:
+        parser.error("TARGET_REPO (or --target-repo) is required")
+    now = args.now
+    if not now:
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    state_path = Path(args.state_file)
+    state = json.loads(state_path.read_text()) if state_path.exists() else {"retry_tracker": {}}
+
+    new_state = run_stale_base_heal(
+        args.target_repo, state, now,
+        dry_run=args.dry_run,
+        gh_run=_real_gh_run, rebase_fn=_real_rebase, gh_mutate=_real_gh_mutate,
+    )
+
+    if args.dry_run:
+        print("DRY_RUN: no state written.")
+    else:
+        _write_state(state_path, new_state)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/tests/test_stale_base_heal.py
+++ b/pipeline/tests/test_stale_base_heal.py
@@ -1,0 +1,142 @@
+"""Pure stale-base-heal planner (plan_stale_base_heal). No I/O, NoCallForge."""
+
+from __future__ import annotations
+
+from wgmesh_pipeline.selfheal import (
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_STALE_BASE_REBASE,
+    plan_stale_base_heal,
+)
+from wgmesh_pipeline.selfheal.models import parse_iso
+
+NOW = "2026-06-21T12:00:00Z"
+FUTURE = "2026-06-21T18:00:00Z"  # > NOW: an active cooldown
+PAST = "2026-06-21T06:00:00Z"  # < NOW: an expired cooldown
+
+
+def pr(
+    number: int,
+    head: str,
+    mergeable: str | None,
+    *,
+    behind_by: int = 1,
+    failing: bool = True,
+) -> dict:
+    return {
+        "number": number,
+        "headRefName": head,
+        "mergeable": mergeable,
+        "behindBy": behind_by,
+        "hasFailingCheck": failing,
+    }
+
+
+def kinds(plan) -> list[str]:
+    return [a.kind for a in plan.actions]
+
+
+def test_happy_stale_base_bot_pr_yields_one_rebase() -> None:
+    plan = plan_stale_base_heal([pr(7, "bot/impl-7", "MERGEABLE")], {}, NOW)
+
+    assert kinds(plan) == [HEAL_KIND_STALE_BASE_REBASE]
+    assert plan.actions[0].number == 7
+    assert plan.actions[0].target == "pr"
+    # planner does NOT increment a rebase attempt (executor updates next cycle)
+    assert plan.tracker == {}
+
+
+def test_non_bot_branch_is_never_touched() -> None:
+    plan = plan_stale_base_heal([pr(7, "feature/human-7", "MERGEABLE")], {}, NOW)
+
+    assert plan.actions == ()
+
+
+def test_conflicting_and_none_states_skip() -> None:
+    prs = [
+        pr(1, "bot/impl-1", "CONFLICTING"),  # conflict-heal's job
+        pr(2, "bot/impl-2", None),  # GitHub still computing
+    ]
+
+    plan = plan_stale_base_heal(prs, {}, NOW)
+
+    assert plan.actions == ()
+
+
+def test_current_branch_not_behind_is_skipped() -> None:
+    plan = plan_stale_base_heal(
+        [pr(7, "bot/impl-7", "MERGEABLE", behind_by=0)], {}, NOW
+    )
+
+    assert plan.actions == ()
+
+
+def test_green_pr_is_never_force_pushed() -> None:
+    plan = plan_stale_base_heal(
+        [pr(7, "bot/impl-7", "MERGEABLE", failing=False)], {}, NOW
+    )
+
+    assert plan.actions == ()
+
+
+def test_active_cooldown_skips() -> None:
+    tracker = {"pr-7": {"retries": 1, "cooldown_until": FUTURE}}
+
+    plan = plan_stale_base_heal([pr(7, "bot/impl-7", "MERGEABLE")], tracker, NOW)
+
+    assert plan.actions == ()
+    # tracker passed through unchanged
+    assert plan.tracker == tracker
+
+
+def test_expired_cooldown_below_cap_rebases() -> None:
+    tracker = {"pr-7": {"retries": 1, "cooldown_until": PAST}}
+
+    plan = plan_stale_base_heal([pr(7, "bot/impl-7", "MERGEABLE")], tracker, NOW)
+
+    assert kinds(plan) == [HEAL_KIND_STALE_BASE_REBASE]
+
+
+def test_cap_reached_escalates_not_rebases() -> None:
+    tracker = {"pr-7": {"retries": 2}}
+
+    plan = plan_stale_base_heal([pr(7, "bot/impl-7", "MERGEABLE")], tracker, NOW)
+
+    assert kinds(plan) == ["escalate"]
+    action = plan.actions[0]
+    assert action.add_label == "needs-human"
+    assert action.comment and "human" in action.comment.lower()
+    assert action.comment and "diff" in action.comment.lower()
+    # escalation sets a fresh cooldown (CONFLICT_ESCALATE_COOLDOWN_HOURS)
+    cooldown = plan.tracker["pr-7"]["cooldown_until"]
+    delta_hours = (parse_iso(cooldown) - parse_iso(NOW)).total_seconds() / 3600
+    assert delta_hours == CONFLICT_ESCALATE_COOLDOWN_HOURS
+
+
+def test_below_cap_with_one_retry_still_rebases() -> None:
+    tracker = {"pr-7": {"retries": 1}}
+
+    plan = plan_stale_base_heal([pr(7, "bot/impl-7", "MERGEABLE")], tracker, NOW)
+
+    assert kinds(plan) == [HEAL_KIND_STALE_BASE_REBASE]
+
+
+def test_dry_run_is_surfaced_on_the_plan() -> None:
+    plan = plan_stale_base_heal(
+        [pr(7, "bot/impl-7", "MERGEABLE")], {}, NOW, dry_run=True
+    )
+
+    assert plan.dry_run is True
+    # plan content is identical to a non-dry run (executor honors the flag)
+    assert kinds(plan) == [HEAL_KIND_STALE_BASE_REBASE]
+
+
+def test_input_order_is_preserved() -> None:
+    prs = [
+        pr(3, "bot/impl-3", "MERGEABLE"),
+        pr(1, "bot/spec-1", "MERGEABLE"),
+        pr(2, "bot/impl-2", "MERGEABLE"),
+    ]
+
+    plan = plan_stale_base_heal(prs, {}, NOW)
+
+    assert [a.number for a in plan.actions] == [3, 1, 2]

--- a/pipeline/wgmesh_pipeline/selfheal/__init__.py
+++ b/pipeline/wgmesh_pipeline/selfheal/__init__.py
@@ -40,6 +40,7 @@ from wgmesh_pipeline.selfheal.models import (
     ESCALATE_COOLDOWN_HOURS,
     HEAL_KIND_CHECK_REARM,
     HEAL_KIND_CONFLICT_REBASE,
+    HEAL_KIND_STALE_BASE_REBASE,
     IDLE_DISPATCH_COOLDOWN_SECONDS,
     MAX_RETRIES_BEFORE_ESCALATE,
     REARM_RECHECK_COOLDOWN_HOURS,
@@ -49,10 +50,12 @@ from wgmesh_pipeline.selfheal.models import (
     HealAction,
     SelfHealInputs,
     SelfHealRun,
+    StaleBaseHealPlan,
     SweepOutcome,
 )
 from wgmesh_pipeline.selfheal.rearm import plan_check_rearm
 from wgmesh_pipeline.selfheal.retry_policy import Decision, apply_retry_gate
+from wgmesh_pipeline.selfheal.stale_base import plan_stale_base_heal
 from wgmesh_pipeline.selfheal.runner import needs_human_from_forge, run_self_heal
 from wgmesh_pipeline.selfheal.signals import (
     assert_state_mutation,
@@ -79,6 +82,7 @@ __all__ = [
     "ESCALATE_COOLDOWN_HOURS",
     "HEAL_KIND_CHECK_REARM",
     "HEAL_KIND_CONFLICT_REBASE",
+    "HEAL_KIND_STALE_BASE_REBASE",
     "IDLE_DISPATCH_COOLDOWN_SECONDS",
     "MAX_RETRIES_BEFORE_ESCALATE",
     "REARM_RECHECK_COOLDOWN_HOURS",
@@ -89,6 +93,7 @@ __all__ = [
     "HealAction",
     "SelfHealInputs",
     "SelfHealRun",
+    "StaleBaseHealPlan",
     "SweepOutcome",
     "apply_retry_gate",
     "assert_state_mutation",
@@ -101,6 +106,7 @@ __all__ = [
     "needs_human_from_forge",
     "plan_check_rearm",
     "plan_conflict_heal",
+    "plan_stale_base_heal",
     "run_self_heal",
     "sweep_needs_human",
     "sweep_stale_approved",

--- a/pipeline/wgmesh_pipeline/selfheal/models.py
+++ b/pipeline/wgmesh_pipeline/selfheal/models.py
@@ -29,6 +29,15 @@ HEAL_KIND_CONFLICT_REBASE = "conflict_rebase"
 # conflict value (a PR that can't be armed in 2 tries needs a human).
 HEAL_KIND_CHECK_REARM = "check_rearm"
 REARM_RECHECK_COOLDOWN_HOURS = 6
+# Stale-base-heal: a MERGEABLE bot PR (no conflict) can still be RED because its
+# branch was cut before a since-merged fix to main — its tree is stale and the
+# failing check is already resolved on current main. conflict-heal only rebases
+# CONFLICTING PRs, so these stay frozen. We rebase them onto main so checks
+# re-run against the fixed tree. Only ever touch a PR that is behind main AND has
+# a failing check (a green-or-current PR needs no force-push — thrash guard). If
+# it still fails after the shared retry cap, the failure is in the PR's own diff,
+# not a stale base → escalate. Cooldown reuses the conflict value.
+HEAL_KIND_STALE_BASE_REBASE = "stale_base_rebase"
 IDLE_DISPATCH_COOLDOWN_SECONDS = 6 * 60 * 60
 CHECK_INTERVAL_HOURS = 0.5
 ACTIVE_PIPELINE_LABELS = (
@@ -132,6 +141,19 @@ class CheckRearmPlan:
     ``escalate`` actions plus the retry tracker the executor persists. Like the
     conflict planner, it does NOT record the re-arm attempt — the executor
     reports the outcome and the next cycle's tracker reflects it."""
+
+    actions: tuple[HealAction, ...] = ()
+    tracker: dict[str, Any] = field(default_factory=dict)
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class StaleBaseHealPlan:
+    """Result of the pure stale-base-heal planner: the planned
+    ``stale_base_rebase`` / ``escalate`` actions plus the retry tracker the
+    executor persists. Like the conflict planner, it does NOT increment a rebase
+    attempt — the executor reports the outcome and the next cycle's tracker
+    reflects it (R5: clean rebase resets, failure increments)."""
 
     actions: tuple[HealAction, ...] = ()
     tracker: dict[str, Any] = field(default_factory=dict)

--- a/pipeline/wgmesh_pipeline/selfheal/stale_base.py
+++ b/pipeline/wgmesh_pipeline/selfheal/stale_base.py
@@ -1,0 +1,111 @@
+"""Stale-base-heal planner — pure decision for stale-base-broken bot PRs.
+
+A bot PR (`bot/spec-*`, `bot/impl-*`) can be ``mergeable=MERGEABLE`` (no conflict)
+yet have a FAILING check because its branch was cut before a since-merged fix to
+``main`` — its tree is stale and the failure is already resolved on current main.
+``conflict-heal`` only rebases CONFLICTING PRs, so these stay frozen. This planner
+decides, per PR, whether to rebase (onto current main, so checks re-run against
+the fixed tree) or escalate; the git/forge writes live in the workflow executor
+(``company/scripts/stale-base-heal/``). Mirrors the ``selfheal/`` planning-vs-
+execution split and the ``conflict.py`` shape — ``NoCallForge``-unit-testable.
+
+Scope guards: only ``bot/``-prefixed head branches are ever considered (human PRs
+are never touched). ``mergeable is None`` (GitHub still computing) and
+``CONFLICTING`` (conflict-heal's job) are skipped. A PR is a candidate only when
+it is BEHIND main (``behindBy > 0`` — a current branch needs no rebase) AND has a
+failing check (``hasFailingCheck`` — a green PR must not be force-pushed; thrash
+guard). Both signals are pre-resolved by the workflow so the planner stays pure.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from wgmesh_pipeline.selfheal.models import (
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_STALE_BASE_REBASE,
+    MAX_RETRIES_BEFORE_ESCALATE,
+    HealAction,
+    StaleBaseHealPlan,
+    tracker_entry,
+)
+from wgmesh_pipeline.selfheal.retry_policy import apply_retry_gate
+
+BOT_BRANCH_PREFIX = "bot/"
+MERGEABLE = "MERGEABLE"
+
+
+def plan_stale_base_heal(
+    prs: Sequence[Mapping[str, Any]],
+    tracker: Mapping[str, Any],
+    now: str,
+    *,
+    dry_run: bool = False,
+    max_retries: int = MAX_RETRIES_BEFORE_ESCALATE,
+    escalate_cooldown_hours: float = CONFLICT_ESCALATE_COOLDOWN_HOURS,
+) -> StaleBaseHealPlan:
+    """Plan rebase/escalate actions for stale-base-broken MERGEABLE bot PRs.
+
+    ``prs`` are plain dicts carrying ``number``, ``headRefName``, the tri-state
+    ``mergeable`` (``"MERGEABLE"`` / ``"CONFLICTING"`` / ``None``), ``behindBy``
+    (int commits behind ``origin/main``) and ``hasFailingCheck`` (bool) — all
+    resolved by the workflow so the planner stays pure. Order is stable (input
+    order preserved). Returns the planned actions plus the tracker the executor
+    persists; ``dry_run`` is surfaced for the executor to honor (the plan itself
+    is identical either way).
+    """
+    out_tracker: dict[str, Any] = dict(tracker)
+    actions: list[HealAction] = []
+
+    for pr in prs:
+        head = str(pr.get("headRefName") or "")
+        if not head.startswith(BOT_BRANCH_PREFIX):
+            continue  # never touch human PRs
+        if pr.get("mergeable") != MERGEABLE:
+            continue  # CONFLICTING (conflict-heal's job) or None (computing) → skip
+        if int(pr.get("behindBy") or 0) <= 0:
+            continue  # already current → a rebase would be a no-op force-push
+        if not bool(pr.get("hasFailingCheck")):
+            continue  # green PR → never force-push it (thrash guard)
+        number = int(pr["number"])
+        key = f"pr-{number}"
+        entry = tracker_entry(out_tracker, key)
+        decision = apply_retry_gate(
+            entry,
+            now,
+            max_retries=max_retries,
+            escalate_cooldown_hours=escalate_cooldown_hours,
+        )
+        if decision.kind == "skip":
+            continue
+        if decision.kind == "escalate":
+            actions.append(HealAction(
+                kind="escalate",
+                number=number,
+                target="pr",
+                add_label="needs-human",
+                comment=(
+                    f"Stale-base-heal rebased this PR onto main "
+                    f"{decision.retries} times and its checks still fail — the "
+                    f"failure is in the PR's own diff, not a stale base. A human "
+                    f"needs to fix or close it."
+                ),
+                reason="2 consecutive rebase attempts still red",
+            ))
+            out_tracker[key] = {**entry, "cooldown_until": decision.cooldown_until}
+            continue
+        # decision.kind == "act": below the cap → attempt a rebase. The planner
+        # does NOT increment retries here; the executor reports success/failure
+        # and the next cycle's tracker reflects it (R5: clean reset / failure
+        # increment). Preserve the entry so the executor can update it.
+        actions.append(HealAction(
+            kind=HEAL_KIND_STALE_BASE_REBASE,
+            number=number,
+            target="pr",
+        ))
+
+    return StaleBaseHealPlan(
+        actions=tuple(actions),
+        tracker=out_tracker,
+        dry_run=dry_run,
+    )


### PR DESCRIPTION
## Problem

A bot PR can be `mergeable=MERGEABLE` (no conflict) yet **RED** because its branch was cut before a since-merged fix to `main` — its tree is stale and the failing check is already resolved on current main. `conflict-heal` only rebases **CONFLICTING** PRs, so these freeze.

Surfaced live: after the `pkg/analytics` build-break fix landed on wgmesh main (#810), the frozen bot PRs kept failing `build-test`. Re-running their checks doesn't help — the branch **tree** must be rebased onto the fixed main. No lane did that.

## Fix — a third pass on the merge-lane-heal workflow, mirroring conflict-heal

- **`selfheal/stale_base.py`** — pure planner `plan_stale_base_heal`. Selects `bot/*` + `MERGEABLE` + `behindBy>0` + `hasFailingCheck`. **Thrash guard:** never force-pushes a green or already-current PR. Retry-gated via the shared `apply_retry_gate` — rebase below the cap, escalate to `needs-human` at the cap (*"rebased N times, still failing → the PR's own diff is broken, not a stale base"*).
- **`company/scripts/stale-base-heal/run.py`** — orchestrator mirroring `conflict-heal/run.py`. Resolves `behindBy` (`gh api compare main...branch`) + `hasFailingCheck` (`gh pr view statusCheckRollup`) **only for bot MERGEABLE PRs** (bounds gh calls), then **reuses `conflict-heal/rebase.sh`** (bot guard + `--force-with-lease` + empty-after-rebase) — one rebase implementation, no drift.
- **`conflict-heal.yml`** — Pass C step + its own `stale-base-heal-state-<label>.json`, committed via the same sanitise + state-PR path. Cron/matrix/token unchanged.
- **`models.py`** — `HEAL_KIND_STALE_BASE_REBASE` + `StaleBaseHealPlan`.

## Tests / verification

- 11 pure-planner units (bot-only guard, MERGEABLE-only, CONFLICTING/None skip, `behindBy==0` skip, green-PR-never-pushed, cooldown, escalate-at-cap, dry_run, order).
- Full `selfheal`/`conflict`/`rearm`/`stale` sweep green: **99 passed**.
- Executor verified with injected fakes: only the behind+failing bot PR rebases; current/green/human PRs skipped; clean rebase resets the retry entry, no escalate.

## Design notes

Lane runs every cron tick (01/07/13/19) after Pass A (conflict) + Pass B (re-arm). Bounded: `hasFailingCheck` skips green PRs, `behindBy>0` skips current ones, shared retry cooldown bounds re-attempts, escalate-at-cap stops infinite rebasing of a genuinely-broken diff.