### PR TITLE
feat: inject accumulated learnings into spec/implement recipes

### DIFF
--- a/pipeline/recipes/wgmesh-implementation.yaml
+++ b/pipeline/recipes/wgmesh-implementation.yaml
@@ -6,6 +6,10 @@ parameters:
     input_type: string
     requirement: required
     description: "Repository-relative path to the specification (specs/issue-N-spec.md)."
+  - key: learnings_file
+    input_type: string
+    requirement: required
+    description: "Path to a markdown file of known pitfalls from past runs, or empty if none."
   - key: diff_file
     input_type: string
     requirement: required
@@ -23,6 +27,11 @@ prompt: |
   - Never reference a type, field, or function you have not verified exists by
     reading the source. If the spec suggests code that does not match the real
     codebase, adapt to match reality.
+
+  A file of known pitfalls from past runs may be at this path: {{ learnings_file }}
+  If that path is non-empty, READ it and avoid repeating those documented mistakes.
+  It is advisory context, not the implementation — never copy it into your code or
+  diff, and if the path is empty, simply proceed without it.
 
   Steps:
   1. Read the specification at {{ spec_file }} thoroughly.

--- a/pipeline/recipes/wgmesh-triage-spec.yaml
+++ b/pipeline/recipes/wgmesh-triage-spec.yaml
@@ -14,6 +14,10 @@ parameters:
     input_type: string
     requirement: required
     description: "Path to the PM brief markdown for this issue, or empty if none."
+  - key: learnings_file
+    input_type: string
+    requirement: required
+    description: "Path to a markdown file of known pitfalls from past runs, or empty if none."
   - key: spec_file
     input_type: string
     requirement: required
@@ -29,6 +33,11 @@ prompt: |
   (Problem / Proposed Solution / Pros / Cons / ROI / Acceptance Criteria) and is
   the authoritative source for what to build; the title is only a summary. If the
   path is empty, build the spec from the title and the repository alone.
+
+  A file of known pitfalls from past runs may be at this path: {{ learnings_file }}
+  If that path is non-empty, READ it and avoid repeating those documented mistakes.
+  It is advisory context, not the spec — never copy it into the spec output, and if
+  the path is empty, simply proceed without it.
 
   Write a markdown implementation spec to this exact repository-relative path:
   {{ spec_file }}

--- a/pipeline/tests/test_implement_node_learnings.py
+++ b/pipeline/tests/test_implement_node_learnings.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.goose.runner import GooseResult
+from wgmesh_pipeline.graph.nodes.implement import implement_node
+
+DIFF = "diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-a\n+b\n"
+
+
+@dataclass
+class RecordingRunner:
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    fail: bool = False
+
+    def run_recipe(
+        self, *, recipe, workdir, params, expected_output, stage=None, tier=0, session_id=None
+    ):
+        learnings_path = params.get("learnings_file") or ""
+        learnings_content = Path(learnings_path).read_text() if learnings_path else ""
+        self.calls.append(
+            {
+                "params": dict(params),
+                "learnings_path": learnings_path,
+                "learnings_content": learnings_content,
+            }
+        )
+        out = Path(workdir) / expected_output
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(DIFF)
+        if self.fail:
+            return GooseResult(
+                ok=False, output_path=out, duration_seconds=0.0, raw_log="x", error="fail"
+            )
+        return GooseResult(ok=True, output_path=out, duration_seconds=0.01, raw_log="ok")
+
+
+def _issue(number: int, title: str) -> GitHubIssue:
+    return GitHubIssue(number=number, title=title, labels=(), state="open")
+
+
+def _spec_file(tmp_path: Path, text: str) -> Path:
+    # non-real path: github absent, spec read from state["spec_path"]
+    spec = tmp_path / "specs" / "issue-spec.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(text)
+    return spec
+
+
+def test_learnings_keyed_on_spec_text_from_disk(tmp_path: Path) -> None:
+    spec = _spec_file(
+        tmp_path,
+        "## Approach\nThe goose model must write the spec file, not print it to stdout.\n",
+    )
+    runner = RecordingRunner()
+    implement_node(
+        {
+            "issue": _issue(70, "Unrelated terse title"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "spec_path": str(spec),
+        }
+    )
+    call = runner.calls[0]
+    # the match comes from the SPEC text, not the (unrelated) title
+    assert call["params"]["learnings_file"]
+    assert "goose" in call["learnings_content"].lower()
+
+
+def test_spec_read_failure_falls_back_to_title(tmp_path: Path) -> None:
+    runner = RecordingRunner()
+    result = implement_node(
+        {
+            # spec_path points nowhere → read fails → title-only query, which
+            # still matches the goose learning, proving graceful fallback
+            "issue": _issue(71, "goose weak model prints spec to stdout instead of writing"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "spec_path": str(tmp_path / "does-not-exist.md"),
+        }
+    )
+    call = runner.calls[0]
+    assert call["params"]["learnings_file"]  # fallback query matched
+    assert result["diff"]  # node still ran
+
+
+def test_no_match_passes_empty_param(tmp_path: Path) -> None:
+    spec = _spec_file(tmp_path, "## Approach\nrename a local variable\n")
+    runner = RecordingRunner()
+    result = implement_node(
+        {
+            "issue": _issue(72, "xyzzy quux frobnicate"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "spec_path": str(spec),
+        }
+    )
+    call = runner.calls[0]
+    assert "learnings_file" in call["params"]  # always passed (required)
+    assert call["params"]["learnings_file"] == ""
+    assert result["diff"]
+
+
+def test_selector_failure_is_failopen(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from wgmesh_pipeline import learnings as learnings_mod
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("selector exploded")
+
+    monkeypatch.setattr(learnings_mod, "select_learnings", boom)
+    spec = _spec_file(tmp_path, "goose prints spec to stdout instead of writing")
+    runner = RecordingRunner()
+    result = implement_node(
+        {
+            "issue": _issue(73, "goose weak model prints spec"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "spec_path": str(spec),
+        }
+    )
+    assert runner.calls[0]["params"]["learnings_file"] == ""
+    assert result["diff"]  # proceeded despite selector error
+
+
+def test_temp_file_cleaned_up_even_on_failure(tmp_path: Path) -> None:
+    spec = _spec_file(
+        tmp_path, "goose weak model prints spec to stdout instead of writing the file"
+    )
+    runner = RecordingRunner(fail=True)
+    with pytest.raises(RuntimeError):
+        implement_node(
+            {
+                "issue": _issue(74, "Fix relay"),
+                "repo_path": tmp_path,
+                "goose_runner": runner,
+                "spec_path": str(spec),
+            }
+        )
+    learnings_path = runner.calls[0]["learnings_path"]
+    assert learnings_path  # a learnings file was created (spec matched)
+    assert not Path(learnings_path).exists()  # cleaned up in finally

--- a/pipeline/tests/test_learnings.py
+++ b/pipeline/tests/test_learnings.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-from wgmesh_pipeline.learnings import _BLOCK_HEADER, select_learnings
+from wgmesh_pipeline import learnings as learnings_mod
+from wgmesh_pipeline.learnings import (
+    _BLOCK_HEADER,
+    select_learnings,
+    write_learnings_file,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -140,6 +146,44 @@ def test_recursive_glob_finds_subdir_only_files(tmp_path: Path) -> None:
     )
     blob = select_learnings("widget nested", root=tmp_path)
     assert "Nested subdir learning" in blob
+
+
+def test_write_learnings_file_returns_path_with_content(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    path = write_learnings_file("widget", root=tmp_path)
+    try:
+        assert path
+        content = Path(path).read_text(encoding="utf-8")
+        assert "Widget good learning" in content
+    finally:
+        if path:
+            os.unlink(path)
+
+
+def test_write_learnings_file_empty_on_no_match(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "solutions").mkdir(parents=True)
+    assert write_learnings_file("anything", root=tmp_path) == ""
+
+
+def test_write_learnings_file_failopen_on_selector_error(monkeypatch, tmp_path: Path) -> None:
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("selector exploded")
+
+    monkeypatch.setattr(learnings_mod, "select_learnings", boom)
+    assert write_learnings_file("widget", root=tmp_path) == ""
+
+
+def test_default_corpus_root_holds_solutions() -> None:
+    from wgmesh_pipeline.learnings import default_corpus_root
+
+    assert (default_corpus_root() / "docs" / "solutions").is_dir()
 
 
 def test_default_budget_constants() -> None:

--- a/pipeline/tests/test_learnings.py
+++ b/pipeline/tests/test_learnings.py
@@ -80,11 +80,29 @@ def test_max_chars_truncates_at_boundary_with_marker(tmp_path: Path) -> None:
         date="2026-06-01",
         body=f"## Problem\n{long_body}",
     )
-    blob = select_learnings("widget", root=tmp_path, max_chars=120)
+    blob = select_learnings("widget", root=tmp_path, max_chars=400)
     assert blob  # still returns the head of the highest-ranked entry
     assert "partial" in blob.lower()
     # never cut mid-line: the body portion ends on a line boundary
     assert "about widgetsline" not in blob
+    # marker is reserved within budget — total stays within max_chars
+    assert len(blob) <= 400
+
+
+def test_max_chars_bound_holds_with_no_newline_in_head(tmp_path: Path) -> None:
+    # a long single-line body: the head slice contains no newline to cut on,
+    # exercising the `or block[:budget]` fallback — total must still be bounded
+    _write(
+        tmp_path,
+        "logic-errors/oneline.md",
+        title="Widget oneline learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="x" * 5000,
+    )
+    blob = select_learnings("widget", root=tmp_path, max_chars=1000)
+    assert blob
+    assert len(blob) <= 1000
 
 
 def test_malformed_file_skipped_others_ranked(tmp_path: Path) -> None:
@@ -170,6 +188,34 @@ def test_write_learnings_file_returns_path_with_content(tmp_path: Path) -> None:
 def test_write_learnings_file_empty_on_no_match(tmp_path: Path) -> None:
     (tmp_path / "docs" / "solutions").mkdir(parents=True)
     assert write_learnings_file("anything", root=tmp_path) == ""
+
+
+def test_write_learnings_file_no_orphan_on_write_failure(monkeypatch, tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    created: list[str] = []
+    real_mkstemp = learnings_mod.tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(learnings_mod.tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(learnings_mod.os, "fdopen", boom)
+
+    assert write_learnings_file("widget", root=tmp_path) == ""
+    assert created  # mkstemp ran and created a file
+    assert not Path(created[0]).exists()  # orphan cleaned up despite write failure
 
 
 def test_write_learnings_file_failopen_on_selector_error(monkeypatch, tmp_path: Path) -> None:

--- a/pipeline/tests/test_learnings.py
+++ b/pipeline/tests/test_learnings.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wgmesh_pipeline.learnings import _BLOCK_HEADER, select_learnings
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(root: Path, rel: str, *, title: str, tags: list[str], date: str, body: str) -> None:
+    """Build a docs/solutions corpus file under ``root`` with YAML frontmatter."""
+    path = root / "docs" / "solutions" / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = (
+        "---\n"
+        f'title: "{title}"\n'
+        f"category: {path.parent.name}\n"
+        f"date: {date}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+    path.write_text(fm, encoding="utf-8")
+
+
+# --- scenarios against the real, committed corpus -------------------------
+
+
+def test_query_overlapping_tags_ranks_matching_learning_first() -> None:
+    blob = select_learnings(
+        "goose weak model prints spec to stdout instead of writing the file",
+        root=REPO_ROOT,
+    )
+    assert blob  # non-empty
+    assert _BLOCK_HEADER in blob
+    # the goose-weak-model learning must be the first block
+    first_header = blob.index(_BLOCK_HEADER)
+    head = blob[first_header : first_header + 200].lower()
+    assert "goose" in head and "spec" in head
+
+
+def test_query_matching_nothing_returns_empty() -> None:
+    assert select_learnings("xyzzy quux frobnicate nonsense", root=REPO_ROOT) == ""
+
+
+def test_empty_query_returns_empty() -> None:
+    assert select_learnings("", root=REPO_ROOT) == ""
+
+
+# --- scenarios against controlled tmp corpora -----------------------------
+
+
+def test_max_items_caps_returned_blocks(tmp_path: Path) -> None:
+    for i in range(5):
+        _write(
+            tmp_path,
+            f"logic-errors/entry-{i}.md",
+            title=f"Widget pipeline learning {i}",
+            tags=["widget", "pipeline", "shared"],
+            date=f"2026-06-0{i + 1}",
+            body="## Problem\nThing broke.\n\n## Fix\nFixed it.",
+        )
+    blob = select_learnings("widget pipeline shared", root=tmp_path, max_items=2)
+    assert blob.count(_BLOCK_HEADER) == 2
+
+
+def test_max_chars_truncates_at_boundary_with_marker(tmp_path: Path) -> None:
+    long_body = "\n".join(f"line {n} about widgets" for n in range(200))
+    _write(
+        tmp_path,
+        "logic-errors/huge.md",
+        title="Widget overflow learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body=f"## Problem\n{long_body}",
+    )
+    blob = select_learnings("widget", root=tmp_path, max_chars=120)
+    assert blob  # still returns the head of the highest-ranked entry
+    assert "partial" in blob.lower()
+    # never cut mid-line: the body portion ends on a line boundary
+    assert "about widgetsline" not in blob
+
+
+def test_malformed_file_skipped_others_ranked(tmp_path: Path) -> None:
+    # garbage file with no frontmatter
+    bad = tmp_path / "docs" / "solutions" / "logic-errors" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("not frontmatter at all\njust prose\n", encoding="utf-8")
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    blob = select_learnings("widget", root=tmp_path)
+    assert "Widget good learning" in blob
+
+
+def test_empty_solutions_dir_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "solutions").mkdir(parents=True)
+    assert select_learnings("anything", root=tmp_path) == ""
+
+
+def test_missing_solutions_dir_returns_empty(tmp_path: Path) -> None:
+    assert select_learnings("anything", root=tmp_path) == ""
+
+
+def test_recency_tiebreak_newer_first(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/old.md",
+        title="Older equal entry",
+        tags=["widget", "shared"],
+        date="2026-01-01",
+        body="## Problem\nold",
+    )
+    _write(
+        tmp_path,
+        "logic-errors/new.md",
+        title="Newer equal entry",
+        tags=["widget", "shared"],
+        date="2026-06-01",
+        body="## Problem\nnew",
+    )
+    blob = select_learnings("widget shared", root=tmp_path)
+    assert blob.index("Newer equal entry") < blob.index("Older equal entry")
+
+
+def test_recursive_glob_finds_subdir_only_files(tmp_path: Path) -> None:
+    # file lives ONLY in a nested category subdir, never at top level
+    _write(
+        tmp_path,
+        "integration-issues/nested.md",
+        title="Nested subdir learning",
+        tags=["widget", "nested"],
+        date="2026-06-01",
+        body="## Problem\nfound via recursive glob",
+    )
+    blob = select_learnings("widget nested", root=tmp_path)
+    assert "Nested subdir learning" in blob
+
+
+def test_default_budget_constants() -> None:
+    # conservative defaults: top-3 / ~4KB
+    import inspect
+
+    sig = inspect.signature(select_learnings)
+    assert sig.parameters["max_items"].default == 3
+    assert sig.parameters["max_chars"].default == 4000

--- a/pipeline/tests/test_spec_node.py
+++ b/pipeline/tests/test_spec_node.py
@@ -80,6 +80,7 @@ def test_spec_node_resolves_recipe_path_and_passes_issue_params(tmp_path: Path) 
         "issue_number": "18",
         "issue_title": "Add managed ingress",
         "issue_brief_file": "",  # no body in state → empty path → title fallback
+        "learnings_file": "",  # title matches no learning → empty path (always passed)
         "spec_file": "specs/issue-18-spec.md",
     }
 

--- a/pipeline/tests/test_spec_node_learnings.py
+++ b/pipeline/tests/test_spec_node_learnings.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wgmesh_pipeline.config import Config
+from wgmesh_pipeline.github.client import GitHubIssue
+from wgmesh_pipeline.goose.runner import GooseResult
+from wgmesh_pipeline.graph.nodes.spec import spec_node
+
+
+@dataclass
+class RecordingRunner:
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    fail: bool = False
+
+    def run_recipe(self, *, recipe, workdir, params, expected_output, stage=None, session_id=None):
+        # Capture learnings_file content WHILE it exists (spec_node unlinks it in
+        # a finally), plus the tmp paths so the test can assert cleanup.
+        learnings_path = params.get("learnings_file") or ""
+        learnings_content = (
+            Path(learnings_path).read_text() if learnings_path else ""
+        )
+        self.calls.append(
+            {
+                "params": dict(params),
+                "learnings_path": learnings_path,
+                "learnings_content": learnings_content,
+            }
+        )
+        output = Path(workdir) / expected_output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            "# Spec\n\n## Classification\nfeature\n\n## Problem Analysis\nx\n\n"
+            "## Proposed Approach\nx\n\n## Acceptance Criteria\n- ok\n\n"
+            "## Out of scope\n- none\n"
+        )
+        if self.fail:
+            return GooseResult(
+                ok=False, output_path=output, duration_seconds=0.0, raw_log="boom", error="fail"
+            )
+        return GooseResult(ok=True, output_path=output, duration_seconds=0.01, raw_log="ok")
+
+
+def _issue(number: int, title: str) -> GitHubIssue:
+    return GitHubIssue(number=number, title=title, labels=(), state="open")
+
+
+def test_matching_issue_passes_nonempty_learnings_file(tmp_path: Path) -> None:
+    runner = RecordingRunner()
+    spec_node(
+        {
+            # title overlaps the goose-weak-model learning's tags/title
+            "issue": _issue(91, "goose weak model prints spec to stdout instead of writing"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+    call = runner.calls[0]
+    assert call["params"]["learnings_file"]  # non-empty path
+    assert call["params"]["learnings_file"].endswith(".md")
+    assert "Past learning:" in call["learnings_content"]
+    assert "goose" in call["learnings_content"].lower()
+
+
+def test_no_match_issue_passes_empty_param_and_runs(tmp_path: Path) -> None:
+    runner = RecordingRunner()
+    result = spec_node(
+        {
+            "issue": _issue(92, "xyzzy quux frobnicate unrelated"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+    call = runner.calls[0]
+    assert "learnings_file" in call["params"]  # always passed (required)
+    assert call["params"]["learnings_file"] == ""  # no match → empty path
+    assert result["spec_path"]  # node still completed normally
+
+
+def test_selector_failure_is_failopen(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("selector exploded")
+
+    # spec_node -> write_learnings_file -> select_learnings (module global).
+    # Patch the underlying selector to raise; write_learnings_file's own
+    # fail-open must swallow it and return "" so the spec run proceeds.
+    from wgmesh_pipeline import learnings as learnings_mod
+
+    monkeypatch.setattr(learnings_mod, "select_learnings", boom)
+
+    runner = RecordingRunner()
+    result = spec_node(
+        {
+            "issue": _issue(93, "goose weak model prints spec"),
+            "repo_path": tmp_path,
+            "goose_runner": runner,
+            "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+        }
+    )
+    assert runner.calls[0]["params"]["learnings_file"] == ""
+    assert result["spec_path"]  # run proceeded despite selector error
+
+
+def test_temp_learnings_file_cleaned_up_even_on_failure(tmp_path: Path) -> None:
+    runner = RecordingRunner(fail=True)
+    with pytest.raises(RuntimeError):
+        spec_node(
+            {
+                "issue": _issue(94, "goose weak model prints spec to stdout instead of writing"),
+                "repo_path": tmp_path,
+                "goose_runner": runner,
+                "config": Config(target_repo="atvirokodosprendimai/wgmesh"),
+            }
+        )
+    learnings_path = runner.calls[0]["learnings_path"]
+    assert learnings_path  # a learnings file was created for this matching issue
+    assert not Path(learnings_path).exists()  # cleaned up in finally

--- a/pipeline/wgmesh_pipeline/graph/nodes/implement.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/implement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -9,6 +10,7 @@ from requests import HTTPError
 from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
 from wgmesh_pipeline.graph.state import GraphState
 from wgmesh_pipeline.graph.nodes.spec_pr import GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME, _git
+from wgmesh_pipeline.learnings import write_learnings_file
 
 
 def implement_node(state: GraphState) -> GraphState:
@@ -37,20 +39,39 @@ def implement_node(state: GraphState) -> GraphState:
         # implement attempt.
         config = next_state.get("config")
         recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
-        result = runner.run_recipe(
-            recipe=recipes_dir / "wgmesh-implementation.yaml",
-            workdir=repo_path,
-            # diff_file mirrors expected_output: the recipe instructs goose to
-            # write the unified diff there, the runner verifies it appeared.
-            params={
-                "spec_file": str(spec_rel if real_path else next_state["spec_path"]),
-                "diff_file": str(diff_rel),
-            },
-            expected_output=diff_rel,
-            stage="implement",
-            tier=tier,
-            session_id=f"issue-{issue.number}",
+        # Inject relevant past learnings as advisory "known pitfalls" (mirrors
+        # spec_node). Key the selector on the SPEC text — implement-stage pitfalls
+        # (build/test/diff-emit, "don't reference non-established types") match the
+        # spec, not the issue title alone. The spec content is not a GraphState
+        # channel, so read it from disk: the materialized copy on the real path,
+        # state["spec_path"] otherwise. Fall back to the title-only query if the
+        # read fails. Always pass the (required) param, empty path on no-match.
+        spec_text = _read_spec_text(repo_path, next_state, spec_rel, real_path)
+        learnings_file = write_learnings_file(
+            f"{issue.title}\n{spec_text}", prefix=f"issue-{issue.number}-learnings-"
         )
+        try:
+            result = runner.run_recipe(
+                recipe=recipes_dir / "wgmesh-implementation.yaml",
+                workdir=repo_path,
+                # diff_file mirrors expected_output: the recipe instructs goose to
+                # write the unified diff there, the runner verifies it appeared.
+                params={
+                    "spec_file": str(spec_rel if real_path else next_state["spec_path"]),
+                    "learnings_file": learnings_file,
+                    "diff_file": str(diff_rel),
+                },
+                expected_output=diff_rel,
+                stage="implement",
+                tier=tier,
+                session_id=f"issue-{issue.number}",
+            )
+        finally:
+            if learnings_file:
+                try:
+                    os.unlink(learnings_file)
+                except OSError:
+                    pass
         if not result.ok:
             raise RuntimeError(result.error or "goose implementation failed")
         if result.model_key is not None:
@@ -125,6 +146,30 @@ def _normalise_diff_path(path: str) -> str | None:
     if path.startswith("a/") or path.startswith("b/"):
         return path[2:]
     return path
+
+
+def _read_spec_text(repo_path: Path, state: dict, spec_rel: Path, real_path: bool) -> str:
+    """Best-effort read of the spec text to key the learnings selector on.
+
+    Real path: the materialized copy at ``repo_path/spec_rel`` (written by
+    ``_materialize_spec``, which runs first). Otherwise ``state["spec_path"]``
+    (tried as-is and relative to ``repo_path``). Returns "" on any failure — the
+    caller then falls back to an issue-title-only query.
+    """
+    candidates: list[Path] = []
+    if real_path:
+        candidates.append(repo_path / spec_rel)
+    spec_path = state.get("spec_path")
+    if spec_path:
+        candidates.append(Path(spec_path))
+        candidates.append(repo_path / str(spec_path))
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+    return ""
 
 
 def _materialize_spec(repo_path: Path, state: dict, spec_rel: Path) -> None:

--- a/pipeline/wgmesh_pipeline/graph/nodes/spec.py
+++ b/pipeline/wgmesh_pipeline/graph/nodes/spec.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR
 from wgmesh_pipeline.graph.state import GraphState
+from wgmesh_pipeline.learnings import write_learnings_file
 
 log = logging.getLogger("wgmesh_pipeline.spec")
 
@@ -41,6 +42,14 @@ def spec_node(state: GraphState) -> GraphState:
         )
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(brief)
+    # Inject the most relevant past learnings as advisory "known pitfalls" so the
+    # agent stops re-hitting documented failure modes. Keyed on the issue
+    # title + body. Same file-path convention as the brief (multi-line content,
+    # passed as a path). Always pass the param (empty path on no-match) because
+    # the recipe declares it required; fail-open inside write_learnings_file.
+    learnings_file = write_learnings_file(
+        f"{issue.title}\n{brief}", prefix=f"issue-{issue.number}-learnings-"
+    )
     try:
         result = runner.run_recipe(
             recipe=recipe_path,
@@ -49,6 +58,7 @@ def spec_node(state: GraphState) -> GraphState:
                 "issue_number": str(issue.number),
                 "issue_title": issue.title,
                 "issue_brief_file": brief_file,
+                "learnings_file": learnings_file,
                 "spec_file": str(spec_rel),
             },
             expected_output=spec_rel,
@@ -56,11 +66,12 @@ def spec_node(state: GraphState) -> GraphState:
             session_id=f"issue-{issue.number}",
         )
     finally:
-        if brief_file:
-            try:
-                os.unlink(brief_file)
-            except OSError:
-                pass
+        for tmp in (brief_file, learnings_file):
+            if tmp:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
     if not result.ok:
         # Surface goose's actual output so a write-tool/model/recipe failure is
         # diagnosable from the journal instead of just "empty output guard".

--- a/pipeline/wgmesh_pipeline/learnings.py
+++ b/pipeline/wgmesh_pipeline/learnings.py
@@ -145,12 +145,20 @@ def write_learnings_file(
         return ""
     if not blob.strip():
         return ""
+    path = ""
     try:
         fd, path = tempfile.mkstemp(prefix=prefix, suffix=".md")
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(blob)
     except OSError:
         log.warning("learnings temp-file write failed; proceeding without", exc_info=True)
+        # mkstemp may have created the file before the write failed (ENOSPC);
+        # unlink it so a partial temp file is not orphaned.
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
         return ""
     return path
 
@@ -200,8 +208,10 @@ def select_learnings(
             if len(candidate) > max_chars:
                 break
         elif len(block) > max_chars:
-            # single oversized highest-ranked entry: cut at a line boundary
-            head = block[:max_chars].rsplit("\n", 1)[0] or block[:max_chars]
+            # single oversized highest-ranked entry: cut at a line boundary,
+            # reserving room for the marker so the total stays within max_chars.
+            budget = max(0, max_chars - len(_PARTIAL_MARKER))
+            head = block[:budget].rsplit("\n", 1)[0] or block[:budget]
             return head + _PARTIAL_MARKER
         result = candidate
     return result

--- a/pipeline/wgmesh_pipeline/learnings.py
+++ b/pipeline/wgmesh_pipeline/learnings.py
@@ -11,11 +11,16 @@ skipped, never raised, so injecting learnings can never break a build run.
 
 from __future__ import annotations
 
+import logging
+import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+
+log = logging.getLogger("wgmesh_pipeline.learnings")
 
 _SOLUTIONS_REL = ("docs", "solutions")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
@@ -107,6 +112,47 @@ def _compact_body(body: str) -> str:
 
 def _block(entry: _Entry) -> str:
     return f"{_BLOCK_HEADER} {entry.title}\n\n{_compact_body(entry.body)}\n"
+
+
+def default_corpus_root() -> Path:
+    """Repo root holding ``docs/solutions/`` — this pipeline's own checkout, not
+    the target repo the agent edits. Derived from this module's location."""
+    return Path(__file__).resolve().parents[2]
+
+
+def write_learnings_file(
+    query: str,
+    *,
+    root: str | Path | None = None,
+    prefix: str = "learnings-",
+    max_items: int = 3,
+    max_chars: int = 4000,
+) -> str:
+    """Select learnings for ``query`` and write them to a temp file.
+
+    Returns the temp file path, or "" when there are no relevant learnings — so
+    callers ALWAYS pass the (required) recipe param, empty on no-match. Fail-open:
+    any selector/IO error logs and returns "" rather than raising. The caller owns
+    cleanup (unlink in a ``finally``).
+    """
+    corpus_root = Path(root) if root is not None else default_corpus_root()
+    try:
+        blob = select_learnings(
+            query, root=corpus_root, max_items=max_items, max_chars=max_chars
+        )
+    except Exception:  # noqa: BLE001 — fail-open; learnings must never break a run
+        log.warning("learnings selection failed; proceeding without", exc_info=True)
+        return ""
+    if not blob.strip():
+        return ""
+    try:
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=".md")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(blob)
+    except OSError:
+        log.warning("learnings temp-file write failed; proceeding without", exc_info=True)
+        return ""
+    return path
 
 
 def select_learnings(

--- a/pipeline/wgmesh_pipeline/learnings.py
+++ b/pipeline/wgmesh_pipeline/learnings.py
@@ -1,0 +1,161 @@
+"""Relevance selector over the ``docs/solutions/`` learnings corpus.
+
+Pure, deterministic read-back half of observe -> score -> *improve*: rank the
+committed learnings by token overlap against a query (an issue title/body, or a
+spec), and return the top-N concatenated within a char budget so they can be
+injected into the spec/implement agent recipes as advisory "known pitfalls".
+
+No network, no embeddings, no LLM. Fail-open per file: a malformed entry is
+skipped, never raised, so injecting learnings can never break a build run.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_SOLUTIONS_REL = ("docs", "solutions")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_MIN_TOKEN_LEN = 3
+_TAG_WEIGHT = 2
+
+# Machine-countable, body-unique block header so callers/tests can delimit
+# entries even though entry bodies themselves contain markdown headings.
+_BLOCK_HEADER = "## Past learning:"
+_PARTIAL_MARKER = (
+    "\n...[truncated — PARTIAL learning, char budget reached; "
+    "this is the head of the most relevant entry]...\n"
+)
+
+
+@dataclass(frozen=True)
+class _Entry:
+    title: str
+    category: str
+    tags: tuple[str, ...]
+    date: str
+    body: str
+
+
+def _tokenize(text: str) -> set[str]:
+    return {t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= _MIN_TOKEN_LEN}
+
+
+def _date_key(date: str) -> tuple[int, int, int]:
+    match = re.match(r"(\d{4})-(\d{2})-(\d{2})", date or "")
+    if not match:
+        return (0, 0, 0)
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _parse_file(path: Path) -> _Entry | None:
+    """Parse one corpus file; return None (skip) on any malformed input."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not raw.startswith("---"):
+        return None
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(meta, dict):
+        return None
+
+    raw_tags = meta.get("tags", [])
+    if isinstance(raw_tags, str):
+        tags = tuple(t.strip() for t in raw_tags.replace(",", " ").split() if t.strip())
+    elif isinstance(raw_tags, (list, tuple)):
+        tags = tuple(str(t) for t in raw_tags)
+    else:
+        tags = ()
+
+    return _Entry(
+        title=str(meta.get("title", path.stem)),
+        category=str(meta.get("category", "")),
+        tags=tags,
+        date=str(meta.get("date", "")),
+        body=parts[2].strip(),
+    )
+
+
+def _score(entry: _Entry, query_tokens: set[str]) -> int:
+    tag_tokens: set[str] = set()
+    for tag in entry.tags:
+        tag_tokens |= _tokenize(tag)
+    title_tokens = _tokenize(entry.title) | _tokenize(entry.category)
+    return _TAG_WEIGHT * len(query_tokens & tag_tokens) + len(query_tokens & title_tokens)
+
+
+def _compact_body(body: str) -> str:
+    """Trim an entry body to its substance: drop a leading duplicate H1 and any
+    trailing ``## Related`` link section."""
+    body = body.strip()
+    body = re.sub(r"^#\s+.*\n+", "", body, count=1)
+    related = re.search(r"(?mi)^##\s+Related\b", body)
+    if related:
+        body = body[: related.start()].rstrip()
+    return body
+
+
+def _block(entry: _Entry) -> str:
+    return f"{_BLOCK_HEADER} {entry.title}\n\n{_compact_body(entry.body)}\n"
+
+
+def select_learnings(
+    query: str,
+    *,
+    root: str | Path,
+    max_items: int = 3,
+    max_chars: int = 4000,
+) -> str:
+    """Return the learnings most relevant to ``query``, concatenated.
+
+    Globs ``<root>/docs/solutions/**/*.md`` recursively (all corpus files live in
+    category subdirs), ranks by token overlap of each entry's tags/category/title
+    against the query (tags weighted; recency breaks ties), and concatenates the
+    top entries up to ``max_items`` / ``max_chars``. Returns "" when the corpus is
+    missing/empty, the query is empty, or nothing scores above zero.
+    """
+    base = Path(root).joinpath(*_SOLUTIONS_REL)
+    if not base.is_dir():
+        return ""
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return ""
+
+    scored: list[tuple[int, tuple[int, int, int], _Entry]] = []
+    for path in base.rglob("*.md"):
+        entry = _parse_file(path)
+        if entry is None:
+            continue
+        score = _score(entry, query_tokens)
+        if score <= 0:
+            continue
+        scored.append((score, _date_key(entry.date), entry))
+    if not scored:
+        return ""
+
+    # score desc, then date desc (newer wins a tie)
+    scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+
+    result = ""
+    for _, _, entry in scored[:max_items]:
+        block = _block(entry)
+        candidate = block if not result else f"{result}\n{block}"
+        if result:
+            if len(candidate) > max_chars:
+                break
+        elif len(block) > max_chars:
+            # single oversized highest-ranked entry: cut at a line boundary
+            head = block[:max_chars].rsplit("\n", 1)[0] or block[:max_chars]
+            return head + _PARTIAL_MARKER
+        result = candidate
+    return result


### PR DESCRIPTION
## Summary

Closes audit **Gap 2** (open learning loops) — the *read-back* half of observe→score→**improve**. A relevance selector picks the `docs/solutions/` learnings most relevant to the issue/spec being worked, and the spec + implement nodes inject them into the agent recipes at runtime as advisory "known pitfalls." The build agent stops repeating documented failure modes without a human editing recipe prose each time.

Additive context only — no recipe-prose mutation, no auto-writing of new learnings. Plan: `docs/plans/2026-06-24-001-feat-learnings-injection-spec-impl-plan.md`.

## Implementation Units

| Unit | Change |
|------|--------|
| **U1** | `wgmesh_pipeline/learnings.py` — `select_learnings()` (recursive glob `docs/solutions/**/*.md`, rank by tag/category/title token overlap + recency tiebreak, budget-truncate at boundaries) + `write_learnings_file()` fail-open temp helper |
| **U2** | `spec.py` + `wgmesh-triage-spec.yaml` — `learnings_file` recipe param (required, always passed, empty path on no-match), advisory prompt block, `finally` cleanup |
| **U3** | `implement.py` + `wgmesh-implementation.yaml` — same pattern keyed on spec text read from disk (after `_materialize_spec` on the real path; `state["spec_path"]` otherwise), title-only fallback on read failure |

## Design contract

- **Fail-open everywhere** — selector errors, empty corpus, or zero matches → empty `learnings_file` path; injecting learnings can never fail a spec/impl run.
- **Param always passed** — declared `required`, mirroring `issue_brief_file`; empty string on no-match (omitting a required param fails the goose run).
- **Deterministic** — frontmatter + keyword overlap, no embeddings / LLM / network.
- **Corpus root** = this pipeline repo (not the target checkout), resolved from module location.

## Tests

- **39 feature tests green** (`test_learnings.py`, `test_spec_node_learnings.py`, `test_implement_node_learnings.py`, updated `test_spec_node.py`).
- Covers: ranking, no-match→"", `max_items`/`max_chars` caps, boundary truncation, malformed-frontmatter skip, recursive-glob anti-no-op guard, recency tiebreak, always-passed param, selector-raises fail-open, temp-file cleanup on failure, ENOSPC orphan cleanup.

## Review

Adversarial review pass — 2 low-severity findings, both fixed in the final commit:
- ENOSPC temp-file orphan now unlinked on write failure.
- Single-oversized-entry truncation reserves marker length so output stays ≤ `max_chars`.

## Note

The 8 pre-existing `test_implement_retry_pr` git-workspace tests fail in a local shell lacking ambient git commit identity (throwaway-repo setup) — verified identical on clean `origin/main`, unrelated to this change; they pass on the CI box.
