### PR TITLE
feat(state): one-shot --reset-queue-and-exit to drain orphaned store rows

### DIFF
--- a/.github/workflows/requeue-failed-issues.yml
+++ b/.github/workflows/requeue-failed-issues.yml
@@ -15,6 +15,10 @@ on:
       target_stage:
         description: 'actionable target stage'
         default: 'spec_ready'
+      reset_queue:
+        description: 'DANGER: clear the ENTIRE issue queue + run history and exit (drains orphaned rows after a forge cutover). Ignores issues/target_stage.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,6 +57,7 @@ jobs:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           ISSUES: ${{ github.event.inputs.issues }}
           TARGET_STAGE: ${{ github.event.inputs.target_stage }}
+          RESET_QUEUE: ${{ github.event.inputs.reset_queue }}
         run: |
           set -euo pipefail
           if [[ ! "$ISSUES" =~ ^[0-9,]*$ ]]; then
@@ -67,9 +72,10 @@ jobs:
           printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/deploy_key"
           SSH_ISSUES=$(printf '%q' "$ISSUES")
           SSH_TARGET_STAGE=$(printf '%q' "$TARGET_STAGE")
+          SSH_RESET_QUEUE=$(printf '%q' "$RESET_QUEUE")
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -o ConnectTimeout=15 -i "$RUNNER_TEMP/deploy_key" root@"$BOX_IP" \
-              "ISSUES=$SSH_ISSUES TARGET_STAGE=$SSH_TARGET_STAGE bash -se" <<'REMOTE'
+              "ISSUES=$SSH_ISSUES TARGET_STAGE=$SSH_TARGET_STAGE RESET_QUEUE=$SSH_RESET_QUEUE bash -se" <<'REMOTE'
           set -euo pipefail
           # /etc/wgmesh-pipeline/env is a systemd EnvironmentFile (values may
           # contain spaces/JSON, e.g. STAGE_ROUTING). Parse KEY=VALUE WITHOUT
@@ -82,6 +88,14 @@ jobs:
             esac
           done < /etc/wgmesh-pipeline/env
           cd /opt/wgmesh-pipeline
+          if [ "${RESET_QUEUE}" = "true" ]; then
+            # One-shot store wipe (drain orphaned rows after a forge cutover).
+            # --reset-queue-and-exit clears issues+runs then EXITS — it does NOT
+            # start a second poller (that's what plain --reset-queue would do).
+            echo '===== reset queue (clear issues + runs, no restart) ====='
+            /opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main --reset-queue-and-exit 2>&1
+            exit 0
+          fi
           cmd=(/opt/wgmesh-pipeline/.venv/bin/python -m wgmesh_pipeline.main --requeue-failed)
           if [ -n "${ISSUES}" ]; then
             cmd+=(--issues "$ISSUES")

--- a/pipeline/tests/test_main.py
+++ b/pipeline/tests/test_main.py
@@ -104,6 +104,28 @@ def test_main_requeue_failed_runs_one_shot_and_does_not_poll(monkeypatch, capsys
     )
 
 
+def test_main_reset_queue_and_exit_clears_and_does_not_poll(monkeypatch, capsys) -> None:
+    store = Store()
+    cfg = Config(
+        target_repo="atvirokodosprendimai/wgmesh", mode="shadow", database_mode="local"
+    )
+
+    async def fail_async_main(*, reset_queue: bool = False) -> None:
+        raise AssertionError("--reset-queue-and-exit must not enter async_main")
+
+    monkeypatch.setattr(main, "load_config", lambda: cfg)
+    monkeypatch.setattr(main, "open_state_store", lambda config: store)
+    monkeypatch.setattr(main, "async_main", fail_async_main)
+
+    main.main(["--reset-queue-and-exit"])
+
+    assert store.reset_calls == 1
+    assert (
+        "[pipeline] reset_queue_and_exit cleared issues=3 runs=4"
+        in capsys.readouterr().err
+    )
+
+
 def test_main_requeue_failed_passes_issue_filter(monkeypatch) -> None:
     store = Store()
     cfg = Config(

--- a/pipeline/wgmesh_pipeline/main.py
+++ b/pipeline/wgmesh_pipeline/main.py
@@ -57,6 +57,22 @@ def requeue_failed_main(
     )
 
 
+def reset_queue_main() -> None:
+    """One-shot: clear the durable issue queue + run history and EXIT — never
+    starts the poller (unlike ``--reset-queue``, which resets then runs forever).
+    Used to drain orphaned store rows after a forge cutover without spawning a
+    second poller alongside the systemd service. Migrations + the Quackback
+    post-id map survive (``reset_queue`` deletes only ``issues``/``runs``)."""
+    config = load_config()
+    store = open_state_store(config)
+    cleared = store.reset_queue()
+    print(
+        f"[pipeline] reset_queue_and_exit cleared "
+        f"issues={cleared['issues']} runs={cleared['runs']}",
+        file=sys.stderr,
+    )
+
+
 async def async_main(*, reset_queue: bool = False) -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -120,6 +136,11 @@ def main(argv: list[str] | None = None) -> None:
         help="move failed issues back to an actionable stage and exit",
     )
     parser.add_argument(
+        "--reset-queue-and-exit",
+        action="store_true",
+        help="clear the durable issue queue + run history and exit (no polling)",
+    )
+    parser.add_argument(
         "--issues",
         type=_parse_issue_numbers,
         help="comma-separated issue numbers to requeue",
@@ -132,6 +153,9 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     if args.requeue_failed:
         requeue_failed_main(numbers=args.issues, target_stage=args.target_stage)
+        return
+    if args.reset_queue_and_exit:
+        reset_queue_main()
         return
     asyncio.run(async_main(reset_queue=args.reset_queue))
 


### PR DESCRIPTION
## Summary
After the Quackback cutover, closing GitHub issues left orphaned rows in the box's durable store — the poller keeps claiming them and grinding langchain (timeout, no PRs), burning agent calls. `--reset-queue` resets *then runs the poller forever*, so it can't be a one-shot beside the systemd service.

Adds **`--reset-queue-and-exit`**: clears `issues` + run history via `store.reset_queue()` and **exits** (migrations + the Quackback post-id map survive — reset deletes only `issues`/`runs`, so a later re-Accept still maps cleanly). Wired into the **Requeue Failed Issues** workflow behind a `reset_queue` boolean input.

## Test plan
- `test_main_reset_queue_and_exit_clears_and_does_not_poll` — clears the store, never enters `async_main` (no second poller).
- YAML valid, ruff clean. 7 main tests green.