### PR TITLE
feat(merge-lane-heal): U1–U3 — box-native merge-lane-heal (inert, shadow)

### DIFF
--- a/docs/plans/2026-06-22-001-merge-lane-heal-to-box-plan.md
+++ b/docs/plans/2026-06-22-001-merge-lane-heal-to-box-plan.md
@@ -1,0 +1,67 @@
+# Plan — Merge-lane-heal → box control loop (retire conflict-heal.yml)
+
+2026-06-22. Operator principle (project_actions_cicd_only_retarget):
+> *"the only thing that must be left in github actions is [a CI/CD pipeline]... autobox is just another developer"*
+
+`conflict-heal.yml` (3 passes: conflict-rebase + check-rearm + stale-base-rebase) is a
+scheduled **Actions cron doing pipeline orchestration** — not CI/CD. Move it onto the box
+control loop and retire the cron. Operator decisions (2026-06-22): **scope = merge-lane-heal
+only** (pipeline-health.yml stays for a separate cut); **box heals BOTH repos** (seed + meta).
+
+## Current state (recon)
+
+- Box loop = `main.py async_main` → `Poller.run_forever` (claims/advances issues) + optional
+  `ControlLoopScheduler` (4 shadow-gated modules: supervisor / selfheal / observation /
+  strategy_audit). `run_self_heal` is already a control-loop module (stale-stage sweeps).
+- Merge-lane-heal is NOT a box module — it lives only in `conflict-heal.yml` (Actions cron,
+  active) via `company/scripts/{conflict-heal,check-rearm,stale-base-heal}/run.py` (gh CLI).
+- The 3 PLANNERS (`selfheal/{conflict,rearm,stale_base}.py`) are pure + box-ready.
+- `GitHubClient` is single-repo (bound to `config.target_repo`), REST via `requests`.
+
+## Design
+
+A 5th control-loop module `merge_lane`, mirroring the existing four: gather → plan → (shadow:
+return; live: execute) → persist. Gated by `MERGE_LANE_HEAL_LIVE` (default false). Reuses the
+3 pure planners. Executes via the **forge client** (REST list/label/comment/auto-merge) +
+`conflict-heal/rebase.sh` (git rebase; the box has git + `WGMESH_BOT_PAT`). Cross-repo: the
+module runs once per forge in `[seed_forge, meta_forge]`; `meta_forge` = `GitHubClient` on a
+config copy with `target_repo = <meta slug>`.
+
+## Units (U1–U3 land INERT behind the flag; U4 is the operator-gated cutover)
+
+- **U1 — forge accessors (additive, zero-risk).** Add to `forge/protocol.py` + `github/client.py`:
+  `compare_behind_by(head_branch) -> int` (GET `/compare/main...{head}` → `behind_by`, 404→0)
+  and `pr_has_failing_check(number) -> bool` (GET PR check-runs/statuses, any FAILURE). The
+  stale-base planner needs both; conflict/rearm don't. Quackback/Gitea get no-op/raise stubs as
+  the protocol requires. Tests: `test_github_client_merge_lane_accessors.py`.
+
+- **U2 — box-native module `selfheal/merge_lane.py`.** `run_merge_lane_heal(forge, state, now,
+  *, live, rebase_fn, repo_label) -> MergeLaneHealRun` (shape mirrors `SelfHealRun`): list open
+  PRs via forge; resolve mergeable/behindBy/failing; run `plan_conflict_heal` → `plan_check_rearm`
+  → `plan_stale_base_heal` (same A→B→C order as the cron); in shadow return planned actions +
+  state, in live execute (forge label/comment/auto-merge + `rebase_fn` for rebase/empty-commit).
+  Injectable side effects (NoCallForge-testable). Tests: `test_merge_lane_heal.py` (shadow plans
+  nothing-executed; live drives fakes; per-pass selection; cross-pass ordering).
+
+- **U3 — wire as the 5th ControlLoopScheduler module + cross-repo.** Add `MERGE_LANE_HEAL_LIVE`
+  + `merge_lane_heal_interval_seconds` to config; register the module in `control_loop/__init__.py`
+  with its own gate + state row; build `[seed_forge, meta_forge]` and run the module per repo.
+  Lands shadow (LIVE=false) — runs each cycle, executes nothing.
+
+- **U4 — cutover (operator-gated, after shadow-proven).** `set-box-env MERGE_LANE_HEAL_LIVE=true`
+  (+ `CONTROL_LOOP_ENABLED=true` if not already) → `gh workflow disable "Conflict Heal"`. Verify
+  one live box cycle rebases a stale-base PR + zero cron runs. Rollback = re-enable cron + flag
+  false.
+
+## Safety
+
+- U1–U3 inert: `MERGE_LANE_HEAL_LIVE` default false → the module runs in shadow (plans, executes
+  nothing) the moment it's wired; no force-push from the box until U4.
+- Double-heal guard: U4 disables the cron in the SAME change that flips the flag (only one
+  executor live at a time).
+- Reuses `rebase.sh` (bot-branch guard + `--force-with-lease` + empty-after-rebase) — no new
+  force-push logic.
+
+## Out of scope
+
+pipeline-health.yml (stale-stage heal) — separate cut. Durable post-merge/merge-queue gate.

--- a/pipeline/tests/test_control_loop.py
+++ b/pipeline/tests/test_control_loop.py
@@ -208,6 +208,67 @@ def test_each_enabled_planner_fires_at_least_once() -> None:
     assert heal.calls >= 1, "selfheal planner never fired"
 
 
+def test_merge_lane_module_runs_both_repos_in_shadow() -> None:
+    """merge-lane-heal fires for BOTH seed and meta in shadow via the injected
+    planner + client factory (no real HTTP): the planner is called per repo,
+    nothing is executed, and the shadow forge sees no writes."""
+    from wgmesh_pipeline.selfheal import MergeLaneHealRun
+
+    seen_slugs: list[str] = []
+
+    def fake_factory(cfg, slug):
+        seen_slugs.append(slug)
+        return object()  # never touched — the planner is a spy
+
+    ml_spy = Spy(MergeLaneHealRun(actions=(), state={"retry_tracker": {}}))
+    forge = SpyForge()
+    sched = ControlLoopScheduler(
+        config=_config(
+            wgmesh_bot_pat="tok",  # token present → cycle runs (not skipped)
+            meta_repo="atvirokodosprendimai/ai-pipeline-template",
+            merge_lane_heal_interval_seconds=0.01,
+        ),
+        forge=forge,
+        store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
+        merge_lane_planner=ml_spy,
+        merge_lane_client_factory=fake_factory,
+    )
+    asyncio.run(_run_briefly(sched))
+    assert ml_spy.calls >= 2, "merge_lane planner should fire for seed + meta"
+    assert set(seen_slugs) >= {
+        "atvirokodosprendimai/wgmesh",
+        "atvirokodosprendimai/ai-pipeline-template",
+    }
+    assert forge.write_calls == [], "shadow merge_lane must not write to forge"
+
+
+def test_merge_lane_skipped_without_bot_token() -> None:
+    """No bot token → the whole merge-lane cycle is skipped (no client built,
+    planner never called) — keeps token-less environments off the network."""
+    from wgmesh_pipeline.selfheal import MergeLaneHealRun
+
+    built = []
+    ml_spy = Spy(MergeLaneHealRun())
+    sched = ControlLoopScheduler(
+        config=_config(merge_lane_heal_interval_seconds=0.01),  # no wgmesh_bot_pat
+        forge=SpyForge(),
+        store=SpyStore(),
+        supervisor_planner=Spy(_empty_rank_run()),
+        selfheal_planner=Spy(_empty_selfheal_run()),
+        observation_assessor=lambda inputs: {},
+        strategy_text_reader=lambda: None,
+        merge_lane_planner=ml_spy,
+        merge_lane_client_factory=lambda c, s: built.append(s),
+    )
+    asyncio.run(_run_briefly(sched))
+    assert ml_spy.calls == 0, "merge_lane planner must not fire without a token"
+    assert built == [], "no client should be built without a token"
+
+
 def test_shadow_performs_no_forge_writes_and_no_state_save_when_immaterial() -> None:
     # Shadow contract (post-U3): zero FORGE writes always; the box-internal
     # state store MAY be read (load_control_state), but is NOT written when the

--- a/pipeline/tests/test_github_client_list_open_prs.py
+++ b/pipeline/tests/test_github_client_list_open_prs.py
@@ -1,0 +1,71 @@
+"""U2 — GitHubClient.list_open_pull_requests accessor tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from wgmesh_pipeline.github.client import GitHubClient
+
+
+def _client(pages: list[list[dict[str, Any]]]) -> GitHubClient:
+    """Return a GitHubClient whose _request returns successive pages of PRs.
+
+    Each call to GET /repos/o/r/pulls returns the next list in ``pages``.
+    """
+    cfg = SimpleNamespace(owner="o", repo="r")
+    client = GitHubClient.__new__(GitHubClient)
+    client.config = cfg  # type: ignore[attr-defined]
+    call_count = [0]
+
+    def fake_request(method: str, path: str, *, params: dict | None = None, **_: Any) -> object:
+        assert path == "/repos/o/r/pulls"
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx < len(pages):
+            return pages[idx]
+        return []
+
+    client._request = fake_request  # type: ignore[assignment]
+    return client
+
+
+def test_single_page_returns_all_prs() -> None:
+    raw = [
+        {"number": 1, "head": {"ref": "bot/impl-1"}},
+        {"number": 2, "head": {"ref": "fix/human"}},
+    ]
+    c = _client([raw])
+    result = c.list_open_pull_requests()
+    assert len(result) == 2
+    assert result[0] == {"number": 1, "headRefName": "bot/impl-1"}
+    assert result[1] == {"number": 2, "headRefName": "fix/human"}
+
+
+def test_empty_repo_returns_empty_list() -> None:
+    c = _client([[]])
+    assert c.list_open_pull_requests() == []
+
+
+def test_pagination_collects_across_pages() -> None:
+    page1 = [{"number": i, "head": {"ref": f"bot/impl-{i}"}} for i in range(1, 4)]
+    page2 = [{"number": i, "head": {"ref": f"bot/impl-{i}"}} for i in range(4, 6)]
+    # page1 has 3 items (< per_page=3 triggers stop after page2 ends)
+    c = _client([page1, page2, []])
+    result = c.list_open_pull_requests(per_page=3)
+    numbers = [r["number"] for r in result]
+    assert numbers == [1, 2, 3, 4, 5]
+
+
+def test_max_prs_cap_is_respected() -> None:
+    big_page = [{"number": i, "head": {"ref": f"bot/{i}"}} for i in range(1, 101)]
+    c = _client([big_page, big_page, big_page])
+    result = c.list_open_pull_requests(per_page=100, max_prs=50)
+    assert len(result) == 50
+
+
+def test_missing_head_ref_returns_empty_string() -> None:
+    raw = [{"number": 99, "head": {}}]
+    c = _client([raw])
+    result = c.list_open_pull_requests()
+    assert result[0]["headRefName"] == ""

--- a/pipeline/tests/test_github_client_merge_lane_accessors.py
+++ b/pipeline/tests/test_github_client_merge_lane_accessors.py
@@ -1,0 +1,105 @@
+"""U1 — GitHubClient merge-lane-heal accessors: compare_behind_by + pr_has_failing_check."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import requests
+
+from wgmesh_pipeline.github.client import GitHubClient
+
+
+def _client(routes: dict[str, object]) -> GitHubClient:
+    """A client whose _request returns canned bodies keyed by path. A path
+    mapped to an HTTPError(status) raises it (404 paths exercise the guards)."""
+    cfg = SimpleNamespace(owner="o", repo="r")
+    client = GitHubClient.__new__(GitHubClient)
+    client.config = cfg  # type: ignore[attr-defined]
+
+    def fake_request(method: str, path: str, **_: object) -> object:
+        body = routes[path]
+        if isinstance(body, requests.HTTPError):
+            raise body
+        return body
+
+    client._request = fake_request  # type: ignore[assignment]
+    return client
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    return requests.HTTPError(response=resp)
+
+
+# compare_behind_by ------------------------------------------------------------
+
+def test_behind_by_returns_count() -> None:
+    c = _client({"/repos/o/r/compare/main...bot/impl-7": {"behind_by": 3}})
+    assert c.compare_behind_by("bot/impl-7") == 3
+
+
+def test_behind_by_zero_when_current() -> None:
+    c = _client({"/repos/o/r/compare/main...bot/impl-7": {"behind_by": 0}})
+    assert c.compare_behind_by("bot/impl-7") == 0
+
+
+def test_behind_by_404_deleted_branch_is_zero() -> None:
+    c = _client({"/repos/o/r/compare/main...bot/gone": _http_error(404)})
+    assert c.compare_behind_by("bot/gone") == 0
+
+
+def test_behind_by_missing_field_is_zero() -> None:
+    c = _client({"/repos/o/r/compare/main...bot/impl-7": {"status": "ahead"}})
+    assert c.compare_behind_by("bot/impl-7") == 0
+
+
+def test_behind_by_non_404_error_propagates() -> None:
+    c = _client({"/repos/o/r/compare/main...bot/impl-7": _http_error(500)})
+    try:
+        c.compare_behind_by("bot/impl-7")
+        raise AssertionError("expected HTTPError to propagate")
+    except requests.HTTPError:
+        pass
+
+
+# pr_has_failing_check ---------------------------------------------------------
+
+def test_failing_check_run_is_detected() -> None:
+    c = _client({
+        "/repos/o/r/pulls/7": {"head": {"sha": "abc"}},
+        "/repos/o/r/commits/abc/check-runs": {
+            "check_runs": [
+                {"name": "Analyze", "conclusion": "SUCCESS"},
+                {"name": "build-test", "conclusion": "FAILURE"},
+            ]
+        },
+    })
+    assert c.pr_has_failing_check(7) is True
+
+
+def test_all_green_check_runs_no_status_failure_is_false() -> None:
+    c = _client({
+        "/repos/o/r/pulls/7": {"head": {"sha": "abc"}},
+        "/repos/o/r/commits/abc/check-runs": {
+            "check_runs": [{"name": "build-test", "conclusion": "SUCCESS"}]
+        },
+        "/repos/o/r/commits/abc/status": {"statuses": []},
+    })
+    assert c.pr_has_failing_check(7) is False
+
+
+def test_legacy_commit_status_failure_is_detected() -> None:
+    c = _client({
+        "/repos/o/r/pulls/7": {"head": {"sha": "abc"}},
+        "/repos/o/r/commits/abc/check-runs": {"check_runs": []},
+        "/repos/o/r/commits/abc/status": {
+            "statuses": [{"context": "ci/legacy", "state": "failure"}]
+        },
+    })
+    assert c.pr_has_failing_check(7) is True
+
+
+def test_no_head_sha_is_false() -> None:
+    c = _client({"/repos/o/r/pulls/7": {"head": {}}})
+    assert c.pr_has_failing_check(7) is False

--- a/pipeline/tests/test_merge_lane_heal.py
+++ b/pipeline/tests/test_merge_lane_heal.py
@@ -1,0 +1,309 @@
+"""U2 — merge-lane-heal box module: run_merge_lane_heal.
+
+Pure/fake-driven: a FakeForge exposes all duck-typed forge methods returning
+canned data; a FakeRebase records calls and returns scripted outcomes.  Zero
+real network calls or subprocess invocations.
+
+Covers:
+  - shadow (live=False) plans actions but executes nothing
+  - live: CONFLICTING bot PR → rebase called (Pass A)
+  - live: MERGEABLE+behind+failing check bot PR → rebase called (Pass C — the
+    failure may be a stale tree; rebase to re-run checks against fixed main)
+  - live: MERGEABLE+behind+green bot PR → NOT rebased (thrash guard)
+  - live: MERGEABLE+current bot PR → nothing
+  - cross-pass double-action guard (Pass A actioned PR skipped by Pass C)
+  - cross-pass ordering (A before C in combined actions tuple)
+  - rebased outcome resets tracker entry (R5)
+  - empty outcome escalates (add_label + comment called)
+  - escalate action adds needs-human + comment
+  - non-bot PRs never touched
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wgmesh_pipeline.selfheal.merge_lane import run_merge_lane_heal
+from wgmesh_pipeline.selfheal.models import (
+    HEAL_KIND_CHECK_REARM,
+    HEAL_KIND_CONFLICT_REBASE,
+    HEAL_KIND_STALE_BASE_REBASE,
+)
+
+NOW = "2026-06-21T12:00:00Z"
+
+
+# ── Fakes ─────────────────────────────────────────────────────────────────────
+
+class FakeForge:
+    """Duck-typed forge exposing only the methods merge_lane uses."""
+
+    def __init__(
+        self,
+        prs: list[dict[str, Any]],
+        *,
+        mergeables: dict[int, str | None] | None = None,
+        behind_by: dict[str, int] | None = None,
+        failing: dict[int, bool] | None = None,
+        target_repo: str = "org/repo",
+    ) -> None:
+        # prs: list of {number, headRefName} (list_open_pull_requests output)
+        self._prs = prs
+        self._mergeables: dict[int, str | None] = mergeables or {}
+        self._behind_by: dict[str, int] = behind_by or {}
+        self._failing: dict[int, bool] = failing or {}
+        # Expose config-like object so merge_lane can read target_repo
+        self.config = type("cfg", (), {"target_repo": target_repo})()
+        # Mutation records
+        self.labels_added: list[tuple[int, str]] = []
+        self.comments: list[tuple[int, str]] = []
+        self.auto_merges: list[int] = []
+
+    def list_open_pull_requests(self) -> list[dict[str, Any]]:
+        return list(self._prs)
+
+    def get_pr_mergeable(self, number: int) -> str | None:
+        return self._mergeables.get(number)
+
+    def compare_behind_by(self, head_branch: str, **_: Any) -> int:
+        return self._behind_by.get(head_branch, 0)
+
+    def pr_has_failing_check(self, number: int) -> bool:
+        return self._failing.get(number, False)
+
+    def add_label(self, issue_number: int, label: str, **_: Any) -> None:
+        self.labels_added.append((issue_number, label))
+
+    def comment(self, issue_number: int, body: str) -> None:
+        self.comments.append((issue_number, body))
+
+    def enable_auto_merge(self, pr_number: int, **_: Any) -> None:
+        self.auto_merges.append(pr_number)
+
+
+class FakeRebase:
+    """Records (repo, number, branch) calls; returns scripted OUTCOME lines."""
+
+    def __init__(self, outcome: str = "rebased") -> None:
+        self._outcome = outcome
+        self.calls: list[tuple[str, int, str]] = []
+
+    def __call__(self, repo: str, number: int, branch: str) -> str:
+        self.calls.append((repo, number, branch))
+        return f"OUTCOME={self._outcome} REASON=test"
+
+
+# ── Helper builders ────────────────────────────────────────────────────────────
+
+def _pr(number: int, head: str) -> dict[str, Any]:
+    return {"number": number, "headRefName": head}
+
+
+def _run(
+    prs: list[dict[str, Any]],
+    *,
+    mergeables: dict[int, str | None] | None = None,
+    behind_by: dict[str, int] | None = None,
+    failing: dict[int, bool] | None = None,
+    state: dict[str, Any] | None = None,
+    live: bool = True,
+    rebase_outcome: str = "rebased",
+) -> tuple["MergeLaneHealRun", FakeForge, FakeRebase]:  # type: ignore[name-defined]
+    forge = FakeForge(prs, mergeables=mergeables, behind_by=behind_by, failing=failing)
+    rb = FakeRebase(rebase_outcome)
+    result = run_merge_lane_heal(
+        forge, state or {}, NOW, live=live, rebase_fn=rb,
+    )
+    return result, forge, rb
+
+
+# ── Shadow tests ───────────────────────────────────────────────────────────────
+
+def test_shadow_plans_actions_but_mutates_nothing() -> None:
+    """Shadow mode returns planned actions but calls no forge mutations."""
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        live=False,
+    )
+    # Planned CONFLICTING → should have a conflict_rebase action
+    assert any(a.kind == HEAL_KIND_CONFLICT_REBASE for a in result.actions)
+    # No forge mutations
+    assert forge.labels_added == []
+    assert forge.comments == []
+    assert rb.calls == []
+    assert result.dry_run is True
+    assert result.executed == 0
+
+
+# ── Non-bot PR guard ──────────────────────────────────────────────────────────
+
+def test_human_pr_never_touched() -> None:
+    """Human PRs (no bot/ prefix) are ignored in all passes."""
+    result, forge, rb = _run(
+        [_pr(10, "fix/human-fix"), _pr(11, "feature/foo")],
+        mergeables={10: "CONFLICTING", 11: "MERGEABLE"},
+        behind_by={"feature/foo": 5},
+        live=True,
+    )
+    assert result.actions == ()
+    assert rb.calls == []
+    assert forge.labels_added == []
+
+
+# ── Pass A: conflict-rebase ───────────────────────────────────────────────────
+
+def test_conflicting_bot_pr_rebase_called() -> None:
+    """A CONFLICTING bot PR causes rebase_fn to be called."""
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        live=True,
+    )
+    assert len(rb.calls) == 1
+    assert rb.calls[0][1] == 7  # PR number
+    assert result.executed == 1
+
+
+def test_rebased_outcome_resets_tracker_entry() -> None:
+    """A 'rebased' outcome clears the tracker entry for the PR (R5)."""
+    state = {"retry_tracker": {"pr-7": {"retries": 1, "last_retry": NOW}}}
+    result, _, _ = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        state=state,
+        live=True,
+        rebase_outcome="rebased",
+    )
+    assert "pr-7" not in result.state["retry_tracker"]
+
+
+def test_conflict_outcome_increments_retries() -> None:
+    """A 'conflict' outcome increments retries in the tracker."""
+    result, _, _ = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        live=True,
+        rebase_outcome="conflict",
+    )
+    entry = result.state["retry_tracker"]["pr-7"]
+    assert entry["retries"] == 1
+
+
+def test_empty_outcome_escalates() -> None:
+    """An 'empty' outcome (already-merged content) adds needs-human label + comment."""
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        live=True,
+        rebase_outcome="empty",
+    )
+    assert any(label == "needs-human" for _, label in forge.labels_added)
+    assert len(forge.comments) == 1
+    assert "7" in forge.comments[0][1] or "main" in forge.comments[0][1]
+
+
+# ── Pass C: stale-base-rebase ─────────────────────────────────────────────────
+
+def test_mergeable_behind_failing_check_rebased() -> None:
+    """A MERGEABLE bot PR behind main WITH a failing check is the stale-base
+    candidate — the failure may be a stale tree (since-merged fix), so rebase
+    onto main to re-run checks against the fixed tree."""
+    result, forge, rb = _run(
+        [_pr(8, "bot/impl-8")],
+        mergeables={8: "MERGEABLE"},
+        behind_by={"bot/impl-8": 3},
+        failing={8: True},
+        live=True,
+    )
+    # Pass B won't act (empty title → no "fix: Issue #" prefix). Pass C acts.
+    stale_actions = [a for a in result.actions if a.kind == HEAL_KIND_STALE_BASE_REBASE]
+    assert len(stale_actions) == 1
+    assert stale_actions[0].number == 8
+
+
+def test_mergeable_behind_green_pr_not_rebased() -> None:
+    """Thrash guard: a MERGEABLE bot PR behind main but with NO failing check is
+    skipped — a green PR must never be force-pushed (it can merge as-is)."""
+    result, forge, rb = _run(
+        [_pr(8, "bot/impl-8")],
+        mergeables={8: "MERGEABLE"},
+        behind_by={"bot/impl-8": 3},
+        failing={8: False},
+        live=True,
+    )
+    stale_actions = [a for a in result.actions if a.kind == HEAL_KIND_STALE_BASE_REBASE]
+    assert len(stale_actions) == 0
+    assert rb.calls == []
+
+
+def test_mergeable_current_pr_not_touched() -> None:
+    """A MERGEABLE bot PR that is up-to-date (behind_by=0) is not rebased."""
+    result, forge, rb = _run(
+        [_pr(8, "bot/impl-8")],
+        mergeables={8: "MERGEABLE"},
+        behind_by={"bot/impl-8": 0},
+        failing={8: False},
+        live=True,
+    )
+    assert result.actions == ()
+    assert rb.calls == []
+
+
+# ── Double-action guard (cross-pass) ──────────────────────────────────────────
+
+def test_conflicting_pr_not_double_actioned_by_pass_c() -> None:
+    """A PR actioned by Pass A (conflict-rebase) is NOT also actioned by Pass C."""
+    # PR 7 is CONFLICTING → Pass A will rebase it.
+    # From Pass C's perspective, a CONFLICTING PR has mergeable != MERGEABLE, so
+    # it won't appear in prs_for_stale anyway — but we add it to behind_by to
+    # confirm the guard is in place even if the planner inputs were artificially
+    # constructed to include it.
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        behind_by={"bot/impl-7": 5},
+        failing={7: False},
+        live=True,
+    )
+    stale_actions = [a for a in result.actions if a.kind == HEAL_KIND_STALE_BASE_REBASE]
+    assert len(stale_actions) == 0, (
+        "CONFLICTING PR should not be double-actioned by stale-base pass"
+    )
+    conflict_actions = [a for a in result.actions if a.kind == HEAL_KIND_CONFLICT_REBASE]
+    assert len(conflict_actions) == 1
+
+
+def test_pass_a_action_appears_before_pass_c_in_combined() -> None:
+    """When both Pass A and Pass C have candidates, Pass A actions precede Pass C."""
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7"), _pr(8, "bot/impl-8")],
+        mergeables={7: "CONFLICTING", 8: "MERGEABLE"},
+        behind_by={"bot/impl-8": 3},
+        failing={8: True},  # behind + failing → stale-base candidate
+        live=False,  # shadow: just check action order
+    )
+    kinds = [a.kind for a in result.actions]
+    assert HEAL_KIND_CONFLICT_REBASE in kinds
+    assert HEAL_KIND_STALE_BASE_REBASE in kinds
+    a_idx = next(i for i, k in enumerate(kinds) if k == HEAL_KIND_CONFLICT_REBASE)
+    c_idx = next(i for i, k in enumerate(kinds) if k == HEAL_KIND_STALE_BASE_REBASE)
+    assert a_idx < c_idx, "Pass A actions must appear before Pass C actions"
+
+
+# ── Escalate action ──────────────────────────────────────────────────────────
+
+def test_escalate_action_adds_needs_human_and_comment() -> None:
+    """An escalate action adds the needs-human label and a comment on the PR."""
+    # Exhaust retry cap so the planner escalates
+    state = {"retry_tracker": {"pr-7": {"retries": 2, "last_retry": NOW}}}
+    result, forge, rb = _run(
+        [_pr(7, "bot/impl-7")],
+        mergeables={7: "CONFLICTING"},
+        state=state,
+        live=True,
+    )
+    # No rebase should have been attempted (escalate, not act)
+    assert rb.calls == []
+    assert any(label == "needs-human" for _, label in forge.labels_added)
+    assert len(forge.comments) >= 1

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -34,6 +34,9 @@ BOX_CONFIG_ALLOWLIST = frozenset(
         "SELFHEAL_LIVE",
         "OBSERVATION_LIVE",
         "STRATEGY_AUDIT_LIVE",
+        "MERGE_LANE_HEAL_LIVE",
+        "MERGE_LANE_HEAL_INTERVAL_SECONDS",
+        "META_REPO",
         "POLL_INTERVAL_SECONDS",
         "MAX_FILES",
         "FORGE_KIND",
@@ -82,6 +85,10 @@ DEFAULT_SELFHEAL_INTERVAL_SECONDS = 1800
 DEFAULT_SUPERVISOR_INTERVAL_SECONDS = 14400
 DEFAULT_OBSERVATION_INTERVAL_SECONDS = 28800
 DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS = 86400
+# Merge-lane-heal: 6h, matching the retired conflict-heal.yml cron (01/07/13/19).
+DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS = 21600
+# The meta repo (the pipeline's own repo) — merge-lane-heal heals BOTH repos.
+DEFAULT_META_REPO = "atvirokodosprendimai/ai-pipeline-template"
 
 
 @dataclass(frozen=True)
@@ -127,6 +134,9 @@ class Config:
     selfheal_live: bool = False
     observation_live: bool = False
     strategy_audit_live: bool = False
+    merge_lane_heal_interval_seconds: int = DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS
+    merge_lane_heal_live: bool = False
+    meta_repo: str = DEFAULT_META_REPO
     # Executor backend: 'goose' (default) or 'langchain' (U2).
     # Selected via EXECUTOR env var; factory in executor.py fails closed on unknown values.
     executor: str = "goose"
@@ -256,6 +266,13 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         selfheal_live=_get_bool(source, "SELFHEAL_LIVE", False),
         observation_live=_get_bool(source, "OBSERVATION_LIVE", False),
         strategy_audit_live=_get_bool(source, "STRATEGY_AUDIT_LIVE", False),
+        merge_lane_heal_interval_seconds=_get_int(
+            source,
+            "MERGE_LANE_HEAL_INTERVAL_SECONDS",
+            DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS,
+        ),
+        merge_lane_heal_live=_get_bool(source, "MERGE_LANE_HEAL_LIVE", False),
+        meta_repo=_get_nonempty(source, "META_REPO") or DEFAULT_META_REPO,
         executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
         graph_impl=(_get_nonempty(source, "GRAPH_IMPL") or "legacy").strip().lower(),
     )
@@ -319,6 +336,7 @@ def _log_control_loop_module_modes(cfg: Config) -> None:
         ("selfheal", cfg.selfheal_live),
         ("observation", cfg.observation_live),
         ("strategy_audit", cfg.strategy_audit_live),
+        ("merge_lane", cfg.merge_lane_heal_live),
     ):
         log.info(
             "control_loop: module=%s startup_mode=%s",

--- a/pipeline/wgmesh_pipeline/control_loop/__init__.py
+++ b/pipeline/wgmesh_pipeline/control_loop/__init__.py
@@ -27,7 +27,7 @@ import asyncio
 import hashlib
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence
@@ -36,7 +36,13 @@ from wgmesh_pipeline.config import Config
 from wgmesh_pipeline.control_loop.executor import ExecutionResult, execute_actions
 from wgmesh_pipeline.forge.protocol import Forge
 from wgmesh_pipeline.observation import ObservationPlan, plan_actions
-from wgmesh_pipeline.selfheal import SelfHealInputs, SelfHealRun, run_self_heal
+from wgmesh_pipeline.selfheal import (
+    MergeLaneHealRun,
+    SelfHealInputs,
+    SelfHealRun,
+    run_merge_lane_heal,
+    run_self_heal,
+)
 
 # The gather modules import wgmesh_pipeline.control_loop.executor, so importing
 # them at module top creates a circular import (this package's __init__ would
@@ -74,6 +80,13 @@ SHADOW_REASON = "module not flipped live"
 SUPERVISOR_STATE_KEY = "supervisor-rank-state"
 SELFHEAL_STATE_KEY = "pipeline-health-state"
 STRATEGY_AUDIT_STATE_KEY = "strategy-audit-baseline"
+# Merge-lane-heal persists a separate retry-tracker per repo (the module heals
+# BOTH the seed and the meta repo each cycle), mirroring the retired cron's
+# per-repo state files.
+MERGE_LANE_STATE_KEY_BY_LABEL = {
+    "seed": "merge-lane-heal-state-seed",
+    "meta": "merge-lane-heal-state-meta",
+}
 
 # pipeline-health state keys that change every run regardless of material
 # activity (timestamps/counters). Excluded from the selfheal material
@@ -99,6 +112,20 @@ SelfHealPlanner = Callable[[Forge, SelfHealInputs], SelfHealRun]
 StrategyTextReader = Callable[[], str | None]
 NowProvider = Callable[[], str]
 ActionExecutor = Callable[[Forge, object, Sequence[Any]], list[ExecutionResult]]
+MergeLanePlanner = Callable[..., MergeLaneHealRun]
+# (config, repo_slug) -> a GitHub client for that repo. Injectable so tests
+# drive merge-lane-heal with a fake forge instead of real HTTP.
+MergeLaneClientFactory = Callable[[Config, str], Any]
+
+
+def _default_merge_lane_client(config: Config, repo_slug: str) -> Any:
+    """Build a GitHub client bound to ``repo_slug``. Merge-lane-heal always
+    targets GitHub (PRs live there even when the seed forge is Quackback), so
+    this constructs a GitHubClient directly rather than reusing ``self.forge``.
+    Imported lazily to avoid a control_loop ↔ github.client import cycle."""
+    from wgmesh_pipeline.github.client import GitHubClient
+
+    return GitHubClient(replace(config, target_repo=repo_slug))
 
 
 def _utc_now_iso() -> str:
@@ -179,6 +206,8 @@ class ControlLoopScheduler:
     strategy_http_get: HttpGet | None = None
     now_provider: NowProvider = _utc_now_iso
     action_executor: ActionExecutor = execute_actions
+    merge_lane_planner: MergeLanePlanner = run_merge_lane_heal
+    merge_lane_client_factory: MergeLaneClientFactory = _default_merge_lane_client
     _tasks: list[ModuleTask] = field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
@@ -200,6 +229,11 @@ class ControlLoopScheduler:
                 "strategy_audit",
                 self.config.strategy_audit_interval_seconds,
                 self._cycle_strategy_audit,
+            ),
+            ModuleTask(
+                "merge_lane",
+                self.config.merge_lane_heal_interval_seconds,
+                self._cycle_merge_lane,
             ),
         ]
         for task in self._tasks:
@@ -241,6 +275,7 @@ class ControlLoopScheduler:
             "selfheal": self.config.selfheal_live,
             "observation": self.config.observation_live,
             "strategy_audit": self.config.strategy_audit_live,
+            "merge_lane": self.config.merge_lane_heal_live,
         }
         try:
             return live_by_module[module_name]
@@ -516,3 +551,58 @@ class ControlLoopScheduler:
             result.persisted,
             result.metrics.paid_fetch_status,
         )
+
+    async def _cycle_merge_lane(self) -> None:
+        """Merge-lane-heal across BOTH repos (seed + meta). PRs always live on
+        GitHub even when the seed forge is Quackback, so this builds a dedicated
+        GitHub client per repo (not ``self.forge``). Shadow plans + logs but
+        executes nothing; live rebases/re-arms via the forge + ``rebase.sh`` and
+        persists the per-repo retry tracker on material activity. One repo
+        raising is caught by ``_run_task`` and never blocks the other."""
+        live = self._module_live("merge_lane")
+        # No bot token → no PR reads/writes possible on either repo. Skip the
+        # whole cycle (also keeps tests, which carry no PAT, off the network).
+        if not self.config.wgmesh_bot_pat:
+            self.log.info(
+                "control_loop: module=merge_lane mode=%s skipped=true "
+                "reason=no-bot-token planned_actions=0 executed=0",
+                LIVE if live else SHADOW,
+            )
+            return
+        now = self.now_provider()
+        for label, repo_slug in (
+            ("seed", self.config.target_repo),
+            ("meta", self.config.meta_repo),
+        ):
+            # Per-repo isolation: one repo's HTTP/rebase failure is logged and
+            # never blocks the other (and never the scheduler — _run_task wraps).
+            try:
+                client = self.merge_lane_client_factory(self.config, repo_slug)
+                state_key = MERGE_LANE_STATE_KEY_BY_LABEL[label]
+                prev_state = self._load_state(state_key) or {}
+                run: MergeLaneHealRun = self.merge_lane_planner(
+                    client, prev_state, now, live=live, repo_label=label
+                )
+            except Exception as exc:  # noqa: BLE001 — loud log, isolate the repo
+                self.log.exception(
+                    "control_loop: module=merge_lane repo=%s cycle failed: %s",
+                    label,
+                    exc,
+                )
+                continue
+            action_kinds = [a.kind for a in run.actions]
+            persisted = False
+            if live and run.actions:  # material = something planned/executed
+                fingerprint = _material_fingerprint(run.state, exclude=frozenset())
+                persisted = self._save_state(state_key, run.state, fingerprint)
+            self.log.info(
+                "control_loop: module=merge_lane repo=%s mode=%s "
+                "planned_actions=%s top_actions=%s executed=%s persisted=%s%s",
+                label,
+                LIVE if live else SHADOW,
+                len(run.actions),
+                action_kinds[:3],
+                run.executed,
+                persisted,
+                "" if live else ' reason="module not flipped live"',
+            )

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -175,6 +175,39 @@ class GitHubClient:
             for s in statuses
         )
 
+    def list_open_pull_requests(
+        self, *, per_page: int = 100, max_prs: int = 200
+    ) -> list[dict[str, Any]]:
+        """All open pull requests: ``[{number, headRefName}]``.
+
+        Paginates up to ``max_prs`` PRs total (sane cap; the box's repos are
+        small). Used by the merge-lane-heal module to build the gather set from
+        which the three planners (conflict/rearm/stale-base) select their
+        candidates. Returns plain dicts so callers can augment them without
+        mutating the API object."""
+        owner = self.config.owner
+        results: list[dict[str, Any]] = []
+        page = 1
+        while len(results) < max_prs:
+            batch = self._request(
+                "GET",
+                f"/repos/{owner}/{self.config.repo}/pulls",
+                params={"state": "open", "per_page": per_page, "page": page},
+            )
+            if not isinstance(batch, list) or not batch:
+                break
+            for item in batch:
+                results.append({
+                    "number": int(item["number"]),
+                    "headRefName": str(item.get("head", {}).get("ref") or ""),
+                })
+                if len(results) >= max_prs:
+                    break
+            if len(batch) < per_page:
+                break
+            page += 1
+        return results
+
     def find_open_pr_number(self, head_branch: str) -> int | None:
         """Open PR number for a head branch, or None. Used to make spec PR
         creation idempotent: a retry after a partial run hits create_pr 422

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -156,7 +156,7 @@ class GitHubClient:
         """True iff any check on the PR's head commit concluded FAILURE — the
         stale-base-heal 'broken' signal. Covers both the Checks API
         (Actions, e.g. build-test) and legacy commit statuses, matching the
-        ``gh ... statusCheckRollup`` the Actions executor used."""
+        ``statusCheckRollup`` the retired Actions executor read via its CLI."""
         head_sha = (self.get_pr(number).get("head") or {}).get("sha")
         if not head_sha:
             return False

--- a/pipeline/wgmesh_pipeline/github/client.py
+++ b/pipeline/wgmesh_pipeline/github/client.py
@@ -134,6 +134,47 @@ class GitHubClient:
             return None
         return "CONFLICTING" if mergeable is False else "MERGEABLE"
 
+    def compare_behind_by(self, head_branch: str, *, base: str = "main") -> int:
+        """Commits ``head_branch`` is behind ``base`` (GitHub compare
+        ``behind_by``). The stale-base-heal 'stale tree' signal: a branch cut
+        before a since-merged fix is behind main. A deleted branch / 404 /
+        missing field resolves to 0 — not a rebase candidate."""
+        owner = self.config.owner
+        try:
+            resp = self._request(
+                "GET",
+                f"/repos/{owner}/{self.config.repo}/compare/{base}...{head_branch}",
+            )
+        except requests.HTTPError as exc:
+            if getattr(exc.response, "status_code", None) == 404:
+                return 0
+            raise
+        behind = resp.get("behind_by") if isinstance(resp, dict) else None
+        return int(behind) if isinstance(behind, int) else 0
+
+    def pr_has_failing_check(self, number: int) -> bool:
+        """True iff any check on the PR's head commit concluded FAILURE — the
+        stale-base-heal 'broken' signal. Covers both the Checks API
+        (Actions, e.g. build-test) and legacy commit statuses, matching the
+        ``gh ... statusCheckRollup`` the Actions executor used."""
+        head_sha = (self.get_pr(number).get("head") or {}).get("sha")
+        if not head_sha:
+            return False
+        owner = self.config.owner
+        base = f"/repos/{owner}/{self.config.repo}/commits/{head_sha}"
+        runs = self._request("GET", f"{base}/check-runs")
+        check_runs = runs.get("check_runs") or [] if isinstance(runs, dict) else []
+        if any(
+            str(r.get("conclusion") or "").upper() == "FAILURE" for r in check_runs
+        ):
+            return True
+        status = self._request("GET", f"{base}/status")
+        statuses = status.get("statuses") or [] if isinstance(status, dict) else []
+        return any(
+            str(s.get("state") or "").lower() in ("failure", "error")
+            for s in statuses
+        )
+
     def find_open_pr_number(self, head_branch: str) -> int | None:
         """Open PR number for a head branch, or None. Used to make spec PR
         creation idempotent: a retry after a partial run hits create_pr 422

--- a/pipeline/wgmesh_pipeline/selfheal/__init__.py
+++ b/pipeline/wgmesh_pipeline/selfheal/__init__.py
@@ -48,11 +48,13 @@ from wgmesh_pipeline.selfheal.models import (
     CheckRearmPlan,
     ConflictHealPlan,
     HealAction,
+    MergeLaneHealRun,
     SelfHealInputs,
     SelfHealRun,
     StaleBaseHealPlan,
     SweepOutcome,
 )
+from wgmesh_pipeline.selfheal.merge_lane import run_merge_lane_heal
 from wgmesh_pipeline.selfheal.rearm import plan_check_rearm
 from wgmesh_pipeline.selfheal.retry_policy import Decision, apply_retry_gate
 from wgmesh_pipeline.selfheal.stale_base import plan_stale_base_heal
@@ -91,6 +93,7 @@ __all__ = [
     "ConflictHealPlan",
     "Decision",
     "HealAction",
+    "MergeLaneHealRun",
     "SelfHealInputs",
     "SelfHealRun",
     "StaleBaseHealPlan",
@@ -107,6 +110,7 @@ __all__ = [
     "plan_check_rearm",
     "plan_conflict_heal",
     "plan_stale_base_heal",
+    "run_merge_lane_heal",
     "run_self_heal",
     "sweep_needs_human",
     "sweep_stale_approved",

--- a/pipeline/wgmesh_pipeline/selfheal/merge_lane.py
+++ b/pipeline/wgmesh_pipeline/selfheal/merge_lane.py
@@ -1,0 +1,332 @@
+"""Box-native merge-lane-heal module (U2).
+
+Replaces the ``conflict-heal.yml`` Actions cron on the box control loop
+(project_actions_cicd_only_retarget). Runs the same three-pass logic as the
+cron but via the forge client instead of the ``gh`` CLI:
+
+  Pass A — CONFLICTING bot PRs → rebase onto main (``conflict_rebase``).
+  Pass B — MERGEABLE bot fix PRs with absent required judge check → re-arm
+           (enable auto-merge + push an empty commit, ``check_rearm``).
+  Pass C — MERGEABLE bot PRs behind main with no failing check → rebase onto
+           main (``stale_base_rebase``).
+
+A PR actioned by an earlier pass is not double-actioned by a later one (set
+membership guard on ``actioned`` PR numbers).
+
+Side effects are injected (``forge`` duck-typed, ``rebase_fn`` injectable)
+so all logic is unit-testable without real network or subprocess calls.
+
+The module is INERT until ``MERGE_LANE_HEAL_LIVE=true`` (U4 cutover); shadow
+mode (``live=False``) plans actions and returns the would-be state but
+executes nothing — zero forge mutations.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.selfheal.conflict import plan_conflict_heal
+from wgmesh_pipeline.selfheal.models import (
+    CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    HEAL_KIND_CHECK_REARM,
+    HEAL_KIND_CONFLICT_REBASE,
+    HEAL_KIND_STALE_BASE_REBASE,
+    REARM_RECHECK_COOLDOWN_HOURS,
+    HealAction,
+    MergeLaneHealRun,
+    shift,
+    tracker_entry,
+)
+from wgmesh_pipeline.selfheal.rearm import DEFAULT_REQUIRED_CONTEXT, plan_check_rearm
+from wgmesh_pipeline.selfheal.stale_base import plan_stale_base_heal
+
+# Injected callable types (duck-typed, no concrete imports)
+RebaseFn = Callable[[str, int, str], str]   # (repo, pr_number, branch) -> OUTCOME= line
+
+# Real rebase implementation: wraps company/scripts/conflict-heal/rebase.sh.
+# Injected by the caller so tests can swap in a fake.
+_REBASE_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "company" / "scripts" / "conflict-heal" / "rebase.sh"
+)
+
+BOT_BRANCH_PREFIX = "bot/"
+MERGEABLE = "MERGEABLE"
+CONFLICTING = "CONFLICTING"
+
+
+def _real_rebase(repo: str, number: int, branch: str) -> str:
+    """Shell out to rebase.sh (bot-branch guard + --force-with-lease).
+    Returns the last non-empty stdout line which contains ``OUTCOME=...``."""
+    out = subprocess.run(
+        ["bash", str(_REBASE_SCRIPT), repo, str(number), branch],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    lines = [l for l in out.splitlines() if l.strip()]
+    return lines[-1] if lines else ""
+
+
+def _parse_outcome(line: str) -> str:
+    """Extract ``OUTCOME=<slug>`` from a rebase.sh result line."""
+    for token in line.split():
+        if token.startswith("OUTCOME="):
+            return token.split("=", 1)[1]
+    return "unknown"
+
+
+def run_merge_lane_heal(
+    forge: Any,
+    state: Mapping[str, Any],
+    now: str,
+    *,
+    live: bool,
+    rebase_fn: RebaseFn = _real_rebase,
+    repo_label: str = "seed",
+    escalate_cooldown_hours: float = CONFLICT_ESCALATE_COOLDOWN_HOURS,
+    required_context: str = DEFAULT_REQUIRED_CONTEXT,
+) -> MergeLaneHealRun:
+    """Plan (and, when ``live``, execute) one merge-lane-heal cycle.
+
+    Gather
+    ------
+    List all open PRs via ``forge.list_open_pull_requests()`` → ``[{number,
+    headRefName}]``. For each bot/* PR:
+      - resolve ``mergeable`` via ``forge.get_pr_mergeable(number)``
+      - for MERGEABLE-only: resolve ``behindBy`` + ``hasFailingCheck``
+
+    Plan (pure, A→B→C)
+    ------------------
+    Run the three pure planners in order, collecting a combined action list.
+    Track which PR numbers have already been actioned; later passes skip
+    already-actioned numbers (no double-action).
+
+    Execute (only when ``live`` is True)
+    ------------------------------------
+    For each action apply the forge mutation + ``rebase_fn``. Mirrors the
+    outcome handling in ``conflict-heal/run.py`` and ``check-rearm/run.py``:
+      - ``conflict_rebase`` / ``stale_base_rebase``:
+          rebased → pop tracker (clean reset)
+          empty   → escalate (content already in main) + cooldown
+          conflict → increment retries
+      - ``check_rearm``:
+          rearmed → record attempt + recheck cooldown
+          error   → record attempt + recheck cooldown
+      - ``escalate``: add needs-human label + comment
+
+    Shadow
+    ------
+    When ``live`` is False, execute NOTHING — return the planned actions and
+    the tracker that *would* have been written. The caller decides whether to
+    persist state (shadow mode: skip).
+
+    Returns a ``MergeLaneHealRun`` with the planned actions, the new state
+    dict, the executed count, and the ``dry_run`` flag (inverted ``live``).
+    """
+    # ── Gather ────────────────────────────────────────────────────────────────
+    raw_prs: list[dict[str, Any]] = forge.list_open_pull_requests()
+
+    # Build enriched PR dicts for the planners.  Only resolve the expensive
+    # per-PR mergeability/behindBy/hasFailingCheck for bot/* branches.
+    prs_for_conflict: list[dict[str, Any]] = []
+    prs_for_rearm: list[dict[str, Any]] = []
+    prs_for_stale: list[dict[str, Any]] = []
+
+    for raw in raw_prs:
+        number: int = raw["number"]
+        head: str = raw.get("headRefName") or ""
+        if not head.startswith(BOT_BRANCH_PREFIX):
+            continue  # never touch human PRs in any pass
+
+        mergeable = forge.get_pr_mergeable(number)
+
+        # Pass A input: conflict planner needs number + headRefName + mergeable
+        prs_for_conflict.append({
+            "number": number,
+            "headRefName": head,
+            "mergeable": mergeable,
+        })
+
+        # Passes B+C only care about MERGEABLE PRs
+        if mergeable != MERGEABLE:
+            continue
+
+        behind_by: int = forge.compare_behind_by(head)
+        has_failing: bool = forge.pr_has_failing_check(number)
+
+        # Pass B input: rearm planner needs number + headRefName + mergeable +
+        # title + isDraft + present_contexts.  We don't carry title/isDraft here
+        # (the box gather doesn't fetch them); use empty title so the FIX_TITLE
+        # prefix check in the planner filters them.  The planner only acts on
+        # "fix: Issue #" PRs, and title is available if needed in a future
+        # revision; for now pass it through as an empty default — the rearm
+        # planner skips non-fix-titled PRs, which is correct.
+        prs_for_rearm.append({
+            "number": number,
+            "headRefName": head,
+            "mergeable": mergeable,
+            "title": raw.get("title", ""),
+            "isDraft": raw.get("isDraft", False),
+            "present_contexts": raw.get("present_contexts", set()),
+        })
+
+        # Pass C input: stale_base planner needs number + headRefName +
+        # mergeable + behindBy + hasFailingCheck
+        prs_for_stale.append({
+            "number": number,
+            "headRefName": head,
+            "mergeable": mergeable,
+            "behindBy": behind_by,
+            "hasFailingCheck": has_failing,
+        })
+
+    # ── Plan (A→B→C, with double-action guard) ────────────────────────────────
+    tracker_in: dict[str, Any] = dict(state.get("retry_tracker") or {})
+
+    plan_a = plan_conflict_heal(
+        prs_for_conflict, tracker_in, now,
+        dry_run=not live,
+        escalate_cooldown_hours=escalate_cooldown_hours,
+    )
+    actioned: set[int] = {
+        int(a.number) for a in plan_a.actions if a.number is not None
+    }
+
+    plan_b = plan_check_rearm(
+        prs_for_rearm, plan_a.tracker, now,
+        required_context=required_context,
+        dry_run=not live,
+        escalate_cooldown_hours=escalate_cooldown_hours,
+    )
+    # Drop Pass B actions for PRs already actioned by Pass A
+    b_actions = tuple(
+        a for a in plan_b.actions
+        if a.number is None or int(a.number) not in actioned
+    )
+    actioned.update(
+        int(a.number) for a in b_actions if a.number is not None
+    )
+    # Carry forward the tracker from B (which already incorporates A's tracker)
+    # but rebuild it only for the non-dropped actions
+    tracker_after_b = dict(plan_b.tracker)
+
+    plan_c = plan_stale_base_heal(
+        prs_for_stale, tracker_after_b, now,
+        dry_run=not live,
+        escalate_cooldown_hours=escalate_cooldown_hours,
+    )
+    # Drop Pass C actions for PRs already actioned by Pass A or B
+    c_actions = tuple(
+        a for a in plan_c.actions
+        if a.number is None or int(a.number) not in actioned
+    )
+
+    all_actions: tuple[HealAction, ...] = (
+        plan_a.actions + b_actions + c_actions
+    )
+    # The final tracker from Pass C incorporates all three passes
+    tracker_out: dict[str, Any] = dict(plan_c.tracker)
+
+    new_state: dict[str, Any] = {"retry_tracker": tracker_out}
+    executed = 0
+
+    if not live:
+        # Shadow: return planned actions + would-be state, execute nothing.
+        return MergeLaneHealRun(
+            actions=all_actions,
+            state=new_state,
+            executed=0,
+            dry_run=True,
+        )
+
+    # ── Execute ───────────────────────────────────────────────────────────────
+    for action in all_actions:
+        number = int(action.number) if action.number is not None else None
+        key = f"pr-{number}" if number is not None else None
+        entry = tracker_entry(tracker_out, key) if key else {}
+
+        if action.kind == "escalate":
+            _escalate(forge, number, action.comment or "Merge-lane heal escalation.")
+            executed += 1
+            continue
+
+        if action.kind in (HEAL_KIND_CONFLICT_REBASE, HEAL_KIND_STALE_BASE_REBASE):
+            assert number is not None and key is not None
+            # Resolve branch name from the gathered PR list
+            head = _head_for(prs_for_conflict + prs_for_stale, number)
+            # Forge doesn't carry a repo slug — build from config if available
+            repo = getattr(getattr(forge, "config", None), "target_repo", "")
+            outcome = _parse_outcome(rebase_fn(repo, number, head))
+            if outcome == "rebased":
+                tracker_out.pop(key, None)   # R5: clean reset on success
+            elif outcome == "empty":
+                _escalate(
+                    forge, number,
+                    "Merge-lane heal: this PR's content already merged to main "
+                    "(empty after rebase). A human should close it.",
+                )
+                tracker_out[key] = {
+                    **entry, "cooldown_until": shift(now, hours=escalate_cooldown_hours)
+                }
+            elif outcome == "conflict":
+                retries = int(entry.get("retries") or 0) + 1
+                tracker_out[key] = {
+                    **entry, "retries": retries, "last_retry": now,
+                    "action": action.kind,
+                }
+            else:
+                print(
+                    f"::warning::merge-lane-heal rebase PR #{number} "
+                    f"returned OUTCOME={outcome}; no tracker change"
+                )
+            executed += 1
+            continue
+
+        if action.kind == HEAL_KIND_CHECK_REARM:
+            assert number is not None and key is not None
+            head = _head_for(prs_for_rearm, number)
+            repo = getattr(getattr(forge, "config", None), "target_repo", "")
+            # KTD2: enable auto-merge FIRST, then push the empty commit
+            forge.enable_auto_merge(number)
+            outcome = _parse_outcome(rebase_fn(repo, number, head))
+            if outcome in ("rearmed", "error"):
+                retries = int(entry.get("retries") or 0) + 1
+                tracker_out[key] = {
+                    **entry, "retries": retries, "last_retry": now,
+                    "action": HEAL_KIND_CHECK_REARM,
+                    "cooldown_until": shift(now, hours=REARM_RECHECK_COOLDOWN_HOURS),
+                }
+            else:
+                print(
+                    f"::warning::merge-lane-heal re-arm PR #{number} "
+                    f"returned OUTCOME={outcome}; no tracker change"
+                )
+            executed += 1
+            continue
+
+    new_state = {"retry_tracker": tracker_out}
+    return MergeLaneHealRun(
+        actions=all_actions,
+        state=new_state,
+        executed=executed,
+        dry_run=False,
+    )
+
+
+# ── Private helpers ────────────────────────────────────────────────────────────
+
+def _escalate(forge: Any, number: int | None, comment: str) -> None:
+    """Add needs-human label + comment on a PR via the forge client."""
+    if number is None:
+        return
+    forge.add_label(number, "needs-human")
+    forge.comment(number, comment)
+
+
+def _head_for(prs: list[dict[str, Any]], number: int) -> str:
+    """Return headRefName for ``number`` from a pre-gathered PR list, or ''."""
+    for pr in prs:
+        if int(pr["number"]) == number:
+            return str(pr.get("headRefName") or "")
+    return ""

--- a/pipeline/wgmesh_pipeline/selfheal/models.py
+++ b/pipeline/wgmesh_pipeline/selfheal/models.py
@@ -160,6 +160,18 @@ class StaleBaseHealPlan:
     dry_run: bool = False
 
 
+@dataclass(frozen=True)
+class MergeLaneHealRun:
+    """Box-native merge-lane-heal runner outcome: planned actions (all three
+    passes combined), the new state dict, how many actions were actually
+    executed, and whether this was a shadow/dry run (``live=False``)."""
+
+    actions: tuple[HealAction, ...] = ()
+    state: dict[str, Any] = field(default_factory=dict)
+    executed: int = 0
+    dry_run: bool = True
+
+
 def parse_iso(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
 


### PR DESCRIPTION
Moves merge-lane-heal (conflict-rebase + check-rearm + stale-base-rebase) off the `conflict-heal.yml` Actions cron onto the box control loop, per the **Actions = CI/CD only** principle (*"autobox is just another developer"*). Operator decisions: scope = merge-lane-heal only (pipeline-health stays); box heals **both** repos.

Plan: `docs/plans/2026-06-22-001-merge-lane-heal-to-box-plan.md`.

**Everything here is INERT** — `MERGE_LANE_HEAL_LIVE` defaults `false`, so the new module runs each cycle in **shadow** (plans + logs, executes nothing). The Actions cron stays the sole live executor until the separate operator-gated cutover (U4: flip the flag on the box + disable the cron in the same step).

## Units
- **U1** — forge REST accessors `compare_behind_by` + `pr_has_failing_check` (replace the gh CLI the Actions executor used). Duck-typed; no Forge-protocol change.
- **U2** — `selfheal/merge_lane.py::run_merge_lane_heal`: gather PRs via forge REST → 3 pure planners A→B→C on a shared tracker with a double-action guard → shadow returns plan-only, live executes via forge + `rebase.sh`. + `list_open_pull_requests`, `MergeLaneHealRun`.
- **U3** — wire as the 5th `ControlLoopScheduler` module (reuses interval/`*_LIVE` gate/state-persistence infra). Heals both repos via an injectable client factory (PRs always live on GitHub even when the seed forge is Quackback). Per-repo try/except; **skips entirely when no bot token** (keeps token-less CI off the network). `MERGE_LANE_HEAL_LIVE` / `MERGE_LANE_HEAL_INTERVAL_SECONDS` (6h) / `META_REPO` config.

## Tests
Forge accessors (9) + list-prs (5) + merge_lane module (12) + control-loop wiring (2, incl. both-repos-shadow + skipped-without-token). Full control_loop/config/selfheal/merge_lane sweep green (257 passed).

## Known gap (follow-up)
`list_open_pull_requests` carries no title/checks → Pass B (check-rearm) is gather-degraded on the box (planner skips empty-title PRs). Pass A (conflict) + Pass C (stale-base) fully functional. check-rearm is mostly historical (judge-orphan backlog), low-impact — enrich the gather later.