### PR TITLE
ci: add agent-native vulnerability scan

### DIFF
--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -23,3 +23,4 @@ jobs:
       ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
       FEATHERLESS_API_KEY: ${{ secrets.FEATHERLESS_API_KEY }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+# retrigger

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -1,0 +1,25 @@
+name: Vulnerability Scan
+
+# Agent-native vuln scan via the shared reusable workflow
+# (atvirokodosprendimai/vulnscan-action). LLM keys come from org-level secrets.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  scan:
+    # Fork PRs don't receive org secrets, so the scan would fail — only run for
+    # same-repo PRs and manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: atvirokodosprendimai/vulnscan-action/.github/workflows/vulnscan.yml@v1
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      fail_on: HIGH
+    secrets:
+      ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+      FEATHERLESS_API_KEY: ${{ secrets.FEATHERLESS_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/vulnscan.yml
+++ b/.github/workflows/vulnscan.yml
@@ -23,4 +23,4 @@ jobs:
       ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
       FEATHERLESS_API_KEY: ${{ secrets.FEATHERLESS_API_KEY }}
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-# retrigger
+# retrigger2


### PR DESCRIPTION
Adds `.github/workflows/vulnscan.yml` calling the shared reusable workflow `atvirokodosprendimai/vulnscan-action@v1`.

- Triggers: `pull_request` (same-repo only) + `workflow_dispatch`. Fork PRs are skipped (org secrets are withheld from forks).
- LLM keys (ZAI/FEATHERLESS/DEEPSEEK) inherited from org-level secrets.
- Uploads SARIF to code scanning; fails CI on HIGH+ findings.

Draft to avoid auto-merge bots. Each run calls 3 LLM APIs (cost) — adjust triggers if needed before merging.