### PR TITLE
fix(decision-lane): cap proposal comments at Quackback's 5000-char limit

### DIFF
--- a/pipeline/recipes/wgmesh-decision-proposal.yaml
+++ b/pipeline/recipes/wgmesh-decision-proposal.yaml
@@ -59,6 +59,8 @@ prompt: |
       never assert a market or competitor fact as settled.
   - Keep it public-repo safe: no secrets, no customer PII, no exact revenue figures.
   - Be concrete enough that a co-founder can approve or push back on specifics.
+  - Keep the WHOLE proposal under 4500 characters — it is posted as a single
+    comment with a hard 5000-character limit. Be concise; cut filler, not substance.
 extensions:
   - type: builtin
     name: developer

--- a/pipeline/tests/test_quackback_forge.py
+++ b/pipeline/tests/test_quackback_forge.py
@@ -512,6 +512,28 @@ def test_post_proposal_comment_blocked_by_sanitise_failure() -> None:
     assert "comment" not in [c[0] for c in qb.calls]  # never reached the board
 
 
+def test_post_proposal_comment_truncates_over_the_limit() -> None:
+    from wgmesh_pipeline.forge.quackback import COMMENT_MAX_CHARS
+
+    forge, _, qb = _forge()
+    big = "x" * (COMMENT_MAX_CHARS + 2000)
+
+    forge.post_proposal_comment("post_01", big)
+
+    posted = next(c[1][1] for c in qb.calls if c[0] == "comment")
+    assert len(posted) <= COMMENT_MAX_CHARS
+    assert posted.endswith("[proposal truncated to fit the comment limit]")
+
+
+def test_post_proposal_comment_under_limit_unchanged() -> None:
+    forge, _, qb = _forge()
+
+    forge.post_proposal_comment("post_01", "short proposal")
+
+    posted = next(c[1][1] for c in qb.calls if c[0] == "comment")
+    assert posted == "short proposal"
+
+
 def test_open_final_proposal_sanitises_and_creates_plain_post() -> None:
     forge, gh, qb = _forge()
 

--- a/pipeline/wgmesh_pipeline/forge/quackback.py
+++ b/pipeline/wgmesh_pipeline/forge/quackback.py
@@ -63,6 +63,18 @@ NEEDS_REFINEMENT_SLUG = "needs_refinement"
 # new posts enter the voting flow (U6).
 OPEN_FOR_VOTE_STATUS = "Open for Vote"
 
+# Quackback rejects a comment body over this length (HTTP 400 BAD_REQUEST).
+COMMENT_MAX_CHARS = 5000
+_TRUNCATION_MARKER = "\n\n…[proposal truncated to fit the comment limit]"
+
+
+def _fit_comment(body: str) -> str:
+    """Trim ``body`` to the Quackback comment limit, with a marker if cut."""
+    if len(body) <= COMMENT_MAX_CHARS:
+        return body
+    keep = COMMENT_MAX_CHARS - len(_TRUNCATION_MARKER)
+    return body[:keep] + _TRUNCATION_MARKER
+
 
 class QuackbackForge:
     """Composition adapter: ``_qb`` for posts, ``_gh`` for PRs (KTD1)."""
@@ -205,9 +217,14 @@ class QuackbackForge:
     def post_proposal_comment(self, post_id: str, body: str) -> Any:
         """Post a proposal (or a revision) as a comment on the discussion post —
         sanitise-walled (KTD10). A comment is the only verified write to an
-        existing post, so the proposal thread lives in comments."""
+        existing post, so the proposal thread lives in comments.
+
+        Quackback rejects comments over ``COMMENT_MAX_CHARS`` (HTTP 400), so a
+        long proposal is truncated with a marker before posting — the sanitise
+        wall runs on the FULL body first (a leak in the dropped tail still
+        blocks). The recipe is also instructed to stay under the limit."""
         self._gh._sanitise_write("decision_proposal", {"body": body})
-        return self._qb.comment(post_id, body)
+        return self._qb.comment(post_id, _fit_comment(body))
 
     def open_final_proposal(self, title: str, body: str) -> dict[str, Any]:
         """Create the clean final proposal post (the decision record) on


### PR DESCRIPTION
The live decision lane posted a >5000-char proposal as a comment → Quackback 400 (`content Too big: <=5000`). The proposal never landed and, with nothing recorded, the lane re-drafted **every cycle**, burning Goose calls. `post_proposal_comment` now truncates with a marker (the sanitise wall still runs on the full body, so a leak in the dropped tail still blocks); the proposal recipe is instructed to stay under 4500 chars. +2 tests. Surfaced by the post-deploy journal.