### PR TITLE
fix(dedup): semantic Build-Suggestion dedup + Open-for-Vote status fix

### DIFF
--- a/docs/brainstorms/2026-06-23-dedup-hardening-semantic-requirements.md
+++ b/docs/brainstorms/2026-06-23-dedup-hardening-semantic-requirements.md
@@ -1,0 +1,103 @@
+# Harden Build-Suggestion dedup with semantic similarity
+
+**Date:** 2026-06-23 · **Scope:** Standard · **Status:** ready for `/ce-plan`
+**Origin:** operator — "check all proposals, duplicates are being generated" → "harden dedup"
+(live diagnosis on the Quackback board, 2026-06-22).
+
+## Problem
+
+The box-native observation loop floods the board with **reworded near-duplicate** Build
+Suggestions — e.g. four variants of the same lead-capture idea ("Add email lead-capture form" /
+"Add lead-capture email form" / "cloudroof.eu landing: add email lead-capture"). Root cause,
+confirmed against the live code:
+
+- The **fuzzy keyword dedup** (`observation.py` `is_duplicate`, 5-keyword/2-hit) runs against
+  `build_dedup_corpus(inputs)`, whose corpus is `forge.list_open_issues()` — and for
+  `QuackbackForge` that returns **only `Accepted for Build` posts** (KTD3). New suggestions sit in
+  `Open` / `Open for Vote`, so the corpus is effectively **empty → the fuzzy layer never fires**.
+- The **forge backstop** (`_find_duplicate_post`) *does* list all board posts (cross-status) but
+  matches **exact normalized title only** — so any rewording slips it.
+
+So the one layer that catches rewording is blind, and the layer that sees everything can't match
+fuzzily. (A volume amplifier compounds it — see Out of scope.)
+
+## Outcome
+
+A reworded suggestion that means the same thing as an existing board post is recognized as a
+duplicate and does **not** create a new post — restoring the dedup the bash loop had, but more
+robust to paraphrase. The board stays one-post-per-intent instead of accreting near-dups.
+
+## What we're building
+
+The **forge backstop becomes the single authoritative dedup**, upgraded from exact-title to
+**semantic cosine similarity** over all board posts:
+
+- **Embed title + body** of the candidate and of existing posts; the candidate is a duplicate when
+  its cosine similarity to any existing post is **≥ a configurable threshold**.
+- **Conservative threshold**, config-tunable — bias against over-merging two genuinely distinct
+  asks that happen to be topically close. Start high; loosen only if real duplicates slip.
+- **Cache embeddings per post** (embed once when a post is created, persist it) — re-embedding
+  every existing post on each create is the perf cost; the cache makes dedup one embedding (the
+  candidate) plus a vector compare against stored vectors.
+- **Provider:** z.ai embeddings, reusing the existing `ZAI_API_KEY` / z.ai host (no new credential).
+- **Fail-closed-degrade:** if the embeddings call fails, fall back to the current exact-title match
+  rather than skipping dedup — a degraded backstop beats none.
+- **On duplicate:** unchanged — comment the new body on the existing post (accretes context); never
+  silently drop the signal.
+
+The now-redundant `observation.py` keyword layer (empty corpus under Quackback) is retired or
+demoted to a cheap pre-filter — the authoritative guarantee moves to the forge, which sees every
+post regardless of status.
+
+## Scope boundaries
+
+**In:** semantic dedup at the forge create backstop; per-post embedding cache; z.ai embeddings
+wiring; conservative configurable threshold; fail-closed-degrade to exact-title; retire/demote the
+empty-corpus keyword layer.
+
+**Out of scope:**
+- **The restart-amplifier** — observation runs a *full* create cycle on every box restart (no
+  "ran recently" guard), and today's ~6 restarts drove the flood. That is the *volume* driver;
+  perfect dedup makes re-runs create nothing new, but the wasted work (and embedding cost per
+  re-eval) remains. Separate fix — a sibling brainstorm.
+- **Wrong default board status** — new posts land in `Open` (a Quackback default), not
+  `Open for Vote`. Off-decision-flow + off-roadmap. A one-call config fix, tracked separately.
+- **Semantic dedup on the decision lane** — proposals there are comment-threaded, not new posts;
+  dedup is a Build-Suggestion concern.
+
+## Success criteria
+
+- Two board posts whose titles/bodies express the same intent in different words are detected as
+  duplicates; the second does not create a new post (it comments on the first).
+- Two genuinely distinct asks that share keywords are **not** merged (precision — the over-merge
+  guard the exact-title match implicitly gave up).
+- An embeddings-API outage degrades to exact-title dedup, not to no dedup.
+- Re-running observation against a board that already contains an intent creates zero new posts for
+  that intent.
+
+## Open questions (for planning)
+
+- **z.ai embeddings endpoint/model — VERIFY.** Confirm the embeddings model id + endpoint reachable
+  with `ZAI_API_KEY` (e.g. an `embedding-*` model on the z.ai host), the vector dimension, and the
+  request/response shape — before building, mirroring the cutover's VERIFY discipline.
+- **Threshold value + tuning.** The initial cosine cutoff and how it's tuned (a handful of known
+  dup/non-dup pairs from the current board are a ready calibration set).
+- **Embedding cache store.** Where the per-post vector lives (the pipeline store vs a side table)
+  and how a post missing a cached vector is backfilled (embed-on-read once).
+- **What exactly to embed.** Title only vs title + full brief vs title + leading brief — longer
+  bodies cost more tokens and may dilute the title's intent signal.
+
+## Dependencies / assumptions
+
+- The live Quackback instance + bot key (present). The forge already pages all board posts for the
+  cross-status dedup — the listing half is done; only the match changes.
+- **Assumption (unverified):** z.ai exposes an embeddings endpoint usable with the existing key. If
+  not, the provider decision reopens (a small local sentence-embedding model is the fallback) — the
+  match mechanism (cosine over cached vectors) is provider-agnostic.
+
+## Approach
+
+**Extend, not net-new:** keep `_find_duplicate_post`'s all-posts cross-status listing; swap its
+matcher from normalized-title equality to cosine-over-embeddings, backed by a per-post vector cache,
+with exact-title as the degrade path. The observation keyword dedup is removed or demoted once the
+forge owns the guarantee.

--- a/docs/plans/2026-06-23-001-fix-dedup-hardening-semantic-plan.md
+++ b/docs/plans/2026-06-23-001-fix-dedup-hardening-semantic-plan.md
@@ -1,0 +1,204 @@
+# fix: Harden Build-Suggestion dedup with semantic similarity
+
+**Date:** 2026-06-23 · **Type:** fix · **Depth:** Standard
+**Origin:** `docs/brainstorms/2026-06-23-dedup-hardening-semantic-requirements.md`
+
+---
+
+## Summary
+
+The forge dedup backstop matches **exact normalized title** only, so reworded near-duplicate
+Build Suggestions slip and the board accretes the same intent four ways. Replace that matcher
+with **semantic cosine similarity** over post embeddings (title + body), cached per post,
+sourced from z.ai (the existing provider/key), degrading to exact-title when the embeddings call
+fails. Retire the now-blind keyword dedup layer, and — bundled — fix `create_issue` so new posts
+land in `Open for Vote` instead of the stray `Open` default.
+
+## Problem frame
+
+Confirmed against the live code (see origin):
+
+- `observation.py`'s fuzzy keyword dedup (`is_duplicate`, 5-keyword/2-hit) runs against
+  `build_dedup_corpus(inputs)` ← `forge.list_open_issues()`, which for `QuackbackForge` returns
+  **only `Accepted for Build` posts** (KTD3). New suggestions sit in `Open` / `Open for Vote`, so
+  the corpus is empty → the fuzzy layer never fires.
+- `QuackbackForge._find_duplicate_post` *does* list **all** board posts (cross-status) but matches
+  exact normalized title (`_normalize_title`) → any rewording slips.
+
+So the layer that catches rewording is blind, and the layer that sees everything can't match
+fuzzily. The forge backstop is where both the full-board view and the fix belong.
+
+## Key technical decisions
+
+- **KTD1 — semantic matcher at the forge backstop, not a new layer.** Keep
+  `_find_duplicate_post`'s all-posts cross-status listing; swap only the *matcher* from
+  title-equality to cosine-over-embeddings. Single authoritative dedup that sees every post
+  regardless of status (origin Approach).
+- **KTD2 — embed title + body.** The body is the PM brief now, which carries the real intent a
+  title abbreviates. Embed the concatenation (title is the strongest signal; body disambiguates).
+- **KTD3 — persistent per-post embedding cache (operator-confirmed).** Each post's vector is
+  computed once and stored (keyed by post id), so a dedup pass embeds only the *candidate* and
+  compares against stored vectors — not re-embedding the whole board, which the restart-storm
+  context makes expensive. A post with no cached vector is embedded once on read (backfill).
+- **KTD4 — z.ai embeddings, reuse the existing key.** The box already uses z.ai
+  (`ANTHROPIC_HOST`/`ZAI_API_KEY`); the embeddings model + endpoint reach the same account. Exact
+  model id / endpoint / dimension are **VERIFY-first** (U1) before the client is built.
+- **KTD5 — fail-closed-degrade, not fail-open.** An embeddings-API error degrades to the current
+  exact-title match (a weaker backstop), never to "no dedup". The threshold is a conservative,
+  config-tunable cosine cutoff — bias against over-merging two genuinely distinct asks.
+- **KTD6 — on duplicate, unchanged behavior.** Comment the new body on the matched post (accretes
+  context); never silently drop the signal — the current `create_issue` behavior.
+
+---
+
+## High-level technical design
+
+```mermaid
+flowchart TD
+    A[create_issue: candidate title+body] --> B[sanitise wall]
+    B --> C[list ALL board posts cross-status]
+    C --> D[embed candidate via z.ai]
+    D -->|API error| E[degrade: exact-title match]
+    D -->|ok| F[for each post: cached vector?]
+    F -->|miss| G[embed post once, store in cache]
+    F -->|hit| H[cosine candidate vs post]
+    G --> H
+    H --> I{max cosine >= threshold?}
+    I -->|yes| J[comment new body on matched post, no new post]
+    I -->|no| K[create new post in Open for Vote]
+    E -->|exact match| J
+    E -->|no match| K
+```
+
+---
+
+## Implementation units
+
+### U1. z.ai embeddings client (VERIFY-first)
+**Goal:** a small client that turns text into a vector via z.ai, fail-closed-loud.
+**Requirements:** KTD4, KTD5; origin "z.ai embeddings — VERIFY". **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/forge/embeddings.py` (new),
+`pipeline/wgmesh_pipeline/config.py` (model id + enable flag, allowlisted),
+`pipeline/tests/test_embeddings.py`.
+**Approach:** **First probe** the z.ai embeddings endpoint/model/dimension with the box key (a
+throwaway request, recorded in the plan/runbook) — mirror the cutover VERIFY discipline; do not
+hardcode an unverified model id. Then a urllib client (injectable http caller, like
+`quackback_client`) `embed(text) -> list[float]`, reusing `ZAI_API_KEY` + the z.ai host. Raise
+`EmbeddingError` on non-2xx / malformed (never return a zero vector silently).
+**Execution note:** VERIFY the endpoint before writing the client; test-first against a recorded
+response fixture, no live call in tests.
+**Patterns to follow:** `forge/quackback_client.py` (injectable `http_caller`, shape-assert,
+fail-closed `_call`).
+**Test scenarios:** valid response → returns the float vector of expected dim; non-2xx → raises;
+malformed/no-vector body → raises; empty input → raises or returns documented sentinel (decide at
+impl). `Covers: the embeddings source the matcher depends on.`
+
+### U2. Persistent per-post embedding cache
+**Goal:** store and retrieve a post's embedding by post id, so dedup embeds only the candidate.
+**Requirements:** KTD3. **Dependencies:** none (schema only).
+**Files:** `pipeline/wgmesh_pipeline/state/migrations/0006_post_embeddings.sql` (new),
+`pipeline/wgmesh_pipeline/state/store.py` (get/put embedding methods),
+`pipeline/tests/test_state.py`.
+**Approach:** table `post_embeddings(post_id TEXT PK, model TEXT, vector TEXT, updated_at)` —
+vector serialized (JSON array) keyed by post id + model (a model change invalidates the cache).
+`get_post_embedding(post_id, model) -> list[float] | None`; `put_post_embedding(post_id, model,
+vector)`. Mirror the `0005_decision_lane` / `decision_posts` store-method shape.
+**Test scenarios:** put then get round-trips the vector; get on a missing id → None; a different
+`model` → cache miss (None), not the stale vector; migration 0006 adds the table (assert the
+migration list includes `0006`).
+
+### U3. Cosine similarity matcher
+**Goal:** a pure function that decides duplicate-or-not from two vectors + a threshold.
+**Requirements:** KTD5. **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/forge/similarity.py` (new),
+`pipeline/tests/test_similarity.py`.
+**Approach:** `cosine(a, b) -> float`; `is_similar(a, b, threshold) -> bool`. Pure, no I/O; guard
+zero-norm vectors (return 0.0, not a divide error).
+**Execution note:** test-first — this is the precision/recall gate; pin the threshold behavior.
+**Test scenarios:** identical vectors → cosine 1.0, similar at any threshold ≤ 1; orthogonal → 0.0,
+not similar; just-above / just-below threshold flips `is_similar`; a zero vector → 0.0 (no crash).
+
+### U4. Wire semantic matching into the forge dedup
+**Goal:** `_find_duplicate_post` matches semantically over all posts, with the exact-title degrade.
+**Requirements:** KTD1, KTD2, KTD5, KTD6. **Dependencies:** U1, U2, U3.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback.py`,
+`pipeline/wgmesh_pipeline/config.py` (dedup threshold + what-to-embed config, allowlisted),
+`pipeline/tests/test_quackback_forge.py`.
+**Approach:** in the dedup path: embed the candidate (U1); for each listed post, read its cached
+vector (U2) or embed-and-cache once on miss; compute cosine (U3); the duplicate is the post with
+the max cosine ≥ threshold. On any `EmbeddingError`, fall back to the existing `_normalize_title`
+exact match (degrade, KTD5). The candidate text and post text are title + body (KTD2). Keep the
+`_DEDUP_MAX_POSTS` page cap. On match, comment-on-existing as today (KTD6).
+**Execution note:** characterization-first on the degrade path — assert the exact-title behavior is
+preserved when embeddings raise, so a provider outage can't regress dedup to nothing.
+**Test scenarios:** two same-intent / different-title posts (similar vectors via injected fake
+embedder) → matched, no new post, body commented on existing; two distinct asks (dissimilar
+vectors) → not matched, new post created; embeddings raise → falls back to exact-title (exact dup
+caught, reworded not — documented degrade); a post missing a cached vector → embedded once and
+stored, then compared; cache hit avoids re-embedding (assert the embedder is not called for cached
+posts). `Covers origin success criteria: reworded dup caught, distinct asks not merged, outage
+degrades not disables.`
+
+### U5. Retire the blind keyword dedup layer
+**Goal:** remove the empty-corpus keyword dedup so dedup has one authoritative owner.
+**Requirements:** origin "retire/demote the keyword layer". **Dependencies:** U4.
+**Files:** `pipeline/wgmesh_pipeline/observation.py`, `pipeline/wgmesh_pipeline/observation_gather.py`
+(remove the dedup-corpus plumbing if now unused), `pipeline/tests/test_observation.py`.
+**Approach:** remove `is_duplicate` / `build_dedup_corpus` use from `plan_actions` (the forge
+backstop now owns dedup). Keep the assess prompt's "do NOT re-propose" board context — that's
+prevention, not the guarantee. Delete now-dead helpers + their tests, or demote `is_duplicate` to a
+documented cheap pre-filter if research shows it still adds value over a fed corpus (decide at impl;
+default is remove).
+**Test scenarios:** `plan_actions` no longer drops items via the keyword corpus (the forge dedups);
+removed helpers' tests deleted; no import of the removed symbols remains. `Test expectation: behavior
+parity — plan_actions still emits the planned creates; dedup moved downstream.`
+
+### U6. Fix the create-default status (bundled)
+**Goal:** new Build Suggestions land in `Open for Vote`, not the stray `Open` default.
+**Requirements:** origin "wrong default board status (bundled)". **Dependencies:** none.
+**Files:** `pipeline/wgmesh_pipeline/forge/quackback.py`,
+`pipeline/tests/test_quackback_forge.py`.
+**Approach:** `create_issue`'s `create_post` currently passes no status → lands in the Quackback
+system default `Open` despite `Open for Vote` being `isDefault`. Pass the `Open for Vote` status id
+explicitly (resolve via the existing `_status_id_for` / slug lookup) so new suggestions enter the
+decision flow. KTD9 unaffected — `Open for Vote` is the board's intended *entry* status, set at
+create, not a box-driven decision transition.
+**Test scenarios:** `create_issue` calls `create_post` with the Open-for-Vote status id; a created
+post's status is Open for Vote (fake asserts the status arg). `Covers: new posts enter the voting
+flow + appear correctly off-roadmap.`
+
+---
+
+## Scope boundaries
+
+**In:** semantic matcher at the forge backstop; z.ai embeddings client (VERIFY-first); persistent
+per-post embedding cache; conservative configurable threshold; fail-closed-degrade to exact-title;
+retire the keyword layer; the create-default-status fix.
+
+**Deferred to Follow-Up Work:**
+- **The restart-amplifier** — observation re-creates a full batch on every box restart (the *volume*
+  driver). Perfect dedup makes re-runs create nothing new, but the wasted embedding/agent cost
+  remains. Sibling fix (a "ran recently" guard), out of this plan (origin Out of scope).
+- **Threshold tuning to data** — ship a conservative default; calibrate against known dup/non-dup
+  pairs from the current board as a fast follow.
+- **Semantic dedup on the decision lane** — proposals there are comment-threaded, not new posts.
+
+## Risks & dependencies
+
+- **z.ai embeddings shape unverified** — model id / endpoint / dimension are confirmed-to-exist but
+  not pinned. U1 VERIFY gates the client; if z.ai exposes no usable embeddings endpoint, the
+  provider reopens (a local sentence-embedding model is the fallback — the matcher + cache are
+  provider-agnostic).
+- **Over-merge (false positive)** — a too-low threshold merges distinct asks (the precision the
+  exact-title match implicitly had). Mitigated by a conservative default + the distinct-asks test.
+- **Embedding cost / latency per create** — bounded by the cache (candidate-only embed in steady
+  state) and the `_DEDUP_MAX_POSTS` cap.
+- **Depends on** the pipeline store (migrations), the existing z.ai credential, and the forge's
+  existing all-posts listing (the listing half already works — only the matcher changes).
+
+## Sequencing
+
+U1 (VERIFY-first), U2, U3 are independent and parallelizable. U4 depends on U1+U2+U3 and is the
+integration. U5 follows U4 (don't remove the keyword layer until the forge owns dedup). U6 is
+independent and can land any time. Test-first on U1/U3 (the provider seam and the precision gate);
+characterization-first on U4's degrade path.

--- a/pipeline/tests/test_dedup.py
+++ b/pipeline/tests/test_dedup.py
@@ -1,0 +1,98 @@
+"""Semantic deduper (U4) — cosine match, cache reuse, fail-closed propagation."""
+
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.forge.dedup import SemanticDeduper
+from wgmesh_pipeline.forge.embeddings import EmbeddingError
+
+
+class FakeEmbedder:
+    """Maps text -> vector; counts embed calls. Raises for text == 'BOOM'."""
+
+    def __init__(self, vectors: dict[str, list[float]]) -> None:
+        self.vectors = vectors
+        self.calls: list[str] = []
+
+    def embed(self, text: str) -> list[float]:
+        self.calls.append(text)
+        if text == "BOOM":
+            raise EmbeddingError("boom")
+        return self.vectors[text]
+
+
+class FakeCache(dict):
+    def get_post_embedding(self, post_id, model):
+        return self.get((post_id, model))
+
+    def put_post_embedding(self, post_id, model, vector):
+        self[(post_id, model)] = list(vector)
+
+
+def _deduper(embedder, cache, threshold=0.9):
+    return SemanticDeduper(embedder, cache, model="m", threshold=threshold)
+
+
+def test_similar_candidate_matches_post() -> None:
+    emb = FakeEmbedder(
+        {
+            "lead capture form": [1.0, 0.0],
+            "add email lead-capture\nbody": [0.99, 0.01],  # candidate
+        }
+    )
+    posts = [{"id": "p1", "title": "lead capture form", "content": ""}]
+    match = _deduper(emb, FakeCache()).find_duplicate("add email lead-capture\nbody", posts)
+    assert match is not None and match["id"] == "p1"
+
+
+def test_distinct_candidate_no_match() -> None:
+    emb = FakeEmbedder(
+        {"android vpn": [0.0, 1.0], "pricing decision\nbody": [1.0, 0.0]}
+    )
+    posts = [{"id": "p1", "title": "android vpn", "content": ""}]
+    assert _deduper(emb, FakeCache()).find_duplicate("pricing decision\nbody", posts) is None
+
+
+def test_cache_hit_skips_re_embedding_the_post() -> None:
+    emb = FakeEmbedder({"cand": [1.0, 0.0]})
+    cache = FakeCache()
+    cache.put_post_embedding("p1", "m", [1.0, 0.0])  # pre-cached
+    posts = [{"id": "p1", "title": "x", "content": ""}]
+
+    match = _deduper(emb, cache).find_duplicate("cand", posts)
+
+    assert match["id"] == "p1"
+    assert emb.calls == ["cand"]  # only the candidate embedded, not the post
+
+
+def test_cache_miss_embeds_and_stores_post() -> None:
+    emb = FakeEmbedder({"cand": [1.0, 0.0], "post1 title\npost body": [1.0, 0.0]})
+    cache = FakeCache()
+    posts = [{"id": "p1", "title": "post1 title", "content": "post body"}]
+
+    _deduper(emb, cache).find_duplicate("cand", posts)
+
+    assert cache.get_post_embedding("p1", "m") == [1.0, 0.0]
+
+
+def test_embeddings_failure_propagates() -> None:
+    emb = FakeEmbedder({})
+    with pytest.raises(EmbeddingError):
+        _deduper(emb, FakeCache()).find_duplicate("BOOM", [{"id": "p1"}])
+
+
+def test_picks_highest_similarity_above_threshold() -> None:
+    emb = FakeEmbedder(
+        {
+            "cand": [1.0, 0.0],
+            "near": [0.95, 0.31],   # ~0.95 cosine
+            "nearer": [0.99, 0.14], # ~0.99 cosine
+        }
+    )
+    posts = [
+        {"id": "near", "title": "near", "content": ""},
+        {"id": "nearer", "title": "nearer", "content": ""},
+    ]
+    match = _deduper(emb, FakeCache(), threshold=0.9).find_duplicate("cand", posts)
+    assert match["id"] == "nearer"

--- a/pipeline/tests/test_embeddings.py
+++ b/pipeline/tests/test_embeddings.py
@@ -1,0 +1,81 @@
+"""z.ai embeddings client (U1) — fail-closed against the OpenAI-compatible shape."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from wgmesh_pipeline.forge.embeddings import (
+    EmbeddingError,
+    EmbeddingsClient,
+    HttpResponse,
+)
+
+
+@dataclass
+class _Config:
+    zai_api_key: str | None = "zai_key"
+    embeddings_base_url: str = "https://api.z.ai/api/paas/v4"
+    embeddings_model: str = "embedding-3"
+
+
+def _client(response: HttpResponse):
+    calls: list[dict] = []
+
+    def caller(method, url, headers, body):
+        calls.append(
+            {"method": method, "url": url, "body": json.loads(body) if body else None}
+        )
+        return response
+
+    return EmbeddingsClient(_Config(), http_caller=caller), calls
+
+
+def test_embed_returns_vector_and_posts_model_input() -> None:
+    body = json.dumps({"data": [{"embedding": [0.1, 0.2, 0.3]}]})
+    client, calls = _client(HttpResponse(200, body))
+
+    vec = client.embed("hello world")
+
+    assert vec == [0.1, 0.2, 0.3]
+    assert calls[0]["url"].endswith("/embeddings")
+    assert calls[0]["body"] == {"model": "embedding-3", "input": "hello world"}
+
+
+def test_missing_key_raises_at_construction() -> None:
+    with pytest.raises(EmbeddingError, match="ZAI_API_KEY"):
+        EmbeddingsClient(_Config(zai_api_key=None), http_caller=lambda *a: None)
+
+
+def test_empty_text_raises() -> None:
+    client, _ = _client(HttpResponse(200, json.dumps({"data": [{"embedding": [1.0]}]})))
+    with pytest.raises(EmbeddingError, match="empty text"):
+        client.embed("   ")
+
+
+def test_non_2xx_raises() -> None:
+    client, _ = _client(HttpResponse(429, "rate limited"))
+    with pytest.raises(EmbeddingError, match="429"):
+        client.embed("x")
+
+
+def test_malformed_no_data_raises() -> None:
+    client, _ = _client(HttpResponse(200, json.dumps({"ok": 1})))
+    with pytest.raises(EmbeddingError, match="missing 'data'"):
+        client.embed("x")
+
+
+def test_malformed_no_vector_raises() -> None:
+    client, _ = _client(HttpResponse(200, json.dumps({"data": [{"id": "x"}]})))
+    with pytest.raises(EmbeddingError, match="missing 'embedding'"):
+        client.embed("x")
+
+
+def test_non_numeric_vector_raises() -> None:
+    client, _ = _client(
+        HttpResponse(200, json.dumps({"data": [{"embedding": ["a", "b"]}]}))
+    )
+    with pytest.raises(EmbeddingError, match="non-numeric"):
+        client.embed("x")

--- a/pipeline/tests/test_quackback_forge.py
+++ b/pipeline/tests/test_quackback_forge.py
@@ -521,6 +521,42 @@ def test_open_final_proposal_sanitises_and_creates_plain_post() -> None:
     assert ops.count("create_post") == 1
 
 
+def test_create_issue_uses_bound_semantic_deduper() -> None:
+    forge, gh, qb = _forge()
+    qb.board_posts = [{"id": "post_existing", "title": "Lead capture form"}]
+
+    class _Deduper:
+        def find_duplicate(self, candidate_text, posts):
+            return {"id": "post_existing", "title": "Lead capture form"}
+
+    forge.bind_deduper(_Deduper())
+    forge.create_issue(title="Add email lead-capture", body="b")
+
+    # matched semantically → comment on existing, no new create_post
+    ops = [c[0] for c in qb.calls]
+    assert "comment" in ops
+    assert ops.count("create_post") == 0
+
+
+def test_create_issue_degrades_to_exact_title_when_embeddings_fail() -> None:
+    from wgmesh_pipeline.forge.embeddings import EmbeddingError
+
+    forge, gh, qb = _forge()
+    qb.board_posts = [{"id": "post_x", "title": "Add SSO"}]
+
+    class _BoomDeduper:
+        def find_duplicate(self, candidate_text, posts):
+            raise EmbeddingError("down")
+
+    forge.bind_deduper(_BoomDeduper())
+    # exact-title match still catches an identical title (degrade path)
+    forge.create_issue(title="Add SSO", body="b")
+
+    ops = [c[0] for c in qb.calls]
+    assert "comment" in ops  # degrade found the exact-title dup
+    assert ops.count("create_post") == 0
+
+
 def test_mark_superseded_comments_marker_never_sets_status() -> None:
     forge, gh, qb = _forge()
 

--- a/pipeline/tests/test_quackback_forge.py
+++ b/pipeline/tests/test_quackback_forge.py
@@ -75,6 +75,7 @@ class FakeQB:
     def list_statuses(self) -> list[dict[str, Any]]:
         self.calls.append(("list_statuses", ()))
         return [
+            {"id": "status_ofv", "name": "Open for Vote", "slug": "open-for-vote"},
             {
                 "id": "status_afb",
                 "name": "Accepted for Build",
@@ -323,8 +324,8 @@ def test_create_issue_tags_post_with_build_suggestion_and_label_tags() -> None:
     board_id, title, _content, status_id, tag_ids = create[1]
     assert board_id == "board_1"
     assert title == "Add SSO login"
-    # Default status: no statusId — the board's default ("Open for Vote").
-    assert status_id is None
+    # U6: set Open for Vote explicitly (the system default "Open" was the bug).
+    assert status_id == "status_ofv"
     # The two pre-existing Build-Suggestion tags plus the growth label tag.
     assert set(tag_ids) == {"tag_sugg", "tag_cand", "tag_growth"}
 
@@ -519,6 +520,18 @@ def test_open_final_proposal_sanitises_and_creates_plain_post() -> None:
     assert ("final_proposal", {"title": "Pricing decided", "body": "## Recommendation\n€9/mo"}) in gh.sanitised
     ops = [c[0] for c in qb.calls]
     assert ops.count("create_post") == 1
+
+
+def test_create_issue_sets_open_for_vote_status() -> None:
+    # U6: new Build Suggestions enter the voting flow, not the stray 'Open' default.
+    forge, gh, qb = _forge()
+
+    forge.create_issue(title="New idea", body="b")
+
+    create = next(c for c in qb.calls if c[0] == "create_post")
+    # FakeQB.create_post records (board_id, title, content, status_id, tag_ids)
+    status_id = create[1][3]
+    assert status_id == "status_ofv"
 
 
 def test_create_issue_uses_bound_semantic_deduper() -> None:

--- a/pipeline/tests/test_similarity.py
+++ b/pipeline/tests/test_similarity.py
@@ -1,0 +1,36 @@
+"""Cosine similarity matcher (U3) — the dedup precision gate."""
+
+from __future__ import annotations
+
+from wgmesh_pipeline.forge.similarity import cosine, is_similar
+
+
+def test_identical_vectors_are_cosine_one() -> None:
+    v = [1.0, 2.0, 3.0]
+    assert cosine(v, list(v)) == 1.0
+    assert is_similar(v, list(v), 0.99) is True
+
+
+def test_orthogonal_vectors_are_zero() -> None:
+    assert cosine([1.0, 0.0], [0.0, 1.0]) == 0.0
+    assert is_similar([1.0, 0.0], [0.0, 1.0], 0.5) is False
+
+
+def test_threshold_flips_is_similar() -> None:
+    a = [1.0, 0.0]
+    b = [1.0, 1.0]  # cosine = 1/sqrt(2) ≈ 0.707
+    assert is_similar(a, b, 0.70) is True
+    assert is_similar(a, b, 0.71) is False
+
+
+def test_zero_vector_is_dissimilar_not_crash() -> None:
+    assert cosine([0.0, 0.0], [1.0, 2.0]) == 0.0
+    assert is_similar([0.0, 0.0], [1.0, 2.0], 0.0) is True  # 0.0 >= 0.0
+
+
+def test_mismatched_length_is_zero() -> None:
+    assert cosine([1.0, 2.0], [1.0]) == 0.0
+
+
+def test_empty_vectors_are_zero() -> None:
+    assert cosine([], []) == 0.0

--- a/pipeline/tests/test_state.py
+++ b/pipeline/tests/test_state.py
@@ -61,7 +61,7 @@ def test_injected_connection_adapter_roundtrip() -> None:
     assert len(db.list_runs()) == 1
     # migrations tracked through the adapter
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004", "0005"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005", "0006"]
 
 
 def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
@@ -79,7 +79,7 @@ def test_reset_queue_clears_issues_and_runs_idempotently(tmp_path) -> None:
     assert db.list_issues() == []
     assert db.list_runs() == []
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004", "0005"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005", "0006"]
 
 
 def test_requeue_failed_all_preserves_linkage_and_clears_attempts(tmp_path) -> None:
@@ -193,7 +193,7 @@ def test_migrations_apply_idempotently(tmp_path) -> None:
     assert db.get_issue(1).stage == "queued"
     # schema_migrations records the initial migration exactly once
     versions = [r["version"] for r in db._conn.execute("SELECT version FROM schema_migrations").fetchall()]
-    assert versions == ["0001", "0002", "0003", "0004", "0005"]
+    assert versions == ["0001", "0002", "0003", "0004", "0005", "0006"]
 
 
 def test_sqlite_connection_uses_wal_and_busy_timeout(tmp_path) -> None:
@@ -351,3 +351,33 @@ def test_control_state_empty_fingerprint_always_writes(tmp_path) -> None:
     assert db.save_control_state("k", {"a": 1}, fingerprint="") is True
     assert db.save_control_state("k", {"a": 2}, fingerprint="") is True
     assert db.load_control_state("k") == {"a": 2}
+
+
+def test_post_embedding_cache_round_trip(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    assert store.get_post_embedding("post_1", "embedding-3") is None
+
+    store.put_post_embedding("post_1", "embedding-3", [0.1, 0.2, 0.3])
+    assert store.get_post_embedding("post_1", "embedding-3") == [0.1, 0.2, 0.3]
+
+
+def test_post_embedding_model_change_is_a_miss(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.put_post_embedding("post_1", "embedding-3", [1.0, 2.0])
+    # a different model must not return the stale vector
+    assert store.get_post_embedding("post_1", "embedding-9") is None
+
+
+def test_post_embedding_upsert_overwrites(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    store.put_post_embedding("post_1", "embedding-3", [1.0])
+    store.put_post_embedding("post_1", "embedding-3", [9.0])
+    assert store.get_post_embedding("post_1", "embedding-3") == [9.0]
+
+
+def test_migration_0006_adds_post_embeddings_table(tmp_path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    row = store._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='post_embeddings'"
+    ).fetchone()
+    assert row is not None

--- a/pipeline/wgmesh_pipeline/config.py
+++ b/pipeline/wgmesh_pipeline/config.py
@@ -41,6 +41,10 @@ BOX_CONFIG_ALLOWLIST = frozenset(
         "DECISION_COFOUNDER_COUNT",
         "DECISION_MAX_ITERATIONS",
         "DECISION_BOT_AUTHOR",
+        "DEDUP_SEMANTIC_ENABLED",
+        "DEDUP_SIMILARITY_THRESHOLD",
+        "EMBEDDINGS_MODEL",
+        "EMBEDDINGS_BASE_URL",
         "META_REPO",
         "POLL_INTERVAL_SECONDS",
         "MAX_FILES",
@@ -96,6 +100,11 @@ DEFAULT_STRATEGY_AUDIT_INTERVAL_SECONDS = 86400
 # Merge-lane-heal: 6h, matching the retired conflict-heal.yml cron (01/07/13/19).
 DEFAULT_MERGE_LANE_HEAL_INTERVAL_SECONDS = 21600
 DEFAULT_DECISION_LANE_INTERVAL_SECONDS = 3600  # founder decisions, hourly
+# Semantic dedup (z.ai embeddings). OFF until the endpoint/model/dim is VERIFIED
+# against the live z.ai account; until then the forge dedup keeps exact-title.
+DEFAULT_EMBEDDINGS_MODEL = "embedding-3"
+DEFAULT_EMBEDDINGS_BASE_URL = "https://api.z.ai/api/paas/v4"
+DEFAULT_DEDUP_SIMILARITY_THRESHOLD = 0.85
 # The meta repo (the pipeline's own repo) — merge-lane-heal heals BOTH repos.
 DEFAULT_META_REPO = "atvirokodosprendimai/ai-pipeline-template"
 
@@ -154,6 +163,11 @@ class Config:
     # The bot key's authorName on the board — its own comments are excluded from
     # the "new co-founder comment" iteration trigger (KTD5).
     decision_bot_author: str = "autobox-box"
+    # Semantic dedup (z.ai embeddings); see DEFAULT_* notes above.
+    dedup_semantic_enabled: bool = False
+    dedup_similarity_threshold: float = DEFAULT_DEDUP_SIMILARITY_THRESHOLD
+    embeddings_model: str = DEFAULT_EMBEDDINGS_MODEL
+    embeddings_base_url: str = DEFAULT_EMBEDDINGS_BASE_URL
     meta_repo: str = DEFAULT_META_REPO
     # Executor backend: 'goose' (default) or 'langchain' (U2).
     # Selected via EXECUTOR env var; factory in executor.py fails closed on unknown values.
@@ -305,6 +319,14 @@ def load_config(env: Mapping[str, str] | None = None) -> Config:
         decision_max_iterations=_get_int(source, "DECISION_MAX_ITERATIONS", 5),
         decision_bot_author=_get_nonempty(source, "DECISION_BOT_AUTHOR")
         or "autobox-box",
+        dedup_semantic_enabled=_get_bool(source, "DEDUP_SEMANTIC_ENABLED", False),
+        dedup_similarity_threshold=_get_float(
+            source, "DEDUP_SIMILARITY_THRESHOLD", DEFAULT_DEDUP_SIMILARITY_THRESHOLD
+        ),
+        embeddings_model=_get_nonempty(source, "EMBEDDINGS_MODEL")
+        or DEFAULT_EMBEDDINGS_MODEL,
+        embeddings_base_url=_get_nonempty(source, "EMBEDDINGS_BASE_URL")
+        or DEFAULT_EMBEDDINGS_BASE_URL,
         meta_repo=_get_nonempty(source, "META_REPO") or DEFAULT_META_REPO,
         executor=(_get_nonempty(source, "EXECUTOR") or "goose").strip().lower(),
         graph_impl=(_get_nonempty(source, "GRAPH_IMPL") or "legacy").strip().lower(),
@@ -391,6 +413,16 @@ def _get_nonempty(env: Mapping[str, str], name: str) -> str | None:
         return None
     value = value.strip()
     return value or None
+
+
+def _get_float(env: Mapping[str, str], name: str, default: float) -> float:
+    raw = _get_nonempty(env, name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
 
 
 def _get_int(env: Mapping[str, str], name: str, default: int) -> int:

--- a/pipeline/wgmesh_pipeline/control_loop/__init__.py
+++ b/pipeline/wgmesh_pipeline/control_loop/__init__.py
@@ -247,6 +247,36 @@ class ControlLoopScheduler:
                 task.name,
                 LIVE if self._module_live(task.name) else SHADOW,
             )
+        self._bind_semantic_deduper()
+
+    def _bind_semantic_deduper(self) -> None:
+        """Wire the semantic deduper onto the forge when enabled (U4). Best-effort:
+        a missing key / unbindable forge logs and leaves the forge on exact-title."""
+        if not getattr(self.config, "dedup_semantic_enabled", False):
+            return
+        binder = getattr(self.forge, "bind_deduper", None)
+        if not callable(binder):
+            return
+        try:
+            from wgmesh_pipeline.forge.dedup import SemanticDeduper
+            from wgmesh_pipeline.forge.embeddings import EmbeddingsClient
+
+            deduper = SemanticDeduper(
+                EmbeddingsClient(self.config),
+                self.store,
+                model=self.config.embeddings_model,
+                threshold=self.config.dedup_similarity_threshold,
+            )
+            binder(deduper)
+            self.log.info(
+                "control_loop: semantic dedup enabled (model=%s threshold=%s)",
+                self.config.embeddings_model,
+                self.config.dedup_similarity_threshold,
+            )
+        except Exception as exc:  # noqa: BLE001 — never let dedup wiring kill startup
+            self.log.warning(
+                "control_loop: semantic dedup not bound (%s) — using exact-title", exc
+            )
 
     @property
     def tasks(self) -> tuple[ModuleTask, ...]:

--- a/pipeline/wgmesh_pipeline/forge/dedup.py
+++ b/pipeline/wgmesh_pipeline/forge/dedup.py
@@ -1,0 +1,70 @@
+"""Semantic Build-Suggestion deduper (U4).
+
+Decides whether a candidate post duplicates any existing board post by cosine
+similarity of their embeddings, not exact-title equality. Each post's vector is
+cached (by post id + model) so a dedup pass embeds only the candidate plus any
+posts missing a cached vector. An embeddings failure propagates ``EmbeddingError``
+so the forge can degrade to exact-title — this class never swallows it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol, Sequence
+
+from wgmesh_pipeline.forge.similarity import cosine
+
+
+class _Embedder(Protocol):
+    def embed(self, text: str) -> list[float]: ...
+
+
+class _Cache(Protocol):
+    def get_post_embedding(self, post_id: str, model: str) -> list[float] | None: ...
+    def put_post_embedding(
+        self, post_id: str, model: str, vector: list[float]
+    ) -> None: ...
+
+
+def post_text(post: Mapping[str, Any]) -> str:
+    """The text embedded for a post — title plus body (the brief carries the
+    intent a title abbreviates)."""
+    title = str(post.get("title") or "")
+    body = str(post.get("content") or "")
+    return f"{title}\n{body}".strip()
+
+
+class SemanticDeduper:
+    def __init__(
+        self,
+        embedder: _Embedder,
+        cache: _Cache,
+        *,
+        model: str,
+        threshold: float,
+    ) -> None:
+        self._embedder = embedder
+        self._cache = cache
+        self._model = model
+        self._threshold = threshold
+
+    def find_duplicate(
+        self, candidate_text: str, posts: Sequence[Mapping[str, Any]]
+    ) -> Mapping[str, Any] | None:
+        """The existing post most similar to ``candidate_text`` at or above the
+        threshold, or None. Raises ``EmbeddingError`` (from the embedder) on an
+        embeddings failure — the caller degrades to exact-title."""
+        candidate = self._embedder.embed(candidate_text)
+        best: Mapping[str, Any] | None = None
+        best_sim = -1.0
+        for post in posts:
+            post_id = str(post.get("id") or "")
+            if not post_id:
+                continue
+            vector = self._cache.get_post_embedding(post_id, self._model)
+            if vector is None:
+                vector = self._embedder.embed(post_text(post))
+                self._cache.put_post_embedding(post_id, self._model, vector)
+            sim = cosine(candidate, vector)
+            if sim >= self._threshold and sim > best_sim:
+                best, best_sim = post, sim
+        return best

--- a/pipeline/wgmesh_pipeline/forge/embeddings.py
+++ b/pipeline/wgmesh_pipeline/forge/embeddings.py
@@ -1,0 +1,96 @@
+"""z.ai text-embeddings client for semantic dedup (U1).
+
+OpenAI-compatible embeddings shape (``POST {base}/embeddings`` with
+``{model, input}`` → ``{data: [{embedding: [...]}]}``), reusing the box's
+existing z.ai credential. The model id / base URL are config (``EMBEDDINGS_MODEL``
+/ ``EMBEDDINGS_BASE_URL``) so the operator confirms them at deploy — VERIFY the
+exact model + dimension against the live z.ai account before enabling semantic
+dedup (``DEDUP_SEMANTIC_ENABLED``).
+
+Fail-closed-loud: a non-2xx or malformed response raises ``EmbeddingError``; the
+client never returns a zero/empty vector silently (the dedup caller degrades to
+exact-title on the raise, so a swallowed failure would corrupt dedup instead).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.config import Config
+
+USER_AGENT = "wgmesh-pipeline-embeddings/1"
+
+
+class EmbeddingError(RuntimeError):
+    """An embeddings request failed or returned a malformed body."""
+
+
+@dataclass
+class HttpResponse:
+    status: int
+    text: str
+
+
+HttpCaller = Callable[[str, str, Mapping[str, str], bytes | None], HttpResponse]
+
+
+def _default_http_caller(
+    method: str, url: str, headers: Mapping[str, str], body: bytes | None
+) -> HttpResponse:
+    req = urllib.request.Request(url, data=body, method=method)
+    for key, value in headers.items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return HttpResponse(resp.status, resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return HttpResponse(exc.code, exc.read().decode("utf-8", "replace"))
+
+
+class EmbeddingsClient:
+    """Turns text into a vector via the z.ai embeddings endpoint."""
+
+    def __init__(self, config: Config, *, http_caller: HttpCaller | None = None):
+        self._key = config.zai_api_key
+        if not self._key:
+            raise EmbeddingError("ZAI_API_KEY is required for semantic dedup embeddings")
+        self._base = config.embeddings_base_url.rstrip("/")
+        self._model = config.embeddings_model
+        self._http = http_caller or _default_http_caller
+
+    def embed(self, text: str) -> list[float]:
+        if not text or not text.strip():
+            raise EmbeddingError("cannot embed empty text")
+        body = json.dumps({"model": self._model, "input": text}).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {self._key}",
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        }
+        resp = self._http("POST", f"{self._base}/embeddings", headers, body)
+        if not 200 <= resp.status < 300:
+            raise EmbeddingError(
+                f"embeddings {self._model} returned {resp.status}: {(resp.text or '')[:200]}"
+            )
+        return _vector_from(resp.text)
+
+
+def _vector_from(text: str) -> list[float]:
+    try:
+        parsed: Any = json.loads(text)
+    except ValueError as exc:
+        raise EmbeddingError("embeddings response was not JSON") from exc
+    data = parsed.get("data") if isinstance(parsed, dict) else None
+    if not isinstance(data, list) or not data:
+        raise EmbeddingError("embeddings response missing 'data' array")
+    vector = data[0].get("embedding") if isinstance(data[0], dict) else None
+    if not isinstance(vector, list) or not vector:
+        raise EmbeddingError("embeddings response missing 'embedding' vector")
+    try:
+        return [float(x) for x in vector]
+    except (TypeError, ValueError) as exc:
+        raise EmbeddingError("embedding vector held a non-numeric value") from exc

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -43,6 +43,7 @@ from wgmesh_pipeline.forge.quackback_status import (
     BOX_SETTABLE_STATUSES,
     is_box_settable,
 )
+from wgmesh_pipeline.forge.embeddings import EmbeddingError
 from wgmesh_pipeline.github.client import DryRunResult, GitHubClient
 
 log = logging.getLogger("wgmesh_pipeline.forge.quackback")
@@ -96,6 +97,8 @@ class QuackbackForge:
         self._status_id_cache: dict[str, str] = {}
         # name→tagId cache (tags are board-stable; resolved create-if-missing).
         self._tag_id_cache: dict[str, str] = {}
+        # Optional semantic deduper (U4); when None the forge dedups by exact title.
+        self._deduper: Any = None
 
     # ------------------------------------------------------- post → _qb (issues)
 
@@ -123,7 +126,7 @@ class QuackbackForge:
         self._gh._sanitise_write("create_issue", {"title": title, "body": body})
 
         # 2. Cross-status dedup against existing board posts.
-        existing = self._find_duplicate_post(title)
+        existing = self._find_duplicate_post(title, body)
         if existing is not None:
             existing_id = str(existing.get("id") or "")
             if existing_id:
@@ -355,6 +358,11 @@ class QuackbackForge:
 
     # --------------------------------------------------------------- plumbing
 
+    def bind_deduper(self, deduper: Any) -> None:
+        """Bind the semantic deduper after construction (U4). When bound,
+        ``create_issue`` dedups by embedding cosine; unbound → exact-title."""
+        self._deduper = deduper
+
     def bind_resolver(self, resolver: Callable[[int], str | None]) -> None:
         """Bind the store-backed post-id resolver after construction (U6).
 
@@ -417,31 +425,47 @@ class QuackbackForge:
     # board cannot make every Build Suggestion an unbounded scan.
     _DEDUP_MAX_POSTS = 500
 
-    def _find_duplicate_post(self, title: str) -> dict[str, Any] | None:
-        """Return an existing board post whose title matches ``title`` after
-        normalization (case/space/punctuation-insensitive), else None.
+    def _find_duplicate_post(
+        self, title: str, body: str = ""
+    ) -> dict[str, Any] | None:
+        """Return an existing board post that duplicates ``title``/``body``, else None.
 
         Lists posts with NO status filter so a duplicate is caught regardless of
-        where it already sits in the funnel (the cross-status guarantee). Paged
-        up to ``_DEDUP_MAX_POSTS`` via the cursor; an API error propagates
-        (fail-closed) rather than silently skipping dedup."""
+        where it already sits in the funnel (the cross-status guarantee). Paged up
+        to ``_DEDUP_MAX_POSTS``. When a semantic deduper is bound (U4), match by
+        embedding cosine over title+body; on an embeddings failure, degrade to the
+        exact normalized-title match (a weaker backstop, never "no dedup"). An API
+        error on the listing itself propagates (fail-closed)."""
+        candidates = self._gather_board_posts()
+        if self._deduper is not None:
+            try:
+                match = self._deduper.find_duplicate(f"{title}\n{body}".strip(), candidates)
+                return dict(match) if match is not None else None
+            except EmbeddingError:
+                log.warning(
+                    "decision dedup: embeddings failed — degrading to exact-title match"
+                )
         target = _normalize_title(title)
         if not target:
             return None
-        seen = 0
+        for post in candidates:
+            if _normalize_title(str(post.get("title", ""))) == target:
+                return post
+        return None
+
+    def _gather_board_posts(self) -> list[dict[str, Any]]:
+        """All board posts (cross-status), paged up to ``_DEDUP_MAX_POSTS``."""
+        out: list[dict[str, Any]] = []
         cursor: str | None = None
-        while seen < self._DEDUP_MAX_POSTS:
+        while len(out) < self._DEDUP_MAX_POSTS:
             page = self._qb.list_posts(cursor=cursor, limit=100)
             posts = page.get("data", [])
-            for post in posts:
-                seen += 1
-                if _normalize_title(str(post.get("title", ""))) == target:
-                    return post
+            out.extend(posts)
             pagination = (page.get("meta") or {}).get("pagination") or {}
             cursor = pagination.get("cursor")
             if not pagination.get("hasMore") or not cursor or not posts:
                 break
-        return None
+        return out
 
     def _resolve_tag_ids(self, names: tuple[str, ...]) -> list[str]:
         """Map tag names → ids, creating any that don't yet exist.

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -58,6 +58,11 @@ BOARD_ID_ENV = "QUACKBACK_BOARD_ID"
 # a proposal. Slug (not name) — the list filter is by status slug (VERIFIED).
 NEEDS_REFINEMENT_SLUG = "needs_refinement"
 
+# The board's intended entry status for new Build Suggestions. create_post with
+# no status lands in the Quackback system default ("Open"); set this explicitly so
+# new posts enter the voting flow (U6).
+OPEN_FOR_VOTE_STATUS = "Open for Vote"
+
 
 class QuackbackForge:
     """Composition adapter: ``_qb`` for posts, ``_gh`` for PRs (KTD1)."""
@@ -134,9 +139,17 @@ class QuackbackForge:
                 self._number_for(existing_id)
                 return existing
 
-        # 3. Resolve tags and create the tagged Build Suggestion.
+        # 3. Resolve tags + the Open-for-Vote status (U6) and create the post.
+        #    create_post with no status lands in the Quackback system default
+        #    ("Open"), NOT the board's intended entry status — so set it explicitly.
         tag_ids = self._resolve_tag_ids(BUILD_SUGGESTION_TAGS + tuple(labels))
-        post = self._qb.create_post(self._board_id, title, body, tag_ids=tag_ids)
+        try:
+            status_id: str | None = self._status_id_for(OPEN_FOR_VOTE_STATUS)
+        except RuntimeError:
+            status_id = None  # status absent → fall back to board default, don't crash
+        post = self._qb.create_post(
+            self._board_id, title, body, status_id=status_id, tag_ids=tag_ids
+        )
         post_id = str(post.get("id") or "")
         if not post_id:
             raise RuntimeError("Quackback create_post returned a post without an id")

--- a/pipeline/wgmesh_pipeline/forge/similarity.py
+++ b/pipeline/wgmesh_pipeline/forge/similarity.py
@@ -1,0 +1,32 @@
+"""Cosine similarity for semantic dedup (U3).
+
+Pure vector math, no I/O — the precision/recall gate for the Build-Suggestion
+dedup. A duplicate is a post whose embedding is at least ``threshold`` cosine to
+the candidate's. Zero-norm vectors return 0.0 (never a divide error), so a bad
+embedding degrades to "not similar" rather than crashing the dedup pass.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+
+def cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity of two equal-length vectors in [-1, 1]. Mismatched
+    lengths or a zero-norm vector → 0.0 (treated as dissimilar, not an error)."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def is_similar(
+    a: Sequence[float], b: Sequence[float], threshold: float
+) -> bool:
+    """True iff ``cosine(a, b) >= threshold`` — the duplicate decision."""
+    return cosine(a, b) >= threshold

--- a/pipeline/wgmesh_pipeline/state/migrations/0006_post_embeddings.sql
+++ b/pipeline/wgmesh_pipeline/state/migrations/0006_post_embeddings.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+-- Per-post embedding cache for semantic dedup (U2).
+--
+-- The forge dedup compares a candidate's embedding against every board post's.
+-- Re-embedding the whole board on each create is wasteful (worse under a restart
+-- storm), so each post's vector is computed once and cached here, keyed by post
+-- id + model. A model change is a cache miss (the key includes the model), so an
+-- EMBEDDINGS_MODEL bump invalidates stale vectors rather than comparing across
+-- incompatible spaces.
+CREATE TABLE IF NOT EXISTS post_embeddings (
+  post_id TEXT PRIMARY KEY,
+  model TEXT NOT NULL,
+  vector TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/pipeline/wgmesh_pipeline/state/store.py
+++ b/pipeline/wgmesh_pipeline/state/store.py
@@ -520,6 +520,35 @@ class StateStore:
             "iterations": int(row["iterations"]),
         }
 
+    # ----------------------------------------------- embedding cache (U2)
+
+    def get_post_embedding(self, post_id: str, model: str) -> list[float] | None:
+        """The cached embedding for ``post_id`` under ``model``, or None on a
+        miss (unknown post, or a stale vector from a different model)."""
+        row = self._conn.execute(
+            "SELECT vector FROM post_embeddings WHERE post_id = ? AND model = ?",
+            (post_id, model),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            return [float(x) for x in json.loads(row["vector"])]
+        except (ValueError, TypeError):
+            return None  # corrupt cache row degrades to a miss, re-embed
+
+    def put_post_embedding(
+        self, post_id: str, model: str, vector: list[float]
+    ) -> None:
+        """Cache ``vector`` for ``post_id`` under ``model`` (upsert)."""
+        self._conn.execute(
+            "INSERT INTO post_embeddings(post_id, model, vector, updated_at) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(post_id) DO UPDATE SET "
+            "model=excluded.model, vector=excluded.vector, updated_at=excluded.updated_at",
+            (post_id, model, json.dumps(list(vector)), _iso(_now())),
+        )
+        self._conn.commit()
+
     def record_decision_proposal(
         self, post_id: str, *, last_comment_id: str | None
     ) -> int:


### PR DESCRIPTION
## Summary
The forge dedup matched **exact normalized title** only, so reworded near-duplicate Build Suggestions piled up. Replace the matcher with **semantic cosine similarity** over z.ai embeddings (title+body), cached per post, degrading to exact-title on failure. Bundled: fix `create_issue` so new posts land in `Open for Vote`, not the stray `Open` default.

Plan: `docs/plans/2026-06-23-001-fix-dedup-hardening-semantic-plan.md`. **Semantic dedup is OFF by default** (`DEDUP_SEMANTIC_ENABLED=false`) until the z.ai embeddings endpoint is VERIFIED; the status fix is always-on.

## Root cause (confirmed live)
The fuzzy keyword dedup ran against an **empty corpus** under Quackback (`list_open_issues` = Accepted-only), and the all-posts layer only matched exact titles — so the layer that catches rewording was blind and the layer that saw everything couldn't match fuzzily.

## Units
- **U1** z.ai embeddings client (OpenAI-compatible, fail-closed; model/base config — VERIFY at deploy) + dedup config.
- **U2** persistent per-post embedding cache (migration `0006`, keyed by post_id+model).
- **U3** cosine matcher (pure, zero-norm safe).
- **U4** semantic matching in `_find_duplicate_post` (gather all posts → cosine over cached vectors → max ≥ threshold), **degrade to exact-title on `EmbeddingError`**; wired onto the control-loop forge when enabled.
- **U6** `create_issue` sets the Open-for-Vote status explicitly (was the system default `Open`).
- **U5** — the keyword layer is left in place (inert under quackback's empty corpus, functional for the github rollback path); the forge is now authoritative. Deleting it risked the rollback path for low value — documented execution-time decision.

## Test plan
- New: `test_similarity`, `test_embeddings`, `test_dedup` + forge integration (semantic match, exact-title degrade, Open-for-Vote status) + cache round-trip/model-miss + migration 0006.
- 175 touched-area tests green; 933 suite pass. The 23 suite failures are **pre-existing** host-gitconfig/network flakes (`test_langchain_agent_runner`, `test_spec_pr`), identical on main.

## To enable (operator, post-merge)
VERIFY the z.ai embeddings model/endpoint/dimension against the live account, then `set-box-env DEDUP_SEMANTIC_ENABLED=true` (+ confirm `EMBEDDINGS_MODEL`). Until then: exact-title backstop + the always-on status fix.

## Deferred
The restart-amplifier (observation re-creating a full batch on every box restart — the volume driver) is a sibling fix, out of scope.