### PR TITLE
chore(claude): adopt gstack team mode (required) for AI-assisted work

### DIFF
--- a/.claude/hooks/check-gstack.sh
+++ b/.claude/hooks/check-gstack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Block skill usage when gstack is not installed globally.
+
+if [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
+  cat >&2 <<'MSG'
+BLOCKED: gstack is not installed globally.
+
+gstack is required for AI-assisted work in this repo.
+
+Install it:
+  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+  cd ~/.claude/skills/gstack && ./setup --team
+
+Then restart your AI coding tool.
+MSG
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gstack is required but not installed. See stderr for install instructions."}}'
+  exit 2
+fi
+
+echo '{}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ infrastructure/terraform/**/backend.hcl
 
 # Compound Engineering local config
 .compound-engineering/*.local.yaml
+
+# Claude Code per-developer overrides (never commit)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,27 @@ Tool-specific notes for Claude Code only:
 - Curated learnings are in `memory/MEMORY.md`. Consult before changing workflows/scripts;
   add an entry when you learn something non-obvious.
 - This is a **public** repo — never commit secrets, PII, or exact revenue figures.
+
+## gstack (REQUIRED — global install)
+
+**Before doing ANY work, verify gstack is installed:**
+
+```bash
+test -d ~/.claude/skills/gstack/bin && echo "GSTACK_OK" || echo "GSTACK_MISSING"
+```
+
+If GSTACK_MISSING: STOP. Do not proceed. Tell the user:
+
+> gstack is required for all AI-assisted work in this repo.
+> Install it:
+> ```bash
+> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+> cd ~/.claude/skills/gstack && ./setup --team
+> ```
+> Then restart your AI coding tool.
+
+Do not skip skills, ignore gstack errors, or work around missing gstack.
+
+Using gstack skills: After install, skills like /qa, /ship, /review, /investigate,
+and /browse are available. Use /browse for all web browsing.
+Use ~/.claude/skills/gstack/... for gstack file paths (the global path).


### PR DESCRIPTION
## What

Installs [garrytan/gstack](https://github.com/garrytan/gstack) (v1.64.1) into this repo in **team mode (required)** — Garry Tan's Claude Code toolchain (23 specialist slash-commands: /office-hours, /review, /qa, /ship, /cso, /investigate…).

## Why

Human request: install gstack to this repo. gstack turns Claude Code sessions into a structured eng team (CEO review, eng review, QA, release). Machine side already upgraded to 1.64.1.0 with team auto-update enabled.

## Changes

- **CLAUDE.md** — appended `## gstack (REQUIRED)` section (global install + verification instructions); existing AGENTS.md pointer untouched
- **`.claude/hooks/check-gstack.sh`** — PreToolUse gate: denies `Skill` tool use when `~/.claude/skills/gstack/bin` is missing. Verified both paths: PASS → `{}` exit 0; DENY → block message + deny JSON, exit 2
- **`.claude/settings.json`** — committed with the shared hook only; personal `enabledPlugins` relocated to `settings.local.json` (per Claude Code convention, now gitignored)
- **`.gitignore`** — `.claude/settings.local.json`

## Not affected

The Copilot→Goose pipeline agents never read `.claude/`; the hook only gates interactive Claude Code sessions.

## Softening later

`~/.claude/skills/gstack/bin/gstack-team-init optional` regenerates a nudge-only setup if `required` proves too strict.
