### PR TITLE
feat(decision-lane): Phase 1 — the consent loop (capability-ladder, read-only)

### DIFF
--- a/pipeline/recipes/wgmesh-decision-proposal.yaml
+++ b/pipeline/recipes/wgmesh-decision-proposal.yaml
@@ -1,0 +1,70 @@
+version: "1.0.0"
+title: "wgmesh Decision Proposal"
+description: "Draft a grounded proposal for a co-founder decision, for the decision lane."
+parameters:
+  - key: decision_title
+    input_type: string
+    requirement: required
+    description: "The decision being made (the post title)."
+  - key: brief_file
+    input_type: string
+    requirement: required
+    description: "Path to the decision ask / brief markdown (the post body)."
+  - key: strategy_file
+    input_type: string
+    requirement: required
+    description: "Path to the company strategy + target metrics (STRATEGY.md)."
+  - key: prior_proposal_file
+    input_type: string
+    requirement: required
+    description: "Path to the previous proposal to revise, or empty on the first draft."
+  - key: feedback_file
+    input_type: string
+    requirement: required
+    description: "Path to the latest co-founder comment to address, or empty on the first draft."
+  - key: proposal_file
+    input_type: string
+    requirement: required
+    description: "Repository-relative path where the proposal markdown must be written."
+prompt: |
+  You are the decision-support analyst for the autonomous company behind wgmesh
+  (an AGPL WireGuard mesh-VPN) and its hosted service cloudroof. A co-founder has
+  asked the company to decide something. Write a proposal they can act on.
+
+  Decision: {{ decision_title }}
+  The ask / brief is at: {{ brief_file }} — READ it first.
+  Company strategy + target metrics: {{ strategy_file }} — ground the proposal in it.
+
+  If this path is non-empty, you are REVISING, not starting over:
+  - prior proposal: {{ prior_proposal_file }}
+  - co-founder feedback to address: {{ feedback_file }}
+  Read both, and revise the prior proposal to address the feedback specifically.
+
+  Write a markdown proposal to this exact repository-relative path:
+  {{ proposal_file }}
+
+  Requirements:
+  - Create parent directories if needed; write the file, do not only print it.
+  - Use this exact section structure with these exact `##` headings, in order:
+    - `## Recommendation` — the single option you recommend, in one or two sentences.
+    - `## Options Considered` — the alternatives, each with a one-line summary.
+    - `## Pros` — bullet list of upside of the recommendation.
+    - `## Cons` — bullet list of risks / downsides / what it costs.
+    - `## Upsides` — the best-case outcome if this goes well.
+    - `## Downsides` — the worst-case outcome if it goes badly.
+    - `## ROI / Cost` — the effort/spend vs the expected return, against which metric.
+    - `## Assumptions` — EVERY market, competitor, or pricing claim you made that you
+      could not verify from the brief or strategy. The box has NO web research yet,
+      so treat all such claims as UNVERIFIED assumptions and list them here plainly;
+      never assert a market or competitor fact as settled.
+  - Keep it public-repo safe: no secrets, no customer PII, no exact revenue figures.
+  - Be concrete enough that a co-founder can approve or push back on specifics.
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+settings:
+  goose_provider: anthropic
+  goose_model: GLM-5.2

--- a/pipeline/tests/test_decision_comments.py
+++ b/pipeline/tests/test_decision_comments.py
@@ -1,0 +1,69 @@
+"""Decision-lane comment author-distinction + iteration state (U4)."""
+
+from __future__ import annotations
+
+from wgmesh_pipeline.decision_lane.comments import (
+    is_unprocessed,
+    latest_cofounder_comment,
+)
+from wgmesh_pipeline.state.store import StateStore
+
+BOT = "autobox-box"
+
+
+def _c(cid, author, *, team=True, created="2026-06-22T10:00:00Z"):
+    return {
+        "id": cid,
+        "authorName": author,
+        "isTeamMember": team,
+        "createdAt": created,
+    }
+
+
+def test_ignores_bot_own_comment() -> None:
+    comments = [_c("c1", BOT)]
+    assert latest_cofounder_comment(comments, BOT) is None
+
+
+def test_ignores_non_team_comment() -> None:
+    comments = [_c("c1", "random_user", team=False)]
+    assert latest_cofounder_comment(comments, BOT) is None
+
+
+def test_selects_newest_cofounder_comment() -> None:
+    comments = [
+        _c("c1", "marty", created="2026-06-22T09:00:00Z"),
+        _c("c2", "lempa", created="2026-06-22T11:00:00Z"),
+        _c("c3", BOT, created="2026-06-22T12:00:00Z"),  # bot reply, ignored
+    ]
+    latest = latest_cofounder_comment(comments, BOT)
+    assert latest is not None and latest["id"] == "c2"
+
+
+def test_is_unprocessed_against_marker() -> None:
+    c = _c("c2", "marty")
+    assert is_unprocessed(c, last_comment_id="c1") is True
+    assert is_unprocessed(c, last_comment_id="c2") is False
+    assert is_unprocessed(c, last_comment_id=None) is True  # first feedback
+    assert is_unprocessed(None, last_comment_id="c1") is False
+
+
+def test_decision_state_round_trip_and_iteration_cap(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    assert store.get_decision_state("post_01") is None
+
+    assert store.record_decision_proposal("post_01", last_comment_id=None) == 1
+    state = store.get_decision_state("post_01")
+    assert state == {"last_comment_id": None, "iterations": 1}
+
+    assert store.record_decision_proposal("post_01", last_comment_id="c2") == 2
+    state = store.get_decision_state("post_01")
+    assert state == {"last_comment_id": "c2", "iterations": 2}
+
+
+def test_migration_0005_adds_decision_posts_table(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    row = store._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='decision_posts'"
+    ).fetchone()
+    assert row is not None

--- a/pipeline/tests/test_decision_lane.py
+++ b/pipeline/tests/test_decision_lane.py
@@ -1,0 +1,161 @@
+"""Decision-lane orchestrator (U7) — the consent loop, plan + execute."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wgmesh_pipeline.decision_lane import run_decision_cycle
+from wgmesh_pipeline.state.store import StateStore
+
+BOT = "autobox-box"
+
+
+class FakeForge:
+    """Records writes; serves canned asks/comments/votes per post id."""
+
+    def __init__(self, asks, comments=None, votes=None) -> None:
+        self._asks = asks
+        self._comments = comments or {}
+        self._votes = votes or {}
+        self.writes: list[tuple[str, Any]] = []
+
+    def list_decision_asks(self):
+        return list(self._asks)
+
+    def list_post_comments(self, post_id):
+        return list(self._comments.get(post_id, []))
+
+    def post_vote_count(self, post_id):
+        return int(self._votes.get(post_id, 0))
+
+    def post_proposal_comment(self, post_id, body):
+        self.writes.append(("comment", (post_id, body)))
+
+    def open_final_proposal(self, title, body):
+        self.writes.append(("final", (title, body)))
+        return {"id": "post_final"}
+
+    def mark_superseded(self, post_id, final_ref):
+        self.writes.append(("superseded", (post_id, final_ref)))
+
+
+def _store(tmp_path):
+    return StateStore(tmp_path / "state.db")
+
+
+def _proposal(post, latest):
+    return f"## Recommendation\nfor {post['id']}"
+
+
+def _run(forge, store, *, live, cofounders=2, max_iters=3):
+    return run_decision_cycle(
+        forge, store, _proposal,
+        bot_author=BOT, cofounder_count=cofounders, max_iterations=max_iters, live=live,
+    )
+
+
+def test_fresh_ask_plans_and_drafts_a_proposal(tmp_path) -> None:
+    forge = FakeForge(asks=[{"id": "p1", "title": "Decide pricing"}])
+    store = _store(tmp_path)
+
+    result = _run(forge, store, live=True)
+
+    assert result.seen == 1
+    assert result.planned[0].kind == "draft"
+    assert ("comment", ("p1", "## Recommendation\nfor p1")) in forge.writes
+    assert store.get_decision_state("p1")["iterations"] == 1
+
+
+def test_shadow_plans_but_writes_nothing(tmp_path) -> None:
+    forge = FakeForge(asks=[{"id": "p1", "title": "Decide pricing"}])
+    store = _store(tmp_path)
+
+    result = _run(forge, store, live=False)
+
+    assert result.planned[0].kind == "draft"
+    assert result.executed == 0
+    assert forge.writes == []  # zero board writes in shadow
+    assert store.get_decision_state("p1") is None  # nothing recorded
+
+
+def test_new_cofounder_comment_triggers_revise(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.record_decision_proposal("p1", last_comment_id=None)  # v1 already drafted
+    forge = FakeForge(
+        asks=[{"id": "p1", "title": "Decide pricing"}],
+        comments={"p1": [{"id": "c9", "authorName": "marty", "isTeamMember": True,
+                          "createdAt": "2026-06-22T11:00:00Z"}]},
+    )
+
+    result = _run(forge, store, live=True)
+
+    assert result.planned[0].kind == "revise"
+    assert ("comment", ("p1", "## Recommendation\nfor p1")) in forge.writes
+    assert store.get_decision_state("p1")["last_comment_id"] == "c9"
+
+
+def test_bot_own_comment_does_not_trigger_revise(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.record_decision_proposal("p1", last_comment_id=None)
+    forge = FakeForge(
+        asks=[{"id": "p1", "title": "Decide pricing"}],
+        comments={"p1": [{"id": "c9", "authorName": BOT, "isTeamMember": True,
+                          "createdAt": "2026-06-22T11:00:00Z"}]},
+        votes={"p1": 0},
+    )
+
+    result = _run(forge, store, live=True)
+
+    assert result.planned[0].kind == "noop"  # no new co-founder feedback, no votes
+
+
+def test_threshold_met_finalizes_and_supersedes(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.record_decision_proposal("p1", last_comment_id="c9")  # proposal stands
+    forge = FakeForge(
+        asks=[{"id": "p1", "title": "Decide pricing"}],
+        comments={"p1": [{"id": "c9", "authorName": "marty", "isTeamMember": True,
+                          "createdAt": "2026-06-22T11:00:00Z"}]},
+        votes={"p1": 1},  # routine threshold = 1
+    )
+
+    result = _run(forge, store, live=True)
+
+    assert result.planned[0].kind == "finalize"
+    kinds = [w[0] for w in forge.writes]
+    assert "final" in kinds and "superseded" in kinds
+
+
+def test_max_iterations_caps_revision(tmp_path) -> None:
+    store = _store(tmp_path)
+    for _ in range(3):  # already at the cap (max_iters=3)
+        store.record_decision_proposal("p1", last_comment_id="old")
+    forge = FakeForge(
+        asks=[{"id": "p1", "title": "Decide pricing"}],
+        comments={"p1": [{"id": "cNEW", "authorName": "marty", "isTeamMember": True,
+                          "createdAt": "2026-06-22T12:00:00Z"}]},
+    )
+
+    result = _run(forge, store, live=True, max_iters=3)
+
+    assert result.planned[0].kind == "noop"
+    assert result.planned[0].detail == "max iterations reached"
+
+
+def test_one_bad_post_does_not_kill_the_cycle(tmp_path) -> None:
+    class Boom(FakeForge):
+        def list_post_comments(self, post_id):
+            if post_id == "p1":
+                raise RuntimeError("read failed")
+            return []
+
+    store = _store(tmp_path)
+    store.record_decision_proposal("p1", last_comment_id=None)
+    forge = Boom(
+        asks=[{"id": "p1", "title": "bad"}, {"id": "p2", "title": "good"}],
+        votes={"p2": 0},
+    )
+
+    result = _run(forge, store, live=True)
+
+    assert result.seen == 2  # p2 still processed despite p1 raising

--- a/pipeline/tests/test_decision_policy.py
+++ b/pipeline/tests/test_decision_policy.py
@@ -1,0 +1,46 @@
+"""Decision-lane approval-threshold policy (U3) — the consent gate.
+
+Test-first: this is the safety brake on the capability ladder, so every tier /
+count / vote combination is pinned, including the intended N=2 unanimous stall.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.decision_lane.policy import (
+    DANGEROUS,
+    ROUTINE,
+    is_approved,
+    required_approvals,
+)
+
+
+def test_routine_needs_one_regardless_of_count() -> None:
+    assert required_approvals(ROUTINE, 2) == 1
+    assert required_approvals(ROUTINE, 5) == 1
+
+
+def test_dangerous_needs_all_current_cofounders() -> None:
+    assert required_approvals(DANGEROUS, 2) == 2  # unanimous at N=2
+    assert required_approvals(DANGEROUS, 5) == 5
+
+
+def test_dangerous_floors_at_one() -> None:
+    assert required_approvals(DANGEROUS, 0) == 1
+
+
+def test_unknown_tier_raises_never_lowers_bar() -> None:
+    with pytest.raises(ValueError, match="unknown decision risk tier"):
+        required_approvals("freebie", 2)
+
+
+def test_is_approved_true_at_threshold_false_below() -> None:
+    assert is_approved(1, ROUTINE, 2) is True
+    assert is_approved(0, ROUTINE, 2) is False
+
+
+def test_is_approved_dangerous_n2_one_vote_is_the_intended_stall() -> None:
+    # The point of the dangerous tier at N=2: one founder is not enough.
+    assert is_approved(1, DANGEROUS, 2) is False
+    assert is_approved(2, DANGEROUS, 2) is True

--- a/pipeline/tests/test_decision_recipe.py
+++ b/pipeline/tests/test_decision_recipe.py
@@ -1,0 +1,73 @@
+"""Decision-proposal recipe (U5) — characterization of the prompt contract.
+
+The recipe is consumed by Goose at runtime; these tests pin the section contract
++ the single-line-path-param guard (a multi-line param breaks the YAML scalar,
+the same trap the observation recipe guards against)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+RECIPE = (
+    Path(__file__).resolve().parents[1] / "recipes" / "wgmesh-decision-proposal.yaml"
+)
+
+
+def _text() -> str:
+    return RECIPE.read_text(encoding="utf-8")
+
+
+def test_recipe_declares_every_proposal_section() -> None:
+    text = _text()
+    for heading in (
+        "## Recommendation",
+        "## Options Considered",
+        "## Pros",
+        "## Cons",
+        "## Upsides",
+        "## Downsides",
+        "## ROI / Cost",
+        "## Assumptions",
+    ):
+        assert heading in text, f"recipe must require {heading!r}"
+
+
+def test_recipe_requires_unverified_assumptions_framing() -> None:
+    text = _text().lower()
+    assert "no web research" in text
+    assert "unverified" in text
+    # never assert a market fact as settled
+    assert "never assert" in text
+
+
+def test_recipe_params_template_as_single_line_paths() -> None:
+    # Goose substitutes {{ params }} into the YAML before parsing, so every param
+    # must be a single-line path — a multi-line value breaks the prompt scalar.
+    text = _text()
+    for token in (
+        "{{ brief_file }}",
+        "{{ strategy_file }}",
+        "{{ prior_proposal_file }}",
+        "{{ feedback_file }}",
+        "{{ proposal_file }}",
+    ):
+        assert token in text
+    templated = text
+    for token, val in (
+        ("{{ brief_file }}", "/tmp/brief.md"),
+        ("{{ strategy_file }}", "/tmp/STRATEGY.md"),
+        ("{{ prior_proposal_file }}", "/tmp/prior.md"),
+        ("{{ feedback_file }}", "/tmp/fb.md"),
+        ("{{ proposal_file }}", "specs/proposal.md"),
+        ("{{ decision_title }}", "Decide pricing"),
+    ):
+        templated = templated.replace(token, val)
+    assert text.count("\n") == templated.count("\n")
+
+
+def test_recipe_is_valid_yaml() -> None:
+    import yaml
+
+    doc = yaml.safe_load(_text())
+    keys = {p["key"] for p in doc["parameters"]}
+    assert {"decision_title", "brief_file", "proposal_file"} <= keys

--- a/pipeline/tests/test_langchain_agent_prompts.py
+++ b/pipeline/tests/test_langchain_agent_prompts.py
@@ -21,6 +21,7 @@ def test_spec_recipe_renders_required_params() -> None:
         {
             "issue_number": "42",
             "issue_title": "Test title",
+            "issue_brief_file": "",  # the PM brief path (empty = title-only), #1978
             "spec_file": "spec.md",
         },
     )

--- a/pipeline/tests/test_quackback_client.py
+++ b/pipeline/tests/test_quackback_client.py
@@ -279,3 +279,81 @@ def test_create_tag_malformed_payload_raises() -> None:
 
     with pytest.raises(QuackbackError, match="missing 'data' object"):
         client.create_tag("growth")
+
+
+# ------------------------------------------------------- decision lane reads (U1/U2)
+
+
+def test_list_comments_returns_thread_with_author_fields() -> None:
+    body = json.dumps(
+        {
+            "data": [
+                {
+                    "id": "c1",
+                    "principalId": "prin_founder",
+                    "authorName": "marty",
+                    "isTeamMember": True,
+                    "content": "lower the tier",
+                    "createdAt": "2026-06-22T10:00:00Z",
+                }
+            ]
+        }
+    )
+    client, http = _client(
+        [("GET", "/posts/post_01/comments", HttpResponse(200, body))]
+    )
+
+    comments = client.list_comments("post_01")
+
+    assert len(comments) == 1
+    assert comments[0]["authorName"] == "marty"
+    assert comments[0]["isTeamMember"] is True
+    assert http.calls[0]["method"] == "GET"
+
+
+def test_list_comments_empty_thread_is_empty_list() -> None:
+    client, _ = _client(
+        [("GET", "/posts/post_01/comments", HttpResponse(200, json.dumps({"data": []})))]
+    )
+
+    assert client.list_comments("post_01") == []
+
+
+def test_list_comments_malformed_payload_raises() -> None:
+    # 200 but no 'data' array — must fail closed, never read as "no feedback".
+    client, _ = _client(
+        [("GET", "/posts/post_01/comments", HttpResponse(200, json.dumps({"ok": 1})))]
+    )
+
+    with pytest.raises(QuackbackError, match="missing 'data' array"):
+        client.list_comments("post_01")
+
+
+def test_list_comments_api_error_raises() -> None:
+    client, _ = _client(
+        [("GET", "/posts/post_01/comments", HttpResponse(503, "down"))]
+    )
+
+    with pytest.raises(QuackbackError):
+        client.list_comments("post_01")
+
+
+def test_get_vote_count_reads_vote_count_off_post() -> None:
+    body = json.dumps({"data": {"id": "post_01", "title": "t", "voteCount": 3}})
+    client, _ = _client([("GET", "/posts/post_01", HttpResponse(200, body))])
+
+    assert client.get_vote_count("post_01") == 3
+
+
+def test_get_vote_count_missing_field_is_zero() -> None:
+    body = json.dumps({"data": {"id": "post_01", "title": "t"}})
+    client, _ = _client([("GET", "/posts/post_01", HttpResponse(200, body))])
+
+    assert client.get_vote_count("post_01") == 0
+
+
+def test_get_vote_count_api_error_raises() -> None:
+    client, _ = _client([("GET", "/posts/post_01", HttpResponse(500, "boom"))])
+
+    with pytest.raises(QuackbackError):
+        client.get_vote_count("post_01")

--- a/pipeline/tests/test_quackback_forge.py
+++ b/pipeline/tests/test_quackback_forge.py
@@ -479,6 +479,58 @@ def test_post_url_none_when_unresolvable() -> None:
     assert forge.post_url(999) is None
 
 
+# ------------------------------------------------- U6: decision-lane methods
+
+
+def test_list_decision_asks_filters_needs_refinement_slug() -> None:
+    forge, gh, qb = _forge()
+    qb.board_posts = []  # list_posts(status_slug=...) returns [] in the fake
+
+    forge.list_decision_asks()
+
+    # the read went to _qb with the Needs-Refinement slug, not _gh
+    assert ("list_posts", ("needs_refinement", None, None)) in qb.calls
+    assert gh.calls == []
+
+
+def test_post_proposal_comment_runs_sanitise_then_comments() -> None:
+    forge, gh, qb = _forge()
+
+    forge.post_proposal_comment("post_01", "## Recommendation\nDo X")
+
+    assert ("decision_proposal", {"body": "## Recommendation\nDo X"}) in gh.sanitised
+    assert ("comment", ("post_01", "## Recommendation\nDo X")) in qb.calls
+
+
+def test_post_proposal_comment_blocked_by_sanitise_failure() -> None:
+    gh = FakeGH(sanitiser=lambda _t: False)
+    forge, _, qb = _forge(gh=gh)
+
+    with pytest.raises(Exception):
+        forge.post_proposal_comment("post_01", "leaks a secret")
+    assert "comment" not in [c[0] for c in qb.calls]  # never reached the board
+
+
+def test_open_final_proposal_sanitises_and_creates_plain_post() -> None:
+    forge, gh, qb = _forge()
+
+    forge.open_final_proposal("Pricing decided", "## Recommendation\n€9/mo")
+
+    assert ("final_proposal", {"title": "Pricing decided", "body": "## Recommendation\n€9/mo"}) in gh.sanitised
+    ops = [c[0] for c in qb.calls]
+    assert ops.count("create_post") == 1
+
+
+def test_mark_superseded_comments_marker_never_sets_status() -> None:
+    forge, gh, qb = _forge()
+
+    forge.mark_superseded("post_01", "https://qb/posts/post_final")
+
+    comments = [c for c in qb.calls if c[0] == "comment"]
+    assert comments and "SUPERSEDED" in comments[0][1][1]
+    assert "set_post_status" not in [c[0] for c in qb.calls]  # KTD9
+
+
 # ------------------------------------------------- U1: dispatch host seam
 
 

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -61,7 +61,7 @@ def test_injected_connection_adapter_roundtrip() -> None:
     assert len(db.list_runs()) == 1
     # migrations tracked through the adapter
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005"]
 
 
 def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
@@ -79,7 +79,7 @@ def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
     assert db.list_issues() == []
     assert db.list_runs() == []
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005"]
 
 
 def test_requeue_failed_all_preserves_linkage_and_clears_attempts(tmp_path) -> None:
@@ -193,7 +193,7 @@ def test_migrations_apply_idempotently(tmp_path) -> None:
     assert db.get_issue(1).stage == "queued"
     # schema_migrations records the initial migration exactly once
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005"]
 
 
 def test_sqlite_connection_uses_wal_and_busy_timeout(tmp_path) -> None:

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -36,6 +36,11 @@ BOX_CONFIG_ALLOWLIST = frozenset(
         "STRATEGY_AUDIT_LIVE",
         "MERGE_LANE_HEAL_LIVE",
         "MERGE_LANE_HEAL_INTERVAL_SECONDS",
+        "DECISION_LANE_LIVE",
+        "DECISION_LANE_INTERVAL_SECONDS",
+        "DECISION_COFOUNDER_COUNT",
+        "DECISION_MAX_ITERATIONS",
+        "DECISION_BOT_AUTHOR",
         "META_REPO",
         "POLL_INTERVAL_SECONDS",
         "MAX_FILES",
@@ -90,6 +95,7 @@ DEFAULT_OBSERVATION_INTERVAL_SECONDS = 28800
 DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS = 86400
 # Merge-lane-heal: 6h, matching the retired conflict-heal.yml cron (01/07/13/19).
 DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS = 21600
+DEFAULT_DECISION_LANE_INTERVAL_SECONDS = 3600  # founder decisions, hourly
 # The meta repo (the pipeline's own repo) — merge-lane-heal heals BOTH repos.
 DEFAULT_META_REPO = "atvirokodosprendimai/ai-pipeline-template"
 
@@ -140,6 +146,14 @@ class Config:
     strategy_audit_live: bool = False
     merge_lane_heal_interval_seconds: int = DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS
     merge_lane_heal_live: bool = False
+    # Decision lane (capability-ladder Phase 1). Shadow until flipped live.
+    decision_lane_live: bool = False
+    decision_lane_interval_seconds: int = DEFAULT_DECISION_LANE_INTERVAL_SECONDS
+    decision_cofounder_count: int = 2
+    decision_max_iterations: int = 5
+    # The bot key's authorName on the board — its own comments are excluded from
+    # the "new co-founder comment" iteration trigger (KTD5).
+    decision_bot_author: str = "autobox-box"
     meta_repo: str = DEFAULT_META_REPO
     # Executor backend: 'goose' (default) or 'langchain' (U2).
     # Selected via EXECUTOR env var; factory in executor.py fails closed on unknown values.
@@ -281,6 +295,16 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
             DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS,
         ),
         merge_lane_heal_live=_get_bool(source, "MERGE_LANE_HEAL_LIVE", False),
+        decision_lane_live=_get_bool(source, "DECISION_LANE_LIVE", False),
+        decision_lane_interval_seconds=_get_int(
+            source,
+            "DECISION_LANE_INTERVAL_SECONDS",
+            DEFAULT_DECISION_LANE_INTERVAL_SECONDS,
+        ),
+        decision_cofounder_count=_get_int(source, "DECISION_COFOUNDER_COUNT", 2),
+        decision_max_iterations=_get_int(source, "DECISION_MAX_ITERATIONS", 5),
+        decision_bot_author=_get_nonempty(source, "DECISION_BOT_AUTHOR")
+        or "autobox-box",
         meta_repo=_get_nonempty(source, "META_REPO") or DEFAULT_META_REPO,
         executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
         graph_impl=(_get_nonempty(source, "GRAPH_IMPL") or "legacy").strip().lower(),

--- a/pipeline/wgmesh_pipeline/control_loop/__init__.py
+++ b/pipeline/wgmesh_pipeline/control_loop/__init__.py
@@ -235,6 +235,11 @@ class ControlLoopScheduler:
                 self.config.merge_lane_heal_interval_seconds,
                 self._cycle_merge_lane,
             ),
+            ModuleTask(
+                "decision",
+                self.config.decision_lane_interval_seconds,
+                self._cycle_decision,
+            ),
         ]
         for task in self._tasks:
             self.log.info(
@@ -276,6 +281,7 @@ class ControlLoopScheduler:
             "observation": self.config.observation_live,
             "strategy_audit": self.config.strategy_audit_live,
             "merge_lane": self.config.merge_lane_heal_live,
+            "decision": self.config.decision_lane_live,
         }
         try:
             return live_by_module[module_name]
@@ -606,3 +612,44 @@ class ControlLoopScheduler:
                 persisted,
                 "" if live else ' reason="module not flipped live"',
             )
+
+    async def _cycle_decision(self) -> None:
+        """Decision-lane cycle (capability-ladder Phase 1). Quackback-only — the
+        lane reads/writes board posts, which GitHubForge has no analogue for, so
+        it no-ops on the github forge. Shadow plans + logs; live runs the consent
+        loop through the sanitise-walled forge."""
+        if not hasattr(self.forge, "list_decision_asks"):
+            self.log.info(
+                "control_loop: module=decision mode=%s skipped "
+                '(forge has no decision lane — forge_kind != quackback)',
+                self._module_mode("decision"),
+            )
+            return
+        from wgmesh_pipeline.decision_lane import run_decision_cycle
+        from wgmesh_pipeline.decision_lane.proposal_runner import build_proposal_fn
+
+        live = self._module_live("decision")
+        # The proposal recipe runner is built lazily; in shadow it is never called.
+        proposal_fn = (
+            build_proposal_fn(self.config) if live else (lambda post, latest: "")
+        )
+        result = run_decision_cycle(
+            self.forge,
+            self.store,
+            proposal_fn,
+            bot_author=self.config.decision_bot_author,
+            cofounder_count=self.config.decision_cofounder_count,
+            max_iterations=self.config.decision_max_iterations,
+            live=live,
+        )
+        kinds: dict[str, int] = {}
+        for action in result.planned:
+            kinds[action.kind] = kinds.get(action.kind, 0) + 1
+        self.log.info(
+            "control_loop: module=decision mode=%s seen=%s planned=%s executed=%s%s",
+            self._module_mode("decision"),
+            result.seen,
+            kinds,
+            result.executed,
+            "" if live else ' reason="module not flipped live"',
+        )

--- a/pipeline/wgmesh_pipeline/decision_lane/__init__.py
+++ b/pipeline/wgmesh_pipeline/decision_lane/__init__.py
@@ -1,0 +1,157 @@
+"""Decision-lane orchestrator (U7) — the consent loop, Phase 1.
+
+One cycle: ingest the founder-flagged decision posts (``Needs Refinement``), and
+for each, take exactly one step:
+
+  - **no proposal yet** → draft one (run the recipe) and post it as a comment;
+  - **a new co-founder comment** (and under the iteration cap) → revise;
+  - **approval threshold met** → open the final proposal post + retire the
+    discussion post;
+  - otherwise → no-op.
+
+KTD9 holds: the box drives comments / a new post / reads votes — it never sets a
+decision status. KTD7: execution stops at the final proposal post (no self-mod,
+no spend in Phase 1).
+
+The cycle is **plan-then-maybe-execute**: it computes a list of ``PlannedAction``
+and, only when ``live`` is true, performs them through the forge (sanitise-walled).
+In shadow it returns the plan and writes nothing — identical-path shadow, like the
+observation module. The proposal text is produced by an injected ``proposal_fn``
+so the recipe runner is a seam the tests replace.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+from wgmesh_pipeline.decision_lane.comments import (
+    is_unprocessed,
+    latest_cofounder_comment,
+)
+from wgmesh_pipeline.decision_lane.policy import ROUTINE, is_approved
+
+log = logging.getLogger("wgmesh_pipeline.decision_lane")
+
+# Phase 1 is read-only: every proposal is routine (no self-mod / spend exists yet).
+PHASE1_RISK_TIER = ROUTINE
+
+ProposalFn = Callable[[dict[str, Any], dict[str, Any] | None], str]
+"""(post, latest_cofounder_comment_or_None) -> proposal markdown."""
+
+
+class _Forge(Protocol):
+    def list_decision_asks(self) -> list[dict[str, Any]]: ...
+    def list_post_comments(self, post_id: str) -> list[dict[str, Any]]: ...
+    def post_vote_count(self, post_id: str) -> int: ...
+    def post_proposal_comment(self, post_id: str, body: str) -> Any: ...
+    def open_final_proposal(self, title: str, body: str) -> dict[str, Any]: ...
+    def mark_superseded(self, post_id: str, final_ref: str) -> Any: ...
+
+
+@dataclass(frozen=True)
+class PlannedAction:
+    """One step the lane decided to take for one post."""
+
+    post_id: str
+    kind: str  # "draft" | "revise" | "finalize" | "noop"
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class DecisionCycleResult:
+    seen: int
+    planned: tuple[PlannedAction, ...]
+    executed: int
+
+
+def run_decision_cycle(
+    forge: _Forge,
+    store: Any,
+    proposal_fn: ProposalFn,
+    *,
+    bot_author: str,
+    cofounder_count: int,
+    max_iterations: int,
+    live: bool,
+) -> DecisionCycleResult:
+    """Run one decision-lane cycle. Plans an action per post; executes only when
+    ``live``. Never raises into the loop on a single bad post — logs and continues
+    (batch-resilient, like the executor)."""
+    asks = forge.list_decision_asks()
+    planned: list[PlannedAction] = []
+    executed = 0
+
+    for post in asks:
+        post_id = str(post.get("id") or "")
+        if not post_id:
+            continue
+        try:
+            action = _plan_one(
+                forge, store, post, bot_author, max_iterations, cofounder_count
+            )
+            planned.append(action)
+            if live and action.kind != "noop":
+                _execute_one(forge, store, post, action, proposal_fn, bot_author)
+                executed += 1
+        except Exception:  # batch-resilient — one bad post must not kill the cycle
+            log.exception("decision lane: post %s failed; continuing", post_id)
+
+    return DecisionCycleResult(
+        seen=len(asks), planned=tuple(planned), executed=executed
+    )
+
+
+def _plan_one(
+    forge: _Forge,
+    store: Any,
+    post: dict[str, Any],
+    bot_author: str,
+    max_iterations: int,
+    cofounder_count: int,
+) -> PlannedAction:
+    post_id = str(post["id"])
+    state = store.get_decision_state(post_id)
+
+    if state is None:
+        return PlannedAction(post_id, "draft", "no proposal yet")
+
+    comments = forge.list_post_comments(post_id)
+    latest = latest_cofounder_comment(comments, bot_author)
+    if is_unprocessed(latest, state["last_comment_id"]):
+        if state["iterations"] >= max_iterations:
+            return PlannedAction(post_id, "noop", "max iterations reached")
+        return PlannedAction(post_id, "revise", "new co-founder comment")
+
+    votes = forge.post_vote_count(post_id)
+    if is_approved(votes, PHASE1_RISK_TIER, cofounder_count):
+        return PlannedAction(post_id, "finalize", f"approved ({votes} votes)")
+    return PlannedAction(post_id, "noop", "awaiting feedback or votes")
+
+
+def _execute_one(
+    forge: _Forge,
+    store: Any,
+    post: dict[str, Any],
+    action: PlannedAction,
+    proposal_fn: ProposalFn,
+    bot_author: str,
+) -> None:
+    post_id = action.post_id
+    if action.kind in ("draft", "revise"):
+        latest = (
+            latest_cofounder_comment(forge.list_post_comments(post_id), bot_author)
+            if action.kind == "revise"
+            else None
+        )
+        body = proposal_fn(post, latest)
+        forge.post_proposal_comment(post_id, body)
+        store.record_decision_proposal(
+            post_id, last_comment_id=(latest.get("id") if latest else None)
+        )
+    elif action.kind == "finalize":
+        title = f"[Decided] {post.get('title', '')}"
+        body = proposal_fn(post, None)
+        final = forge.open_final_proposal(title, body)
+        forge.mark_superseded(post_id, str(final.get("id") or ""))

--- a/pipeline/wgmesh_pipeline/decision_lane/comments.py
+++ b/pipeline/wgmesh_pipeline/decision_lane/comments.py
@@ -1,0 +1,41 @@
+"""Decision-lane comment author-distinction (U4).
+
+The lane re-drafts a proposal only on a NEW co-founder comment — never on its own
+comment, never twice on the same one. ``isTeamMember`` marks workspace members
+(co-founders); the bot key is also a member, so its own comments are excluded by
+``authorName``. Pure functions over the raw comment dicts from
+``QuackbackClient.list_comments``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+def latest_cofounder_comment(
+    comments: Sequence[Mapping[str, Any]], bot_author: str
+) -> dict[str, Any] | None:
+    """The newest co-founder comment (team member, not the box), or ``None``.
+
+    A co-founder comment is ``isTeamMember`` true AND ``authorName`` not the bot's
+    — the bot is itself a team member, so the name is what separates its own
+    comments from the founders'."""
+    cofounder = [
+        c
+        for c in comments
+        if c.get("isTeamMember") and str(c.get("authorName")) != bot_author
+    ]
+    if not cofounder:
+        return None
+    return dict(max(cofounder, key=lambda c: str(c.get("createdAt") or "")))
+
+
+def is_unprocessed(
+    comment: Mapping[str, Any] | None, last_comment_id: str | None
+) -> bool:
+    """True iff ``comment`` exists and is newer than the last one the lane acted
+    on — the signal to re-draft. Comparing the id (not the timestamp) makes it
+    idempotent against a re-read of the same thread."""
+    if comment is None:
+        return False
+    return str(comment.get("id")) != str(last_comment_id) if last_comment_id else True

--- a/pipeline/wgmesh_pipeline/decision_lane/policy.py
+++ b/pipeline/wgmesh_pipeline/decision_lane/policy.py
@@ -1,0 +1,43 @@
+"""Decision-lane approval-threshold policy (Phase 1).
+
+The brake on the capability-acquisition ladder is co-founder consent. A proposal
+executes only once it clears its approval threshold, and the threshold is
+**risk-tiered**, not a flat quorum — a flat quorum is degenerate at the current
+team size (2 co-founders):
+
+  - ``routine`` (a cheap tool, a low-cost decision) → **1** approve-vote.
+  - ``dangerous`` (self-modify the pipeline, spend over the configured line, rent
+    a stranger) → **all current co-founders** (= 2 today; unanimous).
+
+The threshold is expressed relative to the *current* co-founder count, so it
+scales (1 / majority / all) as the team grows without a redesign. Phase 1 has no
+dangerous actions — the lane is read-only and only produces the decided artifact —
+so every Phase-1 caller passes ``routine`` and the gate is ``vote_count >= 1``.
+
+Pure functions, no I/O: the count comes from the Quackback ``voteCount`` (the
+private board means every voter is a co-founder, so the count is a sound proxy;
+there is no voter list — ``GET /posts/{id}/votes`` is 404).
+"""
+
+from __future__ import annotations
+
+ROUTINE = "routine"
+DANGEROUS = "dangerous"
+RISK_TIERS = frozenset({ROUTINE, DANGEROUS})
+
+
+def required_approvals(risk_tier: str, cofounder_count: int) -> int:
+    """How many approve-votes a proposal of ``risk_tier`` needs.
+
+    ``routine`` → 1; ``dangerous`` → all current co-founders (at least 1). Raises
+    on an unknown tier — a mis-typed tier must never silently lower the bar."""
+    if risk_tier == ROUTINE:
+        return 1
+    if risk_tier == DANGEROUS:
+        return max(1, int(cofounder_count))
+    raise ValueError(f"unknown decision risk tier: {risk_tier!r}")
+
+
+def is_approved(vote_count: int, risk_tier: str, cofounder_count: int) -> bool:
+    """True iff ``vote_count`` meets the tier's threshold."""
+    return int(vote_count) >= required_approvals(risk_tier, cofounder_count)

--- a/pipeline/wgmesh_pipeline/decision_lane/proposal_runner.py
+++ b/pipeline/wgmesh_pipeline/decision_lane/proposal_runner.py
@@ -1,0 +1,82 @@
+"""Live proposal generator (U7) — runs the decision-proposal recipe via Goose.
+
+Only exercised in LIVE mode (shadow never calls ``proposal_fn``). Mirrors the
+spec node's file-path convention: multi-line content (the brief, the prior
+proposal, the feedback) is handed to the recipe as temp-file paths, never inline
+params (the YAML-scalar trap). Internal grounding only — STRATEGY.md + the post
+body; no web research (Phase 2).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR, Config
+from wgmesh_pipeline.goose.runner import GooseRunner
+
+log = logging.getLogger("wgmesh_pipeline.decision_lane.proposal")
+
+
+def build_proposal_fn(
+    config: Config,
+) -> Callable[[dict[str, Any], dict[str, Any] | None], str]:
+    """Return a ``proposal_fn(post, latest_comment) -> markdown`` backed by the
+    Goose recipe. The returned text is the proposal to post as a comment."""
+    runner = GooseRunner(config)
+    recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
+    recipe = recipes_dir / "wgmesh-decision-proposal.yaml"
+    strategy = str(Path(config.repo_path) / "STRATEGY.md")
+
+    def _proposal(post: dict[str, Any], latest_comment: dict[str, Any] | None) -> str:
+        title = str(post.get("title", ""))
+        brief = str(post.get("content") or "")
+        tmps: list[str] = []
+
+        def _tmp(text: str, suffix: str) -> str:
+            if not text.strip():
+                return ""
+            fd, path = tempfile.mkstemp(prefix="decision-", suffix=suffix)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(text)
+            tmps.append(path)
+            return path
+
+        brief_file = _tmp(brief, "-brief.md")
+        feedback_file = _tmp(
+            str((latest_comment or {}).get("content") or ""), "-feedback.md"
+        )
+        out_rel = Path("specs") / f"decision-{post.get('id','x')}-proposal.md"
+        try:
+            result = runner.run_recipe(
+                recipe=recipe,
+                workdir=Path(config.repo_path),
+                params={
+                    "decision_title": title,
+                    "brief_file": brief_file,
+                    "strategy_file": strategy,
+                    "prior_proposal_file": "",  # Phase 1: stateless re-draft
+                    "feedback_file": feedback_file,
+                    "proposal_file": str(out_rel),
+                },
+                expected_output=out_rel,
+                stage="decision",
+                session_id=f"decision-{post.get('id','x')}",
+            )
+            out_path = Path(config.repo_path) / out_rel
+            if not result.ok or not out_path.exists():
+                raise RuntimeError(
+                    f"decision proposal recipe produced no output for {title!r}"
+                )
+            return out_path.read_text(encoding="utf-8")
+        finally:
+            for path in tmps:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+    return _proposal

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -53,6 +53,10 @@ BUILD_SUGGESTION_TAGS: tuple[str, ...] = ("agent-suggestion", "build-candidate")
 # (not Config) to keep the U1 Config surface untouched — this is a U2 concern.
 BOARD_ID_ENV = "QUACKBACK_BOARD_ID"
 
+# The decision-lane trigger: a founder moves a post here to ask the box to draft
+# a proposal. Slug (not name) — the list filter is by status slug (VERIFIED).
+NEEDS_REFINEMENT_SLUG = "needs_refinement"
+
 
 class QuackbackForge:
     """Composition adapter: ``_qb`` for posts, ``_gh`` for PRs (KTD1)."""
@@ -162,6 +166,42 @@ class QuackbackForge:
         if status_id in (None, ""):
             return None
         return self._status_name_for(str(status_id))
+
+    # ------------------------------------------------- decision lane (U6)
+
+    def list_decision_asks(self) -> list[dict[str, Any]]:
+        """Raw posts the founders flagged for the box to work — the lane trigger.
+
+        A founder moves a decision post to ``Needs Refinement`` (= "box, draft a
+        proposal here"). The box only READS that status (slug-filtered list); it
+        never sets it (KTD9)."""
+        page = self._qb.list_posts(status_slug=NEEDS_REFINEMENT_SLUG)
+        return list(page.get("data", []))
+
+    def post_proposal_comment(self, post_id: str, body: str) -> Any:
+        """Post a proposal (or a revision) as a comment on the discussion post —
+        sanitise-walled (KTD10). A comment is the only verified write to an
+        existing post, so the proposal thread lives in comments."""
+        self._gh._sanitise_write("decision_proposal", {"body": body})
+        return self._qb.comment(post_id, body)
+
+    def open_final_proposal(self, title: str, body: str) -> dict[str, Any]:
+        """Create the clean final proposal post (the decision record) on
+        agreement — sanitise-walled. A plain create (no build-suggestion tags /
+        dedup), distinct from ``create_issue``."""
+        if not self._board_id:
+            raise RuntimeError("open_final_proposal requires a board id")
+        self._gh._sanitise_write("final_proposal", {"title": title, "body": body})
+        return self._qb.create_post(self._board_id, title, body)
+
+    def mark_superseded(self, post_id: str, final_ref: str) -> Any:
+        """Retire the discussion post with a 'superseded' comment pointing at the
+        final proposal — keeps the deliberation thread (KTD6). The box may not set
+        ``Cancelled`` (KTD9), and tag-on-existing-post is unverified, so a comment
+        marker is the verified retirement."""
+        return self._qb.comment(
+            post_id, f"SUPERSEDED — decided. Final proposal: {final_ref}"
+        )
 
     def list_needs_triage(self) -> list[ForgeIssue]:
         """HOST SEAM: GitHub needs-triage labels have no Quackback analogue —

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -178,6 +178,14 @@ class QuackbackForge:
         page = self._qb.list_posts(status_slug=NEEDS_REFINEMENT_SLUG)
         return list(page.get("data", []))
 
+    def list_post_comments(self, post_id: str) -> list[dict[str, Any]]:
+        """The discussion thread for a decision post (raw, post-id keyed)."""
+        return self._qb.list_comments(post_id)
+
+    def post_vote_count(self, post_id: str) -> int:
+        """The decision post's approve-vote count (the threshold gate input)."""
+        return self._qb.get_vote_count(post_id)
+
     def post_proposal_comment(self, post_id: str, body: str) -> Any:
         """Post a proposal (or a revision) as a comment on the discussion post —
         sanitise-walled (KTD10). A comment is the only verified write to an

--- a/pipeline/wgmesh_pipeline/forge/quackback_client.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback_client.py
@@ -174,6 +174,36 @@ class QuackbackClient:
             payload={"content": content},
         )
 
+    def list_comments(self, post_id: str) -> list[dict[str, Any]]:
+        """Read a post's comment thread (VERIFIED ``GET /posts/{id}/comments``).
+
+        Each comment carries ``id`` / ``principalId`` / ``authorName`` /
+        ``isTeamMember`` / ``content`` / ``createdAt`` — enough to distinguish a
+        co-founder comment from the box's own. Fail-closed-loud: a read error must
+        never silently read as "no new feedback" (the decision lane re-drafts on
+        new comments, so a swallowed error would freeze iteration)."""
+        body = self._call(
+            "GET", f"/posts/{urllib.parse.quote(str(post_id))}/comments"
+        )
+        data = body.get("data")
+        if not isinstance(data, list):
+            raise QuackbackError(
+                "Quackback /posts/{id}/comments response missing 'data' array"
+            )
+        return data
+
+    def get_vote_count(self, post_id: str) -> int:
+        """The post's approve-vote count, read off the post payload.
+
+        There is no voter sub-resource (``GET /posts/{id}/votes`` → 404), so this
+        is a count only; that the voters are co-founders rests on the private-board
+        assumption (the decision-lane threshold gate)."""
+        post = self.get_post(post_id)
+        try:
+            return int(post.get("voteCount") or 0)
+        except (TypeError, ValueError):
+            return 0
+
     def delete_post(self, post_id: str) -> None:
         # 204 No Content — no body to shape-check.
         self._call(

--- a/pipeline/wgmesh_pipeline/state/migrations/0005_decision_lane.sql
+++ b/pipeline/wgmesh_pipeline/state/migrations/0005_decision_lane.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+-- Decision-lane iteration state (Phase 1).
+--
+-- The box re-drafts a proposal only on a NEW co-founder comment, and never
+-- twice on the same one. This table is the per-post marker: the last comment id
+-- the lane has already responded to, plus an iteration counter for the
+-- max-iteration loop guard. Keyed on the Quackback post id (raw decision posts
+-- are not int-mapped like build issues). Survives a box restart so iteration
+-- does not loop after a bounce.
+CREATE TABLE IF NOT EXISTS decision_posts (
+  post_id TEXT PRIMARY KEY,
+  last_comment_id TEXT,
+  iterations INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -504,6 +504,49 @@ class StateStore:
         ).fetchone()
         return None if row is None else str(row["quackback_post_id"])
 
+    # ----------------------------------------------------- decision lane (U4)
+
+    def get_decision_state(self, post_id: str) -> dict[str, Any] | None:
+        """Iteration state for a decision post: ``{last_comment_id, iterations}``
+        or ``None`` if the lane has never drafted a proposal for it."""
+        row = self._conn.execute(
+            "SELECT last_comment_id, iterations FROM decision_posts WHERE post_id = ?",
+            (post_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "last_comment_id": row["last_comment_id"],
+            "iterations": int(row["iterations"]),
+        }
+
+    def record_decision_proposal(
+        self, post_id: str, *, last_comment_id: str | None
+    ) -> int:
+        """Mark a proposal drafted for ``post_id`` in response to ``last_comment_id``
+        (None on the first draft), bumping the iteration counter. Returns the new
+        iteration count — the caller enforces the max-iteration loop guard."""
+        row = self._conn.execute(
+            "SELECT iterations FROM decision_posts WHERE post_id = ?",
+            (post_id,),
+        ).fetchone()
+        if row is None:
+            self._conn.execute(
+                "INSERT INTO decision_posts(post_id, last_comment_id, iterations, updated_at) "
+                "VALUES (?, ?, 1, ?)",
+                (post_id, last_comment_id, _iso(_now())),
+            )
+            self._conn.commit()
+            return 1
+        iterations = int(row["iterations"]) + 1
+        self._conn.execute(
+            "UPDATE decision_posts SET last_comment_id = ?, iterations = ?, updated_at = ? "
+            "WHERE post_id = ?",
+            (last_comment_id, iterations, _iso(_now()), post_id),
+        )
+        self._conn.commit()
+        return iterations
+
 
 class _MappingCursor:
     """Wraps a libsql cursor so fetchone/fetchall return name-accessible dict


### PR DESCRIPTION
## Summary
Phase 1 of the capability-acquisition ladder (`docs/plans/2026-06-22-006-feat-decision-lane-plan.md`, origin `docs/brainstorms/2026-06-22-capability-acquisition-ladder-requirements.md`): a **decision lane** that researches a co-founder decision ask, drafts a structured proposal, iterates on comments, and on the approval threshold opens a final proposal post. Execution is **read-only** — it produces the decided artifact only; no self-modification, no spend. New box control-loop module, **shadow-first**. Self-build (rung 2), rent-a-human (rung 3), and web research are out of scope.

KTD9 holds throughout: **the box never sets a decision status** — it drives comments, a new post, tags, and reads votes; co-founders drive status.

## Units (all green)
- **U1+U2** — Quackback `list_comments` (with author attribution) + `get_vote_count` client reads, fail-closed-loud. Both VERIFIED live (`GET /posts/{id}/comments` 200; `voteCount` on payload, `/votes` is 404 → count-only, private-board attribution).
- **U3** — risk-tiered approval-threshold policy (routine=1, dangerous=all co-founders; graceful at N=2). Test-first.
- **U4** — iteration state: `latest_cofounder_comment` (excludes the bot), processed-comment marker, migration `0005`.
- **U5** — proposal recipe (Recommendation/Options/Pros/Cons/Upsides/Downsides/ROI/**Assumptions** — unverified market claims flagged; no web research yet).
- **U6** — lane forge methods: `list_decision_asks` (Needs-Refinement trigger, slug filter), sanitise-walled `post_proposal_comment`/`open_final_proposal`, `mark_superseded` (comment marker — keeps the thread; KTD9-safe).
- **U7** — orchestrator (plan-then-maybe-execute; shadow plans + writes nothing) + control-loop module registration + config flags (`DECISION_LANE_LIVE` etc.) + live recipe runner.
- **U8** — observability satisfied by the `_cycle_decision` structured log + the existing KPI (Needs Refinement is already in the undecided-age signal).

## Execution refinements (deferred-to-impl)
- Proposal lives as **comments** in the discussion thread (only verified write to an existing post), final = new post — matches the brainstorm's "each version a comment → final post on agreement".
- The int-keyed forge doesn't map raw decision posts → the lane uses post-id-direct client/forge reads, like the KPI collector.

## Test plan
- 36 new tests (client reads, policy, comments/iteration + migration 0005, recipe, forge methods, orchestrator shadow/live/iterate/finalize/cap/batch-resilience). 908 suite pass.
- Includes a residual fix: `#1978` added `{{ issue_brief_file }}` to the spec recipe but didn't update one langchain prompt-render test (CI disabled at merge) — now aligned.
- The 21 remaining suite failures are **pre-existing** host-gitconfig/network flakes (`test_langchain_agent_runner`, `test_spec_pr`), identical on `main`.

## Not in this PR
Going live (`DECISION_LANE_LIVE=true`) is an operator cutover after shadow-prove. Rungs 2-3 + web research are later phases.