### PR TITLE
docs: 2026-06-22 session design records (brainstorms, plans, runbook)

### DIFF
--- a/docs/brainstorms/2026-06-22-capability-acquisition-ladder-requirements.md
+++ b/docs/brainstorms/2026-06-22-capability-acquisition-ladder-requirements.md
@@ -1,0 +1,161 @@
+# Capability-acquisition ladder — the box grows its own abilities, gated by co-founder consent
+
+**Date:** 2026-06-22 · **Scope:** Deep — product · **Status:** ready for `/ce-plan`
+**Origin:** operator — "I expect a proper plan/suggestion grounded on research, strategy,
+pros/cons … then I decide; if something is not ok I comment and the LLM revisits, iterating"
+→ "if it cannot research/lacks a feature, can it build it? if not, rent a human?" → target
+**"1 & 4, but co-founders must agree on the proposal."**
+**Builds on:** the Quackback decision layer (`project_quackback_decision_layer`).
+
+## Outcome
+
+The autonomous company stops being capped by the capabilities it shipped with. When the box
+hits a gap it cannot directly satisfy, it **climbs a ladder** rather than just punting to a
+human:
+
+1. **Do it** — already capable → acts (today's build lane).
+2. **Build it** — lacks a tool but can code it → ships the tool *(self-extension)*, then uses it.
+3. **Rent a human** — can't build it (needs a real-world act, capital, a signature) → delegates
+   to a human.
+4. **Escalate** — can't acquire it at all → surfaces to the founders.
+
+The brake on this power is **co-founder consent**: any rung past "do it" requires the box to
+post a **researched proposal** to the co-founder board and reach a **quorum of approve-votes**
+before it executes. The box proposes; the co-founders decide; only then does it act. The first
+thing it proves is **self-build** — it proposes *"add web research to my own pipeline,"* the
+co-founders agree, and it ships that capability into itself.
+
+This makes the company *self-extending under consent* — the highest-leverage primitive on the
+roadmap and the one with the largest blast radius, which is why the gate is the heart of it.
+
+## The decision/proposal lane (the mechanism that makes the gate real)
+
+A new lane, distinct from the build lane. KTD9 holds throughout: **the box never sets a
+decision status** — it drives body, comments, tags, votes-reading only; co-founders drive status.
+
+1. **Trigger.** The box hits a capability gap mid-work, OR a co-founder posts a decision ask
+   (a `needs-human` "decide X"). Either becomes a proposal task.
+2. **Research.** The box gathers grounding with the web-research tool — competitor/market data,
+   prior art — plus internal context (STRATEGY.md, KPIs, the repo). The proposal cites sources.
+3. **Propose.** It writes a structured proposal as a **discussion post**: recommendation, the
+   options considered, **pros / cons**, **upsides / downsides**, **ROI / cost**, and — when the
+   ask is a capability gap — **which rung** it picked and what executing it costs.
+4. **Iterate.** Co-founders comment. The box **reads the comments**, distinguishes a co-founder
+   comment from its own (author / principal id), and on a new co-founder comment **revises** the
+   proposal and reposts. Loop-guarded: it never reacts to its own comments; it tracks a
+   last-processed-comment marker; it stops at a max-iteration cap.
+5. **Agree.** When the proposal reaches its **approval threshold**, the box opens a clean
+   **final proposal post** — the decision record — and retires the discussion post. The
+   threshold is a **risk-tiered config policy**, not a fixed quorum, because the team is small
+   (currently **2 co-founders**, where a flat quorum is degenerate): **routine** proposals need
+   **1** approve-vote (either co-founder); **dangerous** ones (self-modify the pipeline, spend
+   over a configured €X, rent a stranger) need **all current co-founders** (= both, at N=2).
+   The policy is expressed relative to the *current* co-founder count, so it scales (1 / majority
+   / all) as the team grows without redesign. The private board means every voter is a
+   co-founder, so vote count is a sound proxy for the count side of the threshold.
+6. **Execute.** The box performs the agreed rung (self-build, or — deferred — rent-a-human, or the
+   approved product/business action).
+
+## The rungs
+
+### Rung 2 — Build it (self-extension)
+The box files the missing capability as a build item **targeting `ai-pipeline-template` (itself)**
+and runs its existing spec→impl→PR→judge→merge lane against it. **First proof target: the
+web-research tool** — and note the recursion: the box's first self-build is the very capability
+its proposals need, so once it lands, the decision lane gets its grounding for free.
+
+**Brakes (all required before self-build is enabled):**
+- Front gate: the proposal + co-founder quorum (above).
+- Impl gate: the existing impl-judge.
+- Revertibility: the change lands as a PR (reviewable, revert-able).
+- **Deploy safety:** a self-edit that breaks the pipeline must not brick the loop — the
+  self-build path needs a deploy health-gate + automatic rollback (a bad self-merge reverts the
+  box to the last-good revision instead of leaving it dead). This is the one brake the current
+  product-build lane does not yet need.
+
+### Rung 3 — Rent a human (DEFERRED — design the slot, do not build)
+The proposal format reserves a "hire a human" option (task, who, cost), but the execution
+infrastructure — payment rails, a contractor/marketplace integration, quality control, and a
+hard **budget guard** so the box cannot overspend — is out of scope for v1. Today's `needs-human`
+lane already *is* rung-3-to-the-founders; rung-3-to-strangers is a later build.
+
+### Rungs 1 & 4 — existing
+Do-it is the current build lane. Escalate is the current `needs-human` surface.
+
+## Scope boundaries
+
+**In (v1):** the ladder *policy*; the decision/proposal lane (research → propose → comment-iterate
+→ quorum → final-post → execute); the web-research tool (itself the first self-build); rung-2
+self-build with its safety brakes; quorum-vote reading.
+
+**Explicitly out / deferred:**
+- **Rung 3 rental execution** — payment, marketplace, QC, budget guard. Slot designed, not built.
+- **Public surfaces** — the board stays private/internal (decision-layer KTD9).
+- **Self-build of arbitrary scope** — v1 proves it on a contained, reversible tool (web research);
+  letting the box rewrite its own core control loop is a later, separately-gated step.
+- **Autonomous spend** beyond what a single rung's approved cost covers — no standing budget.
+
+## Success criteria
+
+- A co-founter "decide X" post yields a box-authored proposal in the discussion post containing
+  recommendation + options + pros/cons + upsides/downsides + ROI, with cited sources.
+- A co-founder comment causes the box to post a revised proposal; the box never iterates on its
+  own comment and stops at the cap.
+- A proposal that reaches the vote quorum produces a final proposal post and a retired discussion
+  post, and triggers execution of exactly the agreed rung.
+- The box ships its own web-research tool into `ai-pipeline-template` via a quorum-approved
+  self-build, and a later proposal demonstrably uses it.
+- A self-build that fails the deploy health-gate rolls the box back to the last-good revision (no
+  bricked loop).
+
+## Open questions (for planning)
+
+- **Vote-quorum API — VERIFY.** Does Quackback expose vote *count* and ideally *voter principal
+  ids* per post via REST with the `qb_` key? Quorum needs the count; co-founder-attribution needs
+  the ids. If only count is exposed, the private-board assumption (all voters are co-founders)
+  carries it for v1. Probe the live instance (mirrors the cutover VERIFY discipline).
+- **Comment read API — VERIFY.** `QuackbackClient` has `comment()` (write) but no read. Confirm
+  `GET /posts/{id}/comments` (or equivalent) returns comments with an author/principal field so
+  the box can distinguish co-founder comments from its own and set the processed marker.
+- **Threshold policy values.** Risk-tiered (routine = 1, dangerous = all current co-founders),
+  expressed relative to current co-founder count — but the concrete values are config: the €X
+  spend line that flips a proposal to "dangerous," which rungs/actions count as dangerous, and
+  the named co-founder principal set. Not derivable from code. **N=2 caveat:** "dangerous = all"
+  means unanimous today, so one unavailable founder stalls a dangerous proposal — decide whether
+  that's acceptable (it is the *point* for self-mod/spend) or needs a timeout/override.
+- **Closing the discussion post.** KTD9 blocks the box from setting `Cancelled`. It must instead
+  `delete_post` the discussion post or tag it `superseded` — decide which (delete loses the
+  thread; tag keeps it but clutters).
+- **Self-build target boundary.** Which parts of `ai-pipeline-template` may a self-build touch in
+  v1 (tools/recipes/extensions = yes; the control loop / safety gates = no)? A guardrail the plan
+  must encode.
+- **Where the proposal/research runs.** A new box control-loop module (aligns with box-native /
+  actions=CI-CD-only) vs a Goose recipe like observation. The web-research tool must attach to
+  whichever runs it.
+
+## Dependencies / assumptions
+
+- Quackback instance live, box holds a working `qb_` key with `read/write:feedback`
+  (and the all-scopes key already covers comments/votes reads). **Vote + comment read endpoints
+  are unverified** (see Open Questions) — both are load-bearing and must be confirmed before the
+  lane is built.
+- The box's existing build lane (spec→impl→PR→judge→merge→deploy) works and can be pointed at a
+  second target repo (`ai-pipeline-template`) — the cloudroof second-instance precedent shows a
+  second TARGET_REPO is feasible.
+- **The two dangerous powers are self-modification and spend.** Every design decision defers to:
+  consent (quorum) before action, revertibility after it, and no unbounded budget.
+
+## Approach
+
+**Sequence by risk, prove the gate before the power.**
+1. **Decision lane, read-only-execution first** — research → propose → comment-iterate → quorum →
+   final post, where "execute" is initially just *producing the decided artifact* (no self-mod, no
+   spend). This ships the whole consent loop with zero blast radius.
+2. **Web research as the first self-build** — once the lane works, the box's first quorum-approved
+   *executing* proposal is "add web research to my recipe," with the rung-2 deploy brakes in place.
+   Proving rung 2 on the very tool the lane wants is the tightest possible first loop.
+3. **Rung 3 slot** — carry the "rent a human" option in the proposal schema; build its execution
+   later behind a budget guard.
+
+Net-new, not extend: this is a new lane + a new policy, though it reuses the build lane,
+the judge, the board, and the deploy path as substrate.

--- a/docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md
+++ b/docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md
@@ -1,0 +1,90 @@
+# Requirements — Cloudroof service funnel
+
+**Date:** 2026-06-22 · **Status:** ready for ce-plan · **Scope tier:** Deep
+
+## Problem / why now
+
+The product/service split shipped the *gate* (surface-gate #1960 holds `surface:service`
+issues out of the wgmesh builder) but never the *service builder*. goal-sprint now emits
+mostly `surface:service` (cloudroof GTM) issues → they park as `needs-human` with nowhere to
+build → **0 product convergence across ~4 pulses** while the wgmesh product backlog is
+exhausted. The autonomous company has built out its product and stalled. The missing
+cloudroof-eu funnel is the single highest-leverage constraint on company output.
+
+cloudroof-eu = the monetized service surface (Cloudflare Workers marketing/dashboard site).
+
+## Outcome
+
+A cloudroof site feature flows **autonomously from issue to live deploy** on cloudroof.eu,
+on the same box as wgmesh, without a human in the build loop (after an initial calibration
+phase). Success = one `surface:service` *code* issue goes issue→spec→impl→PR→merge→deployed
+with zero hand edits.
+
+## Decisions (locked in brainstorm)
+
+- **Runtime:** a SECOND `wgmesh_pipeline` instance on the existing Hetzner box, its own
+  systemd unit / env / state DB, `TARGET_REPO=cloudroof-eu`. Reuses all machinery (poller,
+  graph, executor, forge, merge-lane-heal). No core multi-repo refactor — two processes, not
+  one process spanning two repos.
+- **Build scope:** the funnel autonomously builds **code site-features only** (landing pages,
+  FAQ, email capture, comparison pages — Workers/HTML/JS). **Non-code GTM** (outreach, ad
+  spend, Stripe pricing) routes to the cofounder gtm-decision queue, never auto-built.
+- **Build gate:** cofounder **accept-gate for the first N builds** (quality/brand
+  calibration), then flip to auto-build like wgmesh. Throughput isn't founder-limited once
+  trust is established.
+- **MVP = the full chain incl. deploy** (slice 1): issue→spec→impl→PR→merge→**wrangler
+  deploy** to cloudroof.eu. The first built feature goes live end-to-end.
+
+## Key flows
+
+1. **Intake + classify:** a `surface:service` issue is split code-buildable vs GTM. Code →
+   cloudroof funnel queue. GTM → gtm-decision queue (cofounder). Surface-gate's current
+   *block+park* for service issues changes to *route to the cloudroof funnel* (for code) /
+   *gtm queue* (for GTM).
+2. **Accept-gate (first N):** a code issue waits for a cofounder "accepted for build" signal
+   before the funnel spends effort; after N proven builds, the gate lifts.
+3. **Build:** the cloudroof pipeline instance runs spec→impl→PR against cloudroof-eu; its CI
+   is JS/wrangler (not Go); impl-judge applies.
+4. **Deploy:** on merge to cloudroof-eu main, `wrangler deploy` publishes to cloudroof.eu.
+
+## Scope boundaries
+
+- **In:** 2nd pipeline instance (unit/env/DB); cloudroof-eu CI (wrangler build/test/typecheck)
+  + deploy-on-merge; the accept-gate; surface-gate change (route, not park); code-vs-GTM
+  classification at intake.
+- **Deferred (later slices):** extending merge-lane-heal + pulse + supervisor to cloudroof;
+  backfilling the parked service backlog; flipping the gate off after N.
+- **Outside this funnel's identity:** executing non-code GTM (humans do that); the wgmesh
+  product pipeline (untouched); the Quackback forge cutover (independent track).
+
+## Dependencies / assumptions / constraints
+
+- **Two pipeline processes on one cpx22 box** → ~2× LLM/CI/git load. Resource headroom +
+  per-process isolation (distinct DB path, env file, systemd unit, bot-PAT scope for
+  cloudroof-eu) is a real constraint — verify the box can carry it, or size up.
+- **Deploy needs a Cloudflare API token** (Workers deploy) as a box/CI secret — not present
+  in this repo today (assumption: cloudroof-eu deploys via wrangler; confirm the CF account).
+- **Accept-gate mechanism:** Quackback gtm-stream is a label-keyed contract but **not live**
+  (deferred to `feat/quackback-decision-layer`). Interim gate = a GitHub label a cofounder
+  adds (e.g. `accepted-for-build`), Quackback-stream-compatible. (assumption)
+- cloudroof-eu is nascent (Workers site, 0 issues, no CI in-repo). The funnel must create its
+  own CI there. (verified via grounding scout)
+- The bot PAT must have read+write on cloudroof-eu (the merge-lane-heal cutover proved the box
+  token reads both wgmesh+meta; cloudroof-eu access is unverified — confirm).
+
+## Outstanding questions (→ ce-plan)
+
+- Gate mechanism: GitHub label now vs wait for Quackback? (lean: label now.)
+- The "first N" threshold before auto-build flips.
+- Does the cloudroof CI reuse a shared workflow or get its own? (cloudroof-eu repo, JS stack.)
+- Box capacity for a 2nd process, or size up the VM?
+- Does goal-sprint emit cloudroof code-feature issues directly into cloudroof-eu, or stay in
+  wgmesh + route at intake?
+
+## Grounding
+
+`/tmp/compound-engineering/ce-brainstorm/cloudroof-funnel/grounding.md`. Prior art:
+`docs/brainstorms/2026-06-21-cloudroof-issue-routing-gate-requirements.md`,
+`docs/plans/2026-06-21-003-feat-product-service-split-plan.md`,
+`docs/plans/2026-06-21-008-feat-surface-gate-builder-entry-plan.md`. Memory:
+project_product_service_split, project_quackback_decision_layer, project_merge_lane_heal_to_box.

--- a/docs/brainstorms/2026-06-22-quackback-roadmap-changelog-requirements.md
+++ b/docs/brainstorms/2026-06-22-quackback-roadmap-changelog-requirements.md
@@ -1,0 +1,106 @@
+# Wire Quackback roadmap + changelog (internal ops hub)
+
+**Date:** 2026-06-22 · **Scope:** Standard · **Status:** ready for `/ce-plan`
+**Origin:** operator — "wire roadmap, changelog to quackboard as well" (Quackback decision-layer follow-on)
+**Grounding:** `/tmp/compound-engineering/ce-brainstorm/qb-roadmap-changelog/grounding.md`
+
+## Outcome
+
+Consolidate the founding team's internal ops comms into the single private Quackback
+instance (`http://89.167.62.47:3000`): the board already holds **decisions**, this adds a
+**roadmap** (track committed→shipped work) and a **changelog** (the daily ship-log), so the
+team has one private hub instead of the board plus a scattered email digest.
+
+**Audience is internal only** — the board and the whole portal stay private (cofounders),
+exactly as the decision-layer locked (KTD9: "never public/community"). Nothing here exposes
+a public-facing roadmap or changelog.
+
+## What we're building
+
+### 1. Changelog — the daily ship-log moves to Quackback (replaces the email digest)
+- The existing `daily-release-notes.yml` already gathers the day's merged PRs (cross-repo),
+  groups them into themes via an LLM, and emails a formatted digest via Unsend.
+- **Change:** keep the gather + LLM roll-up; **POST the result as one daily Quackback
+  changelog entry** instead of emailing it. The changelog entry is now the home of the
+  ship-log.
+- **Retire the email fully** — no Unsend send. (Accepted risk: no daily push; the team reads
+  the changelog in the portal. Same silent-stall shape as the bare cutover (KTD3) — revisit
+  if the team misses the push; a thin link-email is the obvious follow-up.)
+- Feed = **all merged PRs, one daily entry** (not per-Shipped-post) — full coverage including
+  routine/housekeeping work, matching what the digest captures today.
+- The roll-up text passes the existing sanitise wall before the POST (public-repo discipline,
+  even though the instance is private).
+
+### 2. Roadmap — internal status view of the box lane — ✅ DONE 2026-06-22
+> Applied live: `showOnRoadmap` set `true` on the 4 box-lane statuses, `false` on all others
+> (backlog + negatives + 6 unused defaults) via `PATCH /api/v1/statuses/{id}`. Documented in
+> `docs/runbooks/quackback-cutover.md` §6. Near-zero box code as predicted.
+
+- Quackback renders a roadmap from posts grouped by status where the status carries
+  `showOnRoadmap = true`. The box already drives posts through statuses
+  (`_mirror_quackback`: Building → Ready for Review → Shipped).
+- **Change:** enable `showOnRoadmap` on the **box-lane statuses** — Accepted for Build,
+  Building, Ready for Review, Shipped — so the roadmap shows committed → in-flight → done.
+  Undecided backlog (Open for Vote, Needs Refinement) and terminal-negative (Rejected,
+  Cancelled) stay **off** the roadmap.
+- Near-zero box code: the roadmap auto-populates as the box mirrors status; the only work is
+  setting the `showOnRoadmap` flag on four statuses (see Open Questions for the mechanism).
+
+## Scope boundaries
+
+**In:** daily roll-up → Quackback changelog (new `QuackbackClient.create_changelog`); retire
+the Unsend email; `showOnRoadmap` on the four box-lane statuses; sanitise wall on the
+changelog body.
+
+**Explicitly out:**
+- **Public/community surfaces** — board and portal stay private/internal.
+- **Per-Shipped-post changelog entries** — chose the daily roll-up of all PRs instead.
+- **Backlog/negative statuses on the roadmap** — only the box lane shows.
+- **Box-native migration of the digest** — the roll-up stays in `daily-release-notes.yml`
+  (Actions cron) for now. *Tension noted:* this sits against the actions=CI/CD-only retarget
+  (`project_actions_cicd_only_retarget`); moving the roll-up onto the box control loop is a
+  later, larger move, deferred deliberately.
+- **Comment / two-way steering** — unrelated (U10/U11), out.
+
+## Success criteria
+
+- A daily run posts one changelog entry to the Quackback instance containing the themed
+  merged-PR roll-up; no email is sent.
+- The internal roadmap shows posts under Accepted for Build / Building / Ready for Review /
+  Shipped, and shows nothing under Open for Vote / Needs Refinement / Rejected / Cancelled.
+- A post the box drives to Shipped appears under Shipped on the roadmap with no manual step.
+- The changelog body passes the sanitise wall (a roll-up that fails is blocked/degraded, not
+  posted raw).
+
+## Open questions (for planning)
+
+- **Changelog API shape — VERIFY first.** `QuackbackClient` has no changelog method and the
+  POST endpoint/payload is unconfirmed (the `write:changelog` scope exists; minio is noted as
+  optional changelog image storage). Probe the live instance for the create-changelog
+  endpoint + body shape before implementing, mirroring the cutover's VERIFY discipline
+  (`docs/runbooks/quackback-cutover.md` §2). If a changelog needs a category/release grouping
+  or a publish-vs-draft state, resolve it against the real API.
+- **Roadmap config mechanism.** One-time manual set of `showOnRoadmap` (UI or `PATCH
+  /statuses`, documented in the runbook, zero code) vs the box ensuring it idempotently at
+  startup (drift-proof across a reprovision, small code). Lean: one-time runbook step; add a
+  box ensure-step only if the flag drifts.
+- **Changelog cadence/empty days.** Does an all-housekeeping day still warrant an entry, or
+  skip when nothing notable merged? (The current digest always emails.)
+
+## Dependencies / assumptions
+
+- The Quackback instance is live and the box holds a working `qb_` key (post-cutover: yes).
+- The bot key carries `write:changelog` (all-scopes key — yes).
+- `daily-release-notes.yml` keeps working as the gather + LLM-theming source; only its sink
+  changes (email → changelog POST).
+- **Assumption (unverified):** Quackback exposes a REST create-changelog endpoint usable with
+  the `qb_` Bearer key — must be confirmed (see Open Questions) before the changelog unit is
+  built; the roadmap half does not depend on it.
+
+## Approach
+
+**Extend, not net-new.** Reuse `daily-release-notes.yml` (gather + roll-up) and
+`QuackbackClient`; add one client method (`create_changelog`) and swap the email sink for a
+changelog POST; set `showOnRoadmap` on four statuses. The two halves are independent — the
+roadmap (config) can ship without the changelog (needs the API VERIFY), so they can sequence
+separately.

--- a/docs/plans/2026-06-22-002-feat-cloudroof-service-funnel-plan.md
+++ b/docs/plans/2026-06-22-002-feat-cloudroof-service-funnel-plan.md
@@ -1,0 +1,158 @@
+# feat: Cloudroof service funnel — 2nd pipeline instance for cloudroof-eu
+
+**Date:** 2026-06-22 · **Type:** feat · **Depth:** Deep
+**Origin:** `docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md`
+**Grounding:** `/tmp/compound-engineering/ce-plan/cloudroof-funnel/grounding.md`
+
+---
+
+## Summary
+
+Stand up a SECOND `wgmesh_pipeline` instance on the existing box targeting `cloudroof-eu`,
+so service code issues (already emitted there by the observation loop) get built → PR'd →
+merged → deployed to the Cloudflare Workers site. Reuses all machinery; the only new code is
+infra (2nd systemd unit + env + provision parameterization), the cloudroof instance's surface
+gate inversion, cloudroof-eu's missing CI (impl-judge) + wrangler deploy CD, and a
+Quackback-gated accept step.
+
+## Problem frame
+
+The product/service split shipped the gate (surface-gate holds `surface:service` out of the
+wgmesh builder) and the routing (`observation.py` `SURFACE_REPO` already emits service issues
+to cloudroof-eu), but never the service BUILDER. Service issues land in cloudroof-eu with
+nothing polling/building them → 0 product convergence ~4 pulses while wgmesh's backlog is
+exhausted. This funnel is the company's gating constraint.
+
+## Key technical decisions
+
+- **KTD1 — 2nd instance, not a multi-repo refactor.** A separate `cloudroof-pipeline.service`
+  systemd unit runs the same `wgmesh_pipeline.main` with its own `EnvironmentFile`, DB path,
+  and checkout. Env delta is 5 vars (`TARGET_REPO`, `WGMESH_CHECKOUT_PATH`, `PIPELINE_DB_PATH`,
+  `WGMESH_BOT_PAT` scoped to cloudroof-eu, optional `LANGFUSE_*`). No core code change — the
+  pipeline is already `Config.target_repo`-driven (see origin).
+- **KTD2 — surface gate inverts per instance.** The wgmesh instance keeps blocking `service`;
+  the cloudroof instance must PASS `service` (and block `product`/`unknown`). Drive this off
+  `Config.target_repo` (or a `SURFACE_HOME` config) so one codebase serves both. Routing into
+  cloudroof-eu already works (`observation.py` `SURFACE_REPO`); only the builder-entry gate
+  changes.
+- **KTD3 — Workers deploy stays in cloudroof-eu Actions, not the box.** The box produces code +
+  merges PRs; `wrangler deploy` runs as a cloudroof-eu CD workflow on merge to main (CD = the
+  one thing that stays in Actions, per the Actions=CI/CD-only principle). cloudroof-eu already
+  has `wrangler.jsonc` (`name: creu`, assets `./dist`).
+- **KTD4 — accept-gate via Quackback gtm-stream (operator decision), which couples to the
+  Quackback cutover.** The gated-first-N phase reads "Accepted for Build" from the Quackback
+  gtm-decision stream. Quackback is not yet live (forge still github), so the gate unit (U6) is
+  sequenced AFTER the Quackback cutover. The build+deploy chain (U1–U5) ships independently and
+  proves end-to-end; until the gate lands the funnel runs manually-triggered / limited, NOT
+  open auto-build (avoids spending effort + brand risk on unvetted service features).
+- **KTD5 — impl-judge is repo-agnostic; selfheal is config-driven.** cloudroof-eu just needs
+  its own `impl-judge.yml` (copy from wgmesh + `OPENROUTER_API_KEY` secret + required check).
+  merge-lane-heal (`selfheal/merge_lane.py`) derives target from `Config.target_repo`, so the
+  cloudroof instance heals cloudroof-eu automatically — no change.
+
+---
+
+## High-level technical design
+
+```
+goal-sprint / observation loop (wgmesh instance)
+   └─ surface:service issue ──(SURFACE_REPO, already wired)──▶ cloudroof-eu issue
+                                                                      │
+                          ┌───────────────────────────────────────────┘
+                          ▼
+   cloudroof-pipeline.service  (2nd instance, TARGET_REPO=cloudroof-eu, own env/db/checkout)
+     poller.tick → surface_gate (PASS service) → [U6: Quackback accept-gate, first N]
+        → spec → impl → PR  (cloudroof-eu CI: ci.yml build + impl-judge required)
+        → judge-gated auto-merge → merge to main
+                                       │
+                                       ▼
+                cloudroof-eu Actions: wrangler deploy ./dist ▶ cloudroof.eu  (CD stays in Actions)
+```
+
+---
+
+## Implementation units
+
+### U1. cloudroof-eu CI: impl-judge + build gate
+**Goal:** cloudroof-eu PRs get the same gating wgmesh has so judge-gated auto-merge works.
+**Requirements:** Outcome (autonomous build), KTD5. **Dependencies:** none. **Target repo:** cloudroof-eu.
+**Files:** (in cloudroof-eu) `.github/workflows/impl-judge.yml` (copy from wgmesh), `.github/workflows/ci.yml` (JS/wrangler: `npm ci` + build/typecheck + `wrangler deploy --dry-run`), repo ruleset/required-checks.
+**Approach:** Port wgmesh `impl-judge.yml` verbatim (it's repo-agnostic — reads the PR diff); add `OPENROUTER_API_KEY` as a cloudroof-eu secret. Add a secretless `ci.yml` mirroring wgmesh's all-authors build gate but for the JS/Workers stack (build `./dist`, wrangler dry-run validates config). Set impl-judge + ci as required checks on cloudroof-eu's protect-main ruleset.
+**Patterns to follow:** wgmesh `.github/workflows/impl-judge.yml`, `ci.yml`; the ruleset script `scripts/ruleset/apply-required-checks.sh`.
+**Test scenarios:** workflow YAML validates; impl-judge runs on a sample cloudroof bot PR and posts a check; ci build passes on a clean PR and fails on a broken build. `Covers AE: one service code issue builds to a merged PR.`
+
+### U2. cloudroof-eu wrangler deploy-on-merge (CD)
+**Goal:** a merged cloudroof-eu PR auto-deploys to cloudroof.eu.
+**Requirements:** Outcome (live deploy), KTD3. **Dependencies:** none. **Target repo:** cloudroof-eu.
+**Files:** (in cloudroof-eu) `.github/workflows/deploy.yml` (on push to main → build `./dist` → `wrangler deploy`).
+**Approach:** `workflow_run`/`push:main` triggered; needs `CLOUDFLARE_API_TOKEN` (+ account id) secret on cloudroof-eu. Deploy only on green main. Concurrency cancel-in-progress. This is CD, stays in Actions (KTD3).
+**Patterns to follow:** wgmesh `auto-deploy-on-merge.yml` (the merge→deploy chain shape), cloudroof-eu existing `spec-merged-build.yml`.
+**Test scenarios:** dry-run deploy succeeds with the token; a merge to main triggers deploy and the site serves the new asset; deploy on red main does not fire. `Covers AE: built feature goes live end-to-end.`
+
+### U3. Surface-gate inversion for the service instance
+**Goal:** the cloudroof instance builds `service` issues; the wgmesh instance still blocks them.
+**Requirements:** KTD2, F (intake). **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/graph/nodes/surface_gate.py`, `pipeline/wgmesh_pipeline/config.py`, `pipeline/tests/test_surface_gate.py`.
+**Approach:** Add a `Config.surface_home` (or reuse `target_repo` mapping) = which surface this instance builds (`product` for wgmesh, `service` for cloudroof). `decide_surface_gate` passes when `issue.surface == config.surface_home`, blocks otherwise (incl `unknown`). Default `product` (wgmesh unchanged). The cloudroof instance sets `service`.
+**Patterns to follow:** existing `surface_gate.py` `decide_surface_gate`, `observation.py` `_resolve_surface`/`SURFACE_REPO`.
+**Test scenarios:** `surface_home=service` → service issue PASSES, product BLOCKED, unknown BLOCKED; `surface_home=product` (default) → unchanged from today (service blocked); both graph impls (legacy + langgraph) honor it. Edge: missing surface → block. `Covers F: intake routes code-service to the funnel.`
+
+### U4. 2nd pipeline instance — systemd unit, env, provision parameterization
+**Goal:** the box runs a `cloudroof-pipeline` process with isolated state.
+**Requirements:** KTD1, constraint (2 processes/1 box). **Dependencies:** U3 (so the instance gates correctly).
+**Files:** `pipeline/deploy/cloudroof-pipeline.service`, `.github/workflows/provision-pipeline-box.yml`, `.github/workflows/update-pipeline-box.yml`, `.github/workflows/set-box-env.yml` (add a `service` input: `wgmesh|cloudroof` → resolves unit name + `ENV_FILE` path), `pipeline/wgmesh_pipeline/config.py` (surface_home + SURFACE_HOME env in box-config allowlist).
+**Approach:** New unit mirrors `wgmesh-pipeline.service` with `EnvironmentFile=/etc/cloudroof-pipeline/env`, `WorkingDirectory=/opt/cloudroof-checkout`. Parameterize the 3 box workflows with a `service` input (default wgmesh = unchanged) that picks unit + env-file path. The cloudroof env sets the 5 delta vars + `SURFACE_HOME=service` + `CONTROL_LOOP_ENABLED=true`. Use the env-file PARSE-not-source path (the [[feedback_box_env_not_bash_sourceable]] fix already landed).
+**Execution note:** characterization-first on the 3 box workflows — they're load-bearing infra; assert the wgmesh path is byte-unchanged when `service` defaults.
+**Test scenarios:** set-box-env with `service=cloudroof` writes `/etc/cloudroof-pipeline/env` + restarts `cloudroof-pipeline`; `service=wgmesh` (default) unchanged; YAML valid; unit file parses. Test expectation: workflow logic via characterization + YAML lint (no app behavior).
+
+### U5. Provision live + end-to-end smoke (MVP proof)
+**Goal:** one real cloudroof-eu issue → spec → impl → PR → merge → deployed, no hand edits.
+**Requirements:** Outcome. **Dependencies:** U1, U2, U3, U4.
+**Files:** none (operational); runbook `docs/runbooks/cloudroof-funnel-cutover.md`.
+**Approach:** Verify box capacity for a 2nd process (`cpx22` headroom — if thin, size up the VM; record decision). Mint a fine-grained `WGMESH_BOT_PAT` scoped to cloudroof-eu (read+write). Set cloudroof-eu secrets (OPENROUTER_API_KEY, CLOUDFLARE_API_TOKEN). Provision the 2nd instance. Pick one existing cloudroof-eu issue (e.g. the rerouted onboarding widget #4), run it through, confirm deploy. Run the cloudroof instance in shadow first (like the merge-lane cutover), then live.
+**Execution note:** shadow-prove (poller shadow / one cycle logged) before flipping live, mirroring the merge-lane-heal cutover discipline.
+**Test scenarios:** Test expectation: none — operational verification (the runbook's checklist + the live smoke is the proof). Verification: a cloudroof-eu PR opened by the instance, judge-gated, merged, site updated.
+
+### U6. Quackback accept-gate (gated-first-N) — sequenced after Quackback cutover
+**Goal:** the cloudroof funnel only builds a gated issue after a cofounder "Accepted for Build" in Quackback; auto-build after N proven builds.
+**Requirements:** KTD4, build-gate decision. **Dependencies:** U5 + the Quackback cutover ([[project_quackback_decision_layer]] — NOT yet live).
+**Files:** `pipeline/wgmesh_pipeline/poller.py` (claim gate), `pipeline/wgmesh_pipeline/config.py` (`SERVICE_BUILD_GATE`, `SERVICE_AUTOBUILD_AFTER_N`), `pipeline/tests/test_service_accept_gate.py`.
+**Approach:** Before the cloudroof instance claims a `service` issue for spec, check the Quackback gtm-decision stream for an accept on that issue (reuse the QuackbackForge gtm-stream contract — label-keyed `surface:service`+accepted). Gate active until N merged builds, then `SERVICE_BUILD_GATE=off` (auto). Until Quackback is live, this unit is a no-op stub (gate config defaults to manual/off) and the funnel is run via controlled trigger.
+**Test scenarios:** gated + not-accepted → issue not claimed; gated + accepted → claimed; after N builds → gate flips to auto; gate off → claims like wgmesh. Edge: Quackback unreachable → fail-closed (don't build). `Covers F: accept-gate first N.`
+
+---
+
+## Scope boundaries
+
+- **In:** cloudroof-eu CI (impl-judge + build) + wrangler CD; surface-gate inversion; 2nd
+  systemd instance + provision parameterization; live provision + smoke; the Quackback gate (U6).
+- **Deferred to follow-up:** extending pulse/supervisor metrics to the cloudroof instance;
+  flipping the gate to auto after N (U6's second half, tune later); service-side ideation
+  (goal-sprint emitting service issues — already partly works via observation routing); LLM
+  surface auto-classifier for unlabeled manual issues.
+- **Outside this funnel's identity:** executing non-code GTM (humans); the wgmesh product
+  pipeline (untouched); the Quackback forge cutover itself (independent track, U6 depends on it).
+
+## Sequencing
+
+U1, U2, U3 are independent and parallelizable. U4 depends on U3. U5 depends on U1–U4 (the MVP
+proof). U6 depends on U5 + the Quackback cutover — ships last / when Quackback lands. **MVP
+(slice-1, full chain incl deploy) = U1–U5**; the Quackback gate is U6.
+
+## Risks & dependencies
+
+- **Box capacity:** 2 pipeline processes on one cpx22 (~2× LLM/CI/git load). U5 verifies; size
+  up if thin. Mitigation: independent DB/env/checkout already isolates them.
+- **cloudroof-eu secrets:** needs `CLOUDFLARE_API_TOKEN`, `OPENROUTER_API_KEY`, a cloudroof-scoped
+  `WGMESH_BOT_PAT`. Operator-provisioned (U5).
+- **Quackback dependency (U6):** the accept-gate blocks on a separate incomplete track. Mitigated
+  by shipping U1–U5 first and running the funnel controlled until the gate lands.
+- **Deploy blast radius:** auto-deploy to the live customer site. Mitigation: green-main-gated CD
+  + the impl-judge gate + (initially) controlled/gated builds.
+
+## Open questions (deferred to execution)
+
+- The "N" in gated-first-N (operator tuning; default e.g. 5).
+- Whether cloudroof-eu's existing `spec-merged-build.yml` already covers the build gate or U1
+  adds a distinct `ci.yml`.
+- Exact `cpx22` headroom → size-up decision (U5, runtime).

--- a/docs/plans/2026-06-22-003-feat-quackback-cutover-plan.md
+++ b/docs/plans/2026-06-22-003-feat-quackback-cutover-plan.md
@@ -1,0 +1,268 @@
+# feat: Quackback cutover — flip the decision layer from GitHub Issues to Quackback
+
+**Date:** 2026-06-22 · **Type:** feat · **Depth:** Deep
+**Origin:** `docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md`,
+`docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md` (U9 + activation)
+**Runbook:** `docs/runbooks/quackback-cutover.md`
+
+---
+
+## Status (2026-06-22)
+
+- **U1 — DONE** (PR #1977 `89ed8a3`). `observation-loop.yml` both `gh issue create`
+  steps gated on the `FORGE_KIND` repo var (no-op+log when `quackback`, github
+  byte-unchanged, reversible). `QuackbackForge.dispatch_workflow` → no-op-and-warn
+  host seam (was a latent double-create delegating to `_gh`).
+  *Deviation:* the dispatch no-op landed at the forge layer, not as a guard in
+  `_h_dispatch_observation_loop` — single seam, handler unchanged, conformance-covered.
+- **U2 — DONE** (`4fa8d50`). `QUACKBACK_BOARD_ID` in `BOX_CONFIG_ALLOWLIST` +
+  fail-closed config guard.
+- **U3 — DONE** (PR #1977 `89ed8a3`). Python collector
+  `wgmesh_pipeline/quackback_kpi.py` (`collect_quackback_queue_health` +
+  `select_queue_health`) — posts-by-decision-status + oldest-undecided age,
+  fail-closed-loud. Chose Python over bash (reuses `QuackbackClient` reads; live
+  consumer is the box gather). *Deferred to U4:* wiring `select_queue_health`
+  into the live `observation.py` gather (the loop is halted; built against fixtures).
+- **U4 — IN PROGRESS (2026-06-22).** Drain DONE (wgmesh 0 issues / 0 PRs: 27 service/GTM
+  issues + 12 PRs closed; 3 keepers #778/#729/#539 reseeded as board Open-for-Vote posts).
+  Minted bot key `autobox-box` (admin UI), synced repo secret. Box flipped via `set-box-env`:
+  `FORGE_KIND=quackback` + `QUACKBACK_URL/TOKEN/BOARD_ID` + `CONTROL_LOOP_ENABLED=true`,
+  `OBSERVATION_LIVE=false` (shadow). Box restarted clean (config constructed, `reconcile
+  seen=0` = only Accepted posts ingest = human-gated). Repo var `FORGE_KIND=quackback` set
+  (mutes Actions creator). **REMAINING:** (a) flip `OBSERVATION_LIVE=true` to make the box
+  the live suggestion creator (after a shadow observation cycle); (b) one e2e accept→Shipped
+  verify (needs a founder vote); (c) optional store reset — stale github rows self-drain to
+  terminal `failed`, bounded waste. Rollback = `FORGE_KIND=github` + re-enable workflows.
+
+All code units merged to main and **inert** (`forge_kind` defaults to `github`).
+
+---
+
+## Summary
+
+The Quackback decision-layer adapter (U1–U6, U12 of the decision-layer plan) is **merged on
+main and inert** — `forge_kind` defaults to `github`, so nothing routes to Quackback yet. The
+live instance (`http://89.167.62.47:3000`) is fully provisioned (board `build-suggestions`,
+8 decision statuses, bot key `autobox`, `QUACKBACK_URL`/`QUACKBACK_TOKEN` repo secrets).
+
+This plan is the **cutover** — the last unbuilt unit (U9) plus the minimum activation a safe
+flip requires. The chosen shape (operator, 2026-06-22) is **box-native**: make the box's
+existing observation control-loop module the sole issue/post creator, retire the Actions
+workflow's raw-bash `gh issue create`, repoint the queue-health KPI off GitHub issues, then
+drain → shadow-prove → flip live → verify → (reversible) rollback.
+
+## Problem frame
+
+The box already has a complete, forge-agnostic observation pipeline: `_cycle_observation`
+runs gather → assess (Goose) → `plan_actions` → execute through `self.forge.create_issue`,
+which resolves to `QuackbackForge` when `forge_kind=quackback` (sanitise wall + cross-status
+dedup + tags all built in U2–U5). It runs in **shadow** today. The LIVE issue creation is a
+DIFFERENT path — `.github/workflows/observation-loop.yml` creates issues via raw bash
+`gh issue create` (two sites, ~L735 and ~L817). So flipping `forge_kind` alone does **not**
+repoint production: the bash workflow bypasses the Python forge entirely (the same gap that
+left `_h_create_issue` host-neutral but unused in the live loop).
+
+Cutover therefore means: (1) stop the Actions workflow from creating, (2) make the box module
+the sole live creator against Quackback, (3) keep the queue observable once issues leave
+GitHub, (4) sequence the flip safely with a drain gate and a config-flip rollback.
+
+## Key technical decisions
+
+- **KTD1 — box-native creation, retire the Actions bash creator (operator choice).** The box
+  `_cycle_observation` becomes the single source of new Build Suggestions; the
+  `observation-loop.yml` bash `gh issue create` path is disabled. Aligns with the
+  Actions=CI/CD-only retarget and reuses the merge-lane-heal cron-retirement precedent
+  (box module proven in shadow, then cron retired). No new creation code — the path exists;
+  this activates it and removes the competing one.
+- **KTD2 — flip is a flag, not a code-default change.** `forge_kind` stays `github` in code;
+  cutover sets `FORGE_KIND=quackback` (already box-config allowlisted) + `OBSERVATION_LIVE=true`
+  on the box. Rollback = flip back + re-enable the workflow. The `gh` path is disabled, never
+  deleted (runbook §4).
+- **KTD3 — bare cutover, U8 notifications deferred (operator choice).** No founder-notification
+  / SLA in this cutover. **Accepted risk:** founder attention is the new throughput gate; with
+  no "posts await your vote" signal the queue can stall silently at zero builds. Mitigation:
+  the U3 KPI repoint makes the stall *visible* (oldest-undecided age), and the drain gate keeps
+  the GitHub lane draining in parallel during bake-in. U8 is the immediate follow-up.
+- **KTD4 — KPI redesign, not a 1:1 repoint.** Quackback has no `fn:*` labels; the queue-health
+  signal becomes **posts-by-decision-status** + **oldest-undecided age** on the board. PR /
+  merge-rate / CI / release / stars stay on GitHub (PR side is unchanged — KTD1 of the
+  decision-layer plan). Only the ISSUE-derived signals repoint.
+- **KTD5 — drain before flip (operator decision, carried from 2026-06-21).** In-flight GitHub
+  spec/impl issues+PRs finish-clean (drain to ~0) before the flip, so no work is stranded on
+  the old path. Verified at cutover time, not assumed here.
+
+---
+
+## High-level technical design
+
+```
+BEFORE (today, inert):
+  box _cycle_observation (SHADOW) ─ plans creates, logs, executes nothing
+  observation-loop.yml (Actions, LIVE) ── raw bash `gh issue create` ──▶ GitHub Issues
+  config.forge_kind = github   QuackbackForge merged but unused
+
+AFTER cutover (forge_kind=quackback, observation_live=true):
+  observation-loop.yml ── creation DISABLED (rollback-reversible) ─────▶ (no writes)
+  box _cycle_observation (LIVE)
+     gather ─ assess(Goose) ─ plan_actions ─ executor.create_issue
+                                                   │ make_forge(quackback)
+                                                   ▼
+                                        QuackbackForge.create_issue
+                                        (sanitise wall + cross-status dedup + tags)
+                                                   │  POST /api/v1/posts
+                                                   ▼
+                              Quackback board `build-suggestions` (Open for Vote)
+                                                   │  founder: Accepted for Build
+                                                   ▼
+                              box claims → spec→impl→PR (GitHub, unchanged)
+                                                   │  judge-gated auto-merge
+                                                   ▼            box mirrors status
+                                        merged ───────────────▶ Quackback: Shipped
+
+  KPI:  collect-github (PR/CI/release/stars)  +  collect-quackback (posts-by-status, oldest-undecided age)
+```
+
+---
+
+## Implementation units
+
+### U1. Retire the Actions observation issue-creation; box becomes sole creator — ✅ DONE (PR #1977 `89ed8a3`)
+**Goal:** `observation-loop.yml` stops creating issues so the box `_cycle_observation` module
+is the single source — no double-create, no raw-bash `gh issue create`.
+**Requirements:** KTD1, origin "HARD REPLACE day one" (decision-layer brainstorm). **Dependencies:** none.
+**Files:** `.github/workflows/observation-loop.yml`, `pipeline/wgmesh_pipeline/control_loop/executor.py`
+(guard `_h_dispatch_observation_loop`), `pipeline/tests/test_control_loop_executor.py`.
+**Approach:** Flag-guard the two `gh issue create` sites (~L735 create, ~L817 needs-human) so
+they no-op when the box owns creation — gate on a workflow input / `FORGE_KIND` env so the
+disable is reversible (rollback re-enables). Prefer disabling the *creation steps* over deleting
+the workflow: the gather/assess/close steps and manual dispatch stay available for rollback.
+Guard the selfheal `dispatch_observation_loop` action so an idle signal doesn't fire a
+creation-disabled workflow when `forge_kind=quackback` (no-op + log, mirroring the Gitea
+host-seam pattern). Mirror the merge-lane-heal cron-retirement shape: prove the box path in
+shadow (U4) before the workflow is muted.
+**Execution note:** characterization-first — `observation-loop.yml` is load-bearing infra;
+assert the GitHub creation path is byte-unchanged when the guard defaults to the github/enabled
+value, and only the quackback/disabled branch no-ops.
+**Patterns to follow:** the merge-lane-heal cron retirement (`project_merge_lane_heal_to_box`),
+the cloudroof `service`-input guard pattern (`set-box-env.yml` resolve step), Gitea host-seam
+no-op for `dispatch_workflow`.
+**Test scenarios:** guard defaults (github) → both `gh issue create` sites still fire (characterization);
+guard=quackback/disabled → creation sites no-op, gather/assess/close unaffected; YAML valid;
+`_h_dispatch_observation_loop` no-ops (returns without dispatch) when `forge_kind=quackback`,
+still dispatches for github. `Covers: box is the sole creator post-cutover.`
+
+### U2. Propagate Quackback config to the box (board id + creds + flags) — ✅ DONE (`4fa8d50`)
+**Goal:** the box env carries everything `make_forge(quackback)` needs, and constructing it
+fails loudly if a credential is missing.
+**Requirements:** KTD2, decision-layer U1 (config). **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/config.py` (box-config allowlist + optional board-id field),
+`pipeline/tests/test_config.py`; box env via `set-box-env.yml` / provision (operational, U4).
+**Approach:** Add `QUACKBACK_BOARD_ID` to `BOX_CONFIG_ALLOWLIST` (non-secret board id; the
+adapter reads it from env via `BOARD_ID_ENV`). `QUACKBACK_URL` / `QUACKBACK_TOKEN` are secrets —
+they reach the box env through provision or `set-box-env` (both are flag-charset-safe:
+`https://…` and `qb_…`), NOT box-config.json (allowlist already excludes secret-shaped keys).
+Confirm `load_config` already fails closed when `forge_kind=quackback` and URL/token are unset
+(decision-layer U1) — add a board-id presence check at the same seam if absent. No core forge
+change; this is wiring + a guard.
+**Execution note:** test-first on the config guard.
+**Patterns to follow:** existing `forge_kind=quackback` fail-closed block in `config.py`,
+`BOX_CONFIG_ALLOWLIST` entries (`FORGE_KIND`, `MERGE_LANE_HEAL_LIVE`), the cloudroof `SURFACE_HOME`
+allowlist addition.
+**Test scenarios:** `forge_kind=quackback` + missing `QUACKBACK_URL`/`QUACKBACK_TOKEN` → raises
+at config construction (existing); + missing `QUACKBACK_BOARD_ID` → raises (or adapter raises at
+ctor — assert whichever seam owns it); `QUACKBACK_BOARD_ID` passes through box-config allowlist;
+`forge_kind=github` → none required, unchanged. `Covers: box constructs QuackbackForge or fails loud.`
+
+### U3. Repoint queue-health KPI from GitHub issues to Quackback posts — ✅ DONE (PR #1977 `89ed8a3`)
+**Goal:** the pulse / observation queue-health signal stays meaningful once issues live in
+Quackback — measure posts-by-decision-status and oldest-undecided age, not GitHub issue labels.
+**Requirements:** KTD4, decision-layer "repoint pulse open-age KPI off GH Issues" (load-bearing).
+**Dependencies:** U2 (board id + creds available). 
+**Files:** `company/scripts/collect-quackback.sh` (new) OR a Python collector under
+`pipeline/wgmesh_pipeline/`, wiring in `company/scripts/collect-github.sh` (gate the issue-derived
+block on `forge_kind`) or the box observation/pulse gather; tests
+(`pipeline/tests/test_quackback_kpi.py`).
+**Approach:** When `forge_kind=quackback`, the ISSUE-derived signals (currently `issues_by_label`
+from `search/issues`) are replaced by board reads: count posts per decision status
+(`GET /api/v1/posts?status=<slug>` per the 8 statuses — slug filter, VERIFIED) and compute the
+age of the oldest post still in `open_for_vote` / `needs_refinement` (the founder-attention
+backlog). PR / merge-rate / CI / release / stars **stay GitHub** (PR side unchanged). Emit the
+same JSON shape the pulse/observation consumer expects, with the queue block sourced from
+Quackback. Reads fail-closed-loud for the gating-relevant counts, best-effort for cosmetic ones.
+**Execution note:** test-first against recorded Quackback API fixtures (the runbook's VERIFIED
+shapes) — no live calls in tests.
+**Patterns to follow:** `company/scripts/collect-github.sh` (signal-collector shape + JSON
+envelope), `forge/quackback_client.py` (status-slug filter, cursor pagination, fail-closed read),
+the Mixpost KPI precedent (`reference_mixpost_social_drip_integration`) for a service-scope KPI.
+**Test scenarios:** posts-by-status maps the 8 slugs to counts; oldest-undecided age computed
+from `createdAt` of the oldest `open_for_vote` post; empty board → zero counts, null age (not error);
+API error on a gating count → fail-closed-loud (non-zero / logged), not silent zero; `forge_kind=github`
+→ collector unchanged (GitHub path). `Covers KTD4: the queue stays observable post-cutover.`
+
+### U4. Drain → shadow-prove → flip live → verify → rollback (operational) — ⏳ PENDING (operator; box halted + creds)
+**Goal:** one real cutover: in-flight GitHub work drained, box proven in shadow against the live
+instance, flag flipped, end-to-end accept→build→merge→Shipped confirmed, with a tested rollback.
+**Requirements:** KTD2, KTD3, KTD5, origin verification (decision-layer runbook §3–4).
+**Dependencies:** U1, U2, U3.
+**Files:** `docs/runbooks/quackback-cutover.md` (fill §3 cutover + §4 rollback with the box-native
+sequence). No app code.
+**Approach:** (1) **Drain** in-flight GitHub spec/impl issues+PRs to ~0 (operator gate). (2)
+**Shadow-prove**: with `FORGE_KIND=quackback` but `OBSERVATION_LIVE=false`, run a box observation
+cycle and confirm it *plans* Quackback-bound creates (board id resolves, sanitise+dedup run, no
+GitHub writes) — mirroring the merge-lane-heal shadow proof. (3) **Flip**: `set-box-env` →
+`FORGE_KIND=quackback`, `OBSERVATION_LIVE=true`, `QUACKBACK_BOARD_ID=<board>` (+ confirm
+`QUACKBACK_URL`/`QUACKBACK_TOKEN` present); restart. (4) **Disable** the Actions creation (U1 guard
+on). (5) **Verify**: next observation cycle creates a Quackback post and **zero** GitHub issues;
+one full accept→build→merge→Shipped cycle completes (founder flips Accepted for Build → box claims
+→ PR → judge auto-merge → box mirrors Shipped). (6) **Rollback rehearsal**: document that
+`FORGE_KIND=github` + re-enable the workflow restores the old path (reseed the drained backlog if
+needed).
+**Execution note:** shadow-prove before the live flip, mirroring the merge-lane-heal cutover discipline.
+**Test scenarios:** Test expectation: none — operational verification (the runbook checklist + the
+live smoke is the proof). Verification: a Quackback post created by the box with zero new GitHub
+issues in the same window; one e2e accept→Shipped cycle; rollback flip observed to re-create on GitHub.
+
+---
+
+## Scope boundaries
+
+- **In:** retire the Actions bash issue-creation (box-native); box config propagation +
+  fail-closed guard; queue-health KPI repoint to Quackback; the drain→flip→verify→rollback
+  operation + runbook.
+- **Deferred to Follow-Up Work:** U8 founder notifications + 48h SLA (immediate next — the
+  silent-stall mitigation, KTD3); U7 decision→Langfuse audit score + decision dataset; R4 PR-body
+  post-URL wiring; U10/U11 vote-rerank + in-context steering.
+- **Outside this cutover's identity:** the adapter design (U1–U6/U12, already merged); the PR/merge
+  side (stays GitHub); the cloudroof-funnel accept-gate (a *downstream consumer* this cutover
+  unblocks — `project_cloudroof_service_funnel` U6 — not in scope here).
+
+## Sequencing
+
+U1, U2, U3 are independent and parallelizable (U3 reads config from U2 but can be built against
+fixtures). U4 depends on all three and is the operator-run cutover. Shadow-prove (U4 step 2) gates
+the live flip, exactly as the merge-lane-heal cutover did.
+
+## Risks & dependencies
+
+- **Box observation gather parity.** The box `observation_gather` may be thinner than the Actions
+  workflow's signal gather ("honest degradation" noted in `control_loop/__init__`). Risk: post-cutover
+  the box surfaces fewer/weaker suggestions than the bash loop did. Mitigation: shadow-prove (U4)
+  compares planned creates against a recent workflow run before muting it; if gather is thin, widen
+  it as a fast follow rather than blocking cutover.
+- **Silent founder stall (KTD3).** No notification → posts can sit in Open for Vote unbuilt.
+  Mitigation: U3 oldest-undecided-age KPI makes it visible; U8 is the immediate follow-up.
+- **Creds not yet on the box.** `QUACKBACK_*` secrets were set as repo secrets 2026-06-21, AFTER the
+  box's last `set-box-env` — the box env may lack them. U4 step 3 explicitly propagates them; U2's
+  fail-closed guard turns a miss into a loud config error, not a silent github fallback.
+- **Double-create window.** If the box goes live before the workflow is muted, both create. U4
+  sequences mute (step 4) immediately after flip (step 3) and verifies zero GitHub issues (step 5).
+- **Rollback completeness.** Drained GitHub backlog must be reseedable on rollback (runbook §4).
+
+## Open questions (deferred to execution)
+
+- Exact disable mechanism for `observation-loop.yml` creation: workflow input vs. `FORGE_KIND`
+  env read in the step vs. schedule-disable (U1 picks during implementation; reversibility is the
+  constraint).
+- Whether the KPI collector lands as bash (`collect-quackback.sh`, mirrors `collect-github.sh`) or
+  Python (reuses `QuackbackClient` read paths) — U3 decides by where the pulse gather consumes it.
+- Drain threshold ("~0") and timing — operator call at cutover (U4).

--- a/docs/plans/2026-06-22-004-feat-accept-gate-cleanup-reenable-plan.md
+++ b/docs/plans/2026-06-22-004-feat-accept-gate-cleanup-reenable-plan.md
@@ -1,0 +1,307 @@
+---
+title: "feat: Fail-closed founder accept-gate + GTM cleanup + staged box re-enable"
+type: feat
+date: 2026-06-22
+depth: deep
+origin: docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md
+related:
+  - docs/plans/2026-06-22-003-feat-quackback-cutover-plan.md
+  - docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md
+target_repos:
+  - atvirokodosprendimai/ai-pipeline-template
+  - atvirokodosprendimai/wgmesh
+---
+
+# feat: Fail-closed founder accept-gate + GTM cleanup + staged box re-enable
+
+## Summary
+
+The autonomous box was disabled on 2026-06-22 because it specced, built, and merged GTM/marketing work — cold outreach copy, comparison pages, a 5-email drip, a referral system — with **no founder approval gate**. Tracing confirmed the external blast radius was zero (the merged artifacts were code/docs, no executor sent anything), but the harm the operator named is real on a different axis: **wasted implementation tokens and pollution of the product `main` with features nobody accepted.**
+
+The fix is not to build a gate from scratch. The accept-gate enforcement already exists — but only on the Quackback forge path (un-flipped), while the box runs on the GitHub forge path, which has **no approval signal at all**. This plan makes the gate **forge-agnostic and fail-closed** so the box cannot produce a build artifact for any Issue lacking explicit founder approval, regardless of forge; cleans the unrequested GTM code off wgmesh `main`; and stages a shadow-proven re-enable with a single-flag rollback.
+
+The box stays OFF until this gate is live and shadow-proven.
+
+---
+
+## Problem Frame
+
+**What broke.** On the `forge_kind=github` path (the box default), `github/client.py list_open_issues` returns every open Issue with no approval filter; `reconcile_issues` upserts them all to the execution store at `stage="queued"`; the Poller then claims and builds each one through `triaged → specced → implemented → merged`. There is no point in that path where founder approval is required before a build artifact is produced. The Observation Loop files Issues autonomously, so the loop is self-feeding: it proposes GTM work, then builds it.
+
+**Why the existing enforcement doesn't cover it.** The Quackback decision layer (merged, inert) gates at *ingest*: `QuackbackForge.list_open_issues` returns only posts with status `Accepted for Build`, fail-closed on API error. But that only holds when `forge_kind=quackback`. The full forge cutover (plan `003`) is not done, and coupling the safety gate to that larger cutover delays re-enable and entangles it with an open product question (whether the founder should be the sole build bottleneck).
+
+**What the operator wants.** A gate that (a) defaults to deny, (b) holds on whatever forge the box runs today, (c) is loud and traced when it blocks, (d) can be shadow-proven before going live, and (e) covers both Surfaces (product `wgmesh` and service `cloudroof-eu`). Plus the merged GTM code removed in a way the Observation Loop won't simply re-propose.
+
+**Concept vocabulary** (from `CONCEPTS.md`): *Issue* (proposed work item), *Spec* (approved Issue, authored by Spec writer), *Implementation* (code fulfilling a Spec), *Funnel stage* (`triage/spec_ready/needs_impl/awaiting_merge/merged`), *Surface* (`product` = wgmesh, `service` = cloudroof), *Escalation* (work promoted to the human queue). "Accept-gate" and "Accepted for Build" are decision-layer terms, not yet in `CONCEPTS.md`.
+
+---
+
+## Requirements
+
+- **R1** — No Issue advances from `triaged` to `specced` (the first build-artifact stage) unless it carries explicit founder approval. This is the chokepoint; gating earlier (ingest) is defense-in-depth, not the primary guard.
+- **R2** — The gate is **fail-closed**: missing, unreadable, malformed, or not-yet-approved status → block + escalate, never build. Default-on-missing is *deny*.
+- **R3** — The gate is **forge-agnostic**: it reads an approval signal on both the GitHub path (an `approved-for-build` label) and the Quackback path (status `Accepted for Build`), behind one Protocol method.
+- **R4** — Gate denials are **loud and traced** (escalate to the human queue / `needs-human`), never silent skips.
+- **R5** — The gate is gated by its own live flag (`ACCEPT_GATE_LIVE`) so it can run shadow (observe + log, no behavior change) before enforcing.
+- **R6** — The gate covers **both Surfaces** (`wgmesh` and `cloudroof-eu`); neither repo may route around it.
+- **R7** — The unrequested GTM code is removed from wgmesh `main` such that `collect-capabilities.sh` reconciles it out of the Observation Loop's grounding (so the loop does not re-propose it), and `go build ./... && go vet ./...` stay green.
+- **R8** — Re-enable is staged: shadow-prove the gate blocks unapproved work (journal evidence), then flip live, with rollback = single flag flip + re-disable Actions.
+- **R9** — The gate decision is **deterministic** (a status/label read), never an LLM call, so it cannot fail-open on a model/budget outage.
+
+---
+
+## Key Technical Decisions
+
+### KTD1 — Gate at the build chokepoint, not only at ingest
+Insert the fail-closed guard in `poller.py:_advance_one_stage` immediately before the `triaged → specced` spec call (`poller.py:130-131`) — the single narrowest point every Issue passes before any build artifact exists. The Quackback ingest filter (`list_open_issues`) stays as defense-in-depth, but the chokepoint guard is the primary enforcement and is forge-agnostic. Rationale: gating at the Poller covers manually-filed and reconciled Issues alike, and mirrors the existing exit drift-guard (`_mirror_quackback`, which already reads `get_decision_status` and aborts on drift out of the lane). The accept-gate is the *entry* analogue of that proven *exit* guard.
+
+### KTD2 — One Protocol method, two forge implementations
+Add an approval accessor to the `Forge` Protocol (`forge/protocol.py`) — e.g. `get_decision_status(number) -> str` (already present on `QuackbackForge:147`). Implement it on `github/client.py` by reading the `approved-for-build` label (the same positive label `company/scripts/pr-review-merge.sh` already uses as a merge gate — reuse the established convention, do not invent a new signal). The guard compares against `quackback_status.ACCEPTED_FOR_BUILD` on Quackback and label-presence on GitHub, behind one call. Rationale: decouples the safety gate from the `FORGE_KIND` cutover (plan `003`); the box can re-enable on the GitHub path today.
+
+### KTD3 — Positive assertion, default-deny
+The gate asserts approval is **present** ("Accepted for Build" / label present), not "no objection". Any other state — including unreadable/error — denies. This is the inverse of the Langfuse fail-open trap (numeric judge defaulted *high* on empty input); here the default direction is *block*. (See `docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md`, `docs/solutions/integration-issues/autonomous-review-merge-bootstrap.md` Bug #8.)
+
+### KTD4 — Test through the real boundary
+Unit tests over a faked forge can stay green while the live gate never blocks (the hollow-green / never-run-path class — `docs/solutions/runtime-errors/goose-weak-model-prints-spec-instead-of-writing.md`). Each gate test must drive the actual decision-status read result and confirm the guard *bites* by asserting that flipping the status from approved→unapproved flips build→block. Mirror `test_quackback_drift.py`'s fake-status-read setup in `test_poller.py`.
+
+### KTD5 — Revert-PR convention for cleanup
+Remove the GTM code via `Revert "<title>"` PRs (or equivalently-titled surgical PRs) so `collect-capabilities.sh` subtracts the matching capability from the Observation Loop's grounding. A bare file delete leaves the loop believing the GTM capability shipped, and it will re-propose or defend it. (See `docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md`.)
+
+### KTD6 — Staged re-enable mirrors the proven cutover shape
+Reuse the merge-lane-heal / Quackback-cutover flip shape: inert/shadow on the box → prove with journal evidence (`planned=N, specced=0` because unapproved) → flip a single env flag → rollback = flag-false. Do not invent a new sequence. For the Actions half, verify every gate-triggering event is produced by a user/PAT actor, not a GitHub App `GITHUB_TOKEN` (App-token actions silently do not fire workflow events; a missing required check reads PENDING, never RED — `docs/solutions/integration-issues/github-app-reviews-dont-trigger-workflows.md`).
+
+---
+
+## High-Level Technical Design
+
+### Build path — where the gate sits (fail-closed entry guard)
+
+```mermaid
+flowchart TD
+  OBS[Observation Loop\n_cycle_observation] -->|files Issue| STORE[(execution store\nSQLite)]
+  INGEST[reconcile_issues\nupsert stage=queued] --> STORE
+  STORE -->|claim_next| POLL[Poller._advance_one_stage]
+  POLL --> Q{stage?}
+  Q -->|queued| TRIAGE[triage]
+  TRIAGE --> TR[triaged]
+  TR --> GATE{{ACCEPT-GATE\nget_decision_status == Accepted?\nfail-closed}}
+  GATE -->|approved| SPEC[spec → specced → impl → review → merge]
+  GATE -->|not approved / unreadable| ESC[park + escalate\nneeds-human, traced]
+  ESC -.->|loud, never silent| HUMAN[(human queue)]
+  style GATE fill:#fde,stroke:#c33,stroke-width:2px
+  style ESC fill:#fee,stroke:#c33
+```
+
+The guard is the diamond before `spec`. Ingest filter (Quackback) is upstream defense-in-depth; the chokepoint guard is the primary, forge-agnostic enforcement.
+
+### Approval signal — one method, two forges
+
+| Forge | `get_decision_status(number)` source | "Approved" means |
+|-------|--------------------------------------|------------------|
+| `quackback` | post status (`QuackbackForge:147`, exists) | `== "Accepted for Build"` |
+| `github` | `approved-for-build` label presence (new accessor) | label present |
+| any error / missing | — | **deny + escalate** (KTD3) |
+
+### Re-enable state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> AllOff: current (box halted, Actions disabled)
+  AllOff --> GateMerged: P1 merged (gate code, ACCEPT_GATE_LIVE=false)
+  GateMerged --> Cleaned: P2 merged (GTM reverted, build green)
+  Cleaned --> Shadow: ACCEPT_GATE_LIVE=false + CONTROL_LOOP_ENABLED=true (shadow log only)
+  Shadow --> Proven: journal shows unapproved Issues blocked, 0 specced
+  Proven --> Live: ACCEPT_GATE_LIVE=true + re-enable Actions
+  Live --> Verified: one approved Issue builds; unapproved stays blocked
+  Live --> AllOff: ROLLBACK = flags false + disable Actions
+```
+
+---
+
+## Implementation Units
+
+### Phase 1 — Forge-agnostic fail-closed accept-gate (`ai-pipeline-template`)
+
+### U1. Approval accessor on the Forge Protocol + GitHub client
+**Goal:** A single `get_decision_status`-style method exists on the `Forge` Protocol and on the GitHub client (Quackback already has it), so the gate reads approval through one call on any forge.
+**Requirements:** R3, R9.
+**Dependencies:** none.
+**Files:**
+- `pipeline/wgmesh_pipeline/forge/protocol.py` (add method to `Forge` Protocol + `ForgeIssue` if needed)
+- `pipeline/wgmesh_pipeline/github/client.py` (implement accessor reading `approved-for-build` label)
+- `pipeline/wgmesh_pipeline/forge/quackback.py` (confirm signature parity; no behavior change)
+- `pipeline/tests/test_forge_protocol.py`, `pipeline/tests/test_forge_factory.py` (Protocol conformance)
+- `pipeline/tests/test_github_client.py` (label-read accessor)
+**Approach:** Deterministic label/status read only — no LLM. The GitHub accessor returns a normalized approval state (`approved` / `not_approved`) derived from `approved-for-build` label presence; map to the same comparison the Quackback path uses. Keep the accessor read-only (the box must never author approval).
+**Execution note:** Characterization-first — add a test asserting the *current* GitHub client returns the open-issue set with labels before adding the accessor, so the new method's behavior is pinned against real label data.
+**Patterns to follow:** `QuackbackForge.get_decision_status` (`forge/quackback.py:147`); label handling in `forge/protocol.py ForgeIssue` (`:21`).
+**Test scenarios:**
+- Happy: GitHub issue WITH `approved-for-build` label → accessor returns approved. Covers R3.
+- Happy: Quackback post with status `Accepted for Build` → approved (parity).
+- Edge: GitHub issue with no labels → not_approved (not error).
+- Edge: GitHub issue with other labels but not `approved-for-build` → not_approved.
+- Error: forge API raises / returns malformed → method surfaces the error to the caller (caller denies per U2), does not swallow to a falsy "approved".
+- Protocol: both forges satisfy the updated `Forge` Protocol (conformance test).
+
+### U2. Fail-closed accept-gate at the Poller spec chokepoint
+**Goal:** No Issue advances `triaged → specced` unless its approval state is `approved`; otherwise park + escalate, loudly and traced.
+**Requirements:** R1, R2, R4, R5.
+**Dependencies:** U1.
+**Files:**
+- `pipeline/wgmesh_pipeline/poller.py` (guard before the spec call at `:130-131`)
+- `pipeline/wgmesh_pipeline/config.py` (add `ACCEPT_GATE_LIVE` flag, `_get_bool` pattern at `:274-283`)
+- `company/box-config.json` (add `ACCEPT_GATE_LIVE: "false"` operational toggle)
+- `pipeline/tests/test_poller.py` (gate behavior)
+- `pipeline/tests/test_poller_stage_tracing.py` (escalation trace)
+**Approach:** Before `self.graph.spec(state)`, call the U1 accessor for the Issue. If not approved (or read errored), do not spec: move the Issue to an escalated/parked state and emit a traced escalation (reuse the `_mirror_quackback` abort-and-escalate path at `poller.py:315-324`). When `ACCEPT_GATE_LIVE=false`, run in **shadow**: log the decision the gate *would* make (`would_block` / `would_allow`) into the journal but let the existing flow proceed unchanged — this produces the shadow evidence for U8 without altering behavior. When `true`, enforce.
+**Execution note:** Test-first — write the failing "unapproved Issue is blocked before spec" test against the real decision-read result, then implement; confirm it bites by toggling the fake status approved↔unapproved (KTD4).
+**Patterns to follow:** `_mirror_quackback` drift guard (`poller.py:271,301,311-324`); flag gating like `_module_live` / `*_LIVE`.
+**Test scenarios:**
+- Happy (live): approved Issue → proceeds to `spec`. Covers R1.
+- Happy (live): unapproved Issue → does NOT spec; lands in escalated/parked stage; escalation event emitted. Covers R1, R2, R4.
+- Fail-closed: decision-status read raises → Issue blocked + escalated, never specced. Covers R2.
+- Fail-closed: status present but unrecognized/malformed value → blocked. Covers R2.
+- Shadow (`ACCEPT_GATE_LIVE=false`): unapproved Issue → flow unchanged BUT journal records `would_block`. Covers R5, R8.
+- Bite check: same Issue flips build→block when status flips approved→unapproved (guards against hollow-green). Covers R2/KTD4.
+- Trace: blocked Issue produces a `needs-human`/escalation trace entry, not a silent skip. Covers R4.
+
+### U3. Cover both Surfaces (product + service)
+**Goal:** The gate is enforced for Issues on both `wgmesh` and `cloudroof-eu`; neither Surface can route around it.
+**Requirements:** R6.
+**Dependencies:** U2.
+**Files:**
+- `pipeline/wgmesh_pipeline/config.py` (confirm per-Surface / per-repo forge + gate config; the 2nd cloudroof instance has its own env — see `install-cloudroof-instance.yml`)
+- `company/box-config.json` and the cloudroof instance env (gate flag present in both)
+- `pipeline/tests/test_config.py` (both-Surface gate config resolves)
+**Approach:** Verify the Poller in each instance (wgmesh box + cloudroof box) reads `ACCEPT_GATE_LIVE` and the U1 accessor for its TARGET_REPO. No Surface-specific bypass. If the cloudroof instance uses the interim label gate (Quackback gtm-stream not live), the `approved-for-build` label accessor (U1 GitHub path) covers it.
+**Test scenarios:**
+- Config: `ACCEPT_GATE_LIVE` resolves on both the wgmesh and cloudroof instance configs (box-config + env layering, `config.py:160-161`).
+- Both-forge: gate guard active whether the instance is `forge_kind=github` (label) or `quackback` (status). Covers R6.
+- `Test expectation: none` for any pure-config wiring that carries no branch — annotate with reason.
+
+---
+
+### Phase 2 — Clean unrequested GTM code (`atvirokodosprendimai/wgmesh`)
+
+**Target repo:** `atvirokodosprendimai/wgmesh`. All paths below are repo-relative to that repo. The GTM code is an isolated island — nothing in the real product (`pkg/daemon`, `pkg/mesh`, `pkg/crypto`, `pkg/discovery`) imports it; no `go.mod` deps were added.
+
+### U4. Revert Tier A + B — docs, pages, and the analytics/promo/nurture cluster
+**Goal:** Remove the build-safe GTM artifacts (no daemon wiring) via revert-PRs.
+**Requirements:** R7.
+**Dependencies:** none (independent of U1–U3).
+**Files (delete / revert):**
+- Tier A: `docs/comparison/` (#751); `public/vpn-alternative.md` + 2 `README.md` lines (#742); the 4 positioning docs + `scripts/audit-polar-products.sh` (#761); `pkg/nurture/` (#788, imported by nothing).
+- Tier B (do together — #782 extended #738's `pkg/analytics`, lone revert conflicts): `pkg/promo/`, `pkg/analytics/`, `cmd/analytics-dashboard/`, the stray root binary `analytics-dashboard`, and `docs/outreach-communities.md` / `docs/outreach-templates.md` / `docs/trial-offer-structure.md` (#738).
+**Approach:** Use `Revert "<title>"`-titled PRs (KTD5) so capabilities reconcile. Tier A units are independent and build-safe in any order. Tier B is one consistent tree-state removal of the `#738`+`#782` cluster (surgical delete of the cluster rather than two conflicting merge-reverts).
+**Execution note:** Run `go build ./... && go vet ./...` after the cluster removal to confirm the product still builds (it has no dependency on the removed packages).
+**Patterns to follow:** the `Revert "<title>"` capability-subtraction convention; `collect-capabilities.sh`.
+**Test scenarios:** `Test expectation: none — deletion of unreferenced GTM packages/docs.` Verification is the build/vet pass below, not new tests. Confirm no remaining import of `pkg/nurture`, `pkg/promo`, `pkg/analytics`, `cmd/analytics-dashboard` (`gh search code` / tree grep) returns zero hits after the PRs.
+
+### U5. Revert Tier C — referral (unwire daemon first, build-breaking)
+**Goal:** Remove the referral GTM code that is wired into the production daemon binary, without breaking `go build`.
+**Requirements:** R7.
+**Dependencies:** U4 (do last; this is the only build-breaking unit).
+**Files:**
+- `main.go` (remove `pkg/referral` import at `:20`; remove the `referral` subcommand dispatch + helpers `referralState`/`loadReferralState`/`saveReferralState`/`getOrCreateReferralCode`/`runReferralShow|Stats|Validate`/`printReferralUsage` at `~:281,:355,:1543-1721`; remove referral block from CLI help)
+- `main_test.go` (remove `TestReferral*CLI` tests, `~:374-475`)
+- `pkg/referral/` (delete after unwiring)
+**Approach:** Two-step, ordered: (a) strip the `main.go`/`main_test.go` wiring, (b) then `rm -r pkg/referral/`. `git revert -m 1 aa7ce30` does both atomically **iff** `main.go` has not been touched by intervening merges — verify with `git log main -- main.go` first; if it has, do the surgical two-step. Title the PR as a revert (KTD5).
+**Execution note:** Characterization-first — confirm `go build ./... && go vet ./...` is green BEFORE the change (baseline) and AFTER (no regression). The daemon must still build and its existing subcommands (`join`/`init`/`status`/etc.) must be untouched.
+**Patterns to follow:** existing root `main.go` subcommand structure (leave non-referral subcommands intact).
+**Test scenarios:**
+- Build: `go build ./...` green after referral removed and unwired. Covers R7.
+- Vet: `go vet ./...` clean.
+- Regression: existing daemon subcommands present and unchanged (no referral subcommand; `--version`, `join`, `status` still resolve).
+- Grep: zero references to `pkg/referral` in the tree after the PR.
+
+### U6. Reconcile capabilities + confirm green main
+**Goal:** The Observation Loop's grounding no longer asserts the GTM capabilities as shipped; product `main` is green.
+**Requirements:** R7.
+**Dependencies:** U4, U5.
+**Files:**
+- wgmesh capability digest / `collect-capabilities.sh` output (verify GTM capabilities subtracted)
+- CI on wgmesh `main` (build/vet/test green post-revert)
+**Approach:** Confirm the revert-PRs' titles caused `collect-capabilities.sh` to drop the GTM capabilities, so the next Observation cycle does not re-propose outreach/drip/referral/comparison work. Confirm `main` CI is green.
+**Test scenarios:** `Test expectation: none — verification unit.` Verification: capability digest no longer lists the GTM capabilities; wgmesh `main` build/vet/test green.
+
+---
+
+### Phase 3 — Staged, shadow-proven re-enable (`ai-pipeline-template` + ops)
+
+### U7. Shadow-prove the gate blocks unapproved work
+**Goal:** With the gate code merged but `ACCEPT_GATE_LIVE=false`, run the box control loop in shadow and collect journal evidence that unapproved Issues *would* be blocked.
+**Requirements:** R8, R5.
+**Dependencies:** U2 (gate code merged), U6 (clean main so the loop isn't grounded on GTM).
+**Files:**
+- `company/box-config.json` (`CONTROL_LOOP_ENABLED=true`, `ACCEPT_GATE_LIVE=false` for the shadow window)
+- box journal / control-loop trace output (evidence)
+- `docs/runbooks/accept-gate-reenable.md` (new — shadow section)
+**Approach:** Re-enable only the control loop (not yet the autonomous Actions crons or live gate). Drive at least one cycle where an unapproved Issue is present; confirm the journal records `would_block` and that `specced=0` for unapproved Issues. This is the entry analogue of the merge-lane-heal shadow proof (`planned=N executed=0`).
+**Execution note:** Characterization baseline — record what the box does *without* the gate enforcing (shadow) before flipping live, so the live flip's effect is attributable.
+**Test scenarios:** `Test expectation: none — operational shadow run.` Verification: box journal shows ≥1 `would_block` for an unapproved Issue and zero unapproved Issues reaching `specced` during the shadow window.
+
+### U8. Flip live + re-enable Actions, verified, with rollback
+**Goal:** Enforce the gate and bring the pipeline back online, proven by one approved Issue building end-to-end while an unapproved Issue stays blocked.
+**Requirements:** R8, R6.
+**Dependencies:** U7.
+**Files:**
+- `company/box-config.json` (`ACCEPT_GATE_LIVE=true`) via `set-box-env` (no provision)
+- GitHub Actions workflow states (re-enable the CI/CD + needed crons via `gh workflow enable`; see `project_all_pipelines_disabled_kill_switch`)
+- `docs/runbooks/accept-gate-reenable.md` (flip + verify + rollback sections)
+**Approach:** Flip `ACCEPT_GATE_LIVE=true` (box restart). Re-enable Actions in a deliberate order — CI/CD first, then the autonomous crons only after the gate is confirmed enforcing. Before trusting any re-enabled gate-triggering workflow, verify its triggering actor is a user/PAT, not a GitHub App `GITHUB_TOKEN` (KTD6). Verify: one Issue marked approved builds through to merge; one unapproved Issue is blocked + escalated. **Rollback** = `ACCEPT_GATE_LIVE=false` (or `CONTROL_LOOP_ENABLED=false`) + re-disable Actions — a flag flip, not a code revert.
+**Execution note:** Do not re-enable the autonomous Observation/build crons until the live gate is confirmed enforcing on a real approved/unapproved pair.
+**Test scenarios:** `Test expectation: none — operational flip.` Verification: (a) approved Issue → Implementation merged; (b) unapproved Issue → blocked + escalated, zero build artifacts; (c) rollback flips both behaviors off in one step; (d) every re-enabled gate-triggering workflow fired by a PAT/user actor (no App-token PENDING-forever check).
+
+### U9. Re-enable runbook
+**Goal:** A durable operator runbook for shadow → flip → verify → rollback, so the sequence is repeatable and the rollback is unambiguous.
+**Requirements:** R8.
+**Dependencies:** U7, U8.
+**Files:** `docs/runbooks/accept-gate-reenable.md`.
+**Approach:** Document the staged sequence, the exact flags (`CONTROL_LOOP_ENABLED`, `ACCEPT_GATE_LIVE`, `FORGE_KIND`), the `gh workflow enable` ordering, the verification pairs, and the single-flag rollback. Cross-link the Quackback cutover runbook (`docs/plans/2026-06-22-003`) as the optional follow-on decision-layer activation.
+**Test scenarios:** `Test expectation: none — documentation.`
+
+---
+
+## Scope Boundaries
+
+**In scope:** forge-agnostic fail-closed accept-gate at the build chokepoint (both forges, both Surfaces); removal of the merged GTM code from wgmesh `main`; staged shadow→flip re-enable with rollback.
+
+### Deferred for later
+- **Bounded auto-accept (OQ1).** Whether a low-risk/high-vote class should auto-accept so the box degrades gracefully instead of hard-stopping on founder attention. Decision deferred; this plan ships the **hard gate** (zero build throughput without approval) per the operator's confirmation. Revisit once steady-state throughput pressure is felt.
+- **Full Quackback forge cutover** (`FORGE_KIND=github → quackback`, plan `docs/plans/2026-06-22-003`). Orthogonal: the forge-agnostic gate makes re-enable safe without it. The cutover remains the richer founder-decision UX and can land after.
+
+### Outside this product's identity
+- Reinstating any GTM/marketing build capability inside the autonomous product pipeline. GTM routes to the cofounder queue per the product/service split — the box builds CODE, not GTM (`docs/brainstorms/2026-06-21-product-service-split-requirements.md`).
+
+### Deferred to Follow-Up Work
+- Adding `approved-for-build` as a first-class concept to `CONCEPTS.md` and the Quackback status map documentation (doc-only; not blocking the gate).
+
+---
+
+## Risks & Dependencies
+
+- **Hollow-green gate (high).** A gate green in unit tests but inert live. Mitigation: KTD4 bite-checks through the real decision-read; shadow proof (U7) before trusting it.
+- **Fail-open on read error (high).** An exception path that resolves to "approved". Mitigation: KTD3 default-deny; explicit error-path tests (U1, U2).
+- **Build break on referral revert (medium).** `pkg/referral` is wired into the daemon. Mitigation: U5 unwire-first ordering + before/after build characterization.
+- **Loop re-proposes reverted GTM (medium).** If capabilities aren't reconciled. Mitigation: KTD5 revert-PR convention; U6 verification.
+- **Actions re-enable fails silently (medium).** App-token-triggered workflows never fire; missing check reads PENDING not RED. Mitigation: KTD6 actor verification; deliberate re-enable ordering (U8).
+- **Surface gap (medium).** cloudroof-eu routes around the gate. Mitigation: R6 / U3 both-Surface coverage.
+- **Dependency:** the box remains OFF (current state) until U8 verification passes.
+
+---
+
+## Sources & Research
+
+- Origin: `docs/brainstorms/2026-06-21-quackback-decision-layer-requirements.md` (front-gate = founder "Accepted for Build"; back-gate = judge auto-merge kept).
+- Existing enforcement (Quackback path): `forge/quackback.py` (`get_decision_status:147`, `list_open_issues:185`), `forge/quackback_status.py` (`ACCEPTED_FOR_BUILD`), drift guard `poller.py:_mirror_quackback`.
+- Build path / chokepoint: `poller.py:_advance_one_stage` (`:130-131`), Poller (`poller.py:21`), `config.py` flag layering (`:160-161,:258-283`).
+- Cleanup surface + blast radius: wgmesh PRs #738/#742/#751/#761/#782/#788/#793 (traced; GTM = isolated island, only `pkg/referral` wired to daemon `main.go`).
+- Learnings: `docs/solutions/runtime-errors/goose-weak-model-prints-spec-instead-of-writing.md` (hollow-green), `.../logic-errors/langfuse-evaluators-scored-empty-output.md` (fail-open default-high), `.../integration-issues/github-app-reviews-dont-trigger-workflows.md` (App-token trigger boundary), `.../integration-issues/autonomous-review-merge-bootstrap.md` Bug #8 (positive-label gate), `.../logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md` (revert-PR reconcile), `.../logic-errors/manually-filed-issues-bypass-pipeline-triage.md` (loud-not-silent denial).
+- Related plans: `docs/plans/2026-06-22-003-feat-quackback-cutover-plan.md`, `docs/plans/2026-06-21-001-feat-quackback-decision-layer-plan.md`.
+
+---
+
+## Open Questions
+
+- **OQ1 (product, deferred):** founder as sole build bottleneck (hard gate, this plan) vs. bounded auto-accept class. Confirmed hard gate for now; auto-accept deferred.
+- **OQ2 (execution-time):** exact `approved-for-build` label semantics on cloudroof-eu if its Quackback gtm-decision stream goes live mid-rollout — resolve when the cloudroof instance flips forge.

--- a/docs/plans/2026-06-22-006-feat-decision-lane-plan.md
+++ b/docs/plans/2026-06-22-006-feat-decision-lane-plan.md
@@ -1,0 +1,270 @@
+# feat: Decision lane — Phase 1 (the consent loop, read-only execution)
+
+**Date:** 2026-06-22 · **Type:** feat · **Depth:** Deep
+**Origin:** `docs/brainstorms/2026-06-22-capability-acquisition-ladder-requirements.md`
+**Scope:** Phase 1 of the capability-acquisition ladder — the decision/proposal lane only.
+Self-build (rung 2), rent-a-human (rung 3), and web research are **out of this plan**.
+
+---
+
+## Summary
+
+Give the box a **decision lane**: for a co-founder decision ask, it researches (internal
+context only, for now), drafts a **structured proposal** (recommendation, options, pros/cons,
+upsides/downsides, ROI), iterates on co-founder **comments**, and on reaching the **approval
+threshold** opens a clean **final proposal post** and retires the discussion post. Execution in
+Phase 1 is *just producing the decided artifact* — no self-modification, no spend — so the whole
+consent loop ships with zero blast radius. It is a new box control-loop module, shadow-first,
+exactly like observation and merge-lane.
+
+## Problem frame
+
+Today a `needs-human` decision (e.g. "decide Stripe pricing") is *parked* — the box creates the
+post and does nothing else; it cannot read comments, so there is no iteration. The brainstorm's
+target is the box that *works* decision items under co-founder consent. Phase 1 builds the consent
+loop itself — the gate — before any of the powers (self-build, spend) it will later gate. Proving
+the loop with zero blast radius is the whole point of sequencing it first (see origin: Approach).
+
+KTD9 from the decision-layer holds throughout: **the box never sets a decision status.** It
+drives body, comments, tags, and reads votes; the co-founders drive status. That single constraint
+shapes the trigger, the agreement signal, and the retirement mechanism below.
+
+## VERIFY items — RESOLVED 2026-06-22 (probed against the live instance)
+
+- ✅ **Comment read:** `GET /api/v1/posts/{id}/comments` → 200; each comment carries
+  `principalId`, `authorName`, `isTeamMember`, `content`, `createdAt`, `id`, `parentId`. Enough to
+  read the thread AND distinguish a co-founder comment from the box's own (`authorName` = the bot
+  key name).
+- ✅ **Vote count:** `voteCount` is on the post payload. `GET /posts/{id}/votes` → **404** (no
+  voter list). The threshold reads the count; voter-is-co-founder rests on the private-board
+  assumption (all voters are co-founders), per origin.
+
+---
+
+## Key technical decisions
+
+- **KTD1 — box-native control-loop module, shadow-first.** The lane is a new `ControlLoopScheduler`
+  module (like observation / merge-lane), not an Actions workflow — aligns with the
+  actions=CI/CD-only retarget (`project_actions_cicd_only_retarget`). It runs shadow (plans, no
+  writes) until a `DECISION_LANE_LIVE` flag flips, mirroring the merge-lane cutover discipline.
+- **KTD2 — trigger is a founder-set status, not a box action (KTD9).** The box may not set a
+  decision status, so it cannot move a post into the lane itself. The co-founder moves a decision
+  post to **`Needs Refinement`** = "box, draft/refine a proposal here." The box ingests
+  `Needs Refinement` posts (slug-filtered read, the verified ingest pattern) and works them.
+- **KTD3 — internal grounding only in Phase 1.** The proposal is grounded on `STRATEGY.md`, KPIs,
+  and the repo via the Goose runner — **no web research** (that is Phase 2's first self-build).
+  Market/competitor claims the model makes are explicitly labeled as **assumptions** in the
+  proposal body, not asserted as fact.
+- **KTD4 — risk-tiered approval threshold (config), Phase 1 exercises `routine = 1`.** The policy
+  is built tiered now — routine = 1 approve-vote, dangerous = all current co-founders — but Phase 1
+  has no dangerous actions (read-only), so every proposal is routine and the gate is
+  `voteCount >= 1`. The policy reads `voteCount` from the post (count only; private-board
+  attribution assumption). The N=2 caveat and the €X "dangerous" line are config, surfaced for
+  Phase 2.
+- **KTD5 — iteration via author distinction + a store-backed processed-comment marker.** The box
+  re-drafts only on a **new co-founder comment** (`authorName` ≠ the bot key, `isTeamMember` true),
+  never on its own comment, and tracks the last-processed comment id/timestamp in the store so it
+  doesn't re-process. Loop-guarded by a max-iteration cap.
+- **KTD6 — retire the discussion post by tagging `superseded`, not deleting.** KTD9 blocks the box
+  from setting `Cancelled`. On agreement the box opens a clean **final proposal post** (the decision
+  record) and tags the discussion post `superseded` (the box may set tags) — keeping the
+  deliberation trail rather than `delete_post`-ing it.
+- **KTD7 — execute = produce the decided artifact.** In Phase 1 the lane terminates at the final
+  proposal post. No downstream action (no self-build, no spend) — those are later rungs.
+
+---
+
+## High-level technical design
+
+```mermaid
+stateDiagram-v2
+    [*] --> Parked: co-founder posts "decide X" (needs-human)
+    Parked --> Working: co-founder sets **Needs Refinement** (KTD2 trigger)
+    Working --> Proposed: box researches (internal) → writes proposal to discussion-post body + comment
+    Proposed --> Working: NEW co-founder comment (KTD5) → box re-drafts (≤ max iters)
+    Proposed --> Agreed: voteCount ≥ threshold (KTD4, routine=1)
+    Agreed --> [*]: box opens FINAL proposal post + tags discussion 'superseded' (KTD6)
+    note right of Working
+      box drives body/comments/tags + reads votes only.
+      Co-founders drive status (KTD9).
+      Shadow mode: plans all of this, writes nothing.
+    end note
+```
+
+---
+
+## Implementation units
+
+### U1. Comment-read API on the Quackback client
+**Goal:** the box can read a post's comment thread with author attribution.
+**Requirements:** origin "Iterate" step; KTD5. **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback_client.py`,
+`pipeline/wgmesh_pipeline/forge/quackback.py` (passthrough),
+`pipeline/tests/test_quackback_client.py`, `pipeline/tests/test_quackback_forge.py`.
+**Approach:** add `list_comments(post_id) -> list[dict]` calling the verified
+`GET /posts/{id}/comments`, returning raw comment dicts (carry `id`, `principalId`, `authorName`,
+`isTeamMember`, `content`, `createdAt`). Fail-closed-loud on read error (a missing thread must not
+silently read as "no new feedback"). Surface it on `QuackbackForge` (read path, no allowlist).
+**Patterns to follow:** `list_posts` / `list_statuses` (cursor + shape-assert + fail-closed read).
+**Test scenarios:** returns parsed comments with author fields; empty thread → `[]`; API error →
+raises `QuackbackError` (not silent empty); forge passthrough reaches `_qb`, not `_gh`.
+
+### U2. Vote-count read on the Quackback client
+**Goal:** the box can read a post's approve-vote count for the threshold check.
+**Requirements:** origin "Agree" step; KTD4. **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback_client.py`,
+`pipeline/wgmesh_pipeline/forge/quackback.py`, `pipeline/tests/test_quackback_client.py`.
+**Approach:** add `get_vote_count(post_id) -> int` reading `voteCount` off the post payload
+(`GET /posts/{id}`). No voter list exists (verified 404) — document that attribution rests on the
+private-board assumption. Fail-closed-loud.
+**Patterns to follow:** `get_post` / `get_decision_status` (read, no allowlist).
+**Test scenarios:** returns the integer `voteCount`; missing field → 0 (not crash); API error →
+raises.
+
+### U3. Approval-threshold policy
+**Goal:** a pure policy that, given a proposal's risk tier + current vote count + co-founder count,
+returns approved / not-yet.
+**Requirements:** KTD4; origin "threshold is a risk-tiered config policy". **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/decision_lane/policy.py` (new),
+`pipeline/wgmesh_pipeline/config.py` (config: co-founder principal set, `€X` dangerous-spend line,
+risk-tier→threshold map), `pipeline/tests/test_decision_policy.py`.
+**Approach:** pure functions — `required_approvals(risk_tier, cofounder_count)` (routine → 1;
+dangerous → all current co-founders) and `is_approved(vote_count, risk_tier, cofounder_count)`.
+Threshold expressed *relative to current co-founder count* so it scales (1 / majority / all)
+without redesign. Phase 1 callers always pass `risk_tier="routine"`.
+**Execution note:** test-first — this is the safety gate; pin every tier/threshold combination.
+**Test scenarios:** routine → 1 regardless of count; dangerous at N=2 → 2 (unanimous); dangerous at
+N=5 → 5; `is_approved` true at exactly threshold, false below; N=2 dangerous with 1 vote → not
+approved (the stall case is intended).
+
+### U4. Iteration state — author distinction + processed-comment marker
+**Goal:** the box re-drafts only on a new co-founder comment, never on its own, and never twice.
+**Requirements:** KTD5. **Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/decision_lane/comments.py` (new),
+`pipeline/wgmesh_pipeline/state/store.py` + `state/migrations/0005_decision_lane.sql` (new:
+per-post last-processed comment marker + lane state),
+`pipeline/tests/test_decision_comments.py`, `pipeline/tests/test_state.py`.
+**Approach:** `latest_cofounder_comment(comments, bot_author)` filters to `isTeamMember=true` AND
+`authorName != bot_author`, returns the newest by `createdAt`. Store keeps a
+`decision_posts(post_id, last_comment_id, last_proposed_at, iterations)` row; a comment newer than
+`last_comment_id` is "new". Migration mirrors `0003_quackback_id_map` / `0004_issue_body` style.
+Max-iteration cap is config.
+**Test scenarios:** bot's own comment ignored; non-team comment ignored; newest co-founder comment
+selected; already-processed comment id → not new; iteration counter increments and caps; migration
+0005 adds the table (assert migration list `["0001"…"0005"]`).
+
+### U5. Proposal-generation recipe (internal grounding)
+**Goal:** turn a decision ask + internal context into a structured PM-grade proposal.
+**Requirements:** origin "Propose"/"Research"; KTD3. **Dependencies:** none (recipe is standalone).
+**Files:** `pipeline/recipes/wgmesh-decision-proposal.yaml` (new),
+`pipeline/tests/test_decision_recipe.py`.
+**Approach:** a Goose recipe (mirror `wgmesh-triage-spec.yaml` / the observation assess recipe)
+taking params: the decision title, the decision brief (post body), a path to `STRATEGY.md`, and an
+optional prior-proposal + latest-comment (for revision rounds). Prompt requires exact sections:
+`## Recommendation`, `## Options Considered`, `## Pros`, `## Cons`, `## Upsides`, `## Downsides`,
+`## ROI / Cost`, `## Assumptions` (where market/competitor claims live, flagged unverified until
+web research lands in Phase 2). Public-repo-safe; single-line path params only (the multi-line trap
+from the rich-briefs work — pass the brief/strategy as file paths, never inline).
+**Execution note:** characterization-assert the recipe declares each required section heading + the
+"assumptions are unverified" instruction; assert path params stay single-line (the YAML-scalar
+break guard, mirroring `test_assessment_recipe_templates_params_as_single_line_paths`).
+**Test scenarios:** recipe text declares all 8 section headings; declares the assumptions-unverified
+instruction; templating a param adds no lines; revision params (prior proposal + comment) are
+present and optional.
+
+### U6. Decision-lane forge methods — trigger ingest + discussion→final lifecycle
+**Goal:** the forge can list lane-triggered posts and perform the agreement artifact moves.
+**Requirements:** KTD2, KTD6, KTD7. **Dependencies:** U1.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback.py`,
+`pipeline/tests/test_quackback_forge.py`.
+**Approach:** `list_needs_refinement_posts()` — slug-filtered read of `Needs Refinement` posts (the
+lane trigger; reuses the verified `?status=<slug>` filter). `open_final_proposal(title, body)` →
+`create_post` (sanitise-walled, the existing create path). `mark_superseded(post_id)` → add a
+`superseded` tag (the box may set tags; never `Cancelled` — KTD9). Updating the discussion-post
+proposal body uses the existing post-update path; posting a comment uses the existing `comment()`.
+**Test scenarios:** `list_needs_refinement_posts` filters by the Needs-Refinement slug; final post
+goes through the sanitise wall; `mark_superseded` sets a tag and never calls set_status; a decision
+status is never authored on any path (KTD9 assertion).
+
+### U7. Decision-lane control-loop module (orchestrator)
+**Goal:** wire U1–U6 into one shadow-first module that runs the consent loop end-to-end.
+**Requirements:** all origin steps; KTD1. **Dependencies:** U1, U2, U3, U4, U5, U6.
+**Files:** `pipeline/wgmesh_pipeline/decision_lane/__init__.py` (new orchestrator),
+`pipeline/wgmesh_pipeline/control_loop/__init__.py` (register `decision` module + `_cycle_decision`),
+`pipeline/wgmesh_pipeline/config.py` (`DECISION_LANE_LIVE` flag, allowlisted),
+`pipeline/tests/test_decision_lane.py`, `pipeline/tests/test_control_loop.py`.
+**Approach:** per cycle — ingest `Needs Refinement` posts; for each: read comments (U1) → if no
+proposal yet OR a new co-founder comment (U4), run the proposal recipe (U5) and write the proposal
+to the discussion-post body + a "proposal updated" comment; else read `voteCount` (U2) and if
+`is_approved` (U3, routine) → open final post + tag superseded (U6) + record terminal. All writes
+go through the executor's sanitise wall. Shadow mode (`_module_live("decision")` false) plans +
+logs the actions and writes nothing — identical-path shadow, like observation. Loop-guarded by the
+max-iteration cap (U4).
+**Execution note:** mirror the observation/merge-lane module shape; shadow-prove before any live flip.
+**Test scenarios:** fresh Needs-Refinement post with no proposal → drafts one (or plans it, in
+shadow); a new co-founder comment → re-drafts; no new comment + below threshold → no-op; at
+threshold → opens final post + supersedes discussion; box's own comment never triggers a re-draft;
+shadow mode performs zero writes (DryRun records only); module registers in the scheduler and runs
+under `control_loop_enabled`.
+
+### U8. Shadow-prove wiring + queue observability
+**Goal:** the lane is observable and provable in shadow before going live.
+**Requirements:** KTD1; origin success criteria. **Dependencies:** U7.
+**Files:** `pipeline/wgmesh_pipeline/decision_lane/__init__.py` (structured run record),
+`pipeline/wgmesh_pipeline/quackback_kpi.py` (extend: count posts in `Needs Refinement` awaiting a
+proposal + oldest-awaiting age — the lane's silent-stall canary), `pipeline/tests/test_quackback_kpi.py`.
+**Approach:** emit a per-cycle record (posts seen, proposals planned/written, agreements). Extend the
+queue-health KPI with a "decisions awaiting proposal / awaiting vote" signal so a stalled lane is
+visible (same KTD3 silent-stall mitigation as the cutover — no notification in Phase 1).
+**Test scenarios:** KPI counts Needs-Refinement-without-proposal and the oldest awaiting age; empty
+→ zero/null; the lane record reports planned vs written per cycle.
+
+---
+
+## Scope boundaries
+
+**In:** the consent loop (ingest → propose → comment-iterate → threshold → final post + supersede),
+internal grounding, the risk-tiered policy (routine path exercised), shadow-first box module,
+comment + vote reads, iteration state, the proposal recipe, lane observability.
+
+**Deferred for later** (origin, later rungs/phases):
+- **Web research** (Phase 2's first self-build) — Phase 1 grounds internally; market claims are
+  labeled assumptions.
+- **Rung 2 self-build** (box modifying `ai-pipeline-template`) + its deploy-rollback brakes.
+- **Rung 3 rent-a-human** + payment/marketplace/budget guard.
+- **Dangerous-tier execution** — the policy supports it; Phase 1 never triggers it.
+- **Notifications / SLA** on awaiting decisions (the KPI makes stalls visible; push is later).
+
+**Outside this product's identity** (origin): public/community surfaces — the board and lane stay
+private/internal.
+
+**Deferred to Follow-Up Work** (plan-local): going live (`DECISION_LANE_LIVE=true`) is an operator
+cutover after shadow-prove, not a code unit; voter-principal attribution if Quackback later exposes
+a voter list (today `voteCount` + private-board assumption carries it).
+
+---
+
+## Risks & dependencies
+
+- **No voter attribution.** `voteCount` is a count only (404 on the votes sub-resource). A
+  non-co-founder voter would be miscounted — mitigated by the private board (all voters are
+  co-founders). Revisit if the board ever opens up.
+- **Internal-only grounding produces weak market claims.** Mitigated by the mandatory
+  `## Assumptions` section; the real fix is Phase 2 web research. Do not let the box assert
+  competitor/pricing facts as settled.
+- **Trigger collision.** `Needs Refinement` already exists as an undecided-backlog status (it's in
+  the KPI's undecided set + off the roadmap). Using it as the lane trigger overloads its meaning —
+  acceptable (a Needs-Refinement post *is* "needs the box to refine it"), but note the dual role.
+- **Shadow→live discipline.** Like every box module, prove in shadow (plans the proposal + agreement
+  moves, writes nothing) before flipping `DECISION_LANE_LIVE`.
+- **Depends on** the live Quackback instance + the `qb_` bot key (post-cutover: present); the
+  existing control-loop scheduler + executor sanitise wall; the Goose runner.
+
+---
+
+## Sequencing
+
+U1, U2, U3, U5 are independent and parallelizable. U4 depends on U1. U6 depends on U1. U7 depends
+on U1–U6 and is the orchestrator. U8 depends on U7. Phase grouping: **A — primitives** (U1, U2, U3,
+U4); **B — generation** (U5); **C — orchestration** (U6, U7); **D — observability + shadow-prove**
+(U8). Live flip is operator-run after D, mirroring the merge-lane and cutover cutovers.

--- a/docs/pulse-reports/2026-06-22_09-39.md
+++ b/docs/pulse-reports/2026-06-22_09-39.md
@@ -1,0 +1,52 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-21 09:24 → 2026-06-22 09:24 UTC (24h, 15m buffer)
+**Repos:** meta `ai-pipeline-template` · product `wgmesh` · service `cloudroof-eu`
+
+## Headlines
+
+- **Infra/KTLO window, not product convergence.** main was un-broken (analytics
+  Event/EventType collision fixed, #810), the stale-base rebase lane shipped, and
+  merge-lane-heal was **migrated off GitHub Actions onto the box** (`conflict-heal.yml`
+  retired; box now the sole heal executor — `executed=7` per live cycle).
+- **0 new product merges.** The 8 issue-impls in-window are the same 06-21 breakthrough
+  batch; no fresh `fix: Issue #` merged. goal-sprint keeps emitting `surface:service`
+  (cloudroof) issues that surface-gate correctly holds out of the wgmesh builder.
+- Service still dead: cloudroof 0 PRs, 0 customers, 1 open issue (no service builder).
+
+## Usage (product convergence)
+
+- **product_pr_merged (in-window):** 8 issue-impls (#793/788/782/761/751/742/738…) +
+  3 infra (#810/#799/#798) — **none new** vs last pulse.
+- **autonomous_impl_merge_clean: 0 new.** Convergence flat ~24h; product backlog exhausted,
+  new work is all service-gated.
+- **paid_customer_added: 0.**
+- Open seed PRs: **12** (4 CONFLICTING — now box-healed live; 8 MERGEABLE).
+
+## System performance (action-success KPI — target 1.0, NOT clean)
+
+- **META: 5 failures / 197 runs.** `Deploy Pipeline Box` ×3 — **vestigial docker path**,
+  now confirmed dead weight (git-reset Auto-Deploy-on-Merge works); should be disabled.
+  `Requeue Failed Issues` ×1 + `CI` ×1 — transient/tied to known items.
+- **SEED: 20 failures / 162 runs.** `Impl Judge` ×11 (EXPECTED fail-closed verdicts on
+  off-spec impls). `Deploy Dashboard to GitHub Pages` ×3 — OPEN, **3rd consecutive pulse**,
+  still unaddressed. `CI` ×6 (tied to bad impl branches).
+- New positive: merge-lane-heal runs **on the box** now, executing 7 actions/cycle —
+  one orchestration lane off Actions (the CI/CD-only retarget advancing).
+
+## Aged open items >48h (target 0 — BREACH: 28)
+
+- Meta (5): I#1599, I#934; 3 strategy-drift audit PRs (#1862/1767/1733) still dwelling.
+- Seed (23): 14 issues (needs-human/GTM backlog) + 9 PRs (4 CONFLICTING now being
+  box-rebased → escalating to needs-human after 2 failed attempts).
+
+## Followups
+
+1. **Retire the vestigial `Deploy Pipeline Box` workflow** — red ×3 every pulse, but
+   git-reset auto-deploy works. Pure noise inflating the action-success KPI. Disable it.
+2. **`Deploy Dashboard to GitHub Pages` ×3 red — 3rd pulse running.** Genuinely unaddressed
+   seed infra rot. Disposition it.
+3. **0 product convergence, 4 pulses running.** Product backlog is exhausted; all new
+   work is `surface:service`. The **service funnel still doesn't exist** — this is now
+   the gating constraint on the whole company, not a tooling issue.
+4. **3 strategy-drift audit PRs dwelling >week** — close-with-reason or act.

--- a/docs/runbooks/quackback-cutover.md
+++ b/docs/runbooks/quackback-cutover.md
@@ -184,3 +184,24 @@ GitHub backlog was drained at cutover, reseed it. No code revert required.
 - ✅ Ingest filter = `?status=<slug>` (the `?statusId=` param is ignored — see §2).
 - Still open: Postgres base version in `docker/postgres/Dockerfile` before pinning upgrades
   (not blocking — the stack runs on the built image).
+
+---
+
+## 6. Internal roadmap (configured 2026-06-22)
+
+The internal roadmap is a view of board posts grouped by status where the status carries
+`showOnRoadmap = true`. The box already drives posts through statuses (`_mirror_quackback`),
+so the roadmap auto-populates — the only config is the per-status flag.
+
+**Decision (`docs/brainstorms/2026-06-22-quackback-roadmap-changelog-requirements.md`):** show
+only the **box lane** — Accepted for Build, Building, Ready for Review, Shipped. Backlog
+(Open for Vote, Needs Refinement), terminal-negative (Rejected, Cancelled), and the 6 unused
+Quackback default statuses (open, under_review, planned, in_progress, complete, closed) are
+**off**.
+
+**API (VERIFIED 2026-06-22):** `PATCH /api/v1/statuses/{id}` `{"showOnRoadmap": <bool>}` → 200.
+Applied with the `qb_` bot key — only the four box-lane statuses are `true`. To change the
+roadmap, flip the flag on the relevant status id (`GET /api/v1/statuses` for ids).
+
+> The changelog half of that brainstorm (daily roll-up → Quackback changelog, retire the
+> Unsend email) is NOT built — it needs the create-changelog endpoint VERIFIED first.


### PR DESCRIPTION
Commits the session's uncommitted design artifacts to main so the merged code carries its decision trail: capability-ladder / roadmap-changelog / cloudroof-funnel brainstorms; cloudroof-funnel / quackback-cutover / accept-gate / decision-lane plans; runbook §6 (internal roadmap config); the 09-39 pulse report. Docs only — no code.