### PR TITLE
feat(observation): rich PM-grade Build Suggestion briefs (generate + carry + build from body)

### DIFF
--- a/docs/plans/2026-06-22-005-feat-rich-build-suggestion-briefs-plan.md
+++ b/docs/plans/2026-06-22-005-feat-rich-build-suggestion-briefs-plan.md
@@ -1,0 +1,62 @@
+# feat: rich PM-grade Build Suggestion briefs — generate + carry + build from the body
+
+**Date:** 2026-06-22 · **Type:** feat · **Depth:** Medium
+**Origin:** operator — "I want good suggestions, with pros/cons, ROI, etc, like a normal
+product manager feature description" (Quackback cutover follow-on).
+
+---
+
+## Problem
+
+The box builds from the **title only**. The assess loop emits `{title, body, labels}`, but
+(1) the prompt gives the `body` no structure, so it's thin, and (2) the build path drops the
+body entirely — `reconcile_quackback` carries title-only (KTD10 PII fence), and the spec
+recipe (`wgmesh-triage-spec.yaml`) takes `issue_number` + `issue_title`, never a body. So a
+rich brief can't reach the builder, and Accepting a decision-shaped post specs from a bare
+title → thin/wrong build. The cutover gated the *decision*; it didn't make the *brief* usable.
+
+## Goal
+
+End-to-end rich briefs: the box **generates** PM-grade Build Suggestions (Problem, Pros,
+Cons, ROI/Impact, Proposed Approach, Acceptance) into the post body, the body is **carried**
+into the build (sanitise-walled, resolving KTD10 by sanitising not dropping), and the spec
+**builds from the brief**, not the title alone.
+
+## Units
+
+### U1 — Generate PM-grade bodies (assess prompt)
+**File:** `pipeline/wgmesh_pipeline/observation_gather.py` (the assess recipe prompt).
+Require the `body` of every `issues_to_create` item to be a structured feature brief with
+exact sections: `## Problem`, `## Proposed Solution`, `## Pros`, `## Cons`, `## ROI / Impact`
+(effort vs the metric it moves), `## Acceptance Criteria`. Keep public-repo-safe (no PII /
+revenue). Body already flows `create_issue → create_post → board`, so founders see the brief
+immediately. Prompt-only change.
+**Test:** assert the prompt declares the required body sections (characterization on the
+recipe text). `Covers: founders see PM-grade briefs on the board.`
+
+### U2 — Carry the body into the build (store + reconcile, sanitise-walled)
+**Files:** `state/migrations/0004_issue_body.sql` (add `body TEXT` to issues),
+`state/store.py` (`IssueRecord.body`, `upsert_issue(body=…)`), `github/reconcile.py`
+(`reconcile_quackback` reads `post["content"]` → sanitise → store as body; fail-closed on
+sanitise error — skip that one ingest, never crash the tick).
+KTD10 resolved: the body is **sanitised at ingest** (box-authored bodies already pass the
+create-time wall; founder-edited board bodies get the wall here) instead of dropped.
+github path stays title-only (rollback path; `body` defaults to "").
+**Test:** reconcile_quackback stores the post content as body; a body that fails sanitise is
+skipped (not stored, tick survives); migration adds the column; IssueRecord round-trips body.
+`Covers: the brief survives to spec time.`
+
+### U3 — Build from the brief (spec node + recipe)
+**Files:** `graph/nodes/spec.py` (pass `issue_body` param from `issue.body`),
+`recipes/wgmesh-triage-spec.yaml` (declare `issue_body` param, use it in the prompt:
+"Full brief follows — build from it: {{ issue_body }}"; tolerate empty).
+**Test:** spec passes `issue_body` from the store row; empty body → recipe still valid
+(github fallback). `Covers: the builder specs from the brief, not the title.`
+
+## Scope
+- **In:** quackback live path end-to-end (generate→carry→build), sanitise wall on the body.
+- **Out:** github path body-carry (rollback-only, stays title-only); comment / two-way
+  steering (U10/U11 — larger follow-on); vote-rerank.
+
+## Sequencing
+U1 independent (prompt). U2 before U3 (spec reads what reconcile stored). All TDD.

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -10,6 +10,10 @@ parameters:
     input_type: string
     requirement: required
     description: "GitHub issue title."
+  - key: issue_brief_file
+    input_type: string
+    requirement: required
+    description: "Path to the PM brief markdown for this issue, or empty if none."
   - key: spec_file
     input_type: string
     requirement: required
@@ -19,6 +23,12 @@ prompt: |
   WireGuard mesh networking product with managed ingress.
 
   Issue: #{{ issue_number }} - {{ issue_title }}
+
+  A product brief may be provided at this path: {{ issue_brief_file }}
+  If that path is non-empty, READ it FIRST — it is the PM feature description
+  (Problem / Proposed Solution / Pros / Cons / ROI / Acceptance Criteria) and is
+  the authoritative source for what to build; the title is only a summary. If the
+  path is empty, build the spec from the title and the repository alone.
 
   Write a markdown implementation spec to this exact repository-relative path:
   {{ spec_file }}

--- a/pipeline/tests/test_observation_gather.py
+++ b/pipeline/tests/test_observation_gather.py
@@ -234,6 +234,24 @@ def test_assessment_recipe_templates_params_as_single_line_paths() -> None:
     # paid-customer growth work, not housekeeping.
     assert "PAID CUSTOMERS" in recipe
     assert "lead-capture form" in recipe  # pre-wires the nurture/Mautic handoff
+
+
+def test_assessment_recipe_requires_pm_grade_body_sections() -> None:
+    # The post body becomes the builder's brief (cutover follow-on), so the
+    # assess loop must emit a structured PM-grade feature description, not a
+    # one-liner. Assert the prompt demands each section by its exact heading.
+    from wgmesh_pipeline.observation_gather import _assessment_recipe
+
+    recipe = _assessment_recipe()
+    for heading in (
+        "## Problem",
+        "## Proposed Solution",
+        "## Pros",
+        "## Cons",
+        "## ROI / Impact",
+        "## Acceptance Criteria",
+    ):
+        assert heading in recipe, f"assess prompt must require body section {heading!r}"
     # Templating a param must not add lines (single-line path values only).
     templated = (
         recipe.replace("{{ open_board_file }}", "/tmp/board.md")

--- a/pipeline/tests/test_quackback_discovery.py
+++ b/pipeline/tests/test_quackback_discovery.py
@@ -144,6 +144,49 @@ def test_happy_one_accepted_post_queued_once(store: StateStore) -> None:
     assert branch.rsplit("-", 1)[1] == str(n)
 
 
+def test_reconcile_carries_post_body_as_brief(store: StateStore) -> None:
+    # The PM brief in the post body must reach the builder (not title-only).
+    brief = "## Problem\nTrial drop-off.\n## Acceptance Criteria\n- lead form\n"
+    post = {
+        "id": "post_01",
+        "title": "Add SSO",
+        "updatedAt": "2026-06-21T00:00:00Z",
+        "content": brief,
+    }
+    reconcile_quackback(FakeQuackbackForge([post]), store)
+
+    record = store.list_issues()[0]
+    assert record.body == brief
+
+
+def test_reconcile_drops_body_that_fails_sanitise(
+    store: StateStore, monkeypatch
+) -> None:
+    # A body that fails the sanitise wall degrades to empty (build from title),
+    # never leaks into a public spec — the issue is still queued.
+    monkeypatch.setattr(
+        "wgmesh_pipeline.graph.nodes.review.run_sanitise", lambda _t: False
+    )
+    post = {
+        "id": "post_01",
+        "title": "Add SSO",
+        "updatedAt": "2026-06-21T00:00:00Z",
+        "content": "leaks a secret",
+    }
+    result = reconcile_quackback(FakeQuackbackForge([post]), store)
+
+    assert result.queued == 1  # still queued (title is safe)
+    assert store.list_issues()[0].body == ""  # unsafe brief dropped
+
+
+def test_migration_0004_adds_issue_body_column(store: StateStore) -> None:
+    cols = {
+        str(r["name"])
+        for r in store._conn.execute("PRAGMA table_info(issues)").fetchall()
+    }
+    assert "body" in cols
+
+
 def test_idempotent_same_post_twice_one_row_second_queued_zero(
     store: StateStore,
 ) -> None:

--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -27,12 +27,17 @@ class FakeRunner:
             "## Acceptance Criteria\n- Passes.\n\n"
             "## Out of scope\n- Nothing else.\n"
         )
+        # Capture the brief file's content WHILE it exists — spec_node unlinks
+        # it in a finally, so it's gone by the time the test asserts.
+        brief_path = params.get("issue_brief_file") or ""
+        brief_content = Path(brief_path).read_text() if brief_path else ""
         self.calls.append(
             {
                 "recipe": recipe,
                 "workdir": workdir,
                 "params": params,
                 "expected_output": expected_output,
+                "brief_content": brief_content,
             }
         )
         return GooseResult(ok=True, output_path=output, duration_seconds=0.01, raw_log="ok")
@@ -74,8 +79,31 @@ def test_spec_node_resolves_recipe_path_and_passes_issue_params(tmp_path: Path) 
     assert call["params"] == {
         "issue_number": "18",
         "issue_title": "Add managed ingress",
+        "issue_brief_file": "",  # no body in state → empty path → title fallback
         "spec_file": "specs/issue-18-spec.md",
     }
+
+
+def test_spec_node_hands_the_brief_to_the_recipe_as_a_file(tmp_path: Path) -> None:
+    # The PM brief (issue_body) must reach the builder as a file path (it is
+    # multi-line, so it can't be an inline recipe param), and the file must
+    # carry the brief verbatim.
+    runner = FakeRunner(calls=[])
+    brief = "## Problem\nTrial drop-off.\n## ROI / Impact\n+5% conversion.\n"
+    spec_node(
+        {
+            "issue": GitHubIssue(number=42, title="Onboarding fix", labels=(), state="open"),
+            "issue_body": brief,
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+
+    call = runner.calls[0]
+    assert call["params"]["issue_brief_file"]  # non-empty path
+    assert call["params"]["issue_brief_file"].endswith(".md")
+    assert call["brief_content"] == brief
 
 
 def test_spec_node_puts_spec_content_in_state_for_judge(tmp_path: Path) -> None:

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -61,7 +61,7 @@ def test_injected_connection_adapter_roundtrip() -> None:
     assert len(db.list_runs()) == 1
     # migrations tracked through the adapter
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003"]
+    assert versions == ["0001", "0002", "0003", "0004"]
 
 
 def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
@@ -79,7 +79,7 @@ def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
     assert db.list_issues() == []
     assert db.list_runs() == []
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003"]
+    assert versions == ["0001", "0002", "0003", "0004"]
 
 
 def test_requeue_failed_all_preserves_linkage_and_clears_attempts(tmp_path) -> None:
@@ -193,7 +193,7 @@ def test_migrations_apply_idempotently(tmp_path) -> None:
     assert db.get_issue(1).stage == "queued"
     # schema_migrations records the initial migration exactly once
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003"]
+    assert versions == ["0001", "0002", "0003", "0004"]
 
 
 def test_sqlite_connection_uses_wal_and_busy_timeout(tmp_path) -> None:

--- a/pipeline/wgmesh_pipeline/github/reconcile.py
+++ b/pipeline/wgmesh_pipeline/github/reconcile.py
@@ -191,9 +191,33 @@ def reconcile_quackback(client: object, store: StateStore) -> ReconcileResult:
         number, fresh = store.map_quackback_post(post_id, marker)
         seen += 1
         if fresh:
-            store.upsert_issue(number, title, stage="queued", status="open")
+            store.upsert_issue(
+                number, title, stage="queued", status="open",
+                body=_safe_brief(post, number),
+            )
             queued += 1
     return ReconcileResult(seen=seen, queued=queued, escalated=0, merged=0)
+
+
+def _safe_brief(post: dict, number: int) -> str:
+    """The post body, sanitised, for the builder to spec from (KTD10 handled by
+    the wall, not by dropping). A body that fails the sanitise wall degrades to
+    empty — the issue still builds from its title — rather than leaking PII into
+    a public spec/PR. The title is already sanitised at create time."""
+    content = str(post.get("content") or "")
+    if not content:
+        return ""
+    # Local import: keep the control-loop graph out of module-load import order.
+    from wgmesh_pipeline.graph.nodes.review import run_sanitise
+
+    if run_sanitise(content):
+        return content
+    log.warning(
+        "quackback ingest #%s: post body failed the sanitise wall — "
+        "building from title only (brief dropped)",
+        number,
+    )
+    return ""
 
 
 def _current_stage(store: StateStore, number: int) -> str | None:

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 from pathlib import Path
 
 from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
@@ -26,18 +28,39 @@ def spec_node(state: GraphState) -> GraphState:
     config = next_state.get("config")
     recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
     recipe_path = recipes_dir / "wgmesh-triage-spec.yaml"
-    result = runner.run_recipe(
-        recipe=recipe_path,
-        workdir=repo_path,
-        params={
-            "issue_number": str(issue.number),
-            "issue_title": issue.title,
-            "spec_file": str(spec_rel),
-        },
-        expected_output=spec_rel,
-        stage="spec",
-        session_id=f"issue-{issue.number}",
-    )
+    # The brief (PM body) is multi-line, so it can NOT be inlined as a recipe
+    # param — goose substitutes params into the YAML before parsing and a
+    # multi-line value breaks the `prompt: |` scalar. Hand it over as a FILE
+    # path (the same convention as spec_file / open_board_file); empty body →
+    # empty path → the recipe falls back to the title.
+    brief = str(next_state.get("issue_body", "") or "")
+    brief_file = ""
+    if brief.strip():
+        fd, brief_file = tempfile.mkstemp(
+            prefix=f"issue-{issue.number}-brief-", suffix=".md"
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(brief)
+    try:
+        result = runner.run_recipe(
+            recipe=recipe_path,
+            workdir=repo_path,
+            params={
+                "issue_number": str(issue.number),
+                "issue_title": issue.title,
+                "issue_brief_file": brief_file,
+                "spec_file": str(spec_rel),
+            },
+            expected_output=spec_rel,
+            stage="spec",
+            session_id=f"issue-{issue.number}",
+        )
+    finally:
+        if brief_file:
+            try:
+                os.unlink(brief_file)
+            except OSError:
+                pass
     if not result.ok:
         # Surface goose's actual output so a write-tool/model/recipe failure is
         # diagnosable from the journal instead of just "empty output guard".

--- a/pipeline/wgmesh_pipeline/graph/state.py
+++ b/pipeline/wgmesh_pipeline/graph/state.py
@@ -13,6 +13,7 @@ Decision = Literal["merge", "escalate"]
 
 class GraphState(TypedDict, total=False):
     issue: GitHubIssue
+    issue_body: str
     classification: Classification
     classification_override: Classification
     spec_path: str

--- a/pipeline/wgmesh_pipeline/observation_gather.py
+++ b/pipeline/wgmesh_pipeline/observation_gather.py
@@ -310,9 +310,24 @@ prompt: |
   issues. Leave issues_to_close / prs_to_close empty unless an item is clearly
   obsolete and safe to close.
 
+  The `body` of every issues_to_create item is the BRIEF the build agent specs
+  from — write it like a product manager's feature description, not a one-liner.
+  Use this exact markdown structure with these exact `##` headings, in order:
+    - `## Problem` — the user/business problem and why it matters now.
+    - `## Proposed Solution` — the concrete thing to build, specifically enough
+      for a coding agent to start.
+    - `## Pros` — bullet list of upside.
+    - `## Cons` — bullet list of risks / downsides / what it costs.
+    - `## ROI / Impact` — the effort vs the expected metric lift (which funnel
+      number it moves, roughly how much, against what effort).
+    - `## Acceptance Criteria` — bullet list of what "done" is + the metric it
+      should move. (For a landing/signup/trial task, this MUST include a
+      lead-capture form and an analytics snippet, per above.)
+  Keep the body public-repo safe: no secrets, no customer PII, no exact revenue.
+
   Write ONLY strict JSON to this exact path: {{ assessment_file }}
   Four keys, each an array:
-  - issues_to_create: objects with title, body, labels
+  - issues_to_create: objects with title, body (the PM brief above), labels
   - issues_to_close: objects with number, reason
   - needs_human: objects with request, urgency, reason
   - prs_to_close: objects with repo, number, reason

--- a/pipeline/wgmesh_pipeline/poller.py
+++ b/pipeline/wgmesh_pipeline/poller.py
@@ -95,6 +95,7 @@ class Poller:
         state = {
             **self.scratch.get(issue.number, {}),
             "issue": graph_issue,
+            "issue_body": issue.body,
             "github": self.client,
             "config": self.config,
             "repo_path": Path(self.config.repo_path),

--- a/pipeline/wgmesh_pipeline/state/migrations/0004_issue_body.sql
+++ b/pipeline/wgmesh_pipeline/state/migrations/0004_issue_body.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- Carry the Build Suggestion brief (post body) through to the builder.
+--
+-- The box used to build from the issue TITLE alone — reconcile carried title
+-- only and the spec recipe took title only. A Quackback Build Suggestion now
+-- carries a PM-grade brief (Problem / Pros / Cons / ROI / Acceptance) in its
+-- body; this column threads that brief to the spec agent so it builds from the
+-- brief, not the title. The body is sanitised at ingest (reconcile_quackback),
+-- so the KTD10 PII concern is handled by the wall, not by dropping the body.
+-- Nullable + default '': old rows and the github fallback path stay title-only.
+ALTER TABLE issues ADD COLUMN body TEXT DEFAULT '';

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -55,6 +55,7 @@ class IssueRecord:
     impl_pr: int | None
     last_error: str | None
     updated_at: datetime
+    body: str = ""
 
 
 class StateStore:
@@ -120,6 +121,7 @@ class StateStore:
         impl_pr: int | None = None,
         last_error: str | None = None,
         updated_at: datetime | None = None,
+        body: str | None = None,
     ) -> IssueRecord:
         if stage not in ALLOWED_TRANSITIONS:
             raise ValueError(f"unknown issue stage: {stage}")
@@ -128,9 +130,9 @@ class StateStore:
             """
             INSERT INTO issues (
               number, title, classification, stage, status, risk_tier,
-              attempts, spec_pr, impl_pr, last_error, updated_at
+              attempts, spec_pr, impl_pr, last_error, updated_at, body
             )
-            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
             ON CONFLICT(number) DO UPDATE SET
               title=excluded.title,
               classification=COALESCE(excluded.classification, issues.classification),
@@ -140,7 +142,8 @@ class StateStore:
               spec_pr=COALESCE(excluded.spec_pr, issues.spec_pr),
               impl_pr=COALESCE(excluded.impl_pr, issues.impl_pr),
               last_error=excluded.last_error,
-              updated_at=excluded.updated_at
+              updated_at=excluded.updated_at,
+              body=COALESCE(excluded.body, issues.body)
             """,
             (
                 number,
@@ -153,6 +156,7 @@ class StateStore:
                 impl_pr,
                 last_error,
                 _iso(now),
+                body,
             ),
         )
         self._conn.commit()
@@ -624,6 +628,7 @@ def _issue(row: sqlite3.Row) -> IssueRecord:
         impl_pr=row["impl_pr"],
         last_error=row["last_error"],
         updated_at=_parse(str(row["updated_at"])),
+        body=str(row["body"]) if ("body" in row.keys() and row["body"] is not None) else "",
     )
 
 


### PR DESCRIPTION
## Summary
The box built from the issue **title alone** — the assess loop emitted an unstructured body, `reconcile_quackback` carried title-only (KTD10 PII fence), and the spec recipe took only the title. So a rich brief never reached the builder, and Accepting a decision-shaped post specced from a bare title. This threads a **PM-grade brief end to end** (operator: *"good suggestions, with pros/cons, ROI, etc, like a normal product manager feature description"*).

Plan: `docs/plans/2026-06-22-005-feat-rich-build-suggestion-briefs-plan.md`. Follows the Quackback cutover.

- **U1 — generate.** Assess prompt now requires every `issues_to_create` body to be a structured feature description with exact sections: `## Problem`, `## Proposed Solution`, `## Pros`, `## Cons`, `## ROI / Impact`, `## Acceptance Criteria` (public-repo safe). Body already flows to the board → founders see the brief immediately.
- **U2 — carry.** Migration `0004` adds `issues.body`; `IssueRecord`/`upsert_issue` carry it; `reconcile_quackback` reads the post content, runs the **sanitise wall**, stores it as the brief. **KTD10 resolved by sanitising, not dropping** — a body that fails the wall degrades to empty (build from title), never leaks into a public spec. github path stays title-only (rollback).
- **U3 — build.** Spec node hands the brief to the recipe as a **file path** (multi-line → can't be an inline param without breaking the recipe YAML), temp-written + cleaned up; recipe reads it first as authoritative, falls back to title when empty.

## Test plan
- `test_observation_gather` — assess prompt declares the 6 body sections.
- `test_quackback_discovery` — reconcile carries the brief; a sanitise-failing body is dropped (issue still queued); migration 0004 column present.
- `test_state` — migration list includes 0004.
- `test_spec_node` — spec node hands the brief over as a file with verbatim content; empty body → empty path.
- 65 targeted tests green. The 13 full-suite failures are **pre-existing** host-gitconfig/network flakes (identical on `origin/main`).

## Deploy note
Code + migration take effect on the box only after **Update Pipeline Box** (migration 0004 runs on restart). The box is live on `forge_kind=quackback`; until deploy it keeps building title-only.

## Out of scope
github body-carry (rollback path); comment / two-way steering (U10/U11).