### PR TITLE
feat: cloudroof service funnel — surface-gate inversion + 2nd instance (U3–U5)

### DIFF
--- a/.github/workflows/install-cloudroof-instance.yml
+++ b/.github/workflows/install-cloudroof-instance.yml
@@ -1,0 +1,168 @@
+name: Install Cloudroof Instance
+
+# Stand up the SECOND co-resident pipeline instance (cloudroof-pipeline) on the
+# EXISTING box — NON-DESTRUCTIVE. Unlike "Provision Pipeline Box" (which recreates
+# the server and would kill the wgmesh instance), this only adds the 2nd unit:
+# writes /etc/cloudroof-pipeline/env, clones /opt/cloudroof-checkout, installs +
+# enables cloudroof-pipeline.service. Reuses the wgmesh code install + venv
+# (/opt/wgmesh-pipeline) — KTD1: 2nd instance, not a multi-repo refactor.
+#
+# Prereq: the wgmesh box is already provisioned (Provision Pipeline Box) — this
+# fails loudly if /opt/wgmesh-pipeline/.venv is absent.
+#
+# Auth: DEPLOY_SSH_KEY (box deploy key, same as Update/Set-Env). Starts in shadow.
+#
+# Required secrets:
+#   DEPLOY_SSH_KEY        — box SSH (deploy keypair)
+#   HCLOUD_TOKEN    (org) — resolve box IP
+#   ANTHROPIC_API_KEY     — z.ai/GLM key (→ ZAI_API_KEY); shared with wgmesh
+#   CLOUDROOF_BOT_PAT     — fine-grained PAT scoped to cloudroof-eu (read+write);
+#                           required for spec-only/live, omitted in shadow
+# Optional (shared multi-model routing + observability; absent → single z.ai model):
+#   OPENROUTER_API_KEY / DEEPSEEK_API_KEY / OPENAI_API_KEY / MINIMAX_API_KEY
+#   MODEL_REGISTRY / STAGE_ROUTING
+#   LANGFUSE_HOST / LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+#   GITGUARDIAN_API_KEY
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: 'Hetzner server name (same box as wgmesh)'
+        default: 'wgmesh-pipeline'
+      pipeline_mode:
+        description: 'PIPELINE_MODE (start in shadow)'
+        default: 'shadow'
+      poll_interval:
+        description: 'POLL_INTERVAL_SECONDS'
+        default: '300'
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate secrets
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLOUDROOF_BOT_PAT: ${{ secrets.CLOUDROOF_BOT_PAT }}
+          MODE: ${{ github.event.inputs.pipeline_mode }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
+          : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+          : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY secret missing (the z.ai key)}"
+          # spec-only/live perform real cloudroof-eu writes — require the PAT.
+          if [ "${MODE}" != "shadow" ]; then
+            : "${CLOUDROOF_BOT_PAT:?CLOUDROOF_BOT_PAT required for pipeline_mode=${MODE} (real cloudroof-eu writes)}"
+          fi
+
+      - name: Install hcloud CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz \
+            | tar xz hcloud
+          sudo mv hcloud /usr/local/bin/
+
+      - name: Resolve box IP
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+        run: |
+          set -euo pipefail
+          IP=$(hcloud server ip "${{ github.event.inputs.server_name }}")
+          echo "BOX_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Write cloudroof env (over SSH — secrets never touch metadata)
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLOUDROOF_BOT_PAT: ${{ secrets.CLOUDROOF_BOT_PAT }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          MODEL_REGISTRY: ${{ secrets.MODEL_REGISTRY }}
+          STAGE_ROUTING: ${{ secrets.STAGE_ROUTING }}
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          MAX_ESCALATION_ATTEMPTS: ${{ vars.MAX_ESCALATION_ATTEMPTS }}
+          MODE: ${{ github.event.inputs.pipeline_mode }}
+          PINT: ${{ github.event.inputs.poll_interval }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+            "install -d -m 700 /etc/cloudroof-pipeline; umask 077; cat > /etc/cloudroof-pipeline/env" <<EOF
+          PIPELINE_MODE=$MODE
+          TARGET_REPO=atvirokodosprendimai/cloudroof-eu
+          SURFACE_HOME=service
+          CONTROL_LOOP_ENABLED=true
+          WGMESH_BOT_PAT=$CLOUDROOF_BOT_PAT
+          ZAI_API_KEY=$ANTHROPIC_API_KEY
+          ANTHROPIC_HOST=https://api.z.ai/api/anthropic
+          GOOSE_PROVIDER=anthropic
+          GOOSE_MODEL=glm-4.6
+          OPENROUTER_API_KEY=$OPENROUTER_API_KEY
+          DEEPSEEK_API_KEY=$DEEPSEEK_API_KEY
+          OPENAI_API_KEY=$OPENAI_API_KEY
+          MINIMAX_API_KEY=$MINIMAX_API_KEY
+          MODEL_REGISTRY='$MODEL_REGISTRY'
+          STAGE_ROUTING='$STAGE_ROUTING'
+          MAX_ESCALATION_ATTEMPTS=$MAX_ESCALATION_ATTEMPTS
+          GITGUARDIAN_API_KEY=$GITGUARDIAN_API_KEY
+          WGMESH_CHECKOUT_PATH=/opt/cloudroof-checkout
+          DATABASE_MODE=local
+          PIPELINE_DB_PATH=/opt/wgmesh-pipeline/cloudroof-state.db
+          LANGFUSE_HOST=$LANGFUSE_HOST
+          LANGFUSE_PUBLIC_KEY=$LANGFUSE_PUBLIC_KEY
+          LANGFUSE_SECRET_KEY=$LANGFUSE_SECRET_KEY
+          POLL_INTERVAL_SECONDS=${PINT:-300}
+          MAX_FILES=20
+          EOF
+
+      - name: Install unit + checkout + start (shadow)
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          CLOUDROOF_BOT_PAT: ${{ secrets.CLOUDROOF_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+              -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
+              "CLOUDROOF_BOT_PAT=$(printf '%q' "$CLOUDROOF_BOT_PAT") bash -se" <<'REMOTE'
+          set -euo pipefail
+          # The 2nd instance reuses the wgmesh code install + venv — require it.
+          [ -x /opt/wgmesh-pipeline/.venv/bin/python ] || {
+            echo "::error::/opt/wgmesh-pipeline/.venv missing — run Provision Pipeline Box (wgmesh) first"; exit 1; }
+          install -m 0644 /opt/wgmesh-pipeline/pipeline/deploy/cloudroof-pipeline.service /etc/systemd/system/
+          # Clone the cloudroof-eu working tree goose writes into (idempotent).
+          if [ ! -d /opt/cloudroof-checkout/.git ]; then
+            if [ -n "${CLOUDROOF_BOT_PAT:-}" ]; then
+              git clone "https://x-access-token:${CLOUDROOF_BOT_PAT}@github.com/atvirokodosprendimai/cloudroof-eu.git" /opt/cloudroof-checkout
+            else
+              git clone https://github.com/atvirokodosprendimai/cloudroof-eu.git /opt/cloudroof-checkout
+            fi
+          fi
+          chown -R wgmesh:wgmesh /opt/cloudroof-checkout
+          # cloudroof-state.db lives in the shared (RW) code dir; ensure ownership.
+          touch /opt/wgmesh-pipeline/cloudroof-state.db
+          chown wgmesh:wgmesh /opt/wgmesh-pipeline/cloudroof-state.db
+          systemctl daemon-reload
+          systemctl enable --now cloudroof-pipeline
+          sleep 5
+          systemctl --no-pager status cloudroof-pipeline | head -n 12
+          journalctl -u cloudroof-pipeline --no-pager | tail -n 20
+          systemctl is-active --quiet cloudroof-pipeline || { echo "::error::cloudroof-pipeline not active"; exit 1; }
+          REMOTE
+
+      - name: Report
+        run: echo "cloudroof-pipeline installed on $BOX_IP — started in '${{ github.event.inputs.pipeline_mode }}' mode (co-resident with wgmesh)."

--- a/.github/workflows/set-box-env.yml
+++ b/.github/workflows/set-box-env.yml
@@ -18,6 +18,9 @@ on:
       server_name:
         description: 'Hetzner server name'
         default: 'wgmesh-pipeline'
+      service:
+        description: 'Which co-resident instance to reconfigure (wgmesh|cloudroof)'
+        default: 'wgmesh'
       env_set:
         description: 'Comma-separated KEY=VALUE flags (e.g. GRAPH_IMPL=langgraph,PIPELINE_MODE=shadow)'
         required: true
@@ -37,6 +40,22 @@ jobs:
           set -euo pipefail
           : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
           : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Resolve service target (unit + env file)
+        env:
+          SERVICE: ${{ github.event.inputs.service }}
+        run: |
+          set -euo pipefail
+          # Default wgmesh → byte-identical to the pre-parameterization behavior
+          # (unit wgmesh-pipeline, env /etc/wgmesh-pipeline/env). cloudroof is the
+          # 2nd co-resident instance. Any other value fails closed.
+          case "${SERVICE:-wgmesh}" in
+            wgmesh)   UNIT=wgmesh-pipeline;   ENV_FILE=/etc/wgmesh-pipeline/env ;;
+            cloudroof) UNIT=cloudroof-pipeline; ENV_FILE=/etc/cloudroof-pipeline/env ;;
+            *) echo "::error::unknown service '${SERVICE}' (expected wgmesh|cloudroof)"; exit 2 ;;
+          esac
+          echo "UNIT=$UNIT" >> "$GITHUB_ENV"
+          echo "ENV_FILE=$ENV_FILE" >> "$GITHUB_ENV"
 
       - name: Install hcloud CLI
         run: |
@@ -63,12 +82,13 @@ jobs:
           printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
           SSH_ENV_SET=$(printf '%q' "$ENV_SET")
           # UserKnownHostsFile=/dev/null: provision rotates the host key; the
-          # deploy key is the real gate.
+          # deploy key is the real gate. UNIT + ENV_FILE come from the resolve
+          # step (default wgmesh → unchanged).
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
-              "ENV_SET=$SSH_ENV_SET bash -se" <<'REMOTE'
+              "ENV_SET=$SSH_ENV_SET UNIT=$UNIT ENV_FILE=$ENV_FILE bash -se" <<'REMOTE'
           set -euo pipefail
-          ENV_FILE=/etc/wgmesh-pipeline/env
+          : "${UNIT:?}" "${ENV_FILE:?}"
           [ -f "$ENV_FILE" ] || { echo "::error::$ENV_FILE missing — run full provision first"; exit 1; }
 
           IFS=',' read -ra PAIRS <<< "$ENV_SET"
@@ -101,18 +121,18 @@ jobs:
           done
 
           restart_ts=$(date "+%Y-%m-%d %H:%M:%S")
-          systemctl restart wgmesh-pipeline
+          systemctl restart "$UNIT"
           sleep 10
-          if ! systemctl is-active --quiet wgmesh-pipeline; then
+          if ! systemctl is-active --quiet "$UNIT"; then
             echo "::error::service not active after restart"
-            journalctl -u wgmesh-pipeline -n 30 --no-pager
+            journalctl -u "$UNIT" -n 30 --no-pager
             exit 1
           fi
-          if journalctl -u wgmesh-pipeline --since "$restart_ts" --no-pager | grep -q "tick"; then
+          if journalctl -u "$UNIT" --since "$restart_ts" --no-pager | grep -q "tick"; then
             echo "healthy: tick observed after restart"
           else
             echo "::warning::service active but no tick yet — check journal"
-            journalctl -u wgmesh-pipeline -n 30 --no-pager
+            journalctl -u "$UNIT" -n 30 --no-pager
           fi
           REMOTE
 

--- a/.github/workflows/update-pipeline-box.yml
+++ b/.github/workflows/update-pipeline-box.yml
@@ -16,12 +16,19 @@ on:
       server_name:
         description: 'Hetzner server name'
         default: 'wgmesh-pipeline'
+      service:
+        description: 'Which co-resident instance to restart on latest code (wgmesh|cloudroof)'
+        default: 'wgmesh'
   # Reusable so Auto Deploy on Merge can git-reset the box to a green main.
   workflow_call:
     inputs:
       server_name:
         description: 'Hetzner server name'
         default: 'wgmesh-pipeline'
+        type: string
+      service:
+        description: 'Which co-resident instance to restart (wgmesh|cloudroof)'
+        default: 'wgmesh'
         type: string
 
 permissions:
@@ -39,6 +46,21 @@ jobs:
           set -euo pipefail
           : "${DEPLOY_SSH_KEY:?DEPLOY_SSH_KEY secret missing}"
           : "${HCLOUD_TOKEN:?HCLOUD_TOKEN secret missing (org)}"
+
+      - name: Resolve service unit
+        env:
+          SERVICE: ${{ inputs.service }}
+        run: |
+          set -euo pipefail
+          # Both instances share the /opt/wgmesh-pipeline code install; only the
+          # systemd unit restarted differs. Default wgmesh → unchanged (and the
+          # Auto-Deploy-on-Merge caller passes no service, so it stays wgmesh).
+          case "${SERVICE:-wgmesh}" in
+            wgmesh)   UNIT=wgmesh-pipeline ;;
+            cloudroof) UNIT=cloudroof-pipeline ;;
+            *) echo "::error::unknown service '${SERVICE}' (expected wgmesh|cloudroof)"; exit 2 ;;
+          esac
+          echo "UNIT=$UNIT" >> "$GITHUB_ENV"
 
       - name: Install hcloud CLI
         run: |
@@ -87,10 +109,10 @@ jobs:
              echo \"code: \$OLD -> \$NEW\"
              .venv/bin/pip install -q -e '/opt/wgmesh-pipeline/pipeline[turso,trace]'
              chown -R wgmesh:wgmesh /opt/wgmesh-pipeline
-             systemctl restart wgmesh-pipeline
+             systemctl restart $UNIT
              sleep 8
-             systemctl is-active wgmesh-pipeline
-             journalctl -u wgmesh-pipeline -n 5 --no-pager"
+             systemctl is-active $UNIT
+             journalctl -u $UNIT -n 5 --no-pager"
 
       - name: Report
         run: echo "Box updated in place at $BOX_IP — service restarted on latest main."

--- a/docs/runbooks/cloudroof-funnel-cutover.md
+++ b/docs/runbooks/cloudroof-funnel-cutover.md
@@ -1,0 +1,116 @@
+# Runbook — Cloudroof service funnel cutover (U5)
+
+Created: 2026-06-22
+Owner: operator (mints secrets/PAT, runs provision, flips live)
+Plan: `docs/plans/2026-06-22-002-feat-cloudroof-service-funnel-plan.md`
+
+Stands up the **second** co-resident pipeline instance (`cloudroof-pipeline`) on
+the existing box, targeting `cloudroof-eu`, so `surface:service` issues get
+built → PR'd → judge-gated merged → `wrangler deploy`'d to cloudroof.eu. Mirrors
+the merge-lane-heal cutover discipline: **shadow-prove first, then flip live**.
+
+## What's already on main (the code units — inert until provisioned)
+- **U3 surface-gate inversion** — `Config.surface_home` (`SURFACE_HOME` env).
+  Default `product` (wgmesh unchanged); the cloudroof env sets `service` →
+  builds service issues, blocks product/unknown.
+- **U4 2nd instance** — `pipeline/deploy/cloudroof-pipeline.service` (shares the
+  wgmesh code install + venv, distinct env/checkout/DB), `set-box-env.yml` +
+  `update-pipeline-box.yml` parameterized by `service` input (default wgmesh =
+  unchanged), and the non-destructive **`Install Cloudroof Instance`** workflow.
+- **U1/U2 in cloudroof-eu** — `impl-judge.yml` + `ci.yml` (CI gates) and
+  `deploy.yml` (`wrangler deploy` CD). Wired but require secrets (below).
+
+> Nothing changes runtime behavior until the workflows run + the env flips live.
+> The wgmesh instance is byte-unchanged: it never sees `SURFACE_HOME` and the box
+> workflows default `service=wgmesh`.
+
+## Pre-flight: secrets & PAT (operator)
+
+| Secret / var | Where | Purpose |
+|---|---|---|
+| `CLOUDROOF_BOT_PAT` | ai-pipeline-template repo (Actions) | Fine-grained PAT scoped to **cloudroof-eu**, read+write (contents, PRs, issues). The 2nd instance's bot token (written to the cloudroof env as `WGMESH_BOT_PAT`). |
+| `OPENROUTER_API_KEY` | **cloudroof-eu** repo | impl-judge gate (DeepSeek via OpenRouter). Same key shape as wgmesh. |
+| `CLOUDFLARE_API_TOKEN` | **cloudroof-eu** repo | `wrangler deploy` CD. Scope: Workers Scripts:Edit + the creu account. |
+| `CLOUDFLARE_ACCOUNT_ID` | **cloudroof-eu** repo | Account the `creu` Worker lives in. |
+| `PUSH_TOKEN` | cloudroof-eu (already set) | existing spec-merged-build assigner. |
+
+Mint the PAT at github.com → Settings → Developer settings → Fine-grained tokens,
+resource owner `atvirokodosprendimai`, repo `cloudroof-eu` only.
+
+## Step 1 — cloudroof-eu CI/CD required checks (U1/U2)
+
+After `OPENROUTER_API_KEY`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` are set:
+
+1. Confirm `impl-judge.yml`, `ci.yml`, `deploy.yml` are on cloudroof-eu `main`.
+2. Make **`impl-judge`** and **`ci`** required status checks on the cloudroof-eu
+   `protect-main` ruleset, with auto-merge enabled (mirror wgmesh's ruleset).
+   - This is the gate that lets the box's judge-gated auto-merge actually merge.
+3. Trigger a no-op PR (or wait for the first bot PR) and confirm both checks post.
+4. `deploy.yml` fires only on push to `main` (green) — verify a manual merge to
+   main deploys `./dist` and the site serves it.
+
+## Step 2 — box capacity check
+
+The box runs 2 pipeline processes now (~2× LLM/CI/git load). On the box:
+
+```
+systemctl status wgmesh-pipeline | head
+free -m ; nproc ; df -h /opt
+```
+
+`cpx22` (2 vCPU / 4 GB) headroom is thin under concurrent goose+go builds. If
+memory/CPU is saturated during the smoke (Step 4), size up the VM (cpx32) via a
+fresh `Provision Pipeline Box` for wgmesh, then re-run `Install Cloudroof Instance`.
+Record the decision here.
+
+## Step 3 — install the 2nd instance (shadow)
+
+Run **Actions → Install Cloudroof Instance** with:
+- `server_name=wgmesh-pipeline` (same box)
+- `pipeline_mode=shadow`
+
+This is **non-destructive** — it never recreates the server (that would kill the
+wgmesh instance). It writes `/etc/cloudroof-pipeline/env`, clones
+`/opt/cloudroof-checkout`, installs + enables `cloudroof-pipeline.service`.
+
+Verify on the box:
+```
+systemctl is-active cloudroof-pipeline
+journalctl -u cloudroof-pipeline -n 40 --no-pager   # expect "tick" lines, shadow
+```
+In shadow the instance polls + plans but performs no forge writes. Confirm it
+**gates correctly**: a `surface:service` cloudroof-eu issue advances; a
+`surface:product` one is blocked (`block_product` in the journal).
+
+## Step 4 — live smoke (one real issue, end-to-end)
+
+1. Pick one existing cloudroof-eu service issue (e.g. the rerouted onboarding
+   widget). Confirm it carries `surface:service`.
+2. Flip the cloudroof instance live (keep wgmesh untouched):
+   ```
+   Actions → Set Pipeline Box Env
+     service = cloudroof
+     env_set = PIPELINE_MODE=live,CONTROL_LOOP_MODE=live
+   ```
+   (restarts only `cloudroof-pipeline`.)
+3. Watch: spec PR → impl PR (`fix: Issue #N`) → `impl-judge`+`ci` green →
+   judge-gated auto-merge → `deploy.yml` → cloudroof.eu serves the new asset.
+4. No hand edits at any step = MVP proven (Outcome / AE).
+
+## Rollback
+
+- Stop the 2nd instance: `systemctl disable --now cloudroof-pipeline`. The wgmesh
+  instance is entirely independent (own env/DB/checkout/unit) and unaffected.
+- Back to shadow without uninstalling: `Set Pipeline Box Env service=cloudroof
+  env_set=PIPELINE_MODE=shadow,CONTROL_LOOP_MODE=shadow`.
+- Deploy blast radius: `deploy.yml` is green-main-gated + behind the impl-judge
+  gate; revert a bad merge on cloudroof-eu and the next push redeploys the prior
+  `./dist`.
+
+## Deferred (not this cutover)
+
+- **U6 Quackback accept-gate** — gated-first-N build approval. Ships after the
+  Quackback forge cutover (`docs/runbooks/quackback-cutover.md`). Until then the
+  funnel runs controlled (limited issues), NOT open auto-build.
+- Pulse/supervisor metrics extended to the cloudroof instance.
+- Auto-flip the build gate to open after N proven builds.

--- a/pipeline/deploy/cloudroof-pipeline.service
+++ b/pipeline/deploy/cloudroof-pipeline.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=cloudroof autonomous LangGraph pipeline (service surface → cloudroof-eu)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=wgmesh
+Group=wgmesh
+# Shares the wgmesh code install (one checkout of the pipeline + venv); only the
+# EnvironmentFile differs (TARGET_REPO=cloudroof-eu, SURFACE_HOME=service, own DB
+# + checkout). KTD1: 2nd instance, not a multi-repo refactor.
+WorkingDirectory=/opt/wgmesh-pipeline
+# Unbuffered stdout so journald captures poller logs in real time (Python
+# block-buffers stdout when it is not a tty, hiding logs until exit).
+Environment=PYTHONUNBUFFERED=1
+# Secrets + config live here, root-owned chmod 600 — distinct from the wgmesh
+# instance's /etc/wgmesh-pipeline/env so the two processes never share state.
+EnvironmentFile=/etc/cloudroof-pipeline/env
+ExecStart=/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main
+# main.py installs SIGTERM/SIGINT handlers and shuts down the poll loop
+# gracefully, so a normal stop drains the in-flight tick.
+KillSignal=SIGTERM
+TimeoutStopSec=120
+Restart=on-failure
+RestartSec=10
+# Hardening: the service holds the cloudroof-scoped bot PAT — keep blast radius small.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+# /opt/cloudroof-checkout is the cloudroof-eu working tree goose writes specs into
+# and spec_pr commits/pushes from. The shared /opt/wgmesh-pipeline holds the venv
+# and this instance's state DB (PIPELINE_DB_PATH=/opt/wgmesh-pipeline/cloudroof-state.db);
+# ProtectSystem=strict makes everything outside ReadWritePaths read-only.
+ReadWritePaths=/opt/wgmesh-pipeline /opt/cloudroof-checkout
+
+[Install]
+WantedBy=multi-user.target

--- a/pipeline/tests/test_box_workflows.py
+++ b/pipeline/tests/test_box_workflows.py
@@ -1,0 +1,118 @@
+"""U4 — characterization of the box-instance workflows + the cloudroof unit.
+
+These workflows are load-bearing infra with no app-behavior to unit-test, so the
+guard is: (1) every touched workflow stays valid YAML, (2) the wgmesh path is
+byte-unchanged when ``service`` defaults — the resolve steps map ``wgmesh`` to the
+original unit/env-file, (3) the destructive ``provision-pipeline-box`` is NOT
+parameterized (a co-resident 2nd instance must never recreate the shared box),
+(4) the new cloudroof unit + installer wire the service surface correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WF = _ROOT / ".github" / "workflows"
+_UNIT = _ROOT / "pipeline" / "deploy" / "cloudroof-pipeline.service"
+
+
+def _text(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load(_text(_WF / name))
+
+
+def _inputs(wf: dict) -> dict:
+    # YAML 1.1 parses the bare `on:` key as boolean True (the "Norway problem").
+    on = wf.get("on", wf.get(True, {})) or {}
+    dispatch = on.get("workflow_dispatch") or {}
+    return dispatch.get("inputs") or {}
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "set-box-env.yml",
+        "update-pipeline-box.yml",
+        "install-cloudroof-instance.yml",
+        "provision-pipeline-box.yml",
+    ],
+)
+def test_workflow_is_valid_yaml(name: str) -> None:
+    assert isinstance(_load(name), dict)
+
+
+def test_cloudroof_unit_parses_and_targets_service_surface() -> None:
+    txt = _text(_UNIT)
+    for section in ("[Unit]", "[Service]", "[Install]"):
+        assert section in txt
+    # Distinct env file (never shares the wgmesh instance's state)…
+    assert "EnvironmentFile=/etc/cloudroof-pipeline/env" in txt
+    # …but shares the wgmesh code install + venv (KTD1, 2nd instance not refactor).
+    assert "ExecStart=/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main" in txt
+    # cloudroof working tree must be writable for goose specs/commits.
+    assert "/opt/cloudroof-checkout" in txt
+    assert "ReadWritePaths=/opt/wgmesh-pipeline /opt/cloudroof-checkout" in txt
+
+
+# ---- set-box-env + update: service input, default wgmesh unchanged -----------
+
+@pytest.mark.parametrize("name", ["set-box-env.yml", "update-pipeline-box.yml"])
+def test_service_input_defaults_wgmesh(name: str) -> None:
+    inputs = _inputs(_load(name))
+    assert "service" in inputs
+    assert inputs["service"]["default"] == "wgmesh"
+
+
+@pytest.mark.parametrize("name", ["set-box-env.yml", "update-pipeline-box.yml"])
+def test_resolve_step_maps_both_units(name: str) -> None:
+    txt = _text(_WF / name)
+    # The default-wgmesh path resolves to the original unit (byte-unchanged behavior)…
+    assert "UNIT=wgmesh-pipeline" in txt
+    # …and cloudroof resolves to the 2nd unit. Unknown values fail closed.
+    assert "UNIT=cloudroof-pipeline" in txt
+    assert "expected wgmesh|cloudroof" in txt
+
+
+def test_set_box_env_threads_env_file_per_instance() -> None:
+    txt = _text(_WF / "set-box-env.yml")
+    assert "ENV_FILE=/etc/wgmesh-pipeline/env" in txt
+    assert "ENV_FILE=/etc/cloudroof-pipeline/env" in txt
+    # The remote script must use the resolved unit/env-file, not a hardcoded one.
+    assert 'systemctl restart "$UNIT"' in txt
+
+
+def test_update_box_reuses_workflow_call_default_wgmesh() -> None:
+    # Auto-Deploy-on-Merge calls this reusably with no service → must stay wgmesh.
+    wf = _load("update-pipeline-box.yml")
+    on = wf.get("on", wf.get(True, {})) or {}
+    call_inputs = (on.get("workflow_call") or {}).get("inputs") or {}
+    assert call_inputs["service"]["default"] == "wgmesh"
+
+
+# ---- provision stays destructive-but-unparameterized (no co-resident footgun) -
+
+def test_provision_box_is_not_parameterized_for_service() -> None:
+    # Recreating the shared box to add cloudroof would kill the wgmesh instance —
+    # the 2nd instance is installed non-destructively via install-cloudroof-instance.
+    assert "service" not in _inputs(_load("provision-pipeline-box.yml"))
+
+
+# ---- installer wires the service surface ------------------------------------
+
+def test_installer_writes_cloudroof_env_and_enables_unit() -> None:
+    txt = _text(_WF / "install-cloudroof-instance.yml")
+    assert "TARGET_REPO=atvirokodosprendimai/cloudroof-eu" in txt
+    assert "SURFACE_HOME=service" in txt
+    assert "WGMESH_CHECKOUT_PATH=/opt/cloudroof-checkout" in txt
+    assert "install -m 0644 /opt/wgmesh-pipeline/pipeline/deploy/cloudroof-pipeline.service" in txt
+    assert "systemctl enable --now cloudroof-pipeline" in txt
+    # Non-destructive: never creates/deletes a server.
+    assert "hcloud server create" not in txt
+    assert "hcloud server delete" not in txt

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -42,6 +42,35 @@ def test_full_env_loads_frozen_config_with_shadow_default() -> None:
         cfg.mode = "live"  # type: ignore[misc]
 
 
+def test_surface_home_defaults_product() -> None:
+    cfg = load_config(
+        {"TARGET_REPO": "atvirokodosprendimai/wgmesh", "DATABASE_MODE": "local"}
+    )
+    assert cfg.surface_home == "product"
+
+
+def test_surface_home_service_for_cloudroof_instance() -> None:
+    cfg = load_config(
+        {
+            "TARGET_REPO": "atvirokodosprendimai/cloudroof-eu",
+            "DATABASE_MODE": "local",
+            "SURFACE_HOME": "service",
+        }
+    )
+    assert cfg.surface_home == "service"
+
+
+def test_surface_home_invalid_rejected() -> None:
+    with pytest.raises(ValueError, match="SURFACE_HOME"):
+        load_config(
+            {
+                "TARGET_REPO": "atvirokodosprendimai/wgmesh",
+                "DATABASE_MODE": "local",
+                "SURFACE_HOME": "gtm",
+            }
+        )
+
+
 @pytest.mark.parametrize(
     ("env_name", "field_name"),
     (

--- a/pipeline/tests/test_surface_gate.py
+++ b/pipeline/tests/test_surface_gate.py
@@ -152,3 +152,62 @@ def test_node_classified_product_persists_and_builds() -> None:
     })
     assert out["surface_verdict"] == "build"
     assert (783, "surface:product") in forge.calls
+
+
+# ---- U3: surface-gate inversion (cloudroof instance, surface_home=service) ----
+
+from dataclasses import dataclass as _dc  # noqa: E402
+
+
+@_dc
+class _Cfg:
+    """Minimal stand-in for Config — only ``surface_home`` is read by the node."""
+    surface_home: str = "product"
+
+
+def test_decide_inverted_service_home_builds_service_blocks_product() -> None:
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    d = lambda res: decide_surface_gate(res, "service")
+    assert d(SurfaceResolution("service", 1.0, "label")) == "build"
+    assert d(SurfaceResolution("service", 0.9, "classified")) == "build"
+    assert d(SurfaceResolution("product", 1.0, "label")) == "block_product"
+    assert d(SurfaceResolution("product", 0.8, "classified")) == "block_product"
+    assert d(SurfaceResolution("unknown", 0.0, "none")) == "block_unknown"
+    # low-confidence home (service) guess fails safe, never builds
+    assert d(SurfaceResolution("service", 0.3, "classified")) == "block_unknown"
+
+
+def test_decide_default_surface_home_is_product_unchanged() -> None:
+    # Explicit guard that the default arg keeps the wgmesh path identical.
+    from wgmesh_pipeline.graph.nodes.surface_gate import SurfaceResolution
+    assert decide_surface_gate(SurfaceResolution("product", 1.0, "label")) == "build"
+    assert decide_surface_gate(SurfaceResolution("service", 1.0, "label")) == "block_service"
+
+
+def test_node_service_home_builds_service_label() -> None:
+    forge = FakeForge()
+    out = run_surface_gate({
+        "issue": _issue(labels=("surface:service",)),
+        "github": forge,
+        "config": _Cfg(surface_home="service"),
+    })
+    assert out["surface_verdict"] == "build"
+    assert surface_gate_blocks(out) is False
+
+
+def test_node_service_home_blocks_product_label() -> None:
+    forge = FakeForge()
+    out = run_surface_gate({
+        "issue": _issue(labels=("surface:product",)),
+        "github": forge,
+        "config": _Cfg(surface_home="service"),
+    })
+    assert out["surface_verdict"] == "block_product"
+    assert surface_gate_blocks(out) is True
+
+
+def test_node_default_config_absent_is_product_home() -> None:
+    # No config in state → product home (default); service still blocked.
+    forge = FakeForge()
+    out = run_surface_gate({"issue": _issue(labels=("surface:service",)), "github": forge})
+    assert out["surface_verdict"] == "block_service"

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -40,6 +40,7 @@ BOX_CONFIG_ALLOWLIST = frozenset(
         "POLL_INTERVAL_SECONDS",
         "MAX_FILES",
         "FORGE_KIND",
+        "SURFACE_HOME",
     }
 )
 
@@ -66,6 +67,10 @@ def _read_box_config(path: Path = BOX_CONFIG_PATH) -> dict[str, str]:
 
 VALID_MODES = frozenset({"shadow", "spec-only", "live"})
 VALID_DB_MODES = frozenset({"local", "turso"})
+# Which surface this pipeline instance builds (KTD2). The wgmesh instance is
+# ``product`` (default → byte-unchanged); the cloudroof instance sets ``service``.
+VALID_SURFACE_HOMES = frozenset({"product", "service"})
+DEFAULT_SURFACE_HOME = "product"
 DEFAULT_ANTHROPIC_HOST = "https://api.z.ai/api/anthropic"
 DEFAULT_TARGET_REPO = "atvirokodosprendimai/wgmesh"
 DEFAULT_POLL_INTERVAL_SECONDS = 300
@@ -143,6 +148,9 @@ class Config:
     # Graph backend: 'legacy' (default) or 'langgraph' (U4).
     # Selected via GRAPH_IMPL env var; build_graph dispatches on this value.
     graph_impl: str = "legacy"
+    # Which surface this instance builds (KTD2): 'product' (wgmesh, default) or
+    # 'service' (cloudroof). Drives the surface-gate inversion. SURFACE_HOME env.
+    surface_home: str = DEFAULT_SURFACE_HOME
 
     @property
     def owner(self) -> str:
@@ -201,6 +209,15 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         valid = ", ".join(sorted(VALID_CONTROL_LOOP_MODES))
         raise ValueError(
             f"CONTROL_LOOP_MODE must be one of: {valid}; got {control_loop_mode!r}"
+        )
+
+    surface_home = (
+        _get_nonempty(source, "SURFACE_HOME") or DEFAULT_SURFACE_HOME
+    ).lower()
+    if surface_home not in VALID_SURFACE_HOMES:
+        valid = ", ".join(sorted(VALID_SURFACE_HOMES))
+        raise ValueError(
+            f"SURFACE_HOME must be one of: {valid}; got {surface_home!r}"
         )
 
     goose_provider = _get_nonempty(source, "GOOSE_PROVIDER") or DEFAULT_GOOSE_PROVIDER
@@ -275,6 +292,7 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         meta_repo=_get_nonempty(source, "META_REPO") or DEFAULT_META_REPO,
         executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
         graph_impl=(_get_nonempty(source, "GRAPH_IMPL") or "legacy").strip().lower(),
+        surface_home=surface_home,
     )
     _log_control_loop_module_modes(cfg)
     return cfg

--- a/pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py
@@ -1,13 +1,19 @@
-"""Surface gate — keep service (cloudroof) and unclassified issues out of the
-wgmesh impl pipeline.
+"""Surface gate — build only this instance's *home* surface; park everything else.
 
 Runs on the triage→spec seam (both graph impls). It resolves the issue's surface
 (reading the ``surface:*`` label, else classifying title+body via an injected
-LLM callable), then decides:
+LLM callable), then decides against the instance's ``surface_home`` (``product``
+for the wgmesh instance, ``service`` for the cloudroof instance — KTD2):
 
-  - ``product`` (confident)      → ``build``         (the only path to spec→impl)
-  - ``service``                  → ``block_service`` (park; never built in wgmesh)
-  - unknown / low-confidence     → ``block_unknown`` (fail-safe: park, never build)
+  - home surface (confident)     → ``build``          (the only path to spec→impl)
+  - a known, off-home surface    → ``block_<surface>`` (park; built by the OTHER instance)
+  - unknown / low-confidence     → ``block_unknown``   (fail-safe: park, never build)
+
+The default ``surface_home`` is ``product`` so the wgmesh instance is byte-unchanged:
+``product`` builds, ``service`` → ``block_service``, unknown → ``block_unknown``. The
+cloudroof instance sets ``surface_home=service`` (via ``Config.surface_home`` / the
+``SURFACE_HOME`` env), inverting the gate: ``service`` builds, ``product`` →
+``block_product``.
 
 Blocked issues are parked via labels: a classified surface is persisted, and the
 block path (the graph's existing ``escalate``) adds ``needs-human``. Those labels
@@ -32,6 +38,10 @@ log = logging.getLogger("wgmesh_pipeline.surface_gate")
 # Below this, a classifier verdict is not trusted enough to build on — fail safe
 # to block_unknown rather than spec→impl a shaky guess.
 MIN_CONFIDENCE = 0.5
+
+# Which surface THIS pipeline instance builds. Mirrors ``Config.surface_home``;
+# the literal default keeps this module decoupled from config (no import cycle).
+DEFAULT_SURFACE_HOME = "product"
 
 # (title, body) -> (surface, confidence). Injected so tests and the graph wire a
 # real LLM classifier without this module importing a model client.
@@ -69,13 +79,21 @@ def resolve_issue_surface(
     return SurfaceResolution(surface, float(confidence), "classified")
 
 
-def decide_surface_gate(resolution: SurfaceResolution) -> str:
-    """Map a resolved surface to a gate verdict: ``build`` | ``block_service`` |
-    ``block_unknown``. Policy (confidence gating) lives here, not in resolution."""
-    if resolution.surface == "service":
-        return "block_service"
-    if resolution.surface == "product" and resolution.confidence >= MIN_CONFIDENCE:
+def decide_surface_gate(
+    resolution: SurfaceResolution, surface_home: str = DEFAULT_SURFACE_HOME
+) -> str:
+    """Map a resolved surface to a gate verdict against ``surface_home``:
+    ``build`` | ``block_<surface>`` | ``block_unknown``. Policy (confidence
+    gating) lives here, not in resolution.
+
+    The home surface builds only when confident (a low-confidence classified
+    guess at the home surface fails safe to ``block_unknown``). A confident,
+    known off-home surface is parked under its own ``block_<surface>`` verdict so
+    the OTHER instance can claim it. Everything else (unknown) parks unknown."""
+    if resolution.surface == surface_home and resolution.confidence >= MIN_CONFIDENCE:
         return "build"
+    if resolution.surface in ("product", "service") and resolution.surface != surface_home:
+        return f"block_{resolution.surface}"
     return "block_unknown"
 
 
@@ -88,8 +106,13 @@ def run_surface_gate(state: GraphState) -> GraphState:
     next_state.setdefault("visited", []).append("surface_gate")
     issue = next_state["issue"]
     classifier = next_state.get("surface_classifier")
+    # This instance's home surface (Config.surface_home); default product so the
+    # wgmesh instance — and the existing node tests that pass no config — keep the
+    # original product-builds/service-blocks behavior.
+    cfg = next_state.get("config")
+    surface_home = getattr(cfg, "surface_home", DEFAULT_SURFACE_HOME)
     resolution = resolve_issue_surface(issue, classifier_fn=classifier)
-    verdict = decide_surface_gate(resolution)
+    verdict = decide_surface_gate(resolution, surface_home)
     next_state["surface"] = resolution.surface
     next_state["surface_verdict"] = verdict
 


### PR DESCRIPTION
Builder side of the cloudroof service funnel — plan `docs/plans/2026-06-22-002-feat-cloudroof-service-funnel-plan.md`. Stands up a 2nd `wgmesh_pipeline` instance on the box targeting `cloudroof-eu` so `surface:service` issues get built → PR'd → merged → deployed.

## Units shipped here
- **U3 — surface-gate inversion.** `Config.surface_home` (`SURFACE_HOME` env, box-config allowlisted). Default `product` → wgmesh byte-unchanged (`product`→build, `service`→`block_service`). `surface_home=service` inverts it for the cloudroof instance (`service`→build, `product`→`block_product`). Both graph impls honor it via the shared build/escalate seam. Low-confidence home guesses still fail safe.
- **U4 — 2nd co-resident instance.** `cloudroof-pipeline.service` shares the wgmesh code install + venv but with its own env (`/etc/cloudroof-pipeline/env`), checkout (`/opt/cloudroof-checkout`), and DB. `set-box-env` + `update-pipeline-box` gain a `service` input (default `wgmesh` = byte-unchanged; resolved unit/env-file). New **non-destructive** `Install Cloudroof Instance` workflow stands up the 2nd unit on the existing box — `provision-pipeline-box` is left untouched because recreating the shared box would kill the wgmesh instance.
- **U5 — operator runbook.** `docs/runbooks/cloudroof-funnel-cutover.md`: shadow-first install → live-flip → end-to-end smoke, secrets/PAT, capacity check, rollback.

**U1+U2** (cloudroof-eu CI/CD) ship in [cloudroof-eu#5](https://github.com/atvirokodosprendimai/cloudroof-eu/pull/5) (dogfood `ci` green). **U6** (Quackback accept-gate) deferred until the Quackback cutover, per plan KTD4.

## Tests
- 11 new surface-gate inversion tests + 3 config tests; 13 box-workflow characterization tests (YAML valid, default-wgmesh unchanged, unit wiring). Full pipeline suite green (the 21 local failures are the pre-existing host ggshield `core.hooksPath` leak into test temp repos — env-only, CI-green).

## Scope boundary
No runtime behavior changes until the operator provisions the 2nd instance + flips its env live. The wgmesh instance never sees `SURFACE_HOME` and the box workflows default `service=wgmesh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)