### PR TITLE
feat(quackback): cutover U1–U3 — box-native creation seam + queue-health KPI repoint

### DIFF
--- a/.github/workflows/observation-loop.yml
+++ b/.github/workflows/observation-loop.yml
@@ -694,7 +694,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
           TARGET_REPO: atvirokodosprendimai/wgmesh
+          FORGE_KIND: ${{ vars.FORGE_KIND }}
         run: |
+          # Cutover U1 host seam: once forge_kind=quackback the box's own
+          # observation loop is the sole Build-Suggestion creator. Mute this
+          # Actions creator so the two paths never double-create. Reversible:
+          # clear/flip the FORGE_KIND repo variable back to github to re-enable.
+          if [ "$FORGE_KIND" = "quackback" ]; then
+            echo "FORGE_KIND=quackback — creation owned by the box; skipping gh issue create"
+            exit 0
+          fi
           # Fetch open AND recently closed issue titles for dedup.
           # Checking only open issues misses features that were already implemented
           # and closed — causing the LLM to re-create them as greenfield tasks.
@@ -778,7 +787,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
           TARGET_REPO: atvirokodosprendimai/wgmesh
+          FORGE_KIND: ${{ vars.FORGE_KIND }}
         run: |
+          # Cutover U1 host seam (see "Create issues from assessment"): the box
+          # owns creation under quackback. Mute this needs-human creator too.
+          if [ "$FORGE_KIND" = "quackback" ]; then
+            echo "FORGE_KIND=quackback — creation owned by the box; skipping needs-human gh issue create"
+            exit 0
+          fi
           # Reuse open issues list (or fetch if not available)
           if [ ! -f /tmp/open_issues.txt ]; then
             gh issue list --repo "$TARGET_REPO" --state open --limit 100 --json title --jq '.[].title' > /tmp/open_issues.txt 2>/dev/null || touch /tmp/open_issues.txt

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -362,10 +362,12 @@ def test_quackback_forge_with_creds_loads_successfully() -> None:
             "FORGE_KIND": "quackback",
             "QUACKBACK_URL": "https://quackback.example.com",
             "QUACKBACK_TOKEN": "secret-token",
+            "QUACKBACK_BOARD_ID": "board_01abc",
         }
     )
     assert cfg.quackback_url == "https://quackback.example.com"
     assert cfg.quackback_token == "secret-token"
+    assert cfg.quackback_board_id == "board_01abc"
 
 
 def test_quackback_forge_missing_token_raises_value_error() -> None:
@@ -375,9 +377,34 @@ def test_quackback_forge_missing_token_raises_value_error() -> None:
                 **_MINIMAL_ENV,
                 "FORGE_KIND": "quackback",
                 "QUACKBACK_URL": "https://quackback.example.com",
+                "QUACKBACK_BOARD_ID": "board_01abc",
                 # QUACKBACK_TOKEN intentionally absent
             }
         )
+
+
+def test_quackback_forge_missing_board_id_raises_value_error() -> None:
+    # The cutover (U2) needs the board id at config time — a misconfigured box
+    # must fail loudly, not fall back to github or KeyError at first create.
+    with pytest.raises(ValueError, match="QUACKBACK_BOARD_ID"):
+        load_config(
+            {
+                **_MINIMAL_ENV,
+                "FORGE_KIND": "quackback",
+                "QUACKBACK_URL": "https://quackback.example.com",
+                "QUACKBACK_TOKEN": "secret-token",
+                # QUACKBACK_BOARD_ID intentionally absent
+            }
+        )
+
+
+def test_quackback_board_id_passes_through_box_config_allowlist(tmp_path: Path) -> None:
+    from wgmesh_pipeline.config import _read_box_config
+
+    path = tmp_path / "box-config.json"
+    path.write_text(json.dumps({"QUACKBACK_BOARD_ID": "board_01xyz"}), encoding="utf-8")
+    allowed = _read_box_config(path)
+    assert allowed.get("QUACKBACK_BOARD_ID") == "board_01xyz"
 
 
 def test_github_forge_without_quackback_vars_is_fine() -> None:

--- a/pipeline/tests/test_quackback_forge.py
+++ b/pipeline/tests/test_quackback_forge.py
@@ -477,3 +477,26 @@ def test_post_url_uses_quackback_base_and_post_id() -> None:
 def test_post_url_none_when_unresolvable() -> None:
     forge, _, _ = _forge()
     assert forge.post_url(999) is None
+
+
+# ------------------------------------------------- U1: dispatch host seam
+
+
+def test_dispatch_workflow_is_box_native_host_seam_noop() -> None:
+    # Cutover U1: under forge_kind=quackback the box observation loop is the
+    # sole creator, so dispatch_workflow must NOT fire the (creation-muted)
+    # Actions observation-loop. It no-ops-and-warns like the Gitea seam:
+    # returns a DryRunResult marker and never touches the _gh PR backend.
+    from wgmesh_pipeline.github.client import DryRunResult
+
+    forge, gh, qb = _forge()
+
+    result = forge.dispatch_workflow("observation-loop.yml", {"signal": "idle"})
+
+    assert isinstance(result, DryRunResult)
+    assert result.operation == "dispatch_workflow"
+    assert result.payload["unsupported_host"] == "quackback"
+    assert result.payload["inputs"] == {"signal": "idle"}
+    # No GitHub dispatch attempted (FakeGH has no dispatch_workflow at all).
+    assert gh.calls == []
+    assert qb.calls == []

--- a/pipeline/tests/test_quackback_kpi.py
+++ b/pipeline/tests/test_quackback_kpi.py
@@ -1,0 +1,159 @@
+"""Cutover U3: queue-health KPI repointed from GitHub issues to the Quackback board.
+
+Once Build Suggestions live on the Quackback board (not GitHub Issues), the
+queue-health signal becomes **posts-by-decision-status** + **oldest-undecided
+age**. These tests drive that collector against a recorded fake — no live API —
+and pin the fail-closed-loud contract on the gating reads.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.forge.quackback_client import QuackbackError
+from wgmesh_pipeline.quackback_kpi import (
+    collect_quackback_queue_health,
+    select_queue_health,
+)
+
+NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+# The 8 board statuses (name, slug) the live board carries.
+_STATUSES = [
+    {"id": "s_ofv", "name": "Open for Vote", "slug": "open-for-vote"},
+    {"id": "s_nr", "name": "Needs Refinement", "slug": "needs-refinement"},
+    {"id": "s_afb", "name": "Accepted for Build", "slug": "accepted-for-build"},
+    {"id": "s_bld", "name": "Building", "slug": "building"},
+    {"id": "s_rfr", "name": "Ready for Review", "slug": "ready-for-review"},
+    {"id": "s_shp", "name": "Shipped", "slug": "shipped"},
+    {"id": "s_rej", "name": "Rejected", "slug": "rejected"},
+    {"id": "s_can", "name": "Cancelled", "slug": "cancelled"},
+]
+
+
+class FakeReader:
+    """Records calls; returns posts keyed by status slug. Optionally raises on a
+    chosen slug to exercise the fail-closed-loud gating contract."""
+
+    def __init__(
+        self,
+        posts_by_slug: dict[str, list[dict[str, Any]]],
+        *,
+        statuses: list[dict[str, Any]] | None = None,
+        raise_on_slug: str | None = None,
+    ) -> None:
+        self._posts = posts_by_slug
+        self._statuses = statuses if statuses is not None else _STATUSES
+        self._raise_on_slug = raise_on_slug
+        self.calls: list[tuple[str, Any]] = []
+
+    def list_statuses(self) -> list[dict[str, Any]]:
+        self.calls.append(("list_statuses", None))
+        return list(self._statuses)
+
+    def list_posts(
+        self,
+        status_slug: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(("list_posts", status_slug))
+        if status_slug == self._raise_on_slug:
+            raise QuackbackError(f"boom on {status_slug}")
+        data = list(self._posts.get(status_slug or "", []))
+        return {"data": data, "meta": {"pagination": {"hasMore": False}}}
+
+
+def _post(pid: str, created: str) -> dict[str, Any]:
+    return {"id": pid, "title": pid, "createdAt": created}
+
+
+def test_posts_by_status_maps_all_eight_slugs_to_counts() -> None:
+    reader = FakeReader(
+        {
+            "open-for-vote": [_post("p1", "2026-06-22T09:00:00Z")],
+            "needs-refinement": [],
+            "accepted-for-build": [
+                _post("p2", "2026-06-21T00:00:00Z"),
+                _post("p3", "2026-06-21T01:00:00Z"),
+            ],
+            "building": [_post("p4", "2026-06-20T00:00:00Z")],
+            "ready-for-review": [],
+            "shipped": [
+                _post("p5", "2026-06-19T00:00:00Z"),
+                _post("p6", "2026-06-18T00:00:00Z"),
+                _post("p7", "2026-06-17T00:00:00Z"),
+            ],
+            "rejected": [],
+            "cancelled": [],
+        }
+    )
+
+    out = collect_quackback_queue_health(reader, now=NOW)
+
+    assert out["source"] == "quackback"
+    assert out["posts_by_decision_status"] == {
+        "Open for Vote": 1,
+        "Needs Refinement": 0,
+        "Accepted for Build": 2,
+        "Building": 1,
+        "Ready for Review": 0,
+        "Shipped": 3,
+        "Rejected": 0,
+        "Cancelled": 0,
+    }
+
+
+def test_oldest_undecided_age_from_oldest_open_for_vote_or_needs_refinement() -> None:
+    reader = FakeReader(
+        {
+            # oldest undecided is the needs-refinement post at 06-20T12:00 → 48h
+            "open-for-vote": [_post("p1", "2026-06-22T06:00:00Z")],
+            "needs-refinement": [_post("p2", "2026-06-20T12:00:00Z")],
+            # a much older Shipped post must NOT count (not undecided)
+            "shipped": [_post("p9", "2026-01-01T00:00:00Z")],
+        }
+    )
+
+    out = collect_quackback_queue_health(reader, now=NOW)
+
+    assert out["oldest_undecided_age_seconds"] == 48 * 3600
+    assert out["oldest_undecided_age_hours"] == 48.0
+
+
+def test_empty_board_yields_zero_counts_and_null_age_not_error() -> None:
+    reader = FakeReader({slug["slug"]: [] for slug in _STATUSES})
+
+    out = collect_quackback_queue_health(reader, now=NOW)
+
+    assert set(out["posts_by_decision_status"].values()) == {0}
+    assert out["oldest_undecided_age_seconds"] is None
+    assert out["oldest_undecided_age_hours"] is None
+
+
+def test_api_error_on_a_gating_count_fails_closed_loud() -> None:
+    reader = FakeReader(
+        {"open-for-vote": [_post("p1", "2026-06-22T09:00:00Z")]},
+        raise_on_slug="building",
+    )
+
+    with pytest.raises(QuackbackError, match="boom on building"):
+        collect_quackback_queue_health(reader, now=NOW)
+
+
+def test_select_queue_health_github_returns_github_block_unchanged() -> None:
+    gh = {"issues_by_function_label": {"fn:dev": 3}}
+    qb = {"posts_by_decision_status": {"Open for Vote": 1}}
+
+    assert select_queue_health("github", github_block=gh, quackback_block=qb) is gh
+    assert select_queue_health(None, github_block=gh, quackback_block=qb) is gh
+
+
+def test_select_queue_health_quackback_returns_board_block() -> None:
+    gh = {"issues_by_function_label": {"fn:dev": 3}}
+    qb = {"posts_by_decision_status": {"Open for Vote": 1}}
+
+    assert select_queue_health("quackback", github_block=gh, quackback_block=qb) is qb

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -40,6 +40,9 @@ BOX_CONFIG_ALLOWLIST = frozenset(
         "POLL_INTERVAL_SECONDS",
         "MAX_FILES",
         "FORGE_KIND",
+        # Quackback Build Suggestions board id — non-secret, lets the cutover
+        # set it via box-config or set-box-env (the URL/token stay secrets).
+        "QUACKBACK_BOARD_ID",
     }
 )
 
@@ -109,6 +112,7 @@ class Config:
     gitea_url: str | None = None
     quackback_url: str | None = None
     quackback_token: str | None = None
+    quackback_board_id: str | None = None
     database_mode: str = "local"
     database_path: str = "pipeline/state.db"
     turso_url: str | None = None
@@ -189,9 +193,13 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
     forge_kind = _get_nonempty(source, "FORGE_KIND") or "github"
     quackback_url = _get_nonempty(source, "QUACKBACK_URL")
     quackback_token = _get_nonempty(source, "QUACKBACK_TOKEN")
-    if forge_kind == "quackback" and not (quackback_url and quackback_token):
+    quackback_board_id = _get_nonempty(source, "QUACKBACK_BOARD_ID")
+    if forge_kind == "quackback" and not (
+        quackback_url and quackback_token and quackback_board_id
+    ):
         raise ValueError(
-            "forge_kind=quackback requires QUACKBACK_URL and QUACKBACK_TOKEN"
+            "forge_kind=quackback requires QUACKBACK_URL, QUACKBACK_TOKEN, "
+            "and QUACKBACK_BOARD_ID"
         )
 
     control_loop_mode = (
@@ -224,6 +232,7 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         gitea_url=_get_nonempty(source, "GITEA_URL"),
         quackback_url=quackback_url,
         quackback_token=quackback_token,
+        quackback_board_id=quackback_board_id,
         poll_interval_seconds=_get_int(
             source, "POLL_INTERVAL_SECONDS", DEFAULT_POLL_INTERVAL_SECONDS
         ),

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -43,7 +43,7 @@ from wgmesh_pipeline.forge.quackback_status import (
     BOX_SETTABLE_STATUSES,
     is_box_settable,
 )
-from wgmesh_pipeline.github.client import GitHubClient
+from wgmesh_pipeline.github.client import DryRunResult, GitHubClient
 
 log = logging.getLogger("wgmesh_pipeline.forge.quackback")
 
@@ -273,7 +273,27 @@ class QuackbackForge:
         return self._gh.close_pr(number, comment)
 
     def dispatch_workflow(self, workflow: str, inputs: dict[str, Any]) -> Any:
-        return self._gh.dispatch_workflow(workflow, inputs)
+        """HOST SEAM (cutover U1): under the Quackback decision layer the box's
+        own ``_cycle_observation`` is the sole Build-Suggestion creator, so
+        firing the GitHub Actions ``observation-loop`` (whose creation steps are
+        muted post-cutover) would be a no-op at best and a double-create race at
+        worst. Mirror the Gitea seam: no-op-and-warn, return a ``DryRunResult``
+        marker (no HTTP, never touches ``_gh``) so an idle signal can't re-arm a
+        creation-disabled workflow."""
+        log.warning(
+            "dispatch_workflow(%r) skipped under forge_kind=quackback — the box "
+            "observation loop is the successor creator (cutover U1 host seam)",
+            workflow,
+        )
+        return DryRunResult(
+            dry_run=True,
+            operation="dispatch_workflow",
+            payload={
+                "unsupported_host": "quackback",
+                "workflow": workflow,
+                "inputs": dict(inputs),
+            },
+        )
 
     # Labels are a GitHub PR concern here → _gh (the conformance split routes
     # them to the code backend, not the decision board).

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -72,7 +72,14 @@ class QuackbackForge:
         # false-matches a constructor argument.
         self._gh = gh_client if gh_client is not None else GitHubClient(config)
         self._qb = qb_client if qb_client is not None else QuackbackClient(config)
-        self._board_id = board_id or os.environ.get(BOARD_ID_ENV)
+        # Prefer the explicit arg, then Config (promoted in the cutover U2), then
+        # the env var (back-compat). load_config fail-closes when forge_kind is
+        # quackback and the board id is unset, so this is non-None in production.
+        self._board_id = (
+            board_id
+            or getattr(config, "quackback_board_id", None)
+            or os.environ.get(BOARD_ID_ENV)
+        )
         # Store-backed fallback resolver for ids not in the in-memory _id_map.
         # Posts ingested via the U4 store mapping (reconcile_quackback) never
         # touched _id_map, so set_status/comment/get_issue would KeyError on them

--- a/pipeline/wgmesh_pipeline/forge/quackback_status.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback_status.py
@@ -21,6 +21,13 @@ BOX_SETTABLE_STATUSES: frozenset[str] = frozenset(
 # status are the box's work queue.
 ACCEPTED_FOR_BUILD = "Accepted for Build"
 
+# The founder-attention backlog (cutover U3 KPI): posts still awaiting a human
+# decision. The age of the OLDEST post in these statuses is the queue-health
+# signal that replaces the GitHub open-issue-age KPI once issues live on the
+# Quackback board — a rising oldest-undecided age is the silent-stall canary
+# (no founder vote → nothing builds), the explicit mitigation for KTD3.
+UNDECIDED_STATUSES: frozenset[str] = frozenset({"Open for Vote", "Needs Refinement"})
+
 # The lane the box owns end-to-end: a post that has been accepted and is being
 # driven to ship moves through these statuses (the accept marker + the three
 # box-settable milestones). A post in this lane is the box's to mirror; a post

--- a/pipeline/wgmesh_pipeline/quackback_kpi.py
+++ b/pipeline/wgmesh_pipeline/quackback_kpi.py
@@ -1,0 +1,149 @@
+"""Queue-health KPI sourced from the Quackback board (cutover U3).
+
+Once Build Suggestions live on the Quackback board instead of GitHub Issues, the
+GitHub ``issues_by_function_label`` signal goes blind. This module reconstructs
+the queue-health signal from the board:
+
+  - **posts-by-decision-status** — a count per board status (the 8 the board
+    carries), so the pulse can see where work piles up.
+  - **oldest-undecided age** — the age of the OLDEST post still awaiting a human
+    decision (``Open for Vote`` / ``Needs Refinement``). This is the load-bearing
+    silent-stall canary (KTD3): with no founder-notification in the bare cutover,
+    a rising oldest-undecided age is the only visible signal that the queue has
+    stalled at zero builds.
+
+PR / merge-rate / CI / release / stars stay on GitHub (``collect-github.sh``,
+unchanged) — only the ISSUE-derived queue block repoints. ``select_queue_health``
+is the seam that picks the source by ``forge_kind``.
+
+Reads are **fail-closed-loud** on the gating counts: any ``QuackbackError`` from a
+status read propagates (a silent zero would read as "queue empty / all decided"
+and hide a real stall). The collector performs no live calls in tests — it takes
+any object exposing ``list_statuses`` / ``list_posts`` (the ``QuackbackClient``
+read surface).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Iterator, Optional, Protocol
+
+from wgmesh_pipeline.forge.quackback_status import UNDECIDED_STATUSES
+
+log = logging.getLogger("wgmesh_pipeline.quackback_kpi")
+
+_PAGE_LIMIT = 100
+# Pagination backstop: a status with more pages than this is pathological; stop
+# rather than loop unboundedly (mirrors the dedup-scan cap in QuackbackForge).
+_MAX_PAGES = 50
+
+
+class _Reader(Protocol):
+    def list_statuses(self) -> list[dict[str, Any]]: ...
+
+    def list_posts(
+        self,
+        status_slug: str | None = ...,
+        cursor: str | None = ...,
+        limit: int | None = ...,
+    ) -> dict[str, Any]: ...
+
+
+def _parse_ts(raw: str) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp (``...Z`` or offset) to an aware datetime, or
+    ``None`` if absent/unparseable — a missing createdAt must not crash the KPI."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _iter_posts(client: _Reader, slug: str) -> Iterator[dict[str, Any]]:
+    """Yield every post in ``slug``, following cursor pagination (board read).
+    A read error propagates — the caller treats gating counts as fail-closed."""
+    cursor: str | None = None
+    pages = 0
+    while pages < _MAX_PAGES:
+        page = client.list_posts(status_slug=slug, cursor=cursor, limit=_PAGE_LIMIT)
+        posts = page.get("data", [])
+        for post in posts:
+            yield post
+        pagination = (page.get("meta") or {}).get("pagination") or {}
+        cursor = pagination.get("cursor")
+        pages += 1
+        if not pagination.get("hasMore") or not cursor or not posts:
+            break
+
+
+def collect_quackback_queue_health(
+    client: _Reader, *, now: datetime | None = None
+) -> dict[str, Any]:
+    """Build the Quackback queue-health block. Fail-closed-loud on any status read.
+
+    Returns the same envelope the pulse/observation queue consumer expects, with
+    ``posts_by_decision_status`` (name → count) and ``oldest_undecided_age_*``
+    replacing the GitHub ``issues_by_function_label`` signal.
+    """
+    now = now or datetime.now(timezone.utc)
+    statuses = client.list_statuses()
+
+    posts_by_status: dict[str, int] = {}
+    oldest_undecided: datetime | None = None
+
+    for status in statuses:
+        name = str(status.get("name") or "")
+        slug = status.get("slug")
+        if not slug:
+            # A status with no slug can't be queried — skip it loudly rather than
+            # silently zero it (the slug filter is the only count primitive).
+            log.warning("Quackback status %r has no slug — skipping from KPI", name)
+            continue
+        count = 0
+        is_undecided = name in UNDECIDED_STATUSES
+        for post in _iter_posts(client, str(slug)):
+            count += 1
+            if is_undecided:
+                ts = _parse_ts(
+                    str(post.get("createdAt") or post.get("created_at") or "")
+                )
+                if ts is not None and (
+                    oldest_undecided is None or ts < oldest_undecided
+                ):
+                    oldest_undecided = ts
+        posts_by_status[name] = count
+
+    if oldest_undecided is not None:
+        age = (now - oldest_undecided).total_seconds()
+        age_seconds: int | None = int(age)
+        age_hours: float | None = round(age / 3600, 2)
+    else:
+        age_seconds = None
+        age_hours = None
+
+    return {
+        "source": "quackback",
+        "collected_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "posts_by_decision_status": posts_by_status,
+        "oldest_undecided_age_seconds": age_seconds,
+        "oldest_undecided_age_hours": age_hours,
+    }
+
+
+def select_queue_health(
+    forge_kind: str | None,
+    *,
+    github_block: Any,
+    quackback_block: Any,
+) -> Any:
+    """Pick the queue-health signal source by forge kind (cutover U3 repoint).
+
+    ``quackback`` → the board block; anything else (``github``/``None``) → the
+    unchanged GitHub issues-by-label block. The default is github so a missing /
+    unset ``forge_kind`` never silently drops the GitHub signal.
+    """
+    if forge_kind == "quackback":
+        return quackback_block
+    return github_block


### PR DESCRIPTION
## Summary

Code units of the **Quackback cutover** (`docs/plans/2026-06-22-003-feat-quackback-cutover-plan.md`). Flips the decision layer's *creation* path toward the box + Quackback board, while staying **inert** until the operator flip (`FORGE_KIND=quackback`). All units default to the unchanged GitHub path.

- **U2** (`4fa8d50`) — propagate `QUACKBACK_BOARD_ID` to box config + fail-closed guard.
- **U1** (`73da3ac`) — box becomes sole Build-Suggestion creator:
  - `observation-loop.yml`: both `gh issue create` steps gated on the `FORGE_KIND` repo var → no-op+log when `quackback`, **byte-unchanged for github**. Reversible (flip the var back).
  - `QuackbackForge.dispatch_workflow` no longer delegates to the GitHub backend — that was a **latent double-create** (an idle signal would re-fire the muted Actions loop). Now a no-op-and-warn host seam mirroring Gitea (returns `DryRunResult`, never touches `_gh`).
- **U3** (`73da3ac`) — queue-health KPI repoint:
  - `quackback_kpi.collect_quackback_queue_health()` — posts-by-decision-status (8 board slugs) + oldest-undecided age (the KTD3 silent-stall canary). **Fail-closed-loud** on gating reads.
  - `select_queue_health(forge_kind)` — the repoint seam (`quackback` → board block; `github`/`None` → unchanged GitHub issues-by-label).

PR/merge-rate/CI/release/stars stay on GitHub, unchanged.

## Deviation from plan
Plan U1 said guard `_h_dispatch_observation_loop` in `executor.py`. Solved one layer down at the forge instead — single seam, handler stays clean, conformance-covered. Functionally equivalent and tighter (it also closes the latent `_gh` delegation bug).

## Deferred to U4 (operator cutover)
Wiring `select_queue_health` into the live `observation.py` gather is left for U4 — the live loop is currently halted (kill-switch) and the plan builds U3 against fixtures. Selector is ready.

## Test plan
- `pipeline/tests/test_quackback_forge.py` — dispatch host-seam no-op (DryRunResult, never touches `_gh`/`_qb`).
- `pipeline/tests/test_quackback_kpi.py` (new, 6) — 8-slug counts; oldest-undecided age; empty board → zero/null (not error); API error on a gating count → fail-closed-loud; selector both branches.
- Full suite: 868 passed; 21 failures are **pre-existing** flakes (`test_langchain_agent_runner`, `test_spec_pr` — host-gitconfig / git-remote), confirmed failing on `4fa8d50` without these changes.
- `ruff` + `black` clean on changed files.

## Not in this PR
U4 cutover is operator-run (drain GH→0 → shadow-prove → flip `FORGE_KIND=quackback`+`OBSERVATION_LIVE=true` → verify → rollback). Needs the box un-halted + `QUACKBACK_*` on box env. Runbook: `docs/runbooks/quackback-cutover.md`.