### PR TITLE
feat: GTM rent-a-human executor lane (U1–U9)

### DIFF
--- a/docs/brainstorms/2026-06-24-gtm-rent-a-human-executor-requirements.md
+++ b/docs/brainstorms/2026-06-24-gtm-rent-a-human-executor-requirements.md
@@ -1,0 +1,267 @@
+---
+title: "GTM rent-a-human executor: drain the service-decision queue autonomously"
+type: brainstorm
+date: 2026-06-24
+status: requirements
+surface: service
+---
+
+# GTM rent-a-human executor
+
+## Summary
+
+Give the `surface:service` GTM-decision queue a real autonomous executor: a new
+pipeline lane that takes an approved, low-risk GTM job, dispatches it to a
+**rented human** (human-as-a-service API), verifies completion, and closes the
+loop — so service go-to-market drains without the cofounder doing the work by
+hand. A WISDOM-grounded job-draft step and a cloudroof positioning + Mom-Test
+validation kit ride along as sub-components.
+
+---
+
+## Problem Frame
+
+The product engineering pipeline has converged — the last four pulses show the
+wgmesh backlog drained, CI green, and **0 paid customers**. STRATEGY.md is blunt:
+"converging on code without converging on revenue is theatre." The gating
+constraint is demand/monetization, not engineering.
+
+Grounding traced the specific stall: the Observation Loop already biases toward
+GTM work and emits `surface:service` issues, but every non-code GTM item is
+labelled `needs-human` and parked in a cofounder-only decision queue with **no
+executor after approval**. Even a sound GTM decision (run outreach, set pricing,
+build a list) has nothing that carries it out. The queue grows; nothing ships.
+
+The cofounder-as-executor *is* the babysitting failure STRATEGY commits to
+removing. The pipeline's whole premise is autonomy — so the executor should be a
+rented human dispatched by the pipeline, not the founder. That reframes a
+proposal-quality problem (which a WISDOM-corpus injection would address) into a
+**delivery** problem (which needs an executor with a verification loop).
+
+Serves STRATEGY *Customer Factory / Revenue surface* track — owns paid customers.
+
+---
+
+## Key Decisions
+
+- **Executor is a rented human, not the cofounder.** The lane dispatches GTM
+  jobs to an API-addressable human-task service. This removes the cofounder-only
+  bottleneck and keeps "no babysitting." Accepts a new external dependency and
+  per-task cost.
+
+- **Delivery is the constraint, not proposal quality.** Grounding confirmed
+  decisions stall *after* approval for lack of an executor. So the lane is the
+  primary deliverable; the WISDOM/GTM-learnings injection is demoted to a
+  grounding sub-component of the job-draft step (it grounds what the executor
+  does, never an off-path proposal).
+
+- **Low-risk job class first.** The MVP executor runs only low-blast-radius work
+  (lead research, list-building, manual signups/account creation, content QA,
+  competitor recon, data entry). Outbound contact as the company (cold outreach,
+  posting) stays gated until the dispatch+verify loop is proven.
+
+- **Validation and buildout run in parallel (Traction 50% rule).** The lane
+  doesn't gate behind a validation sprint; the cloudroof positioning frame +
+  Mom-Test kit are prepared alongside, with the actual stargazer conversations
+  deferred behind the risk boundary.
+
+- **Verification mirrors the impl-judge gate.** A rented human spending money and
+  touching brand needs a fail-closed completion check, or the lane is a worse
+  off-path than the current queue.
+
+- **Budget approval is an envelope, not per-task.** The cofounder approves a
+  spend envelope once (via the existing decision-lane); the executor draws
+  against it per job. Per-task human approval would reintroduce the bottleneck.
+
+---
+
+## Actors
+
+- **Observation Loop** — emits `surface:service` GTM issues, labels lane
+  (`fn:dev` vs `needs-human`). Unchanged.
+- **Cofounder** — approves the spend envelope and the GTM strategy once; no
+  longer the per-job executor.
+- **GTM-execution lane (new)** — drafts the job spec, enforces the budget gate,
+  dispatches to the human-task service, runs verification, closes the item.
+- **Rented human (external)** — executes the dispatched low-risk job, returns
+  proof of completion.
+- **Verifier** — fail-closed check that the returned work matches the job spec
+  and safety bounds before the item closes.
+
+---
+
+## Key Flows
+
+**Primary: a low-risk GTM job from queue to closed.**
+
+1. An approved `surface:service` + `needs-human` item that is low-risk-classified
+   enters the GTM-execution lane.
+2. The lane drafts a **job spec** (task, acceptance criteria, safety bounds),
+   grounded by the GTM-learnings corpus.
+3. **Budget gate:** the job's estimated cost is checked against the remaining
+   envelope. Over budget or no envelope → park, do not dispatch.
+4. The lane dispatches the job spec to the human-task service.
+5. The rented human completes it and returns a result + proof.
+6. **Verification:** a fail-closed check compares result against the job spec's
+   acceptance criteria and safety bounds. Pass → close the item, record cost.
+   Fail → retry or escalate (never silently close).
+7. Loop telemetry (cost, pass/fail, latency) feeds the pulse.
+
+**Fail-open principle:** any lane error parks the item back in the queue in its
+prior state — the lane never loses or corrupts a queued decision.
+
+---
+
+## Requirements
+
+**Executor lane (R1–R4)**
+
+- **R1.** A new GTM-execution lane consumes approved `surface:service` items that
+  are classified low-risk, and is the autonomous executor for them.
+- **R2.** Each item produces a structured job spec (task, acceptance criteria,
+  safety bounds) before any dispatch.
+- **R3.** The lane dispatches job specs to an API-addressable human-task service
+  and ingests the returned result + completion proof.
+- **R4.** Any lane error returns the item to the queue in its prior state; the
+  lane never drops, duplicates, or corrupts a queued decision (fail-open).
+
+**Job-class safety boundary (R5–R7)**
+
+- **R5.** The MVP executor accepts only low-risk job classes: lead research,
+  list-building, manual signups/account creation, content QA, competitor recon,
+  data entry.
+- **R6.** Outbound contact as the company (cold outreach, social posting,
+  customer-facing messaging) is rejected by the lane until explicitly enabled
+  after the loop is proven.
+- **R7.** No job may emit secrets, customer PII, or exact revenue figures in its
+  spec or its returned artifact; the existing sanitise wall applies to both
+  directions.
+
+**Verification & budget (R8–R10)**
+
+- **R8.** A fail-closed verifier checks every returned result against the job
+  spec's acceptance criteria and safety bounds before the item closes.
+- **R9.** A failed verification retries or escalates to `needs-human`; it never
+  silently closes the item.
+- **R10.** Spend is gated against a cofounder-approved envelope drawn per job;
+  exceeding or lacking an envelope parks the item rather than dispatching.
+
+**GTM-learnings grounding (R11–R12)**
+
+- **R11.** The job-draft step is grounded by a local GTM-learnings corpus,
+  reusing the shipped `select_learnings`/`write_learnings_file` seam
+  (`pipeline/wgmesh_pipeline/learnings.py`), keyed on the job/decision text.
+- **R12.** The GTM corpus is vendored into this repo (the WISDOM corpus lives in
+  a sibling repo and cannot be globbed from this deploy); grounding is fail-open
+  and never blocks a job.
+
+**Validation kit (R13–R15)**
+
+- **R13.** Produce a cloudroof positioning frame using the Obviously Awesome
+  components (competitive alternatives incl. self-hosting, unique attributes,
+  value, target segment, category).
+- **R14.** Produce a Mom-Test discovery kit (question script that probes past
+  behavior, not pitch; target-segment definition).
+- **R15.** Build the stargazer target list as a low-risk executor job (R5); the
+  actual outbound conversations are deferred behind R6.
+
+---
+
+## Acceptance Examples
+
+- **Low-risk job, verified pass:** a "build a 50-row competitor-pricing sheet"
+  job → spec drafted → within envelope → dispatched → returned sheet passes the
+  verifier's acceptance criteria → item closes, cost recorded.
+- **Outbound job rejected:** a "cold-email the stargazer list" item reaches the
+  lane → R6 rejects it as not-yet-enabled → stays in queue, not dispatched.
+- **Over-budget:** an approved low-risk job whose estimate exceeds the remaining
+  envelope → parked at the budget gate, cofounder notified, no dispatch.
+- **Verification fail:** returned work omits half the acceptance criteria →
+  verifier fails → retry or escalate to `needs-human`, item stays open.
+- **Grounding empty:** no GTM learning matches the job → empty grounding, job
+  proceeds unchanged (fail-open).
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- **Outbound GTM as the company** (cold outreach, posting, customer messaging) —
+  enabled only after the dispatch+verify loop is proven on low-risk jobs (R6).
+- **Actual stargazer validation conversations** — the kit and target list are
+  prepared here; running the conversations waits on the risk boundary.
+- **Installing the cloudroof code-build instance** — the executor for
+  *code-buildable* GTM (landing/signup); its own stalled brainstorm
+  (`docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md`). A
+  parallel dependency, not built here.
+- **WISDOM-injection into the decision-proposal recipe** — proposal quality is
+  not the constraint; revisit only if approved decisions start stalling on
+  draft quality rather than execution.
+
+### Outside this product's identity
+
+- **Cofounder-as-executor** — reverting GTM execution to a human-in-the-loop
+  queue contradicts the "no babysitting" thesis; the whole point is to remove it.
+- **Paywalling product capability** — monetization stays at the managed-service
+  layer per CONSTITUTION.md; nothing here gates wgmesh functionality.
+- **Self-modifying GTM strategy** — the lane executes approved jobs; it does not
+  set pricing, strategy, or brand voice (those remain cofounder decisions).
+
+---
+
+## Dependencies / Assumptions
+
+- **Load-bearing dependency: an API-addressable human-task service with
+  completion proof, reachable within budget.** If none exists, the lane has no
+  executor and reduces to today's queue. Validate this exists before planning
+  commits (Resolve Before Planning).
+- **Assumption:** the existing decision-lane (`wgmesh-decision-proposal.yaml`,
+  `decision_lane/proposal_runner.py`) is the right home for the envelope
+  approval and the new lane's plumbing.
+- **Assumption:** the sanitise wall (`company/scripts/sanitise.sh`) can gate
+  job specs and returned artifacts in both directions.
+- **Dependency:** the GTM-learnings corpus must be authored/vendored into the
+  repo before R11–R12 carry value (distilled from the WISDOM corpus +
+  `docs/solutions/` GTM learnings).
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- Which human-task service(s) meet the API + completion-proof + budget bar? This
+  gates the lane's feasibility.
+- What is the initial spend envelope and who refreshes it?
+
+### Deferred to Planning
+
+- How verification proof is structured per job class (screenshot, artifact diff,
+  third-party check) and how the fail-closed verifier scores it.
+- Whether the GTM-execution lane is a new `decision_lane` sibling module or an
+  extension of the proposal runner.
+- Cost/latency telemetry shape for the pulse.
+
+---
+
+## Sources / Research
+
+- STRATEGY.md — *Customer Factory / Revenue surface* track; product-vs-service
+  split; paid-customers metric; "code without revenue is theatre."
+- Pulse trend: `docs/pulse-reports/2026-06-24_07-08.md` (0 customers, backlog
+  drained, service converging in code, demand is the gating constraint).
+- Learnings-injection seam to mirror: `pipeline/wgmesh_pipeline/learnings.py`
+  (`select_learnings`, `write_learnings_file`); call sites in
+  `graph/nodes/spec.py`, `graph/nodes/implement.py` (PR #1988).
+- Decision-lane seam: `pipeline/recipes/wgmesh-decision-proposal.yaml`,
+  `pipeline/wgmesh_pipeline/decision_lane/proposal_runner.py`,
+  `observation_gather.py` (GTM bias + surface/lane labelling).
+- Social drip: `.github/workflows/wgmesh-social-drip.yml` (copy generation,
+  Mixpost human-review gate).
+- Cloudroof code-executor (parallel dep):
+  `docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md`.
+- GTM corpus source: `ai-vektorius-lt/WISDOM.compiled.md` (31-book GTM stack;
+  TRIGGER→book index; Mom Test, Obviously Awesome, Monetizing Innovation,
+  100M Leads, Traction).
+- CONCEPTS.md — Surface, Escalation, Social Drip, No-component-paywall.

--- a/docs/gtm/cloudroof-positioning.md
+++ b/docs/gtm/cloudroof-positioning.md
@@ -1,0 +1,46 @@
+# cloudroof positioning frame (Obviously Awesome)
+
+**Plan:** `docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md` (U8, R13)
+**Date:** 2026-06-25 · **Status:** draft frame for validation; refine against real discovery
+
+Positioning chooses the frame of reference that makes value obvious. cloudroof's
+value is invisible until the alternatives — especially "do nothing / self-host" —
+are named. Components in order:
+
+## 1. Competitive alternatives (what they'd pick otherwise)
+
+- **Self-host wgmesh (free AGPL)** — the status quo and **fiercest competitor**.
+  Costs the user time: provisioning, upgrades, monitoring, key rotation, uptime.
+- **Headscale** — self-hosted Tailscale control-plane; still self-operated.
+- **Tailscale (hosted)** — managed, but proprietary and not wgmesh's mesh model.
+- **Do nothing** — keep the current ad-hoc VPN / no mesh.
+
+## 2. Unique attributes (true only relative to the above)
+
+- Managed hosting of the **AGPL wgmesh** product — no proprietary lock-in; the
+  software stays free and self-hostable (no component paywall per CONSTITUTION.md).
+- Operator removes the self-host toil (upgrades, monitoring, uptime) without
+  taking the capability hostage.
+
+## 3. Value + proof (the "so what")
+
+- **Value:** time-to-running-mesh and ongoing uptime without operating it yourself.
+- **Proof (to gather):** time-to-first-mesh on cloudroof vs a self-host install;
+  the hours/month a self-hoster spends on upgrades + monitoring.
+
+## 4. Target segment (buys fast, refers)
+
+- A technical team/operator who **wants the wgmesh mesh model** but does not want
+  to run the control plane — already self-hosting *something* and feeling the toil.
+  (Sharpen against real discovery; see the Mom-Test kit.)
+
+## 5. Market category
+
+- **Managed mesh-VPN hosting** for an open-source mesh — framed against self-hosting,
+  not against proprietary VPNs.
+
+## The decisive question (validate first)
+
+Does self-host friction exceed the price? cloudroof only sells if the toil it removes
+is worth more than the subscription. That is the WTP hypothesis the discovery talks
+(Mom-Test kit) must test before the service buildout scales.

--- a/docs/gtm/mom-test-stargazers.md
+++ b/docs/gtm/mom-test-stargazers.md
@@ -1,0 +1,47 @@
+# Mom-Test discovery kit — wgmesh stargazers
+
+**Plan:** `docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md` (U8, R14)
+**Date:** 2026-06-25 · **Status:** kit ready; outbound conversations DEFERRED (R6 risk gate)
+
+Goal: learn whether self-host friction exceeds a managed-hosting price — the
+cloudroof WTP hypothesis — by talking about the stargazer's **life and past
+behaviour**, never pitching cloudroof. Compliments and "I'd totally pay" are NOT
+signal; a sourced past action is.
+
+## Target segment
+
+wgmesh stargazers / forkers / issue-commenters — they showed interest (a warm
+list). The list itself is built as a low-risk lane job (R15, public signals only,
+no scraped private emails — public-repo PII rule).
+
+## Rules (Mom Test)
+
+- Talk about their world, not our idea. Never describe cloudroof until the end.
+- Anchor every generic to a specific past event ("when did that last happen?").
+- Dig motivation behind requests ("what would that let you do?").
+- A lukewarm answer is a NO — record it, ask why, move on. Don't up-pitch.
+- Close with "who else runs a mesh I should talk to?"
+
+## Question script
+
+1. How are you using wgmesh today — what does your mesh actually do for you?
+2. Walk me through setting it up the last time. What took the longest?
+3. Since then, what's broken or needed attention (upgrades, keys, uptime)? When
+   was the last time? What did you do?
+4. Roughly how much of your time per month goes to operating it?
+5. Have you paid for, or seriously looked at, anything to take that off your plate
+   (Tailscale, a managed host, a contractor)? What happened?
+6. What made you star/fork the repo — what were you hoping for?
+7. Who else do you know running a mesh who deals with this?
+
+## What counts as a result (verifiable)
+
+Per contact: a quote for each of Q2–Q5 citing a **real past action** (time spent,
+money paid, workaround built) — not a hypothetical or an opinion. The signal is
+the cost of the status quo, which is what the cloudroof price must beat.
+
+## Deferred
+
+The actual outbound conversations are gated behind R6 (outbound-as-the-company)
+until the rented-human dispatch+verify loop is proven on low-risk jobs. This kit +
+the built list are the prepared inputs; running it is the next gated step.

--- a/docs/gtm/provider-feasibility.md
+++ b/docs/gtm/provider-feasibility.md
@@ -1,0 +1,94 @@
+# GTM rent-a-human provider — feasibility decision note (U1)
+
+**Plan:** `docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md` (U1)
+**Date:** 2026-06-25
+**Status:** research-confirmed; live-probe + funding pending a cofounder action (see Gate 4)
+
+This note is the U1 spike deliverable: name a rented-human provider that clears the
+four gates, state its spend-reporting model, and map its result/proof shape onto the
+U2 adapter contract. The lane build (U2+) targets the **adapter**, so the specific
+provider can be swapped behind the seam; this note picks the default to wire in.
+
+---
+
+## The four gates
+
+| # | Gate | How confirmed |
+|---|------|---------------|
+| 1 | Unattended API dispatch (create task + retrieve result, no human account manager) | Research / vendor docs |
+| 2 | Structured completion proof (machine-readable result + evidence) | Research / vendor docs |
+| 3 | EU/GDPR data-handling posture (Article 28 DPA) — jobs may touch EU contacts | Research / vendor docs |
+| 4 | Acceptable per-task cost **on a funded account** | **Cofounder action** — signup + DPA + funding |
+
+Gates 1–3 are confirmable from documentation and prior art. **Gate 4 (a funded,
+EU-DPA account) is a capital decision the pipeline cannot self-serve** — it needs a
+cofounder to sign up, accept the DPA, and fund the account. The lane build proceeds
+against a fake provider (U2) without it; only the live cutover (real dispatch) waits
+on Gate 4.
+
+---
+
+## Recommendation: Toloka (primary)
+
+| Candidate | Gate 1 API | Gate 2 proof | Gate 3 EU/GDPR | ~cost/task | Verdict |
+|-----------|-----------|--------------|----------------|------------|---------|
+| **Toloka** | Full REST + Python SDK (`toloka-kit`) | Structured JSON per assignment + built-in QC (majority vote, honeypots, skill scoring) | GDPR + ISO 27701, Article 28 DPA | $0.10–0.50 | **Primary** |
+| Microworkers | REST API v2 (campaigns) | Result + configurable screenshot proof URLs | EU domicile (Slovenia); DPA less explicit | $0.10–0.50 | Alt — GTM task types (signups/recon) |
+| HumanOps | REST + **MCP server** | Photo/structured proof before payment settles | **Unverified** | Undisclosed | Watch — best architectural fit; verify pricing + GDPR |
+| MTurk | Best-documented REST API | Structured fields | **US data posture, no DPA** | $0.20–0.60 | **Reject for EU contact data** |
+| Prolific | Full REST API | Completion codes + JSON | GDPR, EU-safe | $12+/hr | Reject — task types prohibit signups/list-building |
+| Upwork / Fiverr | Partner-gated / none | None | — | — | Reject — no autonomous dispatch |
+
+**Why Toloka:** only candidate clearing Gates 1–3 cleanly — a real EU Article 28 DPA
+(ISO 27701), a full programmatic API + SDK, built-in quality control that lowers our
+verification burden, and a low per-task cost. Microworkers is the fallback for
+account-creation/signup tasks where Toloka's worker pool skews research-oriented.
+HumanOps is worth a direct evaluation (MCP-native → near-zero client code) once its
+pricing and GDPR posture are verified.
+
+Prior art: a documented 2025 build dispatched ~300 tasks via MTurk/Toloka/Microworkers
+at ~$0.30/task with programmatic result validation and no human in the loop — the
+dispatch-and-verify loop is proven at small scale.
+
+---
+
+## Spend-reporting model
+
+Provider spend is reported **asynchronously** (rewards settle after worker submission /
+approval, not synchronously at dispatch). A synchronous per-job dollar cap is therefore
+**not implementable**. The budget gate (U6) must be a **pre-dispatch reservation against
+a tracked envelope + a bounded-attempts ceiling**, reconciling actual cost on close —
+never a hoped-for synchronous post-hoc figure. (Confirms the plan KTD and the
+multi-model-routing learning.)
+
+---
+
+## Adapter-contract requirements (input to U2)
+
+The U2 vendor-agnostic protocol must express, provider-independently:
+
+- **`dispatch(job_spec) -> handle`** — submit one task; return an opaque provider handle
+  (Toloka: pool/task id). Idempotency key on the job so a retry does not double-dispatch.
+- **`fetch_result(handle) -> result`** — poll/retrieve. `result` distinguishes four
+  states explicitly (no coercion to "done"): `completed` (with structured payload +
+  proof), `empty`, `garbage/invalid`, `pending`.
+- **Result shape:** `{ payload, proof, worker_meta, cost_estimate? }` where `proof` is a
+  structured artifact (Toloka assignment JSON / Microworkers screenshot URL / HumanOps
+  photo) the U5 verifier checks against the dispatched job.
+- **Credentials:** provider keys reach the adapter via an **allowlist** env (not
+  denylist), re-added only for the routed provider — fail-closed on a missing key.
+- **External-call hygiene:** explicit non-default `User-Agent` on provider HTTP calls
+  (Cloudflare-fronted APIs 403 default `urllib` UAs); stamp any cached endpoint/ID
+  reference with `last_verified` and re-discover via the API at dispatch time rather than
+  trusting baked config.
+
+---
+
+## Open cofounder action (Gate 4 — blocks live cutover, not the build)
+
+1. Sign up for Toloka (requester), accept the Article 28 DPA, fund the account.
+2. Set the **spend envelope** amount + refresh cadence (U6 config input).
+3. Provide the API credential to the pipeline's vault/allowlist env.
+
+Until then: build and test the full lane against the fake provider (U2–U9); the live
+provider swap + first real dispatch is the only step that waits.

--- a/docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md
+++ b/docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md
@@ -1,0 +1,512 @@
+---
+title: "feat: GTM rent-a-human executor lane"
+type: feat
+date: 2026-06-25
+origin: docs/brainstorms/2026-06-24-gtm-rent-a-human-executor-requirements.md
+surface: service
+---
+
+# feat: GTM rent-a-human executor lane
+
+## Summary
+
+Build an autonomous **GTM-execution lane** that drains the `surface:service`
+decision queue: it takes an approved low-risk GTM job, drafts a job spec
+(WISDOM-grounded), reserves spend against a budget envelope, dispatches the job
+to a rented-human provider via a vendor-agnostic adapter, runs a fail-closed
+verification gate on the returned work, and closes the item — removing the
+cofounder-as-executor bottleneck. A provider-feasibility spike gates the build; a
+cloudroof positioning + Mom-Test validation kit ships alongside.
+
+---
+
+## Problem Frame
+
+Four pulses running, **0 paid customers**, wgmesh backlog drained — demand is the
+gating constraint, not engineering (see origin). The Observation Loop already
+emits `surface:service` GTM issues, but every non-code item is parked
+`needs-human` in a cofounder-only queue with **no executor after approval**, so
+nothing ships. The cofounder-as-executor is the babysitting failure STRATEGY.md
+commits to removing. This plan gives the queue an autonomous rented-human
+executor so service GTM drains without a human in the loop.
+
+Advances STRATEGY *Customer Factory / Revenue surface* track (owns paid
+customers).
+
+---
+
+## Key Technical Decisions
+
+- **Provider-feasibility spike gates the build (U1).** No production code beyond a
+  throwaway probe until one concrete provider is confirmed to support API
+  dispatch + structured completion proof + EU DPA + acceptable per-task cost.
+  Landscape research ranks **Toloka** first (GDPR DPA + ISO 27701, full REST/SDK,
+  ~$0.10–0.50/task), with **Microworkers** (EU HQ, GTM task types) and
+  **HumanOps** (MCP-native, pricing/GDPR unverified) as alternates; **avoid MTurk**
+  (US-only data posture) and Upwork/Fiverr (no autonomous dispatch). (see origin
+  Dependencies)
+
+- **Vendor-agnostic provider adapter (U2).** The lane targets a dispatch+verify
+  contract, not a specific vendor; built and tested against a fake provider so the
+  spike's pick wires in behind the seam without lane rework. Keeps momentum
+  despite the spike-first gate.
+
+- **Verification is fail-closed on empty/absent work, proven on a real payload.**
+  The returned-work field is traced to the actual deliverable on a real trace
+  before the gate is trusted; NUMERIC/"not applicable" rubrics default to *fail*,
+  not pass (mirrors the langfuse-empty-output and goose-hollow-green learnings).
+  End-to-end "does returned work match the dispatched job", never HEAD-200.
+
+- **Budget gate is a pre-dispatch reservation + bounded-attempts ceiling.**
+  Provider spend reports asynchronously, so a synchronous per-job dollar cap is
+  not implementable (per the multi-model-routing learning). Reserve against a
+  tracked envelope before dispatch; cap attempts; park on exceed.
+
+- **New decision-lane sibling module, not an extension of the proposal runner.**
+  GTM execution (dispatch + verify + close) is a different concern from proposal
+  drafting; the queue-drain logic lives on its own.
+
+- **Low-risk job allowlist; high-risk stays in the human queue.** MVP accepts only
+  low-blast-radius jobs; outbound-as-the-company (cold outreach, posting) is
+  rejected by the lane until the loop is proven. Security/high-risk reasons go
+  straight to `needs-human`, never climbed (mirrors the build-lane gate).
+
+- **Grounding is a rich best-effort block, not a deterministic match gate.** Reuse
+  the shipped `select_learnings`/`write_learnings_file` seam keyed on job text;
+  fail-open; guard against ingesting the lane's own emitted jobs (self-ingestion).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+    Q[Approved surface:service + needs-human item<br/>low-risk classified] --> DRAFT[Job-spec draft<br/>WISDOM-grounded]
+    DRAFT --> SAFE{Job-class safety gate<br/>low-risk allowlist?}
+    SAFE -- reject --> HQ[Stay in needs-human queue]
+    SAFE -- pass --> BUD{Budget gate<br/>reserve vs envelope}
+    BUD -- over/none --> PARK[Park + notify cofounder]
+    BUD -- reserved --> DISP[Dispatch via provider adapter]
+    DISP --> PROV[(Rented-human provider)]
+    PROV --> RES[Ingest result + completion proof]
+    RES --> VER{Fail-closed verify<br/>work matches spec? non-empty?}
+    VER -- pass --> CLOSE[Close item + record cost + telemetry]
+    VER -- quality fail --> RETRY[Bounded retry / re-dispatch]
+    VER -- empty/absent/security --> ESC[Escalate to needs-human]
+    RETRY --> DISP
+```
+
+*Directional — the prose and Implementation Units are authoritative.*
+
+---
+
+## Output Structure
+
+```
+pipeline/wgmesh_pipeline/gtm_lane/      # new module
+  __init__.py
+  executor.py        # lane orchestration: intake → draft → dispatch → verify → close
+  provider.py        # vendor-agnostic dispatch+verify adapter protocol
+  fake_provider.py   # in-memory provider for tests
+  job_spec.py        # job-spec model + low-risk job-class allowlist
+  verify.py          # fail-closed verification gate
+  budget.py          # envelope reservation + bounded-attempts ceiling
+pipeline/recipes/
+  wgmesh-gtm-job-draft.yaml             # job-spec drafting recipe (learnings-grounded)
+docs/gtm-wisdom/                         # vendored GTM corpus (from WISDOM.compiled.md)
+docs/gtm/
+  cloudroof-positioning.md              # Obviously Awesome frame
+  mom-test-stargazers.md                # discovery question kit
+company/
+  gtm-execution-state.json              # budget envelope + telemetry state
+```
+
+The per-unit `**Files:**` lists are authoritative; the tree is a scope sketch.
+
+---
+
+## Implementation Units
+
+### Phase A — Foundation (gates everything)
+
+### U1. Provider feasibility spike
+
+- **Goal:** Confirm one concrete rented-human provider supports unattended API
+  dispatch + structured completion proof + EU/GDPR DPA + acceptable per-task cost,
+  and determine its spend-reporting model (sync vs async). Produce a short
+  decision note + the adapter-contract requirements. Gates U2–U9.
+- **Requirements:** Resolves origin "Resolve Before Planning" (which provider; the
+  envelope amount remains a cofounder input).
+- **Dependencies:** none
+- **Files:** `docs/gtm/provider-feasibility.md` (decision note; no production code)
+- **Approach:** Evaluate Toloka first (landscape rank #1). Probe the live API with
+  a single throwaway low-risk task end-to-end (dispatch → result → proof) if a
+  free/cheap tier allows; otherwise confirm from docs + a sales-free signup. Record
+  per-task cost, proof shape, DPA availability, latency, and the spend-reporting
+  model. If Toloka fails a gate, fall to Microworkers, then HumanOps. Output names
+  the chosen provider + maps its result/proof shape onto the U2 adapter contract.
+- **Patterns to follow:** the stale-config / end-to-end-verify discipline in
+  `docs/solutions/integration-issues/polar-checkout-404s-from-stale-config-2026-05-08.md`
+  (verify against the live API, stamp `last_verified`).
+- **Execution note:** Spike — research + a throwaway probe, not production code.
+  The lane build (U2+) does not start until this note names a viable provider.
+- **Test scenarios:** Test expectation: none — spike produces a decision note, not
+  shippable behavior.
+- **Verification:** A written decision note names a provider that clears all four
+  gates (API dispatch, structured proof, EU DPA, cost) and states its
+  spend-reporting model; or it concludes no provider qualifies and the lane is
+  not built.
+
+### U2. Provider adapter protocol + fake provider
+
+- **Goal:** A vendor-agnostic dispatch+verify contract the lane targets, plus an
+  in-memory fake provider so the lane is built and tested without a live vendor.
+- **Requirements:** R3 (dispatch + ingest result/proof).
+- **Dependencies:** U1
+- **Files:** `pipeline/wgmesh_pipeline/gtm_lane/provider.py`,
+  `pipeline/wgmesh_pipeline/gtm_lane/fake_provider.py`,
+  `pipeline/tests/test_gtm_provider.py`
+- **Approach:** Define a protocol with `dispatch(job_spec) -> handle` and
+  `fetch_result(handle) -> result_with_proof` (shape informed by U1). The fake
+  provider returns scripted results (success-with-proof, empty, garbage,
+  pending) for deterministic lane tests. Real provider is a later swap behind the
+  same protocol. Credentials reach the adapter via an **allowlist** env (not
+  denylist), per the multi-model-routing learning.
+- **Patterns to follow:** protocol/duck-typing + allowlist env in
+  `pipeline/wgmesh_pipeline/models.py` / `goose/runner.py`.
+- **Test scenarios:**
+  - Fake provider returns success+proof → adapter surfaces a structured result.
+  - Fake returns empty / garbage / still-pending → adapter reports each distinctly
+    (no silent coercion to "done").
+  - Missing provider credential → adapter raises (fail-closed), does not no-op.
+- **Verification:** Lane code can dispatch and fetch through the protocol against
+  the fake; the real provider is swappable without touching lane logic.
+
+### Phase B — Lane and gates
+
+### U3. GTM-execution lane core
+
+- **Goal:** Orchestrate one item end-to-end: intake an approved low-risk item →
+  draft a job spec → (gates U4–U6) → dispatch via adapter → ingest result →
+  close. Fail-open: any lane error returns the item to the queue in its prior
+  state.
+- **Requirements:** R1, R2, R4.
+- **Dependencies:** U2
+- **Files:** `pipeline/wgmesh_pipeline/gtm_lane/executor.py`,
+  `pipeline/wgmesh_pipeline/gtm_lane/job_spec.py`,
+  `pipeline/recipes/wgmesh-gtm-job-draft.yaml`,
+  `pipeline/tests/test_gtm_executor.py`
+- **Approach:** Mirror `decision_lane/proposal_runner.py` for runner shape +
+  recipe params (job spec written to a file path, same convention). The job-spec
+  draft recipe emits task + acceptance criteria + safety bounds. Lane is a new
+  sibling module, not a proposal_runner extension. Wrap the dispatch→ingest path
+  so any exception parks the item unchanged (fail-open) and never double-dispatches.
+- **Patterns to follow:** `pipeline/wgmesh_pipeline/decision_lane/proposal_runner.py`
+  (runner + params + recipe); `graph/nodes/spec.py` (file-path param + finally
+  cleanup).
+- **Execution note:** Characterization-first — capture the no-op / queue-return
+  path before adding dispatch, so fail-open is proven.
+- **Test scenarios:**
+  - Covers AE1. Approved low-risk item → spec drafted → dispatched via fake →
+    result ingested → item closes.
+  - Lane error mid-dispatch → item returns to queue in prior state; not dropped,
+    not double-dispatched (integration test through the real executor + fake
+    provider, no over-mocking).
+  - Job-spec draft is non-empty and carries acceptance criteria + safety bounds
+    (deliverable-in-code, not prompt-trusted).
+- **Verification:** An approved low-risk item flows queue→closed against the fake
+  provider; any failure leaves the queue item intact.
+
+### U4. Job-class safety gate
+
+- **Goal:** Accept only low-risk job classes; reject outbound-as-the-company;
+  enforce the sanitise wall on job specs and returned artifacts both directions.
+- **Requirements:** R5, R6, R7.
+- **Dependencies:** U3
+- **Files:** `pipeline/wgmesh_pipeline/gtm_lane/job_spec.py` (allowlist),
+  `pipeline/wgmesh_pipeline/gtm_lane/executor.py` (gate wiring),
+  `pipeline/tests/test_gtm_safety.py`
+- **Approach:** A positive allowlist of low-risk classes (lead research,
+  list-building, manual signups/account creation, content QA, competitor recon,
+  data entry). Anything else — especially outbound contact as the company — is
+  rejected back to `needs-human`. Run `company/scripts/sanitise.sh` on the
+  outbound job spec and the inbound returned artifact. Scope secret scanning
+  **narrowly** (`api_key`/`private_key`/`credentials`, not bare `key`) to avoid
+  false-positive escalations (per the review-merge-bootstrap learning).
+- **Patterns to follow:** positive-gate + narrow-keyword scan in
+  `docs/solutions/integration-issues/autonomous-review-merge-bootstrap.md`;
+  sanitise wall usage in `.github/workflows/wgmesh-social-drip.yml`.
+- **Test scenarios:**
+  - Covers AE2. A "cold-email the stargazer list" item → rejected by R6, stays in
+    queue, not dispatched.
+  - Each allowlisted low-risk class → accepted.
+  - A non-allowlisted class (e.g. "negotiate pricing") → rejected to `needs-human`.
+  - Job spec or returned artifact containing a secret/PII/exact-revenue token →
+    sanitise rejects in that direction.
+  - Returned GTM copy containing the bare word "key" in prose → NOT falsely
+    flagged (narrow scoping).
+- **Verification:** Only allowlisted classes dispatch; outbound-as-company is
+  blocked; sanitise gates both directions without false positives.
+
+### U5. Fail-closed verification gate
+
+- **Goal:** Verify every returned result against the job spec's acceptance
+  criteria + safety bounds before close; fail-closed on empty/absent work;
+  retry/escalate ladder on failure.
+- **Requirements:** R8, R9.
+- **Dependencies:** U3
+- **Files:** `pipeline/wgmesh_pipeline/gtm_lane/verify.py`,
+  `pipeline/tests/test_gtm_verify.py`
+- **Approach:** Combine a structured-proof check (proof artifact present + matches
+  the dispatched job) with an LLM-judge of the returned-work field against the
+  acceptance criteria — mirroring `pipeline/evals/impl_judge.py` (fail-closed,
+  bounded content). Default empty/absent/"not applicable" to **fail**, never pass.
+  Quality-only fail → bounded retry/re-dispatch; empty/absent or
+  security/high-risk → straight to `needs-human` (never climbed). Single-worker +
+  structured-proof for MVP; N-worker consensus redundancy is deferred (see Scope
+  Boundaries).
+- **Patterns to follow:** `pipeline/evals/impl_judge.py` (fail-closed judge,
+  `_truncate`); the empty-output failure class in
+  `docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md`.
+- **Execution note:** Prove the gate on a **real returned-work payload** (dump one
+  real judgment, confirm the judge saw the deliverable text) before trusting it;
+  add a test that feeds "API success + empty/garbage work" and confirm the gate
+  rejects (revert-the-fix check to confirm the test bites).
+- **Test scenarios:**
+  - Covers AE1. Returned work satisfies acceptance criteria + proof present → pass.
+  - Covers AE4. Returned work omits half the criteria → quality fail → bounded
+    retry, item stays open.
+  - Returned result empty / proof absent → fail-closed → escalate to
+    `needs-human`, never silent close.
+  - "Not applicable" rubric path → resolves to fail, not a passing default.
+  - Security/high-risk reason in returned artifact → straight to `needs-human`,
+    not retried.
+- **Verification:** No item closes without a verified, non-empty, proof-backed
+  result; failures retry or escalate per the ladder; the gate provably rejects
+  empty/garbage on a real payload.
+
+### U6. Budget envelope gate
+
+- **Goal:** Reserve estimated cost against a cofounder-approved envelope before
+  dispatch; cap attempts; park on exceed or no envelope.
+- **Requirements:** R10.
+- **Dependencies:** U3
+- **Files:** `pipeline/wgmesh_pipeline/gtm_lane/budget.py`,
+  `company/gtm-execution-state.json`, `pipeline/tests/test_gtm_budget.py`
+- **Approach:** Pre-dispatch **reservation** against a tracked envelope (config +
+  state file), plus a bounded-attempts ceiling — not a synchronous post-hoc dollar
+  cap (provider spend is async per U1). Record actual cost on close, reconcile the
+  reservation. Over-envelope or absent envelope → park + notify cofounder. Envelope
+  amount is a cofounder input (explicit assumption; placeholder + configurable).
+- **Patterns to follow:** bounded-attempts + cost-ceiling design in
+  `docs/solutions/design-decisions/multi-model-routing.md`; state-file pattern in
+  `company/social-drip-state.json`.
+- **Test scenarios:**
+  - Covers AE3. Job estimate exceeds remaining envelope → parked at the gate,
+    cofounder notified, no dispatch.
+  - No envelope configured → park, do not dispatch.
+  - Within envelope → reserved, dispatched; on close, actual cost reconciled
+    against the reservation.
+  - Bounded-attempts ceiling reached for one item → escalate, stop re-dispatching.
+- **Verification:** No dispatch occurs without a reservation inside a configured
+  envelope; spend is bounded by attempts, not a hoped synchronous dollar figure.
+
+### Phase C — Grounding, validation, ops
+
+### U7. WISDOM / GTM-learnings grounding
+
+- **Goal:** Ground the job-spec draft in a vendored GTM corpus via the shipped
+  learnings seam; fail-open; guard self-ingestion.
+- **Requirements:** R11, R12.
+- **Dependencies:** U3
+- **Files:** `docs/gtm-wisdom/` (vendored corpus distilled from
+  `ai-vektorius-lt/WISDOM.compiled.md`),
+  `pipeline/wgmesh_pipeline/gtm_lane/executor.py` (grounding call),
+  `pipeline/recipes/wgmesh-gtm-job-draft.yaml` (advisory block),
+  `pipeline/tests/test_gtm_grounding.py`
+- **Approach:** Reuse `select_learnings`/`write_learnings_file`
+  (`pipeline/wgmesh_pipeline/learnings.py`) keyed on the job/decision text, rooted
+  at the vendored corpus dir (the WISDOM source lives in a sibling repo and cannot
+  be globbed from this deploy — vendor a distilled copy in). Inject as a
+  dedicated advisory "known GTM playbook" block, not a deterministic match gate.
+  Fail-open: grounding absence never blocks a job. Guard against the corpus
+  ingesting the lane's own emitted jobs (self-ingestion).
+- **Patterns to follow:** `pipeline/wgmesh_pipeline/learnings.py` + its spec/implement
+  call sites (PR #1988); rich-grounding-block discipline in
+  `docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md`.
+- **Test scenarios:**
+  - Covers AE5. No matching GTM learning → empty grounding, job proceeds unchanged
+    (fail-open).
+  - A job whose text overlaps a vendored playbook entry → that entry rides in the
+    draft's advisory block.
+  - Grounding read error → caught, job proceeds (fail-open), not a lane failure.
+  - The lane's own emitted job artifacts are excluded from the corpus
+    (self-ingestion guard).
+- **Verification:** Relevant playbook guidance reaches the draft when present;
+  absence/error never blocks a job.
+
+### U8. Validation kit (positioning + Mom-Test)
+
+- **Goal:** Produce the cloudroof positioning frame and the Mom-Test discovery kit;
+  build the stargazer target list as a low-risk lane job. Actual conversations
+  deferred.
+- **Requirements:** R13, R14, R15.
+- **Dependencies:** U3 (the target-list-build runs as a lane job)
+- **Files:** `docs/gtm/cloudroof-positioning.md`,
+  `docs/gtm/mom-test-stargazers.md`
+- **Approach:** Author the positioning frame with the Obviously Awesome components
+  (competitive alternatives incl. self-hosting wgmesh, unique attributes, value,
+  target segment, category). Author the Mom-Test kit (past-behavior questions, not
+  pitch; target-segment definition). The stargazer target-list build is dispatched
+  as a low-risk job through the lane (U4 allowlist); the outbound conversations
+  themselves are deferred behind R6's risk boundary.
+- **Patterns to follow:** origin doc's validation-kit requirements; the WISDOM
+  corpus TRIGGER index (Obviously Awesome, Mom Test entries).
+- **Test scenarios:** Test expectation: none for the static docs (artifacts, not
+  behavior). The target-list-build job is exercised by U3/U4 dispatch tests.
+- **Verification:** Positioning frame names the alternatives incl. self-hosting and
+  a target segment; Mom-Test kit probes past behavior; target-list build runs as a
+  gated low-risk job; no outbound conversation is auto-run.
+
+### U9. Telemetry + capture memory-only learnings
+
+- **Goal:** Emit lane telemetry (cost, pass/fail, latency) to the pulse; capture
+  the two memory-only learnings as durable `docs/solutions/` entries.
+- **Requirements:** Advances R8–R10 observability; closes a known knowledge gap.
+- **Dependencies:** U5, U6
+- **Files:** `company/gtm-execution-state.json` (telemetry fields),
+  pulse config under `.compound-engineering/config.local.yaml`,
+  `docs/solutions/integration-issues/public-repo-third-party-pii.md` (new),
+  `docs/solutions/integration-issues/cloudflare-urllib-user-agent-block.md` (new)
+- **Approach:** Append best-effort telemetry (per the telemetry-must-be-best-effort
+  learning — a telemetry write must never block the lane). Surface the new
+  KPI line in the pulse. Author the two `docs/solutions/` entries (public-repo PII
+  handling; Cloudflare 1010 user-agent block) since this lane makes both
+  first-class.
+- **Patterns to follow:** best-effort write discipline (telemetry learning);
+  `company/social-drip-state.json` state shape; pulse metric-source config.
+- **Test scenarios:**
+  - A telemetry-write failure does not block or fail a lane run (best-effort).
+  - Telemetry records cost + pass/fail + latency per closed item.
+  - Test expectation: none for the two authored learning docs.
+- **Verification:** The pulse shows a GTM-lane KPI line; a telemetry outage doesn't
+  stall the lane; both learning docs exist.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- **Outbound GTM as the company** (cold outreach, posting, customer messaging) —
+  enabled only after the dispatch+verify loop is proven on low-risk jobs (R6).
+- **Actual stargazer validation conversations** — kit + target list prepared here;
+  running the conversations waits on the risk boundary.
+- **Installing the cloudroof code-build instance** — the executor for
+  code-buildable GTM (landing/signup); its own stalled brainstorm
+  (`docs/brainstorms/2026-06-22-cloudroof-service-funnel-requirements.md`). Parallel
+  dependency, not built here.
+- **WISDOM-injection into the decision-proposal recipe** — proposal quality is not
+  the constraint; revisit only if approved decisions start stalling on draft
+  quality rather than execution.
+
+### Outside this product's identity
+
+- **Cofounder-as-executor** — reverting GTM execution to a human-in-the-loop queue
+  contradicts the "no babysitting" thesis.
+- **Paywalling product capability** — monetization stays at the managed-service
+  layer per CONSTITUTION.md.
+- **Self-modifying GTM strategy** — the lane executes approved jobs; it does not
+  set pricing, strategy, or brand voice.
+
+### Deferred to Follow-Up Work
+
+- **N-worker consensus redundancy** for verification (assign the same job to
+  multiple workers, cross-validate) — MVP uses single-worker + structured-proof +
+  fail-closed check; add redundancy if single-worker quality proves insufficient.
+- **Webhook/callback ingestion** of provider results — MVP may poll; move to
+  webhooks if latency or polling cost warrants.
+
+---
+
+## Risk Analysis & Mitigation
+
+- **Off-execution-path no-op.** A lane wired but never actually draining the queue
+  (the repo's recurring failure mode). *Mitigation:* U3 characterization-first on
+  the queue-return path; verify a real item flows queue→closed against the fake,
+  and a real provider end-to-end in the spike.
+- **Fail-open masquerading as fail-closed.** The verify gate "fires" but scores an
+  empty field and defaults high. *Mitigation:* U5 proves the gate on a real
+  returned-work payload; empty/"not applicable" defaults to fail; revert-the-fix
+  test confirms it bites.
+- **Silent zeros.** Provider result-fetch returns empty and reads as "no work,
+  healthy." *Mitigation:* distinguish "0 jobs" from "fetch broke"; end-to-end
+  verify, never HEAD-200; stamp external refs `last_verified`.
+- **EU/GDPR + third-party PII.** Rented humans touch contact data over an external
+  API on a public repo. *Mitigation:* provider must have an EU DPA (U1 gate);
+  sanitise wall both directions (U4); never commit real contact data; capture the
+  PII learning (U9).
+- **Async spend overrun.** No synchronous dollar cap available. *Mitigation:*
+  pre-dispatch reservation + bounded-attempts ceiling (U6).
+- **External-API client quirks.** e.g. Cloudflare 1010 blocking default
+  user-agents. *Mitigation:* capture the CF learning (U9); set an explicit
+  user-agent on provider calls.
+
+---
+
+## Dependencies / Assumptions
+
+- **Load-bearing (U1 gate):** a provider with API dispatch + structured proof + EU
+  DPA + acceptable cost must exist. If none qualifies, the lane is not built and
+  this plan stops at U1.
+- **Assumption:** the spend envelope amount and refresh cadence are cofounder
+  inputs; the lane treats them as configurable placeholders.
+- **Assumption:** `company/scripts/sanitise.sh` can gate both job specs and
+  returned artifacts.
+- **Reuse:** the shipped `learnings.py` seam (PR #1988) grounds the job draft; the
+  decision-lane runner shape is the template for the executor.
+
+---
+
+## Open Questions
+
+### Resolve Before Planning
+
+- *(Resolved into U1.)* Which provider — handled as the gating spike.
+
+### Deferred to Implementation
+
+- Exact provider result/proof schema and how the verifier scores it (depends on the
+  U1-chosen provider).
+- Whether result ingestion polls or uses webhooks (Follow-Up Work).
+- The precise low-risk allowlist taxonomy may refine once the provider's supported
+  task types are known.
+
+---
+
+## Sources / Research
+
+- Origin: `docs/brainstorms/2026-06-24-gtm-rent-a-human-executor-requirements.md`.
+- Pulse trend: `docs/pulse-reports/2026-06-24_07-08.md` (0 customers, demand is
+  the gating constraint).
+- Provider landscape (external): Toloka (GDPR DPA + ISO 27701, full REST/SDK,
+  ~$0.10–0.50/task) ranked #1; Microworkers (EU HQ, GTM task types); HumanOps /
+  RentAHuman.ai (2026, MCP-native, pricing/GDPR unverified); avoid MTurk (US data
+  posture), Upwork/Fiverr (no autonomous dispatch). Prior art: ~300-task MTurk/
+  Toloka dispatch at ~$0.30/task with programmatic validation. Quality-via-
+  redundancy (3-worker cross-validate) and escrow-on-completion patterns noted.
+- Learnings (institutional): fail-closed-on-empty + LLM-judge empty-output
+  (`docs/solutions/logic-errors/langfuse-evaluators-scored-empty-output.md`);
+  hollow-green / deliverable-in-code
+  (`docs/solutions/runtime-errors/goose-weak-model-prints-spec-instead-of-writing.md`);
+  fail-closed routing + allowlist env + bounded-cost
+  (`docs/solutions/design-decisions/multi-model-routing.md`); silent-zeros +
+  end-to-end-verify (`docs/solutions/integration-issues/polar-checkout-404s-from-stale-config-2026-05-08.md`);
+  positive-gate + narrow-keyword scan
+  (`docs/solutions/integration-issues/autonomous-review-merge-bootstrap.md`);
+  rich-grounding-block
+  (`docs/solutions/logic-errors/capabilities-digest-grounds-loop-against-shipped-work.md`).
+- Reuse seam: `pipeline/wgmesh_pipeline/learnings.py`,
+  `pipeline/wgmesh_pipeline/decision_lane/proposal_runner.py`,
+  `pipeline/evals/impl_judge.py`, `company/scripts/sanitise.sh`,
+  `.github/workflows/wgmesh-social-drip.yml`.

--- a/docs/pulse-reports/2026-06-24_07-08.md
+++ b/docs/pulse-reports/2026-06-24_07-08.md
@@ -1,0 +1,53 @@
+# Product Pulse — ai-pipeline-template
+
+**Window:** 2026-06-23 04:51 → 2026-06-24 04:51 UTC (24h, 15m buffer)
+**Repos:** meta `ai-pipeline-template` · product `wgmesh` · service `cloudroof-eu`
+
+## Headlines
+
+- **Quietest, cleanest 24h in weeks.** CI green both repos — meta **26/26 success, 0
+  failures**; seed 1/1. Last pulse had 25 failures (5 meta + 20 seed); the vestigial
+  `Deploy Pipeline Box` / `Deploy Dashboard` red noise is gone from this window.
+- **wgmesh product backlog fully drained: 0 open issues** (was 14 + 9 aged). Only 2
+  fresh PRs in flight, both **spec-stage** and both service/GTM-topic (Umami analytics
+  #816, "cloudroof vs Headscale" comparison #818).
+- **Service surface came alive.** cloudroof now has 2 open PRs (#4 onboarding widget,
+  #5 impl-judge CI + wrangler deploy CD) — the "service funnel doesn't exist" gating
+  constraint flagged the last 4 pulses is now in-build.
+
+## Usage (product convergence)
+
+- **product_pr_merged (in-window): 0.** **autonomous_impl_merge_clean: 0.**
+  **paid_customer_added: 0.**
+- Convergence flat — but backlog is exhausted, not stuck (0 open seed issues).
+- **Meta merges: 4** — #1986 lang-triad roadmap doc, #1985 LLM-client timeout 60s→600s,
+  #1984 proposal-comment 5000-char cap, #1983 semantic dedup + Open-for-Vote fix.
+- Open seed PRs: **2** (#819/#820, both MERGEABLE, <48h, spec-stage).
+
+## System performance (action-success KPI — target 1.0)
+
+- **META: 0 failures / 26 runs (1.0).** Clean window; no vestigial-workflow red.
+- **SEED: 0 failures / 1 run.** Near-idle (backlog drained → little to build).
+- Sharp improvement vs last pulse (25 failures → 0). Whether this is genuine health or
+  simply low throughput is the open question.
+
+## Aged open items >48h (target 0 — BREACH: 15)
+
+- **Meta (15):** 10 PRs + 5 issues. Persistent: **3 strategy-drift audit PRs
+  #1862/1767/1733 — now 4th+ pulse dwelling >week.** Also heal-state chores
+  (#1963/1956/1950), plan/feat PRs (#1945/1928/1918/1914), issues #1599 (actions-retire),
+  #934 (supervisor-rank), #1946/1942/1932 (GTM/KPI/onboard).
+- **Seed (0).** Down from 23 last pulse.
+
+## Followups
+
+1. **wgmesh backlog = 0 open issues.** Convergence isn't stalled — it's done for the
+   current corpus. Next product work needs fresh observation-loop issue generation, or
+   focus genuinely shifts to service. Decide which.
+2. **Service surface is converging (cloudroof #4/#5).** The 4-pulse gating constraint is
+   finally in-build — watch it land.
+3. **3 strategy-drift audit PRs (#1862/1767/1733) dwelling >week, 4th+ pulse.**
+   Close-with-reason or act. Pure dwell defect.
+4. **2 seed spec PRs (#819/#820) are service/GTM-topic in the PRODUCT repo.** Umami +
+   Headscale-comparison are GTM/content — check surface routing didn't misfile them into
+   the wgmesh builder.

--- a/docs/solutions/gtm-playbook/core-four-warm-outreach.md
+++ b/docs/solutions/gtm-playbook/core-four-warm-outreach.md
@@ -1,0 +1,28 @@
+---
+title: "100M Leads: stargazers are warm — build the list before any outreach"
+category: gtm-playbook
+date: 2026-06-25
+tags: [outreach, lead-generation, list-building, core-four, warm, stargazer, signups, leads, rule-of-100]
+---
+
+# 100M Leads: stargazers are warm — build the list before any outreach
+
+## Problem
+
+A lead is worthless until engaged. The Core Four channels are warm outreach, post
+content, cold outreach, paid ads — and warm is cheapest. wgmesh stargazers already
+showed interest, so they are a warm list, not a cold one.
+
+## Approach
+
+- Build an engaged list first; outreach quality beats volume.
+- Warm-first: people who starred/forked/commented are reachable with context.
+- Rule of 100: sustained primary actions beat sporadic bursts.
+
+## Fix (for a rented-human job)
+
+A list-building job assembles the target list from public signals (stargazers,
+forkers, issue commenters) with: handle, public profile link, and the public
+signal that makes them warm — **no scraped private emails** (public-repo PII rule).
+Verifiable: each row cites a public signal. This is list-building only; the
+outbound contact itself stays gated until the dispatch+verify loop is proven.

--- a/docs/solutions/gtm-playbook/mom-test-discovery.md
+++ b/docs/solutions/gtm-playbook/mom-test-discovery.md
@@ -1,0 +1,29 @@
+---
+title: "Mom Test: discovery talks to past behaviour, never pitches"
+category: gtm-playbook
+date: 2026-06-25
+tags: [mom-test, discovery, lead-research, validation, interview, customer, outreach, stargazer, wtp]
+---
+
+# Mom Test: discovery talks to past behaviour, never pitches
+
+## Problem
+
+Asking people about your idea yields lies — opinions, compliments, and futures
+are over-optimistic. A discovery job that asks "would you pay for cloudroof?"
+collects fool's gold.
+
+## Approach
+
+- Ask about their **life and past behaviour**, not your idea. "How do you host
+  your mesh today?" beats "would you use a managed host?"
+- Anchor generics to specifics: "when did that last happen?" / "what did you try?"
+- Treat compliments and "I would totally…" as a NO; a "meh" carries more signal.
+- End every talk with "who else should I talk to?"
+
+## Fix (for a rented-human job)
+
+A discovery/lead-research job collects: what the contact does today, what they've
+already paid for or built as a workaround, and the cost of that workaround — as
+verbatim quotes, no pitch, no leading questions. Verifiable: each row cites a real
+past action, not a hypothetical.

--- a/docs/solutions/gtm-playbook/obviously-awesome-positioning.md
+++ b/docs/solutions/gtm-playbook/obviously-awesome-positioning.md
@@ -1,0 +1,28 @@
+---
+title: "Obviously Awesome: name the alternatives or value is invisible"
+category: gtm-playbook
+date: 2026-06-25
+tags: [positioning, obviously-awesome, competitor-recon, comparison, alternatives, category, cloudroof, headscale, value]
+---
+
+# Obviously Awesome: name the alternatives or value is invisible
+
+## Problem
+
+A product's value is only obvious inside its best frame of reference. For
+cloudroof, the fiercest competitor is "do nothing / self-host wgmesh free" — if
+the alternatives aren't named, the value of managed hosting is invisible.
+
+## Approach
+
+Positioning components, in order: competitive alternatives → unique attributes →
+value (with proof) → target-segment characteristics → market category. The
+alternatives the customer would otherwise pick (self-host, Headscale, Tailscale)
+define the frame; attributes are "unique" only relative to them.
+
+## Fix (for a rented-human job)
+
+A competitor-recon job gathers, per alternative (Headscale / Tailscale / self-host):
+install path, who it's for, what it costs in time/money, and the friction a
+managed host removes. Verifiable: one row per named alternative with sourced facts,
+no marketing copy. Feeds the cloudroof positioning frame and the "vs" comparison.

--- a/docs/solutions/integration-issues/cloudflare-urllib-user-agent-block.md
+++ b/docs/solutions/integration-issues/cloudflare-urllib-user-agent-block.md
@@ -1,0 +1,35 @@
+---
+title: "Cloudflare error 1010 / 403 blocks default urllib User-Agent; set an explicit UA"
+category: integration-issues
+date: 2026-06-25
+tags: [cloudflare, user-agent, urllib, http-403, error-1010, external-api, bot-block, gtm]
+---
+
+# Cloudflare error 1010 / 403 blocks default urllib User-Agent
+
+## Problem
+
+Calling a Cloudflare-fronted API with Python's default `urllib` User-Agent returns
+HTTP 403 with "error code 1010" — CF blocks the known bot UA. `curl` to the same
+endpoint works, which masks the cause. Any external provider API (Toloka,
+Microworkers, HumanOps, etc.) the GTM lane calls may sit behind Cloudflare.
+
+## Root Cause
+
+Cloudflare bot-management fingerprints and blocks default library User-Agents
+(`Python-urllib/x.y`). The request never reaches the origin; the 403 is from CF.
+
+## Fix / Prevention
+
+- Set an **explicit, non-default `User-Agent`** header on every external provider
+  HTTP call (a real browser-like or named-app UA).
+- Prefer a maintained HTTP client (`requests`/`httpx`) which is less likely to use
+  the flagged default, but still set an explicit UA.
+- When an external call 403s but `curl` works, suspect UA/CF before auth.
+- Stamp cached endpoint/IDs with `last_verified` and re-discover via the API at
+  call time (the stale-config / silent-rot lesson).
+
+## Related
+
+- Provider adapter external-call hygiene: `pipeline/wgmesh_pipeline/gtm_lane/provider.py`
+- `docs/solutions/integration-issues/polar-checkout-404s-from-stale-config-2026-05-08.md`

--- a/docs/solutions/integration-issues/public-repo-third-party-pii.md
+++ b/docs/solutions/integration-issues/public-repo-third-party-pii.md
@@ -1,0 +1,38 @@
+---
+title: "Don't commit third-party PII to a public repo; GitGuardian is alert-only"
+category: integration-issues
+date: 2026-06-25
+tags: [pii, public-repo, privacy, gdpr, gitguardian, outreach, stargazer, sanitise, gtm]
+---
+
+# Don't commit third-party PII to a public repo; GitGuardian is alert-only
+
+## Problem
+
+This is a **public** repo. Committing real third-party emails or contact data
+(e.g. scraped stargazer emails) leaks PII and risks GDPR exposure. GitHub/
+GitGuardian secret scanning is **alert-only** — it warns after the fact, it does
+not block the commit. The GTM lane, which builds lead lists and may handle EU
+contacts, makes this a first-class concern.
+
+## Root Cause
+
+No commit-time gate stops PII. Relying on a post-hoc scanner means the data is
+already public by the time the alert fires; git history keeps it even after a
+"delete".
+
+## Fix / Prevention
+
+- **List-building collects public signals only** — handle, public profile link,
+  and the public signal (starred/forked/commented). Never scraped private emails.
+- Route real contact data through the **sanitise wall** (`company/scripts/sanitise.sh`)
+  in both directions; it warns on email patterns and fails-closed on secrets.
+- Treat any rented-human job that would collect PII as **needs-human / high-risk**,
+  not a low-risk auto-dispatch.
+- Provider handling EU data must have an Article 28 DPA (the cloudroof/GTM provider
+  gate — see `docs/gtm/provider-feasibility.md`).
+
+## Related
+
+- `docs/solutions/gtm-playbook/core-four-warm-outreach.md` (public-signal list-building)
+- GTM rent-a-human lane plan: `docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md`

--- a/pipeline/recipes/wgmesh-gtm-job-draft.yaml
+++ b/pipeline/recipes/wgmesh-gtm-job-draft.yaml
@@ -1,0 +1,65 @@
+version: "1.0.0"
+title: "wgmesh GTM Job Draft"
+description: "Turn an approved low-risk GTM decision into a structured job spec for a rented human."
+parameters:
+  - key: item_title
+    input_type: string
+    requirement: required
+    description: "Title of the approved surface:service decision item."
+  - key: brief_file
+    input_type: string
+    requirement: required
+    description: "Path to the decision brief markdown, or empty."
+  - key: strategy_file
+    input_type: string
+    requirement: required
+    description: "Path to STRATEGY.md for company grounding."
+  - key: learnings_file
+    input_type: string
+    requirement: required
+    description: "Path to a GTM playbook (known-good angles/pitfalls) file, or empty if none."
+  - key: job_spec_file
+    input_type: string
+    requirement: required
+    description: "Repository-relative path where the JSON job spec must be written."
+prompt: |
+  You are drafting a work order for a RENTED HUMAN worker (a microtask/VA service),
+  not an engineer. Turn the approved GTM decision into a small, concrete, low-risk
+  job a stranger can complete and prove.
+
+  Decision: {{ item_title }}
+  A decision brief may be at: {{ brief_file }} — if non-empty, READ it first.
+  Company strategy grounding: {{ strategy_file }}.
+
+  A file of known GTM playbook guidance (proven angles / documented pitfalls) may be
+  at: {{ learnings_file }}. If non-empty, READ it and shape the job to follow it;
+  it is advisory context, never copy it into the job spec. If empty, proceed without it.
+
+  Write a JSON job spec to this exact repository-relative path: {{ job_spec_file }}
+  with these keys:
+    - "id": a short stable id derived from the decision
+    - "task": one clear instruction a non-expert can follow start to finish
+    - "acceptance_criteria": a list of concrete, checkable conditions the returned
+      work must satisfy (counts, fields, format) so completion can be verified
+    - "safety_bounds": a list of hard limits (e.g. "no PII collected", "no outbound
+      contact", "public sources only")
+    - "job_class": one of: lead_research, list_building, manual_signup, content_qa,
+      competitor_recon, data_entry
+    - "payload": an object with any inputs the worker needs
+
+  Rules:
+  - Create parent directories if needed; write the file, do not only print it.
+  - Keep it a LOW-RISK job. Never draft outbound contact as the company, posting,
+    or anything touching customer PII or exact revenue.
+  - Acceptance criteria must be verifiable from the returned artifact alone.
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+settings:
+  goose_provider: anthropic
+  goose_model: GLM-5.2

--- a/pipeline/tests/test_gtm_budget.py
+++ b/pipeline/tests/test_gtm_budget.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.budget import (
+    AttemptsExhausted,
+    BudgetExceeded,
+    BudgetGate,
+    Envelope,
+)
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus, execute_item
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+
+
+def _spec() -> JobSpec:
+    return JobSpec(id="j1", task="t", acceptance_criteria=("c",), job_class="data_entry")
+
+
+def _gate(total=10.0, est=0.5, max_attempts=3) -> BudgetGate:
+    return BudgetGate(envelope=Envelope(total=total, spent=0.0), per_job_estimate=est, max_attempts=max_attempts)
+
+
+# --- reservation ------------------------------------------------------------
+
+
+def test_within_envelope_reserves_and_spends() -> None:
+    gate = _gate(total=10.0, est=0.5)
+    gate.reserve("j1")
+    assert gate.envelope.spent == pytest.approx(0.5)
+    assert gate.envelope.remaining == pytest.approx(9.5)
+
+
+def test_over_envelope_raises() -> None:  # AE3
+    gate = _gate(total=0.3, est=0.5)
+    with pytest.raises(BudgetExceeded):
+        gate.reserve("j1")
+    assert gate.envelope.spent == 0.0  # nothing reserved on rejection
+
+
+def test_no_envelope_raises() -> None:
+    gate = _gate(total=0.0, est=0.5)
+    with pytest.raises(BudgetExceeded):
+        gate.reserve("j1")
+
+
+def test_reconcile_adjusts_spend_on_close() -> None:
+    gate = _gate(total=10.0, est=0.5)
+    gate.reserve("j1")  # reserved 0.5
+    gate.reconcile("j1", actual=0.3)  # actual cheaper
+    assert gate.envelope.spent == pytest.approx(0.3)
+
+
+def test_reserve_is_idempotent_per_job() -> None:
+    # a retry of the same job must NOT double-reserve (the drain-3x cascade)
+    gate = _gate(total=10.0, est=0.5)
+    gate.reserve("j1")
+    gate.reserve("j1")
+    gate.reserve("j1")
+    assert gate.envelope.spent == pytest.approx(0.5)  # held once
+
+
+def test_release_returns_held_estimate() -> None:
+    gate = _gate(total=10.0, est=0.5)
+    gate.reserve("j1")
+    gate.release("j1")
+    assert gate.envelope.spent == pytest.approx(0.0)
+    # after release the job can reserve again
+    gate.reserve("j1")
+    assert gate.envelope.spent == pytest.approx(0.5)
+
+
+# --- bounded attempts -------------------------------------------------------
+
+
+def test_attempts_ceiling_exhausts() -> None:
+    gate = _gate(max_attempts=2)
+    gate.record_attempt("j1")
+    gate.record_attempt("j1")
+    with pytest.raises(AttemptsExhausted):
+        gate.record_attempt("j1")
+
+
+# --- executor integration ---------------------------------------------------
+
+
+def test_over_budget_parks_not_dispatched() -> None:  # AE3
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="ok", proof="p"))
+    gate = _gate(total=0.1, est=0.5)
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate)
+    assert outcome.status is ItemStatus.PARKED
+    assert fake.dispatch_count == 0
+
+
+def test_within_budget_dispatches() -> None:
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="ok", proof="p"))
+    gate = _gate(total=10.0, est=0.5)
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate)
+    assert outcome.status is ItemStatus.CLOSED
+    assert fake.dispatch_count == 1
+    assert gate.envelope.spent == pytest.approx(0.5)
+
+
+def test_retrying_item_does_not_double_spend() -> None:
+    # verify RETRY → REQUEUED; re-running the same item must hold ONE reservation,
+    # not accumulate per attempt (the drain cascade the review flagged)
+    from wgmesh_pipeline.gtm_lane.verify import Verifier
+
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="x", proof="p"))
+    v = Verifier(judge=lambda _s, _r: False, sanitiser=lambda _t: True)  # always RETRY
+    gate = _gate(total=10.0, est=0.5, max_attempts=5)
+    for _ in range(3):
+        out = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate, verifier=v)
+        assert out.status is ItemStatus.REQUEUED
+    assert gate.envelope.spent == pytest.approx(0.5)  # one reservation across retries
+
+
+def test_escalated_item_releases_reservation() -> None:
+    from wgmesh_pipeline.gtm_lane.verify import Verifier
+
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="", proof="p"))  # empty → ESCALATE
+    v = Verifier(judge=lambda _s, _r: True, sanitiser=lambda _t: True)
+    gate = _gate(total=10.0, est=0.5)
+    out = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate, verifier=v)
+    assert out.status is ItemStatus.ESCALATED
+    assert gate.envelope.spent == pytest.approx(0.0)  # reservation released, not stranded
+
+
+def test_closed_reconciles_to_reported_cost() -> None:
+    from wgmesh_pipeline.gtm_lane.verify import Verifier
+
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="x", proof="p", cost_estimate=0.2))
+    v = Verifier(judge=lambda _s, _r: True, sanitiser=lambda _t: True)
+    gate = _gate(total=10.0, est=0.5)
+    out = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate, verifier=v)
+    assert out.status is ItemStatus.CLOSED
+    assert gate.envelope.spent == pytest.approx(0.2)  # reconciled estimate→actual
+
+
+def test_attempts_exhausted_parks() -> None:
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="ok", proof="p"))
+    gate = _gate(total=10.0, est=0.5, max_attempts=1)
+    gate.record_attempt("j1")  # pre-exhaust
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, budget=gate)
+    assert outcome.status is ItemStatus.PARKED
+    assert fake.dispatch_count == 0

--- a/pipeline/tests/test_gtm_executor.py
+++ b/pipeline/tests/test_gtm_executor.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus, execute_item
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec, parse_job_spec
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+
+
+def _item(item_id: str = "item-1") -> dict:
+    return {"id": item_id, "title": "Build competitor pricing sheet", "content": "5 rows"}
+
+
+def _draft(item) -> JobSpec:
+    return JobSpec(
+        id=str(item["id"]),
+        task="build a 5-row competitor pricing sheet",
+        acceptance_criteria=("5 rows", "one column per competitor"),
+        safety_bounds=("no PII",),
+        job_class="competitor_recon",
+    )
+
+
+# --- characterization: fail-open queue-return (write FIRST) ----------------
+
+
+def test_draft_failure_requeues_item_unchanged() -> None:
+    def boom(_item):
+        raise RuntimeError("draft exploded")
+
+    fake = FakeProvider()
+    outcome = execute_item(_item(), draft_fn=boom, provider=fake)
+    assert outcome.status is ItemStatus.REQUEUED  # fail-open, not raised
+    assert fake.dispatch_count == 0  # never dispatched
+    assert outcome.item == _item()  # item returned unchanged
+
+
+def test_dispatch_failure_requeues_item_unchanged() -> None:
+    class ExplodingProvider(FakeProvider):
+        def dispatch(self, job_spec):
+            raise RuntimeError("provider down")
+
+    outcome = execute_item(_item(), draft_fn=_draft, provider=ExplodingProvider())
+    assert outcome.status is ItemStatus.REQUEUED
+    assert outcome.item == _item()
+
+
+def test_execute_item_never_raises_on_internal_error() -> None:
+    def boom(_item):
+        raise ValueError("anything")
+
+    # the lane must never propagate — a queued decision is never lost
+    outcome = execute_item(_item(), draft_fn=boom, provider=FakeProvider())
+    assert outcome.status is ItemStatus.REQUEUED
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_completed_result_closes_item() -> None:
+    fake = FakeProvider()
+    fake.script("item-1", JobResult(state=ResultState.COMPLETED, payload={"rows": 5}, proof="url"))
+    outcome = execute_item(_item("item-1"), draft_fn=_draft, provider=fake)
+    assert outcome.status is ItemStatus.CLOSED
+    assert outcome.result.state is ResultState.COMPLETED
+
+
+@pytest.mark.parametrize("state", [ResultState.EMPTY, ResultState.PENDING, ResultState.GARBAGE])
+def test_non_completed_result_does_not_close(state: ResultState) -> None:
+    fake = FakeProvider()
+    fake.script("item-1", JobResult(state=state))
+    outcome = execute_item(_item("item-1"), draft_fn=_draft, provider=fake)
+    assert outcome.status is not ItemStatus.CLOSED  # only verified-complete closes
+
+
+# --- job_spec parsing -------------------------------------------------------
+
+
+def test_parse_job_spec_from_json() -> None:
+    text = (
+        '{"id": "x", "task": "do thing", "acceptance_criteria": ["a", "b"], '
+        '"safety_bounds": ["no PII"], "job_class": "data_entry"}'
+    )
+    spec = parse_job_spec(text)
+    assert spec.id == "x"
+    assert spec.acceptance_criteria == ("a", "b")
+    assert spec.job_class == "data_entry"
+
+
+def test_parse_job_spec_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        parse_job_spec("")

--- a/pipeline/tests/test_gtm_grounding.py
+++ b/pipeline/tests/test_gtm_grounding.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from wgmesh_pipeline.learnings import select_learnings, write_learnings_file
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_gtm_query_finds_vendored_playbook_entry() -> None:
+    # a GTM list-building/outreach job grounds on the Core Four playbook entry
+    blob = select_learnings("build a warm stargazer outreach lead list", root=REPO_ROOT)
+    assert blob
+    assert "stargazers are warm" in blob.lower() or "core four" in blob.lower()
+
+
+def test_positioning_query_finds_obviously_awesome() -> None:
+    blob = select_learnings(
+        "competitor recon: cloudroof vs headscale alternatives comparison", root=REPO_ROOT
+    )
+    assert "alternatives" in blob.lower()
+
+
+def test_unrelated_query_grounds_empty() -> None:
+    # fail-open: no GTM match → empty, never an error
+    assert select_learnings("xyzzy unrelated frobnicate nonsense", root=REPO_ROOT) == ""
+
+
+def test_write_learnings_file_for_gtm_job() -> None:
+    path = write_learnings_file("warm stargazer outreach list building", root=REPO_ROOT)
+    try:
+        assert path  # vendored corpus matched → a grounding file exists
+        assert "Past learning:" in Path(path).read_text()
+    finally:
+        if path:
+            os.unlink(path)

--- a/pipeline/tests/test_gtm_lane.py
+++ b/pipeline/tests/test_gtm_lane.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.budget import BudgetGate, Envelope
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.lane import GtmLane
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+from wgmesh_pipeline.gtm_lane.safety import SafetyGate
+from wgmesh_pipeline.gtm_lane.verify import Verifier
+
+
+def _lane(provider, *, total=10.0, est=0.5, job_class="competitor_recon", telemetry=None) -> GtmLane:
+    def draft(_item) -> JobSpec:
+        return JobSpec(id="j1", task="t", acceptance_criteria=("c",), job_class=job_class)
+
+    return GtmLane(
+        provider=provider,
+        draft_fn=draft,
+        safety=SafetyGate(sanitiser=lambda _t: True),
+        budget=BudgetGate(envelope=Envelope(total=total), per_job_estimate=est),
+        verifier=Verifier(judge=lambda _s, _r: True, sanitiser=lambda _t: True),
+        telemetry_path=telemetry,
+    )
+
+
+def test_lane_requires_all_gates() -> None:
+    # the assembly must fail loudly if a gate is omitted (no silent None default)
+    with pytest.raises(TypeError):
+        GtmLane(provider=FakeProvider(), draft_fn=lambda _i: None)  # type: ignore[call-arg]
+
+
+def test_lane_happy_path_closes_and_records_telemetry(tmp_path: Path) -> None:
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="x", proof="p", cost_estimate=0.3))
+    state = tmp_path / "gtm-state.json"
+    lane = _lane(fake, telemetry=state)
+    out = lane.run({"id": "i1"})
+    assert out.status is ItemStatus.CLOSED
+    assert fake.dispatch_count == 1
+    assert json.loads(state.read_text())["counts"]["closed"] == 1
+
+
+def test_lane_disallowed_class_escalates_not_dispatched() -> None:
+    fake = FakeProvider()
+    lane = _lane(fake, job_class="cold_outreach")
+    out = lane.run({"id": "i1"})
+    assert out.status is ItemStatus.ESCALATED
+    assert fake.dispatch_count == 0
+
+
+def test_lane_over_budget_parks() -> None:
+    fake = FakeProvider()
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload="x", proof="p"))
+    lane = _lane(fake, total=0.1, est=0.5)
+    out = lane.run({"id": "i1"})
+    assert out.status is ItemStatus.PARKED
+    assert fake.dispatch_count == 0

--- a/pipeline/tests/test_gtm_provider.py
+++ b/pipeline/tests/test_gtm_provider.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.provider import (
+    JobResult,
+    ResultState,
+    provider_env,
+)
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+
+
+def _job(job_id: str = "job-1") -> dict:
+    return {"id": job_id, "task": "build a 5-row competitor sheet", "payload": {}}
+
+
+def test_dispatch_returns_handle_then_fetch_completed() -> None:
+    fake = FakeProvider()
+    fake.script("job-1", JobResult(state=ResultState.COMPLETED, payload={"rows": 5}, proof="sheet-url"))
+    handle = fake.dispatch(_job("job-1"))
+    assert handle
+    result = fake.fetch_result(handle)
+    assert result.state is ResultState.COMPLETED
+    assert result.payload == {"rows": 5}
+    assert result.proof == "sheet-url"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [ResultState.EMPTY, ResultState.GARBAGE, ResultState.PENDING],
+)
+def test_non_completed_states_reported_distinctly(state: ResultState) -> None:
+    fake = FakeProvider()
+    fake.script("job-1", JobResult(state=state))
+    handle = fake.dispatch(_job("job-1"))
+    result = fake.fetch_result(handle)
+    assert result.state is state  # no coercion to COMPLETED
+    if state is not ResultState.COMPLETED:
+        assert not result.payload
+
+
+def test_dispatch_is_idempotent_on_job_id() -> None:
+    fake = FakeProvider()
+    h1 = fake.dispatch(_job("job-1"))
+    h2 = fake.dispatch(_job("job-1"))  # same id → same handle, no double dispatch
+    assert h1 == h2
+    assert fake.dispatch_count == 1
+
+
+def test_provider_env_allowlist_passes_named_keys() -> None:
+    src = {"TOLOKA_TOKEN": "t", "SECRET_OTHER": "x", "PATH": "/bin"}
+    env = provider_env({"TOLOKA_TOKEN"}, source=src)
+    assert env == {"TOLOKA_TOKEN": "t"}  # allowlist: only named keys, fail-closed
+
+
+def test_provider_env_missing_required_key_raises() -> None:
+    with pytest.raises(KeyError):
+        provider_env({"TOLOKA_TOKEN"}, source={"PATH": "/bin"})

--- a/pipeline/tests/test_gtm_safety.py
+++ b/pipeline/tests/test_gtm_safety.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus, execute_item
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+from wgmesh_pipeline.gtm_lane.safety import (
+    SafetyGate,
+    SafetyRejection,
+    run_sanitise,
+)
+
+REPO_ROOT = __import__("pathlib").Path(__file__).resolve().parents[2]
+SANITISE = REPO_ROOT / "company" / "scripts" / "sanitise.sh"
+
+
+def _spec(job_class: str = "competitor_recon", task: str = "build a 5-row sheet") -> JobSpec:
+    return JobSpec(id="j1", task=task, acceptance_criteria=("5 rows",), job_class=job_class)
+
+
+# --- job-class allowlist ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cls", ["lead_research", "list_building", "manual_signup", "content_qa", "competitor_recon", "data_entry"]
+)
+def test_allowlisted_classes_pass(cls: str) -> None:
+    SafetyGate(sanitiser=lambda _t: True).check(_spec(job_class=cls))  # no raise
+
+
+def test_non_allowlisted_class_rejected() -> None:
+    with pytest.raises(SafetyRejection):
+        SafetyGate(sanitiser=lambda _t: True).check(_spec(job_class="pricing_negotiation"))
+
+
+def test_outbound_class_rejected() -> None:
+    with pytest.raises(SafetyRejection):
+        SafetyGate(sanitiser=lambda _t: True).check(_spec(job_class="cold_outreach"))
+
+
+# --- sanitise wall (real script, both directions) ---------------------------
+
+
+def test_sanitise_rejects_secret() -> None:
+    # a Stripe live-key pattern must trip the wall. Assembled at runtime so the
+    # literal never lands in source (GitHub push protection flags the contiguous
+    # token even as a test fixture).
+    secret = "sk_" + "live_" + "a" * 24
+    assert run_sanitise(f"token {secret}", script=SANITISE) is False
+
+
+def test_sanitise_allows_clean_text_with_bare_key_word() -> None:
+    # narrow scoping: the bare word "key" in prose must NOT be flagged
+    assert run_sanitise("press any key to continue, no secrets here", script=SANITISE) is True
+
+
+def test_gate_rejects_spec_carrying_secret() -> None:
+    gate = SafetyGate(sanitiser=lambda t: run_sanitise(t, script=SANITISE))
+    token = "ghp" + "_" + "0" * 36  # GitHub-PAT pattern, assembled at runtime
+    bad = JobSpec(id="j1", task=f"use {token}", acceptance_criteria=(), job_class="data_entry")
+    with pytest.raises(SafetyRejection):
+        gate.check(bad)
+
+
+# --- executor integration: disallowed class escalates, never dispatches -----
+
+
+def test_disallowed_job_escalates_not_dispatched() -> None:
+    fake = FakeProvider()
+    fake.script("item-1", JobResult(state=ResultState.COMPLETED, payload={"x": 1}, proof="p"))
+    gate = SafetyGate(sanitiser=lambda _t: True)
+
+    def draft(_item) -> JobSpec:
+        return _spec(job_class="cold_outreach")  # outbound-as-company
+
+    outcome = execute_item({"id": "item-1"}, draft_fn=draft, provider=fake, safety=gate)
+    assert outcome.status is ItemStatus.ESCALATED
+    assert fake.dispatch_count == 0  # never dispatched
+
+
+def test_allowed_job_with_gate_still_dispatches_and_closes() -> None:
+    fake = FakeProvider()
+    # the fake keys results by the dispatched job_spec.id ("j1"), not the item id
+    fake.script("j1", JobResult(state=ResultState.COMPLETED, payload={"x": 1}, proof="p"))
+    gate = SafetyGate(sanitiser=lambda _t: True)
+    outcome = execute_item({"id": "item-1"}, draft_fn=lambda _i: _spec(), provider=fake, safety=gate)
+    assert outcome.status is ItemStatus.CLOSED
+    assert fake.dispatch_count == 1

--- a/pipeline/tests/test_gtm_telemetry.py
+++ b/pipeline/tests/test_gtm_telemetry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus
+from wgmesh_pipeline.gtm_lane.telemetry import record_outcome
+
+
+def test_records_status_counts_and_cost(tmp_path: Path) -> None:
+    state = tmp_path / "gtm-execution-state.json"
+    record_outcome(ItemStatus.CLOSED, state_path=state, cost=0.4)
+    record_outcome(ItemStatus.CLOSED, state_path=state, cost=0.6)
+    record_outcome(ItemStatus.ESCALATED, state_path=state)
+    data = json.loads(state.read_text())
+    assert data["counts"]["closed"] == 2
+    assert data["counts"]["escalated"] == 1
+    assert data["total_cost"] == 0.4 + 0.6
+
+
+def test_write_failure_is_best_effort(tmp_path: Path) -> None:
+    # an unwritable path must NOT raise — telemetry must never block the lane
+    bad = tmp_path / "nonexistent-dir" / "state.json"  # parent missing
+    # should silently no-op, not raise
+    record_outcome(ItemStatus.CLOSED, state_path=bad, cost=1.0, make_parents=False)
+
+
+def test_records_latency_when_given(tmp_path: Path) -> None:
+    state = tmp_path / "s.json"
+    record_outcome(ItemStatus.CLOSED, state_path=state, cost=0.1, latency_s=12.5)
+    data = json.loads(state.read_text())
+    assert data["last_latency_s"] == 12.5

--- a/pipeline/tests/test_gtm_verify.py
+++ b/pipeline/tests/test_gtm_verify.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus, execute_item
+from wgmesh_pipeline.gtm_lane.fake_provider import FakeProvider
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+from wgmesh_pipeline.gtm_lane.verify import VerifyOutcome, Verifier
+
+
+def _spec() -> JobSpec:
+    return JobSpec(id="j1", task="build a 5-row sheet", acceptance_criteria=("5 rows",), job_class="competitor_recon")
+
+
+def _completed(payload="5 rows of data", proof="sheet-url") -> JobResult:
+    return JobResult(state=ResultState.COMPLETED, payload=payload, proof=proof)
+
+
+_CLEAN = lambda _t: True  # noqa: E731
+_PASS_JUDGE = lambda _s, _r: True  # noqa: E731
+_FAIL_JUDGE = lambda _s, _r: False  # noqa: E731
+
+
+# --- fail-closed gates fire BEFORE the judge --------------------------------
+
+
+def test_completed_proof_and_judge_pass_is_pass() -> None:  # AE1
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    assert v.verify(_spec(), _completed()).outcome is VerifyOutcome.PASS
+
+
+def test_quality_fail_when_judge_rejects() -> None:  # AE4
+    v = Verifier(judge=_FAIL_JUDGE, sanitiser=_CLEAN)
+    assert v.verify(_spec(), _completed()).outcome is VerifyOutcome.RETRY
+
+
+def test_empty_payload_escalates_without_consulting_judge() -> None:
+    consulted = []
+
+    def judge(_s, _r):
+        consulted.append(1)
+        return True
+
+    v = Verifier(judge=judge, sanitiser=_CLEAN)
+    out = v.verify(_spec(), _completed(payload="")).outcome
+    assert out is VerifyOutcome.ESCALATE  # fail-closed on empty
+    assert not consulted  # judge never reached
+
+
+def test_absent_proof_escalates() -> None:
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    assert v.verify(_spec(), _completed(proof=None)).outcome is VerifyOutcome.ESCALATE
+
+
+@pytest.mark.parametrize("state", [ResultState.EMPTY, ResultState.GARBAGE])
+def test_empty_or_garbage_state_escalates(state: ResultState) -> None:
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    assert v.verify(_spec(), JobResult(state=state)).outcome is VerifyOutcome.ESCALATE
+
+
+def test_pending_state_retries() -> None:
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    assert v.verify(_spec(), JobResult(state=ResultState.PENDING)).outcome is VerifyOutcome.RETRY
+
+
+def test_returned_artifact_tripping_sanitise_escalates() -> None:
+    # a secret in the returned work is a security reason → straight to escalate
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=lambda _t: False)
+    assert v.verify(_spec(), _completed()).outcome is VerifyOutcome.ESCALATE
+
+
+def test_judge_raising_is_fail_closed() -> None:
+    def boom(_s, _r):
+        raise RuntimeError("judge error")
+
+    v = Verifier(judge=boom, sanitiser=_CLEAN)
+    # a judge error must not pass — fail-closed to retry, never silent close
+    assert v.verify(_spec(), _completed()).outcome is not VerifyOutcome.PASS
+
+
+# --- executor integration: ladder maps outcomes to item status -------------
+
+
+def test_executor_pass_closes() -> None:
+    fake = FakeProvider()
+    fake.script("j1", _completed())
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, verifier=v)
+    assert outcome.status is ItemStatus.CLOSED
+
+
+def test_executor_quality_fail_requeues() -> None:
+    fake = FakeProvider()
+    fake.script("j1", _completed())
+    v = Verifier(judge=_FAIL_JUDGE, sanitiser=_CLEAN)
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, verifier=v)
+    assert outcome.status is ItemStatus.REQUEUED
+
+
+def test_executor_empty_escalates() -> None:
+    fake = FakeProvider()
+    fake.script("j1", _completed(payload=""))
+    v = Verifier(judge=_PASS_JUDGE, sanitiser=_CLEAN)
+    outcome = execute_item({"id": "i1"}, draft_fn=lambda _i: _spec(), provider=fake, verifier=v)
+    assert outcome.status is ItemStatus.ESCALATED

--- a/pipeline/tests/test_learnings.py
+++ b/pipeline/tests/test_learnings.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from wgmesh_pipeline import learnings as learnings_mod
+from wgmesh_pipeline.learnings import (
+    _BLOCK_HEADER,
+    select_learnings,
+    write_learnings_file,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(root: Path, rel: str, *, title: str, tags: list[str], date: str, body: str) -> None:
+    """Build a docs/solutions corpus file under ``root`` with YAML frontmatter."""
+    path = root / "docs" / "solutions" / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = (
+        "---\n"
+        f'title: "{title}"\n'
+        f"category: {path.parent.name}\n"
+        f"date: {date}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+    path.write_text(fm, encoding="utf-8")
+
+
+# --- scenarios against the real, committed corpus -------------------------
+
+
+def test_query_overlapping_tags_ranks_matching_learning_first() -> None:
+    blob = select_learnings(
+        "goose weak model prints spec to stdout instead of writing the file",
+        root=REPO_ROOT,
+    )
+    assert blob  # non-empty
+    assert _BLOCK_HEADER in blob
+    # the goose-weak-model learning must be the first block
+    first_header = blob.index(_BLOCK_HEADER)
+    head = blob[first_header : first_header + 200].lower()
+    assert "goose" in head and "spec" in head
+
+
+def test_query_matching_nothing_returns_empty() -> None:
+    assert select_learnings("xyzzy quux frobnicate nonsense", root=REPO_ROOT) == ""
+
+
+def test_empty_query_returns_empty() -> None:
+    assert select_learnings("", root=REPO_ROOT) == ""
+
+
+# --- scenarios against controlled tmp corpora -----------------------------
+
+
+def test_max_items_caps_returned_blocks(tmp_path: Path) -> None:
+    for i in range(5):
+        _write(
+            tmp_path,
+            f"logic-errors/entry-{i}.md",
+            title=f"Widget pipeline learning {i}",
+            tags=["widget", "pipeline", "shared"],
+            date=f"2026-06-0{i + 1}",
+            body="## Problem\nThing broke.\n\n## Fix\nFixed it.",
+        )
+    blob = select_learnings("widget pipeline shared", root=tmp_path, max_items=2)
+    assert blob.count(_BLOCK_HEADER) == 2
+
+
+def test_max_chars_truncates_at_boundary_with_marker(tmp_path: Path) -> None:
+    long_body = "\n".join(f"line {n} about widgets" for n in range(200))
+    _write(
+        tmp_path,
+        "logic-errors/huge.md",
+        title="Widget overflow learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body=f"## Problem\n{long_body}",
+    )
+    blob = select_learnings("widget", root=tmp_path, max_chars=400)
+    assert blob  # still returns the head of the highest-ranked entry
+    assert "partial" in blob.lower()
+    # never cut mid-line: the body portion ends on a line boundary
+    assert "about widgetsline" not in blob
+    # marker is reserved within budget — total stays within max_chars
+    assert len(blob) <= 400
+
+
+def test_max_chars_bound_holds_with_no_newline_in_head(tmp_path: Path) -> None:
+    # a long single-line body: the head slice contains no newline to cut on,
+    # exercising the `or block[:budget]` fallback — total must still be bounded
+    _write(
+        tmp_path,
+        "logic-errors/oneline.md",
+        title="Widget oneline learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="x" * 5000,
+    )
+    blob = select_learnings("widget", root=tmp_path, max_chars=1000)
+    assert blob
+    assert len(blob) <= 1000
+
+
+def test_malformed_file_skipped_others_ranked(tmp_path: Path) -> None:
+    # garbage file with no frontmatter
+    bad = tmp_path / "docs" / "solutions" / "logic-errors" / "bad.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("not frontmatter at all\njust prose\n", encoding="utf-8")
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    blob = select_learnings("widget", root=tmp_path)
+    assert "Widget good learning" in blob
+
+
+def test_empty_solutions_dir_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "solutions").mkdir(parents=True)
+    assert select_learnings("anything", root=tmp_path) == ""
+
+
+def test_missing_solutions_dir_returns_empty(tmp_path: Path) -> None:
+    assert select_learnings("anything", root=tmp_path) == ""
+
+
+def test_recency_tiebreak_newer_first(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/old.md",
+        title="Older equal entry",
+        tags=["widget", "shared"],
+        date="2026-01-01",
+        body="## Problem\nold",
+    )
+    _write(
+        tmp_path,
+        "logic-errors/new.md",
+        title="Newer equal entry",
+        tags=["widget", "shared"],
+        date="2026-06-01",
+        body="## Problem\nnew",
+    )
+    blob = select_learnings("widget shared", root=tmp_path)
+    assert blob.index("Newer equal entry") < blob.index("Older equal entry")
+
+
+def test_recursive_glob_finds_subdir_only_files(tmp_path: Path) -> None:
+    # file lives ONLY in a nested category subdir, never at top level
+    _write(
+        tmp_path,
+        "integration-issues/nested.md",
+        title="Nested subdir learning",
+        tags=["widget", "nested"],
+        date="2026-06-01",
+        body="## Problem\nfound via recursive glob",
+    )
+    blob = select_learnings("widget nested", root=tmp_path)
+    assert "Nested subdir learning" in blob
+
+
+def test_write_learnings_file_returns_path_with_content(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    path = write_learnings_file("widget", root=tmp_path)
+    try:
+        assert path
+        content = Path(path).read_text(encoding="utf-8")
+        assert "Widget good learning" in content
+    finally:
+        if path:
+            os.unlink(path)
+
+
+def test_write_learnings_file_empty_on_no_match(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "solutions").mkdir(parents=True)
+    assert write_learnings_file("anything", root=tmp_path) == ""
+
+
+def test_write_learnings_file_no_orphan_on_write_failure(monkeypatch, tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "logic-errors/good.md",
+        title="Widget good learning",
+        tags=["widget"],
+        date="2026-06-01",
+        body="## Problem\nok",
+    )
+    created: list[str] = []
+    real_mkstemp = learnings_mod.tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(learnings_mod.tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(learnings_mod.os, "fdopen", boom)
+
+    assert write_learnings_file("widget", root=tmp_path) == ""
+    assert created  # mkstemp ran and created a file
+    assert not Path(created[0]).exists()  # orphan cleaned up despite write failure
+
+
+def test_write_learnings_file_failopen_on_selector_error(monkeypatch, tmp_path: Path) -> None:
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("selector exploded")
+
+    monkeypatch.setattr(learnings_mod, "select_learnings", boom)
+    assert write_learnings_file("widget", root=tmp_path) == ""
+
+
+def test_default_corpus_root_holds_solutions() -> None:
+    from wgmesh_pipeline.learnings import default_corpus_root
+
+    assert (default_corpus_root() / "docs" / "solutions").is_dir()
+
+
+def test_default_budget_constants() -> None:
+    # conservative defaults: top-3 / ~4KB
+    import inspect
+
+    sig = inspect.signature(select_learnings)
+    assert sig.parameters["max_items"].default == 3
+    assert sig.parameters["max_chars"].default == 4000

--- a/pipeline/wgmesh_pipeline/gtm_lane/__init__.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/__init__.py
@@ -1,0 +1,6 @@
+"""GTM-execution lane — drains the surface:service decision queue by dispatching
+approved low-risk GTM jobs to a rented-human provider, verifying the returned
+work fail-closed, and closing the item.
+
+See docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md.
+"""

--- a/pipeline/wgmesh_pipeline/gtm_lane/budget.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/budget.py
@@ -1,0 +1,76 @@
+"""Budget envelope gate (U6).
+
+Provider spend reports asynchronously, so a synchronous per-job dollar cap is not
+implementable (see docs/gtm/provider-feasibility.md + the multi-model-routing
+learning). The gate is therefore a **pre-dispatch reservation against a tracked
+envelope** plus a **bounded-attempts ceiling**: reserve the per-job estimate
+before dispatch, park when it would exceed the envelope or no envelope exists,
+and reconcile the actual cost on close.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class BudgetExceeded(Exception):
+    """The job's estimate would exceed the remaining envelope (or none exists)."""
+
+
+class AttemptsExhausted(Exception):
+    """The job hit the bounded-attempts ceiling."""
+
+
+@dataclass
+class Envelope:
+    total: float
+    spent: float = 0.0
+
+    @property
+    def remaining(self) -> float:
+        return self.total - self.spent
+
+
+@dataclass
+class BudgetGate:
+    envelope: Envelope
+    per_job_estimate: float
+    max_attempts: int = 3
+    _attempts: dict[str, int] = field(default_factory=dict)
+    _reserved: set[str] = field(default_factory=set)
+
+    def record_attempt(self, job_id: str) -> None:
+        """Count one attempt; raise AttemptsExhausted past the ceiling."""
+        count = self._attempts.get(job_id, 0)
+        if count >= self.max_attempts:
+            raise AttemptsExhausted(f"{job_id}: {count} attempts >= ceiling {self.max_attempts}")
+        self._attempts[job_id] = count + 1
+
+    def reserve(self, job_id: str) -> None:
+        """Reserve the per-job estimate against the envelope, ONCE per job. A
+        retry of an already-reserved job is a no-op — the estimate is held until
+        the job closes (reconcile) or is abandoned (release). Raise BudgetExceeded
+        (reserving nothing) when it would overspend."""
+        if job_id in self._reserved:
+            return  # already holding this job's reservation; do not double-reserve
+        if self.per_job_estimate > self.envelope.remaining:
+            raise BudgetExceeded(
+                f"{job_id}: estimate {self.per_job_estimate} > remaining {self.envelope.remaining}"
+            )
+        self.envelope.spent += self.per_job_estimate
+        self._reserved.add(job_id)
+
+    def reconcile(self, job_id: str, *, actual: float) -> None:
+        """On close, replace the held reservation with the actual cost the provider
+        reported. No-op if the job was never reserved."""
+        if job_id not in self._reserved:
+            return
+        self.envelope.spent += actual - self.per_job_estimate
+        self._reserved.discard(job_id)
+
+    def release(self, job_id: str) -> None:
+        """Abandon a job's reservation (parked/escalated and not re-attempted),
+        returning the held estimate to the envelope."""
+        if job_id in self._reserved:
+            self.envelope.spent -= self.per_job_estimate
+            self._reserved.discard(job_id)

--- a/pipeline/wgmesh_pipeline/gtm_lane/draft.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/draft.py
@@ -3,7 +3,8 @@
 Mirrors ``decision_lane/proposal_runner.build_proposal_fn``: multi-line content
 (the brief, the GTM playbook) is handed to the recipe as temp-file paths, never
 inline params. Returns a ``draft_fn(item) -> JobSpec`` the executor calls. The
-``learnings_file`` param is wired empty until U7 vendors the GTM corpus.
+``learnings_file`` param is grounded via the shipped ``write_learnings_file``
+seam over the vendored GTM corpus in ``docs/solutions/gtm-playbook/`` (U7).
 """
 
 from __future__ import annotations

--- a/pipeline/wgmesh_pipeline/gtm_lane/draft.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/draft.py
@@ -1,0 +1,75 @@
+"""Recipe-backed job-spec drafter (U3).
+
+Mirrors ``decision_lane/proposal_runner.build_proposal_fn``: multi-line content
+(the brief, the GTM playbook) is handed to the recipe as temp-file paths, never
+inline params. Returns a ``draft_fn(item) -> JobSpec`` the executor calls. The
+``learnings_file`` param is wired empty until U7 vendors the GTM corpus.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.config import DEFAULT_RECIPES_DIR, Config
+from wgmesh_pipeline.goose.runner import GooseRunner
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec, parse_job_spec
+from wgmesh_pipeline.learnings import write_learnings_file
+
+log = logging.getLogger("wgmesh_pipeline.gtm_lane.draft")
+
+
+def build_draft_fn(config: Config) -> Callable[[Mapping[str, Any]], JobSpec]:
+    runner = GooseRunner(config)
+    recipes_dir = Path(getattr(config, "recipes_dir", DEFAULT_RECIPES_DIR))
+    recipe = recipes_dir / "wgmesh-gtm-job-draft.yaml"
+    strategy = str(Path(config.repo_path) / "STRATEGY.md")
+
+    def _draft(item: Mapping[str, Any]) -> JobSpec:
+        title = str(item.get("title", ""))
+        brief = str(item.get("content") or "")
+        brief_file = ""
+        if brief.strip():
+            fd, brief_file = tempfile.mkstemp(prefix="gtm-brief-", suffix=".md")
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(brief)
+        # Ground the draft in the vendored GTM playbook (docs/solutions/gtm-playbook
+        # via the shipped learnings seam), keyed on the decision text. Fail-open:
+        # an empty/error result yields an empty path the recipe branches on. The
+        # corpus lives in docs/solutions/; the lane emits jobs to pipeline-output/,
+        # so there is no self-ingestion of the lane's own output.
+        learnings_file = write_learnings_file(
+            f"{title}\n{brief}", prefix=f"gtm-{item.get('id', 'x')}-learnings-"
+        )
+        out_rel = Path("pipeline-output") / f"gtm-job-{item.get('id', 'x')}.json"
+        try:
+            result = runner.run_recipe(
+                recipe=recipe,
+                workdir=Path(config.repo_path),
+                params={
+                    "item_title": title,
+                    "brief_file": brief_file,
+                    "strategy_file": strategy,
+                    "learnings_file": learnings_file,
+                    "job_spec_file": str(out_rel),
+                },
+                expected_output=out_rel,
+                stage="gtm_draft",
+                session_id=f"gtm-{item.get('id', 'x')}",
+            )
+            out_path = Path(config.repo_path) / out_rel
+            if not result.ok or not out_path.exists():
+                raise RuntimeError(f"gtm job-draft produced no output for {title!r}")
+            return parse_job_spec(out_path.read_text(encoding="utf-8"))
+        finally:
+            for tmp in (brief_file, learnings_file):
+                if tmp:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+
+    return _draft

--- a/pipeline/wgmesh_pipeline/gtm_lane/executor.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/executor.py
@@ -1,0 +1,134 @@
+"""GTM-execution lane core (U3).
+
+Orchestrates one approved low-risk item end-to-end: draft a job spec → dispatch
+to the rented-human provider → ingest the result → close (or requeue/escalate).
+
+Fail-open: ANY internal error returns the item to the queue in its prior state.
+A queued decision is never lost, dropped, or double-dispatched. The safety gate
+(U4), verification gate (U5), and budget gate (U6) are layered into this flow in
+their own units.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.provider import HumanTaskProvider, JobResult, ResultState
+from wgmesh_pipeline.gtm_lane.budget import AttemptsExhausted, BudgetExceeded, BudgetGate
+from wgmesh_pipeline.gtm_lane.safety import SafetyGate, SafetyRejection
+from wgmesh_pipeline.gtm_lane.verify import Verifier, VerifyOutcome
+
+log = logging.getLogger("wgmesh_pipeline.gtm_lane.executor")
+
+
+class ItemStatus(enum.Enum):
+    CLOSED = "closed"
+    REQUEUED = "requeued"  # fail-open: returned to queue in prior state
+    ESCALATED = "escalated"  # safety/hard-verify rejected → needs-human, never dispatched
+    PARKED = "parked"  # over budget / attempts exhausted → park + notify cofounder
+
+
+@dataclass(frozen=True)
+class ItemOutcome:
+    status: ItemStatus
+    item: Mapping[str, Any]
+    job_spec: JobSpec | None = None
+    result: JobResult | None = None
+    reason: str = ""
+
+
+DraftFn = Callable[[Mapping[str, Any]], JobSpec]
+
+_VERDICT_TO_STATUS = {
+    VerifyOutcome.PASS: ItemStatus.CLOSED,
+    VerifyOutcome.RETRY: ItemStatus.REQUEUED,
+    VerifyOutcome.ESCALATE: ItemStatus.ESCALATED,
+}
+
+
+def execute_item(
+    item: Mapping[str, Any],
+    *,
+    draft_fn: DraftFn,
+    provider: HumanTaskProvider,
+    safety: SafetyGate | None = None,
+    budget: BudgetGate | None = None,
+    verifier: Verifier | None = None,
+) -> ItemOutcome:
+    """Run one item through draft → safety gate → dispatch → ingest → verify →
+    close. Never raises: any failure yields a REQUEUED outcome carrying the item
+    unchanged. Safety rejection or a hard verify failure yields ESCALATED.
+
+    ``safety``/``verifier`` are optional only to keep lower-layer tests focused;
+    the production lane assembly always supplies both."""
+    try:
+        job_spec = draft_fn(item)
+        if safety is not None:
+            try:
+                safety.check(job_spec)
+            except SafetyRejection as rej:
+                log.info("gtm safety gate rejected item %s: %s", item.get("id"), rej)
+                return ItemOutcome(
+                    status=ItemStatus.ESCALATED, item=item, job_spec=job_spec, reason=str(rej)
+                )
+        if budget is not None:
+            try:
+                budget.record_attempt(job_spec.id)
+                budget.reserve(job_spec.id)
+            except (BudgetExceeded, AttemptsExhausted) as exc:
+                log.info("gtm budget gate parked item %s: %s", item.get("id"), exc)
+                budget.release(job_spec.id)  # abandon any held reservation from prior attempts
+                return ItemOutcome(
+                    status=ItemStatus.PARKED, item=item, job_spec=job_spec, reason=str(exc)
+                )
+        handle = provider.dispatch(_dispatch_payload(job_spec))
+        result = provider.fetch_result(handle)
+        if verifier is not None:
+            verdict = verifier.verify(job_spec, result)
+            # Default unmapped verdicts to ESCALATED (fail-closed): never let a new
+            # VerifyOutcome silently fall through the fail-open except into a retry.
+            status = _VERDICT_TO_STATUS.get(verdict.outcome, ItemStatus.ESCALATED)
+            reason = verdict.reason
+        elif result.state is ResultState.COMPLETED:
+            # No verifier (lower-layer tests only): COMPLETED closes, else requeue.
+            status, reason = ItemStatus.CLOSED, ""
+        else:
+            status, reason = ItemStatus.REQUEUED, f"result not completed: {result.state.value}"
+        _settle_budget(budget, job_spec.id, status, result)
+        return ItemOutcome(status=status, item=item, job_spec=job_spec, result=result, reason=reason)
+    except Exception as exc:  # noqa: BLE001 — fail-open; a queued decision is never lost
+        log.warning("gtm lane error for item %s; requeuing", item.get("id"), exc_info=True)
+        return ItemOutcome(status=ItemStatus.REQUEUED, item=item, reason=str(exc))
+
+
+def _settle_budget(
+    budget: BudgetGate | None, job_id: str, status: ItemStatus, result: JobResult | None
+) -> None:
+    """Settle the held reservation after the outcome is known. CLOSED reconciles
+    to the provider's reported cost (when present); a terminal non-retry outcome
+    releases the held estimate; REQUEUED keeps it (the retry re-uses it)."""
+    if budget is None:
+        return
+    if status is ItemStatus.CLOSED:
+        actual = getattr(result, "cost_estimate", None)
+        if actual is not None:
+            budget.reconcile(job_id, actual=actual)
+    elif status in (ItemStatus.ESCALATED, ItemStatus.PARKED):
+        budget.release(job_id)
+
+
+def _dispatch_payload(job_spec: JobSpec) -> dict[str, Any]:
+    return {
+        "id": job_spec.id,
+        "idempotency_key": job_spec.id,  # real adapters MUST dedupe on this — a
+        # fetch_result failure requeues and re-dispatches the same job (see
+        # provider.HumanTaskProvider contract).
+        "task": job_spec.task,
+        "acceptance_criteria": list(job_spec.acceptance_criteria),
+        "safety_bounds": list(job_spec.safety_bounds),
+        "payload": dict(job_spec.payload),
+    }

--- a/pipeline/wgmesh_pipeline/gtm_lane/fake_provider.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/fake_provider.py
@@ -1,0 +1,38 @@
+"""In-memory fake provider (U2) for deterministic lane tests.
+
+Scripts a JobResult per job id so U3-U9 exercise every result state
+(completed-with-proof / empty / garbage / pending) without a live, funded vendor.
+Idempotent on the job id: re-dispatching the same job returns the same handle and
+does not double-dispatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self._scripted: dict[str, JobResult] = {}
+        self._handles: dict[str, str] = {}  # job_id -> handle
+        self.dispatch_count = 0
+
+    def script(self, job_id: str, result: JobResult) -> None:
+        """Pre-load the result a future fetch should return for ``job_id``."""
+        self._scripted[job_id] = result
+
+    def dispatch(self, job_spec: Mapping[str, Any]) -> str:
+        job_id = str(job_spec["id"])
+        if job_id in self._handles:  # idempotent — no double dispatch
+            return self._handles[job_id]
+        handle = f"fake-handle-{job_id}"
+        self._handles[job_id] = handle
+        self.dispatch_count += 1
+        return handle
+
+    def fetch_result(self, handle: str) -> JobResult:
+        job_id = handle.removeprefix("fake-handle-")
+        # default to PENDING when nothing scripted — never a silent "done"
+        return self._scripted.get(job_id, JobResult(state=ResultState.PENDING))

--- a/pipeline/wgmesh_pipeline/gtm_lane/job_spec.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/job_spec.py
@@ -1,0 +1,64 @@
+"""Job spec model + parser (U3). The job-draft step (recipe) emits a JSON job
+spec; the executor parses it into this structured form. The low-risk job-class
+allowlist is added in U4."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+# Low-risk job classes the MVP lane will dispatch to a rented human (U4). Anything
+# outside this set — especially outbound contact as the company — stays in the
+# needs-human queue until the dispatch+verify loop is proven.
+LOW_RISK_CLASSES: frozenset[str] = frozenset(
+    {
+        "lead_research",
+        "list_building",
+        "manual_signup",
+        "content_qa",
+        "competitor_recon",
+        "data_entry",
+    }
+)
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    id: str
+    task: str
+    acceptance_criteria: tuple[str, ...]
+    safety_bounds: tuple[str, ...] = ()
+    job_class: str = ""
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _as_tuple(value: Any) -> tuple[str, ...]:
+    if not value:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return tuple(str(v) for v in value)
+
+
+def parse_job_spec(text: str) -> JobSpec:
+    """Parse a JSON job spec emitted by the draft recipe. Raises ``ValueError``
+    on empty/malformed input (fail-closed — the executor must not dispatch a
+    blank job)."""
+    if not text or not text.strip():
+        raise ValueError("empty job spec")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed job spec: {exc}") from exc
+    if not isinstance(data, dict) or not data.get("id") or not data.get("task"):
+        raise ValueError("job spec missing required id/task")
+    return JobSpec(
+        id=str(data["id"]),
+        task=str(data["task"]),
+        acceptance_criteria=_as_tuple(data.get("acceptance_criteria")),
+        safety_bounds=_as_tuple(data.get("safety_bounds")),
+        job_class=str(data.get("job_class", "")),
+        payload=data.get("payload") or {},
+    )

--- a/pipeline/wgmesh_pipeline/gtm_lane/lane.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/lane.py
@@ -1,0 +1,52 @@
+"""Production lane assembly (review hardening).
+
+``execute_item`` lets each gate default to None so lower-layer tests can focus on
+one concern. That flexibility is a liability in production: a single wiring slip
+(verifier=None) silently degrades to dispatch-without-safety / close-without-verify.
+``GtmLane`` is the production seam — it REQUIRES every gate (no defaults), so the
+type system guarantees the safe path. The live queue poller constructs one
+``GtmLane`` and calls ``run`` per approved item.
+
+The provider and the verification judge are the only funding-gated pieces (they
+need the funded Toloka account + the live LLM judge); everything else assembles
+from config now.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from wgmesh_pipeline.gtm_lane.budget import BudgetGate
+from wgmesh_pipeline.gtm_lane.executor import DraftFn, ItemOutcome, execute_item
+from wgmesh_pipeline.gtm_lane.provider import HumanTaskProvider
+from wgmesh_pipeline.gtm_lane.safety import SafetyGate
+from wgmesh_pipeline.gtm_lane.telemetry import record_outcome
+from wgmesh_pipeline.gtm_lane.verify import Verifier
+
+
+@dataclass
+class GtmLane:
+    """All gates required — construction fails loudly if one is missing."""
+
+    provider: HumanTaskProvider
+    draft_fn: DraftFn
+    safety: SafetyGate
+    budget: BudgetGate
+    verifier: Verifier
+    telemetry_path: str | Path | None = None
+
+    def run(self, item: Mapping[str, Any]) -> ItemOutcome:
+        outcome = execute_item(
+            item,
+            draft_fn=self.draft_fn,
+            provider=self.provider,
+            safety=self.safety,
+            budget=self.budget,
+            verifier=self.verifier,
+        )
+        if self.telemetry_path is not None:
+            cost = getattr(outcome.result, "cost_estimate", None)
+            record_outcome(outcome.status, state_path=self.telemetry_path, cost=cost)
+        return outcome

--- a/pipeline/wgmesh_pipeline/gtm_lane/provider.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/provider.py
@@ -1,0 +1,77 @@
+"""Vendor-agnostic rented-human provider adapter (U2).
+
+The lane targets this dispatch+verify contract, not a specific vendor, so the
+U1-chosen provider (Toloka by default) wires in behind the seam without lane
+rework. ``FakeProvider`` (see ``fake_provider``) backs the tests so U3-U9 build
+without a live, funded account.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+class ResultState(enum.Enum):
+    """The four states a fetched result may be in. Never coerce to COMPLETED —
+    the verifier (U5) must see EMPTY/GARBAGE/PENDING distinctly so a silent zero
+    is not graded as done."""
+
+    COMPLETED = "completed"
+    EMPTY = "empty"
+    GARBAGE = "garbage"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True)
+class JobResult:
+    """A fetched result. ``proof`` is the structured completion artifact the U5
+    verifier checks against the dispatched job (Toloka assignment JSON /
+    Microworkers screenshot URL / HumanOps photo)."""
+
+    state: ResultState
+    payload: Any = None
+    proof: Any = None
+    worker_meta: Mapping[str, Any] = field(default_factory=dict)
+    cost_estimate: float | None = None
+
+
+@runtime_checkable
+class HumanTaskProvider(Protocol):
+    """A rented-human task provider.
+
+    IDEMPOTENCY IS A HARD CONTRACT: ``dispatch`` MUST dedupe on the payload's
+    ``idempotency_key`` (== the job id). The lane requeues and re-dispatches the
+    SAME job when ``fetch_result`` raises (network/provider error), so a
+    non-idempotent adapter would create a second *paid* task on every fetch
+    failure. A real adapter that cannot dedupe server-side must persist its own
+    job-id→handle map and short-circuit a repeat dispatch.
+    """
+
+    def dispatch(self, job_spec: Mapping[str, Any]) -> str:
+        """Submit one task (deduping on ``job_spec['idempotency_key']``); return an
+        opaque provider handle."""
+        ...
+
+    def fetch_result(self, handle: str) -> JobResult:
+        """Retrieve the result for a previously dispatched handle."""
+        ...
+
+
+def provider_env(allow: set[str], *, source: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Build a provider subprocess env from an **allowlist** (fail-closed).
+
+    Only keys named in ``allow`` are passed; everything else is dropped. A denylist
+    would be fail-open and miss new secrets (see the multi-model-routing learning).
+    A required key absent from ``source`` raises ``KeyError`` rather than silently
+    starting an under-credentialed provider.
+    """
+    src = os.environ if source is None else source
+    out: dict[str, str] = {}
+    for key in allow:
+        if key not in src:
+            raise KeyError(f"required provider credential {key!r} not in environment")
+        out[key] = src[key]
+    return out

--- a/pipeline/wgmesh_pipeline/gtm_lane/safety.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/safety.py
@@ -1,0 +1,72 @@
+"""Job-class safety gate (U4).
+
+Two guards before a job is dispatched to a rented human:
+  1. The job class must be in the low-risk allowlist (job_spec.LOW_RISK_CLASSES) —
+     anything else, especially outbound-as-the-company, is rejected to needs-human.
+  2. The outbound job-spec text passes the sanitise wall (company/scripts/sanitise.sh),
+     which fails-closed on secrets and uses narrow patterns (the bare word "key" is
+     not flagged). The same sanitiser is reused on the inbound returned artifact (U5).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from wgmesh_pipeline.gtm_lane.job_spec import LOW_RISK_CLASSES, JobSpec
+
+
+class SafetyRejection(Exception):
+    """Raised when a job spec fails the safety gate (escalate to needs-human)."""
+
+
+def run_sanitise(text: str, *, script: str | Path) -> bool:
+    """Run the sanitise wall over ``text``. Returns True when clean, False when a
+    secret was detected (the script exits non-zero). Fail-closed: a script error
+    is treated as not-clean."""
+    try:
+        proc = subprocess.run(
+            ["bash", str(script)],
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+# Sanitiser callable: text -> True when clean. Injectable for tests.
+Sanitiser = Callable[[str], bool]
+
+
+@dataclass
+class SafetyGate:
+    sanitiser: Sanitiser
+
+    def check(self, job_spec: JobSpec) -> None:
+        """Raise SafetyRejection if the job is not a low-risk class or its spec
+        text carries a secret. No return value — passing means safe to dispatch."""
+        if job_spec.job_class not in LOW_RISK_CLASSES:
+            raise SafetyRejection(
+                f"job_class {job_spec.job_class!r} not in low-risk allowlist; "
+                "outbound/high-risk work stays in the needs-human queue"
+            )
+        text = self.spec_text(job_spec)
+        if not self.sanitiser(text):
+            raise SafetyRejection("job spec text failed the sanitise wall (secret detected)")
+
+    @staticmethod
+    def spec_text(job_spec: JobSpec) -> str:
+        return json.dumps(
+            {
+                "task": job_spec.task,
+                "acceptance_criteria": list(job_spec.acceptance_criteria),
+                "safety_bounds": list(job_spec.safety_bounds),
+                "payload": dict(job_spec.payload),
+            }
+        )

--- a/pipeline/wgmesh_pipeline/gtm_lane/telemetry.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/telemetry.py
@@ -1,0 +1,50 @@
+"""Best-effort lane telemetry (U9).
+
+Records per-item outcome counts, total cost, and last latency to a state file the
+pulse reads. **Best-effort**: a telemetry write must NEVER block or fail a lane
+run (the telemetry-must-be-best-effort learning) — any IO error is swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from wgmesh_pipeline.gtm_lane.executor import ItemStatus
+
+log = logging.getLogger("wgmesh_pipeline.gtm_lane.telemetry")
+
+
+def record_outcome(
+    status: ItemStatus,
+    *,
+    state_path: str | Path,
+    cost: float | None = None,
+    latency_s: float | None = None,
+    make_parents: bool = True,
+) -> None:
+    """Append one item's outcome to the telemetry state file. Swallows all
+    errors — telemetry is never allowed to break the lane."""
+    try:
+        path = Path(state_path)
+        if make_parents:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        data = _load(path)
+        data["counts"][status.value] = data["counts"].get(status.value, 0) + 1
+        if cost is not None:
+            data["total_cost"] = round(data.get("total_cost", 0.0) + cost, 6)
+        if latency_s is not None:
+            data["last_latency_s"] = latency_s
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception:  # noqa: BLE001 — best-effort; never block the lane
+        log.warning("gtm telemetry write failed (best-effort, ignored)", exc_info=True)
+
+
+def _load(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.setdefault("counts", {})
+        return data
+    except (OSError, json.JSONDecodeError):
+        return {"counts": {}, "total_cost": 0.0}

--- a/pipeline/wgmesh_pipeline/gtm_lane/verify.py
+++ b/pipeline/wgmesh_pipeline/gtm_lane/verify.py
@@ -1,0 +1,82 @@
+"""Fail-closed verification gate (U5).
+
+Mirrors the impl-judge discipline: a deliverable is graded only when it is
+actually present. Fail-closed gates fire BEFORE the LLM judge so an empty or
+absent result can never be scored as "done" (the langfuse-empty-output failure
+class). Security reasons (a secret in the returned artifact) and empty/absent
+work escalate straight to needs-human; only a quality shortfall retries.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+from wgmesh_pipeline.gtm_lane.job_spec import JobSpec
+from wgmesh_pipeline.gtm_lane.provider import JobResult, ResultState
+from wgmesh_pipeline.gtm_lane.safety import Sanitiser
+
+log = logging.getLogger("wgmesh_pipeline.gtm_lane.verify")
+
+
+class VerifyOutcome(enum.Enum):
+    PASS = "pass"          # verified complete → close
+    RETRY = "retry"        # quality shortfall or still pending → bounded retry
+    ESCALATE = "escalate"  # empty/absent/garbage/security → needs-human, never retried
+
+
+@dataclass(frozen=True)
+class VerifyVerdict:
+    outcome: VerifyOutcome
+    reason: str = ""
+
+
+# judge(job_spec, result) -> True when the returned work satisfies the acceptance
+# criteria. A judge that raises or returns non-True is treated as a quality fail.
+Judge = Callable[[JobSpec, JobResult], bool]
+
+
+@dataclass
+class Verifier:
+    judge: Judge
+    sanitiser: Sanitiser
+
+    def verify(self, job_spec: JobSpec, result: JobResult) -> VerifyVerdict:
+        # 1. State gate (fail-closed): only COMPLETED is gradable.
+        if result.state is ResultState.PENDING:
+            return VerifyVerdict(VerifyOutcome.RETRY, "result still pending")
+        if result.state is not ResultState.COMPLETED:
+            return VerifyVerdict(VerifyOutcome.ESCALATE, f"result state {result.state.value}")
+
+        # 2. Presence gate (fail-closed): empty work / absent proof can never pass.
+        if not _nonempty(result.payload):
+            return VerifyVerdict(VerifyOutcome.ESCALATE, "returned work is empty")
+        if not _nonempty(result.proof):
+            return VerifyVerdict(VerifyOutcome.ESCALATE, "completion proof absent")
+
+        # 3. Security gate: a secret in the returned artifact escalates, never retries.
+        if not self.sanitiser(_artifact_text(result)):
+            return VerifyVerdict(VerifyOutcome.ESCALATE, "returned artifact failed sanitise")
+
+        # 4. Quality judge (last, on real content). Raise/non-True → quality fail.
+        try:
+            passed = bool(self.judge(job_spec, result))
+        except Exception:  # noqa: BLE001 — a judge error is a fail, never a pass
+            log.warning("gtm verify judge errored for %s; treating as quality fail", job_spec.id, exc_info=True)
+            passed = False
+        if passed:
+            return VerifyVerdict(VerifyOutcome.PASS, "verified complete")
+        return VerifyVerdict(VerifyOutcome.RETRY, "judge: acceptance criteria not met")
+
+
+def _nonempty(value: object) -> bool:
+    # "Is there work?" — None, empty containers/strings, AND falsy scalars
+    # (0, 0.0, False = a count-of-zero deliverable) all count as no work.
+    return bool(value)
+
+
+def _artifact_text(result: JobResult) -> str:
+    return json.dumps({"payload": result.payload, "proof": result.proof}, default=str)

--- a/pipeline/wgmesh_pipeline/learnings.py
+++ b/pipeline/wgmesh_pipeline/learnings.py
@@ -1,0 +1,217 @@
+"""Relevance selector over the ``docs/solutions/`` learnings corpus.
+
+Pure, deterministic read-back half of observe -> score -> *improve*: rank the
+committed learnings by token overlap against a query (an issue title/body, or a
+spec), and return the top-N concatenated within a char budget so they can be
+injected into the spec/implement agent recipes as advisory "known pitfalls".
+
+No network, no embeddings, no LLM. Fail-open per file: a malformed entry is
+skipped, never raised, so injecting learnings can never break a build run.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger("wgmesh_pipeline.learnings")
+
+_SOLUTIONS_REL = ("docs", "solutions")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_MIN_TOKEN_LEN = 3
+_TAG_WEIGHT = 2
+
+# Machine-countable, body-unique block header so callers/tests can delimit
+# entries even though entry bodies themselves contain markdown headings.
+_BLOCK_HEADER = "## Past learning:"
+_PARTIAL_MARKER = (
+    "\n...[truncated — PARTIAL learning, char budget reached; "
+    "this is the head of the most relevant entry]...\n"
+)
+
+
+@dataclass(frozen=True)
+class _Entry:
+    title: str
+    category: str
+    tags: tuple[str, ...]
+    date: str
+    body: str
+
+
+def _tokenize(text: str) -> set[str]:
+    return {t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= _MIN_TOKEN_LEN}
+
+
+def _date_key(date: str) -> tuple[int, int, int]:
+    match = re.match(r"(\d{4})-(\d{2})-(\d{2})", date or "")
+    if not match:
+        return (0, 0, 0)
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _parse_file(path: Path) -> _Entry | None:
+    """Parse one corpus file; return None (skip) on any malformed input."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not raw.startswith("---"):
+        return None
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(meta, dict):
+        return None
+
+    raw_tags = meta.get("tags", [])
+    if isinstance(raw_tags, str):
+        tags = tuple(t.strip() for t in raw_tags.replace(",", " ").split() if t.strip())
+    elif isinstance(raw_tags, (list, tuple)):
+        tags = tuple(str(t) for t in raw_tags)
+    else:
+        tags = ()
+
+    return _Entry(
+        title=str(meta.get("title", path.stem)),
+        category=str(meta.get("category", "")),
+        tags=tags,
+        date=str(meta.get("date", "")),
+        body=parts[2].strip(),
+    )
+
+
+def _score(entry: _Entry, query_tokens: set[str]) -> int:
+    tag_tokens: set[str] = set()
+    for tag in entry.tags:
+        tag_tokens |= _tokenize(tag)
+    title_tokens = _tokenize(entry.title) | _tokenize(entry.category)
+    return _TAG_WEIGHT * len(query_tokens & tag_tokens) + len(query_tokens & title_tokens)
+
+
+def _compact_body(body: str) -> str:
+    """Trim an entry body to its substance: drop a leading duplicate H1 and any
+    trailing ``## Related`` link section."""
+    body = body.strip()
+    body = re.sub(r"^#\s+.*\n+", "", body, count=1)
+    related = re.search(r"(?mi)^##\s+Related\b", body)
+    if related:
+        body = body[: related.start()].rstrip()
+    return body
+
+
+def _block(entry: _Entry) -> str:
+    return f"{_BLOCK_HEADER} {entry.title}\n\n{_compact_body(entry.body)}\n"
+
+
+def default_corpus_root() -> Path:
+    """Repo root holding ``docs/solutions/`` — this pipeline's own checkout, not
+    the target repo the agent edits. Derived from this module's location."""
+    return Path(__file__).resolve().parents[2]
+
+
+def write_learnings_file(
+    query: str,
+    *,
+    root: str | Path | None = None,
+    prefix: str = "learnings-",
+    max_items: int = 3,
+    max_chars: int = 4000,
+) -> str:
+    """Select learnings for ``query`` and write them to a temp file.
+
+    Returns the temp file path, or "" when there are no relevant learnings — so
+    callers ALWAYS pass the (required) recipe param, empty on no-match. Fail-open:
+    any selector/IO error logs and returns "" rather than raising. The caller owns
+    cleanup (unlink in a ``finally``).
+    """
+    corpus_root = Path(root) if root is not None else default_corpus_root()
+    try:
+        blob = select_learnings(
+            query, root=corpus_root, max_items=max_items, max_chars=max_chars
+        )
+    except Exception:  # noqa: BLE001 — fail-open; learnings must never break a run
+        log.warning("learnings selection failed; proceeding without", exc_info=True)
+        return ""
+    if not blob.strip():
+        return ""
+    path = ""
+    try:
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=".md")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(blob)
+    except OSError:
+        log.warning("learnings temp-file write failed; proceeding without", exc_info=True)
+        # mkstemp may have created the file before the write failed (ENOSPC);
+        # unlink it so a partial temp file is not orphaned.
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        return ""
+    return path
+
+
+def select_learnings(
+    query: str,
+    *,
+    root: str | Path,
+    max_items: int = 3,
+    max_chars: int = 4000,
+) -> str:
+    """Return the learnings most relevant to ``query``, concatenated.
+
+    Globs ``<root>/docs/solutions/**/*.md`` recursively (all corpus files live in
+    category subdirs), ranks by token overlap of each entry's tags/category/title
+    against the query (tags weighted; recency breaks ties), and concatenates the
+    top entries up to ``max_items`` / ``max_chars``. Returns "" when the corpus is
+    missing/empty, the query is empty, or nothing scores above zero.
+    """
+    base = Path(root).joinpath(*_SOLUTIONS_REL)
+    if not base.is_dir():
+        return ""
+    query_tokens = _tokenize(query)
+    if not query_tokens:
+        return ""
+
+    scored: list[tuple[int, tuple[int, int, int], _Entry]] = []
+    for path in base.rglob("*.md"):
+        entry = _parse_file(path)
+        if entry is None:
+            continue
+        score = _score(entry, query_tokens)
+        if score <= 0:
+            continue
+        scored.append((score, _date_key(entry.date), entry))
+    if not scored:
+        return ""
+
+    # score desc, then date desc (newer wins a tie)
+    scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+
+    result = ""
+    for _, _, entry in scored[:max_items]:
+        block = _block(entry)
+        candidate = block if not result else f"{result}\n{block}"
+        if result:
+            if len(candidate) > max_chars:
+                break
+        elif len(block) > max_chars:
+            # single oversized highest-ranked entry: cut at a line boundary,
+            # reserving room for the marker so the total stays within max_chars.
+            budget = max(0, max_chars - len(_PARTIAL_MARKER))
+            head = block[:budget].rsplit("\n", 1)[0] or block[:budget]
+            return head + _PARTIAL_MARKER
+        result = candidate
+    return result


### PR DESCRIPTION
## Summary

Gives the `surface:service` GTM-decision queue a real **autonomous executor** so service go-to-market drains without the cofounder doing the work by hand. Per the last pulses, demand/monetization (not engineering) is the gating constraint, and the cofounder-only queue *is* the "babysitting" failure STRATEGY.md commits to removing.

Flow: approved low-risk item → **draft job spec** (WISDOM-grounded) → **safety gate** (low-risk allowlist + sanitise wall) → **budget gate** (pre-dispatch reservation + bounded attempts) → **dispatch** to a vendor-agnostic rented-human provider → **fail-closed verification** → close / retry / escalate / park.

Origin: `docs/brainstorms/2026-06-24-gtm-rent-a-human-executor-requirements.md` · Plan: `docs/plans/2026-06-25-001-feat-gtm-rent-a-human-executor-plan.md`

## Units

| U | What |
|---|------|
| U1 | Provider feasibility note — **Toloka** primary (EU DPA + API + structured proof + ~$0.10–0.50/task); async-spend → reservation model |
| U2 | Vendor-agnostic provider adapter + fake provider (allowlist env, idempotent on job id) |
| U3 | Execution lane core + job-draft recipe + drafter (fail-open queue-return) |
| U4 | Job-class safety gate (low-risk allowlist; outbound-as-company rejected; sanitise wall both directions) |
| U5 | Fail-closed verification gate (presence/proof/security gates fire before the judge; quality retries, empty/security escalate) |
| U6 | Budget envelope (idempotent reservation + bounded-attempts ceiling; park on overspend) |
| U7 | WISDOM-grounded job drafts via the shipped `learnings.py` seam + vendored GTM playbook |
| U8 | cloudroof positioning frame (Obviously Awesome) + Mom-Test stargazer kit |
| U9 | Best-effort lane telemetry + captured PII / Cloudflare-UA learnings |

## Quality

- **65 GTM tests + 17 learnings tests green**, lint clean. TDD throughout (test-first / characterization-first per plan).
- Adversarial review run; fixes applied: idempotent budget reserve + reconcile/release (kills a 3× envelope-drain on retries), required-gate `GtmLane` assembly (kills the silent None-degrade path), fail-closed verdict mapping, explicit `idempotency_key` + hardened provider contract, `_nonempty` scalar fix.

## Gated on cofounder action (live cutover only — not this PR)

The lane is built and fully tested against a **fake provider**. The live cutover needs: (1) a **funded Toloka account + EU DPA** + API credential (Gate 4 in the feasibility note), (2) the live **LLM verification judge** wired in, (3) the **queue poller** calling `GtmLane.run` per approved item. These are the funding-gated injection points; the seams (`GtmLane`, injectable provider/judge) are in place.

## Stacking notes

- **Stacked on `feat/lang-triad-cutover` (#1987)** — base it on lang-triad per the chosen integration branch; re-target to `main` after #1987 lands.
- Carries a copy of `pipeline/wgmesh_pipeline/learnings.py` from **#1988** (the U7 grounding seam). Dedups cleanly when #1988 merges.
- Path note: GTM playbook vendored under `docs/solutions/gtm-playbook/` (not `docs/gtm-wisdom/` as the plan named) to reuse the learnings seam's existing glob unmodified.
